### PR TITLE
fix(billing): reconcile subscription state on checkout completion

### DIFF
--- a/server/src/billing/lazy-reconcile.ts
+++ b/server/src/billing/lazy-reconcile.ts
@@ -157,10 +157,25 @@ export async function attemptStripeReconciliation(
   }
 
   const subs = (customer as Stripe.Customer).subscriptions?.data ?? [];
+  let productFetchFailed = false;
   const picked = await pickMembershipSubWithProductFetch(
     subs,
-    (productId) => stripe.products.retrieve(productId),
+    async (productId) => {
+      try {
+        return await stripe.products.retrieve(productId);
+      } catch (err) {
+        productFetchFailed = true;
+        throw err;
+      }
+    },
   );
+  if (!picked && productFetchFailed) {
+    logger.warn(
+      { orgId, customerId: org.stripe_customer_id },
+      'lazy-reconcile: Stripe product classification failed; deferring heal',
+    );
+    return { healed: false, reason: 'stripe_error' };
+  }
   if (!picked) return { healed: false, reason: 'no_membership_sub' };
   if (!ENTITLED_STATUSES.has(picked.sub.status)) return { healed: false, reason: 'sub_not_entitled' };
 

--- a/server/src/billing/membership-checkout-attempt.ts
+++ b/server/src/billing/membership-checkout-attempt.ts
@@ -116,6 +116,25 @@ export async function clearMembershipCheckoutAttempt(
   );
 }
 
+/**
+ * Check that a completed Stripe session is still the server-side checkout
+ * generation for this organization. Do not apply the 24-hour intake TTL here:
+ * webhook delivery can be delayed after a valid completion, while a newer
+ * checkout or an explicit admin unlink replaces/deletes this exact session.
+ */
+export async function isExpectedMembershipCheckoutSession(
+  organizationId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const result = await query(
+    `SELECT 1 FROM membership_checkout_attempts
+     WHERE organization_id = $1 AND stripe_session_id = $2
+     LIMIT 1`,
+    [organizationId, sessionId],
+  );
+  return result.rows.length > 0;
+}
+
 /** Clear only failures that prove Stripe did not create a Checkout session. */
 export function isDefinitiveCheckoutFailure(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -38,9 +38,12 @@ import { stripe, STRIPE_WEBHOOK_SECRET, createStripeCustomer, createCustomerPort
 import { handleSubscriptionCreated, type ActivationAdminContext } from "./billing/handle-subscription-created.js";
 import { resolveOrgForStripeCustomer } from "./billing/webhook-helpers.js";
 import { dedupOnSubscriptionCreated } from "./billing/dedup-on-subscription-created.js";
+import { attemptStripeReconciliation } from "./billing/lazy-reconcile.js";
+import { isExpectedMembershipCheckoutSession } from "./billing/membership-checkout-attempt.js";
+import { withOrgIntakeLock } from "./billing/org-intake-lock.js";
 import { pickMembershipSubWithProductFetch } from "./billing/membership-prices.js";
 import Stripe from "stripe";
-import { OrganizationDatabase, getUserSeatType, buildSubscriptionUpdate, MEMBERSHIP_TIER_COLUMNS, resolveMembershipTier, resolveMembershipTierForSubscriptionWrite, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier, type MembershipTierRow } from "./db/organization-db.js";
+import { OrganizationDatabase, StripeCustomerConflictError, getUserSeatType, buildSubscriptionUpdate, MEMBERSHIP_TIER_COLUMNS, resolveMembershipTier, resolveMembershipTierForSubscriptionWrite, TIER_PRESERVING_STATUSES, type SeatType, type MembershipTier, type MembershipTierRow } from "./db/organization-db.js";
 import { MemberDatabase } from "./db/member-db.js";
 import { ensureMemberProfilePublished } from "./services/member-profile-autopublish.js";
 import { getBrandPrimaryDomain, getBrandPrimaryDomainsForOrgs } from "./services/brand-domain-resolver.js";
@@ -5758,13 +5761,33 @@ export class HTTPServer {
             }
 
             if (customerId && workosOrgId) {
+              const stripeClient = stripe;
+              await withOrgIntakeLock(workosOrgId, async () => {
+              const org = await orgDb.getOrganization(workosOrgId);
+              // A Checkout session is immutable and can be replayed long after
+              // an operator explicitly unlinks its customer. A session may
+              // mutate billing state only when it is still the server-recorded
+              // checkout generation, or when its exact customer is already
+              // linked (the buyer-agent payment-link flow). The same per-org
+              // lock wraps admin unlink, closing the check/mutation race.
+              const expectedMembershipCheckout = session.mode !== 'subscription'
+                || org?.stripe_customer_id === customerId
+                || await isExpectedMembershipCheckoutSession(workosOrgId, session.id);
+              if (!expectedMembershipCheckout) {
+                logger.warn(
+                  { customerId, workosOrgId, checkoutSessionId: session.id },
+                  'Ignoring unrecognized or invalidated membership checkout completion',
+                );
+                return;
+              }
+
               // Ensure the Stripe customer has org metadata so that subsequent
               // subscription and invoice webhooks can find the org. Do this
               // before linking the customer locally; otherwise an external
               // Stripe metadata failure can create a DB→Stripe invariant split.
               let customerMetadataReady = false;
               try {
-                const customerRaw = await stripe.customers.retrieve(customerId) as Stripe.Customer | Stripe.DeletedCustomer;
+                const customerRaw = await stripeClient.customers.retrieve(customerId) as Stripe.Customer | Stripe.DeletedCustomer;
                 if ('deleted' in customerRaw && customerRaw.deleted) {
                   logger.warn({ customerId, workosOrgId }, 'Stripe customer was deleted, cannot update metadata');
                 } else {
@@ -5776,7 +5799,7 @@ export class HTTPServer {
                     );
                   } else {
                     if (!stampedOrgId) {
-                      await stripe.customers.update(customerId, {
+                      await stripeClient.customers.update(customerId, {
                         metadata: { workos_organization_id: workosOrgId },
                       });
                       logger.info({ customerId, workosOrgId }, 'Added workos_organization_id metadata to Stripe customer');
@@ -5794,15 +5817,67 @@ export class HTTPServer {
               // customerEmail instead of customerId, causing Stripe to create
               // a new customer. Only link after the metadata pointer is in
               // place so the bidirectional invariant remains true.
-              const org = await orgDb.getOrganization(workosOrgId);
+              let linkedCustomerReady = org?.stripe_customer_id === customerId;
               if (org && !org.stripe_customer_id && customerMetadataReady) {
                 try {
                   await orgDb.setStripeCustomerId(workosOrgId, customerId);
+                  linkedCustomerReady = true;
                   logger.info({ workosOrgId, customerId }, 'Linked Stripe customer to org from checkout.session.completed');
                 } catch (err) {
-                  logger.warn({ err, workosOrgId, customerId }, 'Could not link Stripe customer to org from checkout (possible conflict)');
+                  let isLinkConflict = err instanceof StripeCustomerConflictError;
+                  if (!isLinkConflict) {
+                    // setStripeCustomerId also uses a generic error when a
+                    // concurrent request linked the target org to a different
+                    // customer. Re-read to distinguish that safe conflict from
+                    // a transient DB failure that Stripe should retry.
+                    const currentOrg = await orgDb.getOrganization(workosOrgId);
+                    isLinkConflict = Boolean(
+                      currentOrg?.stripe_customer_id
+                      && currentOrg.stripe_customer_id !== customerId,
+                    );
+                  }
+                  if (!isLinkConflict) throw err;
+                  logger.warn(
+                    { err, workosOrgId, customerId },
+                    'Could not link Stripe customer to org from checkout due to a link conflict',
+                  );
                 }
               }
+
+              // Subscription events can arrive before checkout completion or
+              // occasionally miss delivery altogether. Once checkout has
+              // established the metadata-verified customer↔org link, use the
+              // existing guarded reconciliation path as an independent,
+              // idempotent recovery signal. Its updated_at compare-and-swap
+              // prevents this from overwriting a concurrent subscription
+              // webhook, and its membership-product filter prevents ancillary
+              // Stripe products from granting entitlement.
+              if (
+                session.mode === 'subscription' &&
+                org &&
+                customerMetadataReady &&
+                linkedCustomerReady
+              ) {
+                const reconciliation = await attemptStripeReconciliation(workosOrgId, {
+                  pool,
+                  stripe: stripeClient,
+                  logger,
+                });
+                if (reconciliation.healed) {
+                  invalidateMemberContextCache();
+                  logger.info(
+                    { workosOrgId, customerId, source: 'checkout.session.completed' },
+                    'Reconciled subscription state after checkout completion',
+                  );
+                } else if (reconciliation.reason === 'stripe_error') {
+                  // The checkout event is the independent recovery signal for
+                  // a missed subscription event. Do not acknowledge a
+                  // transient Stripe read failure or this backup path is lost
+                  // too; a 5xx asks Stripe to retry the idempotent handler.
+                  throw new Error('Transient Stripe failure during checkout subscription reconciliation');
+                }
+              }
+              });
             }
             break;
           }

--- a/server/src/routes/billing.ts
+++ b/server/src/routes/billing.ts
@@ -35,6 +35,7 @@ import {
 import { OrganizationDatabase, TIER_PRESERVING_STATUSES, buildSubscriptionUpdate } from "../db/organization-db.js";
 import { invalidateMembershipCache } from "../db/org-filters.js";
 import { pickMembershipSub } from "../billing/membership-prices.js";
+import { withOrgIntakeLock } from "../billing/org-intake-lock.js";
 
 const logger = createLogger("billing-routes");
 
@@ -1090,6 +1091,18 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       }
 
       const org = linkedOrg.rows[0];
+      const unlinked = await withOrgIntakeLock(org.workos_organization_id, async () => {
+      // Re-check after acquiring the same per-org lock used by Checkout
+      // completion. If another operation already changed the link, do not
+      // clear metadata or entitlement for a newly linked customer.
+      const currentLink = await pool.query(
+        `SELECT 1 FROM organizations
+          WHERE workos_organization_id = $1 AND stripe_customer_id = $2`,
+        [org.workos_organization_id, customerId],
+      );
+      if (currentLink.rows.length === 0) {
+        return false;
+      }
 
       // Clear the workos_organization_id metadata on BOTH the Stripe
       // customer AND every active subscription on it BEFORE nulling the DB
@@ -1147,8 +1160,9 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
       // appear as a paying member with no Stripe customer attached. The
       // entitlement gate would silently grant access on stale state until
       // the next webhook (which never fires, since the customer is gone).
-      await pool.query(
-        `UPDATE organizations SET
+      const unlinkResult = await pool.query<{ workos_organization_id: string }>(
+        `WITH unlinked_org AS (
+           UPDATE organizations SET
             stripe_customer_id = NULL,
             stripe_subscription_id = NULL,
             subscription_status = NULL,
@@ -1161,9 +1175,19 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
             subscription_price_id = NULL,
             subscription_price_lookup_key = NULL,
             updated_at = NOW()
-         WHERE stripe_customer_id = $1`,
-        [customerId],
+           WHERE stripe_customer_id = $1
+             AND workos_organization_id = $2
+           RETURNING workos_organization_id
+         ), invalidated_checkout_attempts AS (
+           DELETE FROM membership_checkout_attempts
+            WHERE organization_id IN (
+              SELECT workos_organization_id FROM unlinked_org
+            )
+         )
+         SELECT workos_organization_id FROM unlinked_org`,
+        [customerId, org.workos_organization_id],
       );
+      if (unlinkResult.rows.length === 0) return false;
       invalidateMembershipCache(org.workos_organization_id);
 
       // Forensic record of the entitlement-affecting admin action. Without
@@ -1194,6 +1218,12 @@ export function createBillingRouter(): { pageRouter: Router; apiRouter: Router }
         "Unlinked Stripe customer from org"
       );
 
+      return true;
+      });
+
+      if (!unlinked) {
+        return res.status(409).json({ error: "Customer link changed while unlink was waiting" });
+      }
       res.json({
         success: true,
         message: `Unlinked Stripe customer ${customerId} from "${org.name}"`,

--- a/server/tests/integration/admin-stripe-link-unlink.test.ts
+++ b/server/tests/integration/admin-stripe-link-unlink.test.ts
@@ -177,6 +177,7 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
 
   beforeEach(async () => {
     await pool.query('DELETE FROM registry_audit_log WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM membership_checkout_attempts WHERE organization_id = $1', [TEST_ORG_ID]);
     await pool.query(
       `INSERT INTO organizations (workos_organization_id, name, stripe_customer_id, is_personal, created_at, updated_at)
        VALUES ($1, $2, NULL, false, NOW(), NOW())
@@ -416,6 +417,84 @@ describe('POST /api/admin/stripe-customers/:customerId/link + /unlink', () => {
   });
 
   describe('unlink', () => {
+    it('invalidates the recorded checkout generation atomically with the local unlink', async () => {
+      await pool.query(
+        `UPDATE organizations SET stripe_customer_id = $1 WHERE workos_organization_id = $2`,
+        ['cus_link_test_multi', TEST_ORG_ID],
+      );
+      await pool.query(
+        `INSERT INTO membership_checkout_attempts (
+           organization_id, payload_fingerprint, idempotency_key,
+           initiated_by_user_id, stripe_session_id, stripe_session_url, expires_at
+         ) VALUES ($1, 'unlink-test', 'unlink-test-key', $2, 'cs_old',
+                   'https://checkout.stripe.test/cs_old', NOW() + INTERVAL '24 hours')`,
+        [TEST_ORG_ID, ADMIN_USER_ID],
+      );
+
+      await request(app)
+        .post('/api/admin/stripe-customers/cus_link_test_multi/unlink')
+        .expect(200);
+
+      const attempts = await pool.query(
+        `SELECT 1 FROM membership_checkout_attempts WHERE organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(attempts.rows).toHaveLength(0);
+    });
+
+    it('preserves a checkout generation when the customer link changes during unlink', async () => {
+      await pool.query(
+        `UPDATE organizations SET stripe_customer_id = $1 WHERE workos_organization_id = $2`,
+        ['cus_link_test_multi', TEST_ORG_ID],
+      );
+      await pool.query(
+        `INSERT INTO membership_checkout_attempts (
+           organization_id, payload_fingerprint, idempotency_key,
+           initiated_by_user_id, stripe_session_id, stripe_session_url, expires_at
+         ) VALUES ($1, 'replace-race', 'replace-race-key', $2, 'cs_newer',
+                   'https://checkout.stripe.test/cs_newer', NOW() + INTERVAL '24 hours')`,
+        [TEST_ORG_ID, ADMIN_USER_ID],
+      );
+      let releaseMetadataClear!: () => void;
+      let signalMetadataClear!: () => void;
+      const metadataClearStarted = new Promise<void>((resolve) => {
+        signalMetadataClear = resolve;
+      });
+      const holdMetadataClear = new Promise<void>((resolve) => {
+        releaseMetadataClear = resolve;
+      });
+      mocks.mockCustomersUpdate.mockImplementationOnce(async () => {
+        signalMetadataClear();
+        await holdMetadataClear;
+        return {};
+      });
+
+      const unlinkPromise = request(app)
+        .post('/api/admin/stripe-customers/cus_link_test_multi/unlink')
+        .then((response) => response);
+      await metadataClearStarted;
+      await pool.query(
+        `UPDATE organizations SET stripe_customer_id = $1 WHERE workos_organization_id = $2`,
+        ['cus_replacement_won_race', TEST_ORG_ID],
+      );
+      releaseMetadataClear();
+
+      const response = await unlinkPromise;
+      expect(response.status).toBe(409);
+      const state = await pool.query<{ stripe_customer_id: string; stripe_session_id: string }>(
+        `SELECT o.stripe_customer_id, a.stripe_session_id
+           FROM organizations o
+           JOIN membership_checkout_attempts a
+             ON a.organization_id = o.workos_organization_id
+          WHERE o.workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(state.rows[0]).toEqual({
+        stripe_customer_id: 'cus_replacement_won_race',
+        stripe_session_id: 'cs_newer',
+      });
+    });
+
     it('clears all subscription_* columns (not just stripe_customer_id)', async () => {
       // Pre-populate the org with active subscription state, as if a prior
       // link succeeded.

--- a/server/tests/integration/revenue-tracking.test.ts
+++ b/server/tests/integration/revenue-tracking.test.ts
@@ -10,6 +10,7 @@ import {
   createSubscriptionUpdatedEvent,
 } from '../fixtures/stripe-webhooks.js';
 import type { Pool } from 'pg';
+import { OrganizationDatabase } from '../../src/db/organization-db.js';
 
 // Mock auth middleware to bypass authentication in tests
 vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
@@ -23,6 +24,13 @@ vi.mock('../../src/middleware/auth.js', async (importOriginal) => ({
     next();
   },
   requireAdmin: (_req: any, _res: any, next: any) => next(),
+  requireGlobalAdmin: [
+    (req: any, _res: any, next: any) => {
+      req.user = { id: 'user_test_admin', email: 'admin@test.com', is_admin: true };
+      next();
+    },
+    (_req: any, _res: any, next: any) => next(),
+  ],
 }));
 
 vi.mock('../../src/middleware/csrf.js', () => ({
@@ -37,13 +45,28 @@ const mocks = vi.hoisted(() => ({
   }),
   // Reject to exercise the handler's description-fallback path (try/catch around products.retrieve).
   mockProductsRetrieve: vi.fn().mockRejectedValue(new Error('No Stripe product in test env')),
+  mockCustomersRetrieve: vi.fn().mockResolvedValue({ deleted: true }),
+  mockCustomersUpdate: vi.fn().mockResolvedValue({}),
+  mockSubscriptionsList: vi.fn().mockResolvedValue({ data: [] }),
+  mockSubscriptionsUpdate: vi.fn().mockResolvedValue({}),
+  mockAttemptStripeReconciliation: vi.fn().mockResolvedValue({
+    healed: false,
+    reason: 'already_entitled',
+  }),
 }));
 
 vi.mock('../../src/billing/stripe-client.js', () => ({
   stripe: {
     webhooks: { constructEvent: mocks.mockConstructEvent },
     products: { retrieve: mocks.mockProductsRetrieve },
-    customers: { retrieve: vi.fn().mockResolvedValue({ deleted: true }) },
+    customers: {
+      retrieve: mocks.mockCustomersRetrieve,
+      update: mocks.mockCustomersUpdate,
+    },
+    subscriptions: {
+      list: mocks.mockSubscriptionsList,
+      update: mocks.mockSubscriptionsUpdate,
+    },
   },
   STRIPE_WEBHOOK_SECRET: 'whsec_test_fixture',
   createStripeCustomer: vi.fn().mockResolvedValue(null),
@@ -55,6 +78,10 @@ vi.mock('../../src/billing/stripe-client.js', () => ({
   getBillingProducts: vi.fn().mockResolvedValue([]),
   getStripeSubscriptionInfo: vi.fn().mockResolvedValue(null),
   listCustomersWithOrgIds: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock('../../src/billing/lazy-reconcile.js', () => ({
+  attemptStripeReconciliation: mocks.mockAttemptStripeReconciliation,
 }));
 
 describe('Revenue Tracking Integration Tests', () => {
@@ -73,6 +100,31 @@ describe('Revenue Tracking Integration Tests', () => {
       .post('/api/webhooks/stripe')
       .set('stripe-signature', 't=mock_timestamp,v1=mock_signature')
       .send(event);
+  };
+
+  const recordExpectedCheckoutSession = async (sessionId: string) => {
+    await pool.query(
+      `INSERT INTO membership_checkout_attempts (
+         organization_id, payload_fingerprint, idempotency_key,
+         initiated_by_user_id, stripe_session_id, stripe_session_url, expires_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '24 hours')
+       ON CONFLICT (organization_id) DO UPDATE SET
+         payload_fingerprint = EXCLUDED.payload_fingerprint,
+         idempotency_key = EXCLUDED.idempotency_key,
+         initiated_by_user_id = EXCLUDED.initiated_by_user_id,
+         stripe_session_id = EXCLUDED.stripe_session_id,
+         stripe_session_url = EXCLUDED.stripe_session_url,
+         expires_at = EXCLUDED.expires_at,
+         updated_at = NOW()`,
+      [
+        TEST_ORG_ID,
+        `fingerprint:${sessionId}`,
+        `idempotency:${sessionId}`,
+        'user_test_admin',
+        sessionId,
+        `https://checkout.stripe.test/${sessionId}`,
+      ],
+    );
   };
 
   beforeAll(async () => {
@@ -120,6 +172,7 @@ describe('Revenue Tracking Integration Tests', () => {
     // Clean up test data
     await pool.query('DELETE FROM revenue_events WHERE workos_organization_id = $1', [TEST_ORG_ID]);
     await pool.query('DELETE FROM subscription_line_items WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query('DELETE FROM membership_checkout_attempts WHERE organization_id = $1', [TEST_ORG_ID]);
     await pool.query('DELETE FROM subscription_line_items WHERE workos_organization_id = $1', [TEST_TIER_ORG_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_TIER_ORG_ID]);
     await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [TEST_ORG_ID]);
@@ -129,9 +182,29 @@ describe('Revenue Tracking Integration Tests', () => {
   });
 
   beforeEach(async () => {
+    mocks.mockCustomersRetrieve.mockReset();
+    mocks.mockCustomersRetrieve.mockResolvedValue({ deleted: true });
+    mocks.mockCustomersUpdate.mockReset();
+    mocks.mockCustomersUpdate.mockResolvedValue({});
+    mocks.mockSubscriptionsList.mockReset();
+    mocks.mockSubscriptionsList.mockResolvedValue({ data: [] });
+    mocks.mockSubscriptionsUpdate.mockReset();
+    mocks.mockSubscriptionsUpdate.mockResolvedValue({});
+    mocks.mockAttemptStripeReconciliation.mockReset();
+    mocks.mockAttemptStripeReconciliation.mockResolvedValue({
+      healed: false,
+      reason: 'already_entitled',
+    });
+
     // Clear revenue data before each test
     await pool.query('DELETE FROM revenue_events WHERE workos_organization_id = $1', [TEST_ORG_ID]);
     await pool.query('DELETE FROM subscription_line_items WHERE workos_organization_id = $1', [TEST_ORG_ID]);
+    await pool.query(
+      `UPDATE organizations
+          SET stripe_customer_id = $2
+        WHERE workos_organization_id = $1`,
+      [TEST_ORG_ID, TEST_CUSTOMER_ID],
+    );
     await pool.query(
       `UPDATE organizations
           SET stripe_customer_id = $2,
@@ -275,6 +348,339 @@ describe('Revenue Tracking Integration Tests', () => {
 
       expect(orgResult.rows[0].membership_tier).toBe('company_standard');
       expect(orgResult.rows[0].subscription_price_lookup_key).toBeNull();
+    });
+  });
+
+  describe('checkout.session.completed webhook', () => {
+    it('reconciles an already-linked buyer-agent checkout that has no intake-attempt row', async () => {
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_buyer_agent',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_buyer_agent',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockAttemptStripeReconciliation).toHaveBeenCalledWith(
+        TEST_ORG_ID,
+        expect.objectContaining({ pool }),
+      );
+    });
+
+    it('reconciles billing state for an already-linked, metadata-verified customer', async () => {
+      await recordExpectedCheckoutSession('cs_test_reconcile');
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+      mocks.mockAttemptStripeReconciliation.mockResolvedValue({
+        healed: true,
+        reason: 'healed_from_stripe',
+        subscriptionStatus: 'active',
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_reconcile',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_reconcile',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockAttemptStripeReconciliation).toHaveBeenCalledWith(
+        TEST_ORG_ID,
+        expect.objectContaining({
+          pool,
+          stripe: expect.any(Object),
+          logger: expect.any(Object),
+        }),
+      );
+    });
+
+    it('links a new checkout customer before reconciling billing state', async () => {
+      await recordExpectedCheckoutSession('cs_test_new_customer');
+      await pool.query(
+        `UPDATE organizations
+            SET stripe_customer_id = NULL
+          WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: {},
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_new_customer',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_new_customer',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockCustomersUpdate).toHaveBeenCalledWith(TEST_CUSTOMER_ID, {
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+      const linked = await pool.query<{ stripe_customer_id: string | null }>(
+        `SELECT stripe_customer_id
+           FROM organizations
+          WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(linked.rows[0]?.stripe_customer_id).toBe(TEST_CUSTOMER_ID);
+      expect(mocks.mockAttemptStripeReconciliation).toHaveBeenCalledWith(
+        TEST_ORG_ID,
+        expect.objectContaining({ pool }),
+      );
+    });
+
+    it('does not reconcile when Stripe customer metadata points to another org', async () => {
+      await recordExpectedCheckoutSession('cs_test_conflict');
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: 'org_different_customer_owner' },
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_conflict',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_conflict',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockAttemptStripeReconciliation).not.toHaveBeenCalled();
+    });
+
+    it('does not reconcile when the org is linked to a different Stripe customer', async () => {
+      const checkoutCustomerId = 'cus_test_different_checkout_customer';
+      await recordExpectedCheckoutSession('cs_test_local_link_conflict');
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: checkoutCustomerId,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_local_link_conflict',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_local_link_conflict',
+            mode: 'subscription',
+            customer: checkoutCustomerId,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockAttemptStripeReconciliation).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 so Stripe retries a transient reconciliation failure', async () => {
+      await recordExpectedCheckoutSession('cs_test_transient_failure');
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+      mocks.mockAttemptStripeReconciliation.mockResolvedValue({
+        healed: false,
+        reason: 'stripe_error',
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_transient_failure',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_transient_failure',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      const response = await sendWebhook(event).expect(500);
+
+      expect(response.body).toEqual({ error: 'Webhook processing failed' });
+    });
+
+    it('returns 500 so Stripe retries a transient local-link database failure', async () => {
+      await recordExpectedCheckoutSession('cs_test_link_db_failure');
+      await pool.query(
+        `UPDATE organizations
+            SET stripe_customer_id = NULL
+          WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+      const setCustomerSpy = vi.spyOn(
+        OrganizationDatabase.prototype,
+        'setStripeCustomerId',
+      ).mockRejectedValueOnce(new Error('database unavailable'));
+
+      const event = {
+        id: 'evt_checkout_completed_link_db_failure',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_link_db_failure',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      try {
+        const response = await sendWebhook(event).expect(500);
+        expect(response.body).toEqual({ error: 'Webhook processing failed' });
+        expect(mocks.mockAttemptStripeReconciliation).not.toHaveBeenCalled();
+      } finally {
+        setCustomerSpy.mockRestore();
+      }
+    });
+
+    it('ignores a replay after its checkout generation was invalidated by an admin unlink', async () => {
+      await pool.query(
+        `UPDATE organizations SET
+            stripe_customer_id = NULL,
+            stripe_subscription_id = NULL,
+            subscription_status = NULL,
+            subscription_amount = NULL,
+            subscription_price_lookup_key = NULL
+          WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: {},
+      });
+
+      const event = {
+        id: 'evt_checkout_completed_invalidated_replay',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_invalidated_replay',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      };
+
+      await sendWebhook(event).expect(200, { received: true });
+
+      expect(mocks.mockCustomersRetrieve).not.toHaveBeenCalled();
+      expect(mocks.mockCustomersUpdate).not.toHaveBeenCalled();
+      expect(mocks.mockAttemptStripeReconciliation).not.toHaveBeenCalled();
+      const org = await pool.query<{ stripe_customer_id: string | null }>(
+        `SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(org.rows[0]?.stripe_customer_id).toBeNull();
+    });
+
+    it('serializes admin unlink ahead of a concurrent checkout replay', async () => {
+      await recordExpectedCheckoutSession('cs_test_concurrent_unlink');
+      let releaseMetadataClear!: () => void;
+      let signalMetadataClear!: () => void;
+      const metadataClearStarted = new Promise<void>((resolve) => {
+        signalMetadataClear = resolve;
+      });
+      const holdMetadataClear = new Promise<void>((resolve) => {
+        releaseMetadataClear = resolve;
+      });
+      mocks.mockCustomersUpdate.mockImplementationOnce(async () => {
+        signalMetadataClear();
+        await holdMetadataClear;
+        return {};
+      });
+      mocks.mockCustomersRetrieve.mockResolvedValue({
+        id: TEST_CUSTOMER_ID,
+        deleted: false,
+        metadata: { workos_organization_id: TEST_ORG_ID },
+      });
+
+      const unlinkPromise = request(app)
+        .post(`/api/admin/stripe-customers/${TEST_CUSTOMER_ID}/unlink`)
+        .then((response) => response);
+      await metadataClearStarted;
+
+      const webhookPromise = sendWebhook({
+        id: 'evt_checkout_completed_concurrent_unlink',
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test_concurrent_unlink',
+            mode: 'subscription',
+            customer: TEST_CUSTOMER_ID,
+            metadata: { workos_organization_id: TEST_ORG_ID },
+          },
+        },
+      }).then((response) => response);
+
+      releaseMetadataClear();
+      const unlinkResponse = await unlinkPromise;
+      const webhookResponse = await webhookPromise;
+
+      expect(unlinkResponse.status).toBe(200);
+      expect(webhookResponse.status).toBe(200);
+      expect(mocks.mockCustomersUpdate).toHaveBeenCalledTimes(1);
+      expect(mocks.mockCustomersRetrieve).not.toHaveBeenCalled();
+      expect(mocks.mockAttemptStripeReconciliation).not.toHaveBeenCalled();
+      const org = await pool.query<{ stripe_customer_id: string | null }>(
+        `SELECT stripe_customer_id FROM organizations WHERE workos_organization_id = $1`,
+        [TEST_ORG_ID],
+      );
+      expect(org.rows[0]?.stripe_customer_id).toBeNull();
     });
   });
 

--- a/server/tests/unit/billing/lazy-reconcile.test.ts
+++ b/server/tests/unit/billing/lazy-reconcile.test.ts
@@ -378,6 +378,22 @@ describe('attemptStripeReconciliation', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1);  // only the SELECT, no UPDATE
   });
 
+  it('returns stripe_error when a legacy subscription product cannot be classified', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [fakeOrg()] });
+    mockCustomersRetrieve.mockResolvedValueOnce(
+      fakeCustomerWithSubs([
+        fakeMembershipSub({ lookup_key: null, product: 'prod_unavailable' }),
+      ]),
+    );
+    mockProductsRetrieve.mockRejectedValueOnce(new Error('Stripe product read timed out'));
+
+    const result = await attemptStripeReconciliation('org_x', makeDeps());
+
+    expect(result).toEqual({ healed: false, reason: 'stripe_error' });
+    expect(mockProductsRetrieve).toHaveBeenCalledWith('prod_unavailable');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
   it('returns org_not_found when the org id does not exist', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
 

--- a/server/tests/unit/membership-checkout-attempt.test.ts
+++ b/server/tests/unit/membership-checkout-attempt.test.ts
@@ -8,6 +8,7 @@ import {
   completeMembershipCheckoutAttempt,
   fingerprintMembershipCheckoutPayload,
   isDefinitiveCheckoutFailure,
+  isExpectedMembershipCheckoutSession,
 } from '../../src/billing/membership-checkout-attempt.js';
 
 beforeEach(() => vi.clearAllMocks());
@@ -82,6 +83,17 @@ describe('membership checkout attempts', () => {
       url: 'https://checkout.stripe.test/cs_123',
     })).resolves.toBe(true);
     expect(query.mock.calls[0][0]).toContain('stripe_session_id IS NULL');
+  });
+
+  it('recognizes only the checkout session generation recorded for the org', async () => {
+    query.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+
+    await expect(isExpectedMembershipCheckoutSession('org_1', 'cs_123')).resolves.toBe(true);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('organization_id = $1 AND stripe_session_id = $2'),
+      ['org_1', 'cs_123'],
+    );
   });
 
   it('clears only failures that prove no Stripe session was created', () => {


### PR DESCRIPTION
## Summary

- use `checkout.session.completed` as an independent, idempotent subscription-state recovery signal
- verify the exact customer/org binding and serialize reconciliation against admin unlink
- keep transient Stripe and database failures retryable instead of acknowledging a lost recovery signal
- invalidate Checkout generations atomically on unlink so delayed or concurrent replays cannot restore entitlement

## Safety

- membership product and entitled-status filters remain fail-closed
- reconciliation retains the existing `updated_at` compare-and-swap guard
- buyer-agent payment links remain supported through exact already-linked customer verification
- sequential replay, forced unlink/replay concurrency, and customer-replacement races are covered with real PostgreSQL integration tests

## Verification

- full repository pre-commit gate
- `npm run typecheck`
- 31 focused billing/lock unit tests
- 23 revenue/webhook integration tests
- 12 admin Stripe link/unlink integration tests
- independent code, test, and security reviews: clean

No changeset: server-only billing recovery behavior; no protocol or published package surface changes.

Fixes #6930
