### PR TITLE
fix(training-agent): resolve sync_governance accounts across open-mode session partitions

### DIFF
--- a/server/src/training-agent/account-handlers.ts
+++ b/server/src/training-agent/account-handlers.ts
@@ -2188,13 +2188,18 @@ export async function handleSyncGovernance(args: ToolArgs, ctx: TrainingContext)
   }
 
   const sessionKey = sessionKeyFromArgs(req, ctx.mode, ctx.userId, ctx.moduleId);
-  const accounts = getAccountMap(sessionKey, ctx.principal);
   const results: Record<string, unknown>[] = [];
 
   for (const input of req.accounts) {
     const acctRef = input.account;
-    const acct = findAccountByRef(accounts, acctRef)
-      ?? (acctRef.account_id ? findAccountByIdAcrossSessions(acctRef.account_id, ctx.principal) : undefined);
+    let acct: AccountState | undefined;
+    for (const accounts of accountMapsForPrincipal(sessionKey, ctx.principal)) {
+      acct = findAccountByRef(accounts, acctRef);
+      if (acct) break;
+    }
+    acct ??= acctRef.account_id
+      ? findAccountByIdAcrossSessions(acctRef.account_id, ctx.principal)
+      : undefined;
 
     if (!acct) {
       // Account not found — return a useful error

--- a/server/tests/unit/account-handlers.test.ts
+++ b/server/tests/unit/account-handlers.test.ts
@@ -21,6 +21,7 @@ import {
   handleSyncGovernance,
   MAX_ACCOUNT_WEBHOOK_PROOF_CANDIDATES_PER_SYNC,
   resolveGovernanceAgentsForAccount,
+  seedAccountFixture,
 } from '../../src/training-agent/account-handlers.js';
 import {
   InMemoryGovernanceBindingStore,
@@ -1014,6 +1015,47 @@ describe('sync_governance', () => {
     });
     return (result.accounts as Record<string, unknown>[])[0];
   }
+
+  it('registers the governance agent after controller seeding into a different open-mode partition', async () => {
+    // seed_account keys off empty args (`open:default`). sync_governance keys
+    // off accounts[0].account.brand.domain (`open:<domain>`). Training mode
+    // hides the split because both collapse to training:${userId}:${moduleId}.
+    const account = {
+      brand: { domain: 'acmeoutdoor.example' },
+      operator: 'pinnacle-agency.example',
+      sandbox: true,
+    };
+    expect(sessionKeyFromArgs({}, 'open')).toBe('open:default');
+    expect(sessionKeyFromArgs({ accounts: [{ account }] }, 'open')).toBe('open:acmeoutdoor.example');
+
+    const seeded = seedAccountFixture({
+      params: {
+        account_id: 'acc_sales_dooh_partition',
+        fixture: {
+          brand: account.brand,
+          operator: account.operator,
+          billing: 'operator',
+          sandbox: true,
+          status: 'active',
+        },
+      },
+    }, DEFAULT_CTX);
+    expect(seeded.success).toBe(true);
+
+    const { result } = await simulateCallTool(server, 'sync_governance', {
+      accounts: [{
+        account,
+        governance_agents: [{
+          url: 'https://test-agent.adcontextprotocol.org',
+          authentication: { schemes: ['bearer'], credentials: 'gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' },
+        }],
+      }],
+    });
+
+    expect(result.accounts).toHaveLength(1);
+    const govResult = (result.accounts as Record<string, unknown>[])[0];
+    expect(govResult.status).toBe('synced');
+  });
 
   it('registers the governance agent on an existing account', async () => {
     await createSandboxAccount();


### PR DESCRIPTION
Fixes #7080.

`sales_dooh` never calls `sync_accounts`. Controller seeding writes the sandbox account into the `open:default` partition (`seed_account` keys off empty args). `sync_governance` then keys off `accounts[0].account.brand.domain` (`open:acmeoutdoor.example`) and looks only at that map, so local macOS open-mode runs get `ACCOUNT_NOT_FOUND`. Training-mode CI hides the split because both sides collapse to `training:${userId}:${moduleId}`.

This matches the existing `accountMapsForPrincipal` scan used by `getAccountNotificationSubscribers` and `resolveAccountIdForRef`. No protocol or schema change.

## Test plan
- [x] `npx vitest run --config server/vitest.config.ts tests/unit/account-handlers.test.ts` (41 passed)
- [x] Regression: open-mode `sync_governance` after `seed_account` into a different session partition returns `status: "synced"`