### PR TITLE
fix(tooling): add ADCP_TIMEOUT_SCALE to with-timeout budgets

### DIFF
--- a/scripts/with-timeout.sh
+++ b/scripts/with-timeout.sh
@@ -26,6 +26,23 @@ if ! [[ "$secs" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+# Optional load-compensation scale (ADCP_TIMEOUT_SCALE). Budgets are
+# calibrated for an otherwise-idle machine; on a host running many parallel
+# agent workspaces the same suite can take several times longer, and a
+# killed-at-budget run is indistinguishable from a hang. Setting e.g.
+# ADCP_TIMEOUT_SCALE=3 scales every with-timeout budget without touching
+# call sites, keeping the calibrated ratios between stages intact. The
+# scale only stretches the kill deadline — it never weakens what runs.
+# Invalid values are ignored with a warning rather than failing the hook.
+if [ -n "${ADCP_TIMEOUT_SCALE:-}" ]; then
+  if [[ "${ADCP_TIMEOUT_SCALE}" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+    && awk -v s="${ADCP_TIMEOUT_SCALE}" 'BEGIN { exit !(s >= 1) }'; then
+    secs=$(awk -v t="$secs" -v s="${ADCP_TIMEOUT_SCALE}" 'BEGIN { printf "%d", (t * s) + 0.999999 }')
+  else
+    echo "with-timeout: ignoring invalid ADCP_TIMEOUT_SCALE='${ADCP_TIMEOUT_SCALE}' (need a number >= 1)" >&2
+  fi
+fi
+
 started=$(date +%s)
 
 report_if_timeout() {


### PR DESCRIPTION
## What

`ADCP_TIMEOUT_SCALE` stretches every `scripts/with-timeout.sh` budget by one factor (e.g. `ADCP_TIMEOUT_SCALE=3 git commit ...`) without touching call sites, preserving the calibrated ratios between hook stages. Invalid or sub-1 values are ignored with a warning so a typo cannot silently shrink a budget. It never weakens what runs — only the kill deadline moves.

## Why

Hook budgets are calibrated for an otherwise-idle machine. On a host running many parallel agent workspaces the same suites take several times longer: during the #7079 cycle the 600s precommit server-unit stage timed out five times purely from machine load (load average 30–120), and once the timeout **masked a genuine test failure** across two retries — a killed-at-budget run is indistinguishable from a hang.

## Testing

Behavioral checks: unscaled budget still kills (`1s` vs `sleep 3` → 143 + marker); `ADCP_TIMEOUT_SCALE=5` stretches it (exit 0); `bogus` and `0.5` are warned and ignored. This PR's own commit ran the full precommit hook under `ADCP_TIMEOUT_SCALE=4`.

No changeset: tooling-only, no protocol surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)