### PR TITLE
fix(docs): exclude executable test fixtures from Mintlify

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -11,6 +11,8 @@ server/
 tests/
 scripts/
 skills/
+# Executable conformance fixtures are served by the application, not Mintlify.
+static/test-assets/**/*.js
 *.test.*
 *.spec.*
 CHANGELOG.md

--- a/tests/policy-backed-rejections-storyboard.test.cjs
+++ b/tests/policy-backed-rejections-storyboard.test.cjs
@@ -19,6 +19,7 @@ const FIXTURE_PATH = path.join(
   '..',
   'static/test-assets/acme-outdoor/policy-backed-auto-redirect-http.js',
 );
+const MINTIGNORE_PATH = path.join(__dirname, '..', '.mintignore');
 
 function loadStoryboard() {
   return yaml.load(fs.readFileSync(STORYBOARD_PATH, 'utf8'));
@@ -73,6 +74,11 @@ test('fixture gates applicability on an isolated two-policy product and canonica
   const fixtureSource = fs.readFileSync(FIXTURE_PATH, 'utf8');
   assert.match(fixtureSource, /window\.location\.assign\(/);
   assert.match(fixtureSource, /fetch\('http:\/\//);
+});
+
+test('executable fixture is excluded from Mintlify global custom scripts', () => {
+  const mintignore = fs.readFileSync(MINTIGNORE_PATH, 'utf8');
+  assert.match(mintignore, /^static\/test-assets\/\*\*\/\*\.js$/m);
 });
 
 test('conformance requires exactly two separate policy-backed rejection entries', () => {


### PR DESCRIPTION
## Summary

- exclude executable conformance test fixtures from Mintlify global custom scripts
- retain the fixture for the main application compliance test endpoint
- add a regression assertion covering the Mintlify exclusion

## Root cause

Mintlify executes every JavaScript file in its content tree on every documentation page. The intentional auto-redirect conformance fixture was not listed in `.mintignore`, so Mintlify injected and executed it globally.

This was an accidental publishing interaction. The redirect targets the reserved `.invalid` namespace and does not indicate an external compromise.

## Verification

- focused policy-backed rejection tests: 4 passed
- repository pre-commit suite: 1,074 passed
- TypeScript typecheck passed
- `.mintignore` matcher confirms the fixture is excluded while intended documentation assets remain included