### PR TITLE
fix(compliance): flag embedded native macro values

### DIFF
--- a/.changeset/flag-embedded-native-macros.md
+++ b/.changeset/flag-embedded-native-macros.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Require universal-macro translation diagnostics to flag native ad-server token syntax embedded inside concrete `value` mappings, while preserving ordinary bracketed text as non-suspect.

--- a/docs/creative/universal-macros.mdx
+++ b/docs/creative/universal-macros.mdx
@@ -739,7 +739,7 @@ const {
 // unmapped_macros: []
 // dropped_consent_macros: []   (no consent macro was dropped)
 // frozen_consent_macros: []    (no consent macro was supplied as a fixed value)
-// suspect_native_values: []    (no value entry looks like a native token)
+// suspect_native_values: []    (no value entry contains native-token syntax)
 ```
 
 Behavior:
@@ -761,9 +761,10 @@ Behavior:
   ship a consent-degraded pixel.
 - **Already-minted parameters pass through untouched** — `pkg_id=123456` (no macro) is
   left exactly as-is.
-- **`suspect_native_values`** flags any `value` entry shaped like a native token
-  (`%%…%%`, `{{…}}`, `${…}`, `[UPPER_SNAKE]`) — almost always a mapping that should have
-  used the `native` arm.
+- **`suspect_native_values`** flags any `value` entry containing native-token syntax
+  (`%%…%%`, `{{…}}`, `${…}`, `[UPPER_SNAKE]`), including syntax surrounded by literal
+  prefixes or suffixes. The `value` arm would percent-encode that syntax so it could not
+  expand at impression time; use the `native` arm for the complete value.
 - Only query-parameter **values** are translated; a macro in a key position is left
   untouched. The path and fragment also pass through byte-for-byte.
 - Substitution is single-pass. Macro-shaped text inside a substituted `value` is data,

--- a/static/compliance/source/test-vectors/universal-macro-translation.json
+++ b/static/compliance/source/test-vectors/universal-macro-translation.json
@@ -233,6 +233,75 @@
       }
     },
     {
+      "name": "embedded-percent-native-tokens-are-deduplicated",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "prefix-%%FIRST%%-middle-%%SECOND%%-suffix" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=prefix-%25%25FIRST%25%25-middle-%25%25SECOND%25%25-suffix",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{VALUE}"]
+      }
+    },
+    {
+      "name": "embedded-double-brace-native-token-is-suspect",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "prefix-{{token}}-suffix" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=prefix-%7B%7Btoken%7D%7D-suffix",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{VALUE}"]
+      }
+    },
+    {
+      "name": "embedded-dollar-brace-native-token-is-suspect",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "prefix-${token}-suffix" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=prefix-%24%7Btoken%7D-suffix",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{VALUE}"]
+      }
+    },
+    {
+      "name": "embedded-upper-snake-bracket-native-token-is-suspect",
+      "input_pixel_url": "https://pixel.example/i?v={VALUE}",
+      "mapping": { "{VALUE}": { "value": "prefix-[UPPER_SNAKE]-suffix" } },
+      "expected": {
+        "url": "https://pixel.example/i?v=prefix-%5BUPPER_SNAKE%5D-suffix",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{VALUE}"]
+      }
+    },
+    {
+      "name": "embedded-native-values-are-mapping-scoped-and-ordered",
+      "input_pixel_url": "https://pixel.example/i?first={FIRST}&second={SECOND}",
+      "mapping": {
+        "{SECOND}": { "value": "prefix-{{second}}-suffix" },
+        "{UNUSED}": { "value": "prefix-${unused}-suffix" },
+        "{FIRST}": { "value": "prefix-[FIRST_TOKEN]-suffix" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?first=prefix-%5BFIRST_TOKEN%5D-suffix&second=prefix-%7B%7Bsecond%7D%7D-suffix",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": ["{SECOND}", "{UNUSED}", "{FIRST}"]
+      }
+    },
+    {
       "name": "ordinary-bracketed-values-not-suspect",
       "input_pixel_url": "https://pixel.example/i?a={A}&b={B}",
       "mapping": {
@@ -241,6 +310,22 @@
       },
       "expected": {
         "url": "https://pixel.example/i?a=%5B1%2C2%2C3%5D&b=%5Bredacted%5D",
+        "dropped_params": [],
+        "unmapped_macros": [],
+        "dropped_consent_macros": [],
+        "frozen_consent_macros": [],
+        "suspect_native_values": []
+      }
+    },
+    {
+      "name": "embedded-ordinary-bracketed-values-not-suspect",
+      "input_pixel_url": "https://pixel.example/i?a={A}&b={B}",
+      "mapping": {
+        "{A}": { "value": "prefix-[1,2,3]-suffix" },
+        "{B}": { "value": "prefix-[redacted]-suffix" }
+      },
+      "expected": {
+        "url": "https://pixel.example/i?a=prefix-%5B1%2C2%2C3%5D-suffix&b=prefix-%5Bredacted%5D-suffix",
         "dropped_params": [],
         "unmapped_macros": [],
         "dropped_consent_macros": [],

--- a/tests/universal-macro-translation-vectors.test.cjs
+++ b/tests/universal-macro-translation-vectors.test.cjs
@@ -38,7 +38,13 @@ const REQUIRED_SUCCESS_CASES = [
   'macro-in-key-left-untouched',
   'substitution-is-single-pass',
   'suspect-native-values-are-mapping-scoped-and-ordered',
+  'embedded-percent-native-tokens-are-deduplicated',
+  'embedded-double-brace-native-token-is-suspect',
+  'embedded-dollar-brace-native-token-is-suspect',
+  'embedded-upper-snake-bracket-native-token-is-suspect',
+  'embedded-native-values-are-mapping-scoped-and-ordered',
   'ordinary-bracketed-values-not-suspect',
+  'embedded-ordinary-bracketed-values-not-suspect',
   'privacy-value-mappings-are-encoded-and-reported',
   'bare-query-normalized-away',
 ];
@@ -85,6 +91,28 @@ describe('universal macro translation compliance fixture', () => {
     assert.equal(
       vectorsByName.get('bare-query-normalized-away').expected.url,
       'https://pixel.example/i',
+    );
+  });
+
+  it('flags embedded native-token shapes without flagging ordinary bracketed text', () => {
+    const vectorsByName = new Map(fixture.vectors.map((vector) => [vector.name, vector]));
+    const suspectNames = [
+      'embedded-percent-native-tokens-are-deduplicated',
+      'embedded-double-brace-native-token-is-suspect',
+      'embedded-dollar-brace-native-token-is-suspect',
+      'embedded-upper-snake-bracket-native-token-is-suspect',
+    ];
+
+    for (const name of suspectNames) {
+      assert.deepEqual(vectorsByName.get(name).expected.suspect_native_values, ['{VALUE}'], name);
+    }
+    assert.deepEqual(
+      vectorsByName.get('embedded-ordinary-bracketed-values-not-suspect').expected.suspect_native_values,
+      [],
+    );
+    assert.deepEqual(
+      vectorsByName.get('embedded-native-values-are-mapping-scoped-and-ordered').expected.suspect_native_values,
+      ['{SECOND}', '{UNUSED}', '{FIRST}'],
     );
   });
 });


### PR DESCRIPTION
## Summary

- add language-neutral vectors for embedded `%%…%%`, `{{…}}`, `${…}`, and `[UPPER_SNAKE]` native-token forms
- preserve mapping-scoped ordering and deduplication, including unused mappings
- keep ordinary embedded bracketed values non-suspect
- document why embedded native syntax must use the `native` arm

Addresses #7112. SDK adoption remains tracked by adcontextprotocol/adcp-client#2620.

## Validation

- `node --test tests/universal-macro-translation-vectors.test.cjs`
- `npm run build:compliance -- --check`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `npx --yes @changesets/cli@^3.0.0 status --since=origin/main`
- independent protocol and code review (approved after adding adversarial mapping-order coverage)
- pre-commit unit suite: 1,056 tests passed
- pre-push schema/compliance builds and source lints passed; local storyboard matrix deferred to isolated CI because concurrent workspace runs starved the local runner