### PR TITLE
docs(release): add principal layer to the 3.2 guide

### DIFF
--- a/.changeset/document-principal-3-2.md
+++ b/.changeset/document-principal-3-2.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Document the experimental authenticated-principal connection layer across the AdCP 3.2 release guide, release notes, introduction, roadmap, and cross-surface release instrumentation.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -8,6 +8,13 @@ description: "AdCP is an open agentic advertising standard. Follow Alex's team f
 
 <img src="/images/walkthrough/adcp-01-fragmentation.png" alt="Alex stands arms crossed in a war room of mismatched screens and tangled cables, surveying the chaos — her team hunched over laptops in the background" style={{ width: '100%', borderRadius: '12px', marginBottom: '2rem' }} />
 
+<Info>
+AdCP 3.2 is in beta. It adds an explicit proposal-to-operation lifecycle and
+an experimental authenticated-principal connection layer. See
+[what's new in 3.2](/docs/reference/whats-new-in-3-2) and the
+[beta program](/docs/reference/3-2-beta) before testing.
+</Info>
+
 Alex runs media operations at Pinnacle Agency. Her team buys across six channels — CTV, display, audio, social, retail media, and digital out-of-home. Each channel has its own buying methods, its own terminology, its own way of handling creatives, targeting, and reporting. IOs for some. APIs for others. DSPs for programmatic. Dashboards for everything.
 
 Now her clients want to try AI-generated creative, influencer campaigns, and local radio. Each new channel means new tools, new integrations, new workflows to learn. She can't keep scaling her team every time a client wants to try something new.

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -33,6 +33,7 @@ Each beta is immutable. The `3.2-beta` documentation selector advances to the la
 ### 3.2 feature index
 
 - **Media buying:** compact listing, immutable proposal negotiation, direct purchase, proposal acceptance, operational control, seller-optimized budgets and bidding, atomic total-budget changes, revenue-share pricing, creative rotation, warnings, and durable indicators.
+- **Identity and connections:** an experimental authenticated-principal layer for caller-scoped webhooks, reusable reporting destinations, asynchronous capability declarations, optimistic replacement, and `principal.changed` repair.
 - **Targeting and audiences:** targeting-aware discovery, portable demographic predicates, named places, value-aware regions, browser families, property exclusions, audience evidence, and exact package readback.
 - **Inventory identity:** first-class programmed channel collections, including FAST and virtual linear streams, with host-property carriage mapping and collection-scoped host attestation for owner-sold avails.
 - **Creative:** canonical capability discovery, image pixel density and rendition sets, localization, async preview opt-in, audio loudness, VAST 4.3 and validation levels, accessibility detail, and synthetic depiction provenance.

--- a/docs/reference/roadmap.mdx
+++ b/docs/reference/roadmap.mdx
@@ -21,6 +21,7 @@ lifecycle usable, verifiable, and legible—not adding another broad feature wav
 
 | Workstream | Release outcome |
 |---|---|
+| [Principal + reporting end-to-end cycle](https://github.com/adcontextprotocol/adcp/issues/7075) | Carry the experimental principal layer and tiered reporting from protocol through SDKs, reference implementations, docs, training, and implementation pilots. |
 | [Hosted verification reliability](https://github.com/adcontextprotocol/adcp/issues/7061) | External agents are not failed by runner discovery, capability-gating, credential, version, or timeout defects. |
 | [Enterprise protocol positioning](https://github.com/adcontextprotocol/adcp/issues/7062) | The docs explain why production adopters should use maintained SDKs and where the 3.2 commercial boundary sits. |
 | [Publish the elected AgenticAdvertising.org board](https://github.com/adcontextprotocol/adcp/issues/7055) | The post-AGM board and governance record replace incorporation-era interim information. |

--- a/docs/reference/whats-new-in-3-2.mdx
+++ b/docs/reference/whats-new-in-3-2.mdx
@@ -88,6 +88,37 @@ Cross-agent transfer of a committed hold is deliberately not implied: the
 agent that accepts a proposal must be able to authenticate its buyer binding,
 resolve the immutable snapshot, and consume its inventory hold atomically.
 
+### A durable connection for authenticated principals
+
+3.2 adds an experimental principal layer for configuration that belongs to an
+authenticated caller's standing relationship with a seller, rather than to one
+advertiser account or media buy. The seller's authorization system still
+issues credentials and resolves the stable party before AdCP begins; the
+protocol does not turn a self-asserted agent URL or key ID into identity.
+
+After authentication, [`sync_principal`](/docs/protocol/sync_principal) lets a
+buyer agent or operator synchronize the sections a seller advertises:
+
+- caller-level webhook subscriptions, including a one-call endpoint kill
+  switch;
+- reusable reporting destinations whose setup and suspension state can be
+  shared across separately authorized accounts; and
+- declarations of asynchronous AdCP versions, signing algorithms, and
+  experimental features the caller can consume.
+
+[`get_principal`](/docs/protocol/get_principal) is the side-effect-free repair
+path. It returns the seller-resolved principal kind, an opaque configuration
+version for guarded replacement, destination generations and setup state, and
+the accepted intersection of caller declarations with seller support.
+`principal.changed` invalidates cached state after seller-side changes.
+
+Principal configuration never grants advertiser-account authority. Every
+account and reporting-feed binding is still authorized independently, and
+credential rotation preserves a record only when the seller maps the new
+credential to the same stable principal. The surface remains experimental so
+implementers can validate rotation, multi-account destination reuse,
+revocation timing, and delegated-operator boundaries before it freezes.
+
 ### Targeting that survives discovery and execution
 
 Targeting-aware discovery separates concrete constraints from future

--- a/specs/release-instrumentation/3.2.json
+++ b/specs/release-instrumentation/3.2.json
@@ -57,6 +57,15 @@
       }
     },
     {
+      "id": "principal_connection_layer",
+      "surfaces": {
+        "docs": { "status": "covered", "evidence": ["docs/protocol/sync_principal.mdx", "docs/protocol/get_principal.mdx", "docs/reference/experimental-status.mdx"] },
+        "training_agent": { "status": "deferred", "reason": "The live principal handlers wait for an SDK generated from the release-candidate bundle; tracked by issue #7056." },
+        "compliance": { "status": "covered", "evidence": ["static/compliance/source/universal/principal.yaml"] },
+        "training": { "status": "deferred", "reason": "The hands-on registration lab waits for the live training-agent implementation; tracked by issues #7057 and #7074." }
+      }
+    },
+    {
       "id": "idempotency_retention_and_retry_binding",
       "surfaces": {
         "docs": { "status": "covered", "evidence": ["docs/learning/specialist/security.mdx"] },

--- a/tests/release-instrumentation.test.cjs
+++ b/tests/release-instrumentation.test.cjs
@@ -17,6 +17,7 @@ const expectedFeatureFamilies = [
   'idempotency_retention_and_retry_binding',
   'measurement_tracking_candidate',
   'portable_attestations',
+  'principal_connection_layer',
   'radio_and_place_based_audio_candidates',
   'request_signing_profile_3_2',
   'targeting_aware_discovery',


### PR DESCRIPTION
## Summary

- add the experimental authenticated-principal layer to the 3.2 what’s-new guide, release notes, intro banner, and roadmap
- add principal-layer coverage to the 3.2 cross-surface release instrumentation
- keep training-agent and curriculum work explicitly deferred until the 3.2 RC-generated SDK is available

## Validation

- `npm run test:release-instrumentation`
- `npm run test:docs-nav`
- `npm run test:doc-compliance-drift`
- `npm run test:compliance-snippets`
- `git diff --check`

Includes a patch changeset because the repository classifies normative reference documentation as protocol scope.

Refs #7075, #7056, #7057, #7074.
