### PR TITLE
refactor(addie): share terminal turn decisions

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1762,6 +1762,7 @@ export class AddieClaudeClient {
       if (turn.discardedRecoveryToolCalls) {
         logger.warn({ iteration }, 'Addie: Ignoring tool use from text-only recovery');
       }
+      const acceptedTurnText = turn.textBlocks.map((block) => block.text).join('\n\n');
 
       let turnDecision: AddieAcceptedTurnDecision | undefined;
       for await (const event of orchestrateAcceptedAddieTurn({
@@ -1771,6 +1772,15 @@ export class AddieClaudeClient {
         messages: modelMessages,
         ledger: executionLedger,
         execute: executeToolCall,
+        emptyResponseRecovery: {
+          loop: modelLoop,
+          deliverableText: stripBannedRituals(acceptedTurnText.trim()),
+          eligibility: {
+            allowInitial: operationalExecution,
+            initialEligible: !hasExecutedCustomTool && toolExecutions.length === 0,
+            postToolEligible: hasExecutedCustomTool,
+          },
+        },
       })) {
         if (event.type === 'provider_tool') {
           logger.debug(
@@ -1796,20 +1806,32 @@ export class AddieClaudeClient {
       }
       if (!turnDecision) throw new Error('Accepted model turn produced no orchestration decision');
 
-      const stopAction = turnDecision.action;
-
-      if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
-        // Anthropic pause_turn and compaction responses are resumable only
-        // when their content is included in the next request. Repeating the
-        // unchanged prompt can loop or repeat server-side work.
-        logger.info(
-          { stopReason: response.providerFinishReason, iteration },
-          'Addie: Continuing resumable provider turn',
-        );
+      if (turnDecision.disposition.type === 'continue') {
+        if (
+          turnDecision.disposition.reason === 'continue'
+          || turnDecision.disposition.reason === 'continue_provider_tools'
+        ) {
+          // Anthropic pause_turn and compaction responses are resumable only
+          // when their content is included in the next request. Repeating the
+          // unchanged prompt can loop or repeat server-side work.
+          logger.info(
+            { stopReason: response.providerFinishReason, iteration },
+            'Addie: Continuing resumable provider turn',
+          );
+        }
         continue;
       }
 
-      if (stopAction === 'truncated') {
+      if (turnDecision.disposition.type === 'recover') {
+        if (turnDecision.disposition.reason === 'initial') {
+          logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
+        } else {
+          logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
+        }
+        continue;
+      }
+
+      if (turnDecision.disposition.reason === 'truncated') {
         const rawText = turnDecision.text.trim();
         const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions, true);
         if (finalized.emptyReason) {
@@ -1867,32 +1889,9 @@ export class AddieClaudeClient {
       }
 
       // Done - no tool use, just text
-      if (stopAction === 'complete') {
+      if (turnDecision.disposition.reason === 'complete') {
         // Collect ALL text blocks (web search responses have multiple text blocks)
         const rawText = turnDecision.text.trim();
-        // A provider-successful but wholly empty first sample has no visible
-        // output or side effect. Production may safely resample it once; eval
-        // and replay preserve the original terminal outcome for integrity.
-        const emptyRecovery = modelLoop.scheduleEmptyResponseRecovery(
-          response,
-          stripBannedRituals(rawText),
-          {
-            allowInitial: operationalExecution,
-            initialEligible: !hasExecutedCustomTool && toolExecutions.length === 0,
-            postToolEligible: hasExecutedCustomTool,
-          },
-        );
-        if (emptyRecovery === 'initial') {
-          logger.warn({ iteration }, 'Addie: Retrying wholly empty initial response');
-          continue;
-        }
-        // Anthropic can occasionally return an empty end_turn immediately
-        // after a tool result. Resampling the unchanged post-tool turn once is
-        // safe because no assistant response has reached the caller yet.
-        if (emptyRecovery === 'post_tool') {
-          logger.warn({ iteration, toolsUsed }, 'Addie: Retrying empty response after tool use');
-          continue;
-        }
         const finalized = finalizeAssistantText(userMessage, rawText, toolExecutions);
         const text = finalized.text;
 
@@ -2483,6 +2482,7 @@ export class AddieClaudeClient {
         if (turn.discardedRecoveryToolCalls) {
           logger.warn({ iteration }, 'Addie Stream: Ignoring tool use from text-only recovery');
         }
+        const acceptedTurnText = turn.textBlocks.map((block) => block.text).join('\n\n');
 
         let turnDecision: AddieAcceptedTurnDecision | undefined;
         for await (const event of orchestrateAcceptedAddieTurn({
@@ -2492,6 +2492,15 @@ export class AddieClaudeClient {
           messages: modelMessages,
           ledger: executionLedger,
           execute: executeToolCall,
+          emptyResponseRecovery: {
+            loop: modelLoop,
+            deliverableText: stripBannedRituals(acceptedTurnText),
+            eligibility: {
+              allowInitial: operationalExecution,
+              initialEligible: toolExecutions.length === 0 && logicalText.length === 0,
+              postToolEligible: toolExecutions.length > 0,
+            },
+          },
         })) {
           if (event.type === 'provider_tool') {
             yield {
@@ -2516,7 +2525,10 @@ export class AddieClaudeClient {
             );
           } else if (event.type === 'turn_decision') {
             turnDecision = event.decision;
-            if (event.decision.action === 'execute_tools') {
+            if (
+              event.decision.disposition.type === 'continue'
+              && event.decision.disposition.reason === 'execute_tools'
+            ) {
               // Preserve accepted text before a tool handler can fail.
               logicalText += event.decision.text;
             }
@@ -2559,18 +2571,36 @@ export class AddieClaudeClient {
           }
         };
 
-        const stopAction = turnDecision.action;
         const iterationText = turnDecision.text;
-        if (stopAction === 'continue' || stopAction === 'continue_provider_tools') {
-          // Resume from the provider response without exposing interim text.
-          logger.info(
-            { stopReason: currentResponse.providerFinishReason, iteration },
-            'Addie Stream: Continuing resumable provider turn',
-          );
+        if (turnDecision.disposition.type === 'continue') {
+          if (
+            turnDecision.disposition.reason === 'continue'
+            || turnDecision.disposition.reason === 'continue_provider_tools'
+          ) {
+            // Resume from the provider response without exposing interim text.
+            logger.info(
+              { stopReason: currentResponse.providerFinishReason, iteration },
+              'Addie Stream: Continuing resumable provider turn',
+            );
+          } else if (logicalText.length > 0 && !logicalText.endsWith('\n')) {
+            // Add spacing between tool use and subsequent text to prevent run-on text.
+            logicalText += '\n\n';
+          }
           continue;
         }
 
-        if (stopAction === 'truncated') {
+        if (turnDecision.disposition.type === 'recover') {
+          if (turnDecision.disposition.reason === 'initial') {
+            logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
+          } else {
+            // Logical-turn buffering means no text from this iteration has
+            // been emitted, so retrying ritual-only output cannot duplicate text.
+            logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
+          }
+          continue;
+        }
+
+        if (turnDecision.disposition.reason === 'truncated') {
           logicalText += iterationText;
           const finalized = finalizeAssistantText(userMessage, logicalText, toolExecutions, true);
           if (finalized.emptyReason) {
@@ -2628,28 +2658,7 @@ export class AddieClaudeClient {
         }
 
         // Done - no tool use
-        if (stopAction === 'complete') {
-          const emptyRecovery = modelLoop.scheduleEmptyResponseRecovery(
-            currentResponse,
-            stripBannedRituals(iterationText),
-            {
-              allowInitial: operationalExecution,
-              initialEligible: toolExecutions.length === 0 && logicalText.length === 0,
-              postToolEligible: toolExecutions.length > 0,
-            },
-          );
-          if (emptyRecovery === 'initial') {
-            logger.warn({ iteration }, 'Addie Stream: Retrying wholly empty initial response');
-            continue;
-          }
-
-          // Logical-turn buffering means no text from this iteration has been
-          // emitted, so retrying ritual-only output cannot duplicate text.
-          if (emptyRecovery === 'post_tool') {
-            logger.warn({ iteration, toolsUsed }, 'Addie Stream: Retrying empty response after tool use');
-            continue;
-          }
-
+        if (turnDecision.disposition.reason === 'complete') {
           logicalText += iterationText;
           totalToolExecutionMs = toolExecutions.reduce((sum, t) => sum + t.duration_ms, 0);
           const finalized = finalizeAssistantText(userMessage, logicalText, toolExecutions);
@@ -2716,13 +2725,6 @@ export class AddieClaudeClient {
           return;
         }
 
-        // Handle tool use
-        if (stopAction === 'execute_tools') {
-          // Add spacing between tool use and subsequent text to prevent run-on text
-          if (logicalText.length > 0 && !logicalText.endsWith('\n')) {
-            logicalText += '\n\n';
-          }
-        }
       }
 
       // Max iterations reached

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.08.126';
+export const CODE_VERSION = '2026.08.127';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "2c1e2eff0dac14e7f413de118fd7eaaa62484254d3cc9fd8b9471e8fb9f790ac",
+    "server/src/addie/claude-client.ts": "5f7432da424e204d02cd230ba748b6e0f8393f75b58ff3086dd062531884042d",
     "server/src/addie/prompts.ts": "27be3d63dfaa3c0335f1ec2213c0ee81369e705f056a341f9bc25fd8800191e9",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -29,7 +29,10 @@ import type {
 import {
   appendModelTurnContinuation,
   type AcceptedModelTurn,
+  type EmptyResponseRecoveryEligibility,
+  type EmptyResponseRecoveryKind,
   type ModelTurnAction,
+  type ModelTurnLoopState,
 } from './model-turn.js';
 
 const logger = createLogger('addie-tool-orchestration');
@@ -110,10 +113,24 @@ export interface AddieProviderToolExecution {
 }
 
 export interface AddieAcceptedTurnDecision {
-  action: ModelTurnAction;
+  disposition: AddieAcceptedTurnDisposition;
   text: string;
   hasCustomToolCalls: boolean;
 }
+
+export type AddieAcceptedTurnDisposition =
+  | Readonly<{
+      type: 'continue';
+      reason: Extract<ModelTurnAction, 'execute_tools' | 'continue' | 'continue_provider_tools'>;
+    }>
+  | Readonly<{
+      type: 'recover';
+      reason: EmptyResponseRecoveryKind;
+    }>
+  | Readonly<{
+      type: 'terminal';
+      reason: Extract<ModelTurnAction, 'complete' | 'truncated'>;
+    }>;
 
 export type AddieAcceptedTurnEvent =
   | { type: 'provider_tool'; recorded: AddieProviderToolExecution }
@@ -127,6 +144,11 @@ export interface OrchestrateAcceptedAddieTurnOptions {
   messages: ModelMessage[];
   ledger: AddieToolExecutionLedger;
   execute: AddieToolExecutor;
+  emptyResponseRecovery: {
+    loop: Pick<ModelTurnLoopState, 'scheduleEmptyResponseRecovery'>;
+    deliverableText: string;
+    eligibility: EmptyResponseRecoveryEligibility;
+  };
 }
 
 /**
@@ -232,6 +254,7 @@ export async function* orchestrateAcceptedAddieTurn(
     messages,
     ledger,
     execute,
+    emptyResponseRecovery,
   } = options;
 
   const providerExecutions = ledger.recordProviderResults(
@@ -244,19 +267,38 @@ export async function* orchestrateAcceptedAddieTurn(
     yield { type: 'provider_tool', recorded };
   }
 
+  const text = turn.textBlocks.map((block) => block.text).join('\n\n');
+  const emptyRecovery = turn.action === 'complete'
+    ? emptyResponseRecovery.loop.scheduleEmptyResponseRecovery(
+        turn.response,
+        emptyResponseRecovery.deliverableText,
+        emptyResponseRecovery.eligibility,
+      )
+    : null;
+  const disposition: AddieAcceptedTurnDisposition = emptyRecovery
+    ? Object.freeze({ type: 'recover', reason: emptyRecovery })
+    : turn.action === 'complete' || turn.action === 'truncated'
+      ? Object.freeze({ type: 'terminal', reason: turn.action })
+      : Object.freeze({ type: 'continue', reason: turn.action });
   const decision: AddieAcceptedTurnDecision = Object.freeze({
-    action: turn.action,
-    text: turn.textBlocks.map((block) => block.text).join('\n\n'),
+    disposition,
+    text,
     hasCustomToolCalls: turn.toolCalls.length > 0,
   });
   yield { type: 'turn_decision', decision };
 
-  if (decision.action === 'continue' || decision.action === 'continue_provider_tools') {
+  if (
+    decision.disposition.type === 'continue'
+    && decision.disposition.reason !== 'execute_tools'
+  ) {
     appendModelTurnContinuation(messages, turn.response);
     return;
   }
 
-  if (decision.action !== 'execute_tools') return;
+  if (
+    decision.disposition.type !== 'continue'
+    || decision.disposition.reason !== 'execute_tools'
+  ) return;
 
   const toolResults: ModelToolResultContent[] = [];
   for await (const event of ledger.executeCustomCalls(

--- a/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
+++ b/server/tests/unit/addie/model-provider-tool-orchestration.test.ts
@@ -523,8 +523,27 @@ describe('orchestrateAcceptedAddieTurn', () => {
     isError: false,
   };
 
-  function accept(response: ModelResponse) {
-    return new ModelTurnLoopState(2).beginNext().acceptResponse(response);
+  function accept(
+    response: ModelResponse,
+    eligibility = {
+      allowInitial: false,
+      initialEligible: false,
+      postToolEligible: false,
+    },
+    limit = 2,
+  ) {
+    const loop = new ModelTurnLoopState(limit);
+    return {
+      turn: loop.beginNext().acceptResponse(response),
+      emptyResponseRecovery: {
+        loop,
+        deliverableText: response.content
+          .filter((content) => content.type === 'text')
+          .map((content) => content.text)
+          .join('\n\n'),
+        eligibility,
+      },
+    };
   }
 
   it('owns provider receipts, custom-tool dispatch, and continuation ordering', async () => {
@@ -566,7 +585,7 @@ describe('orchestrateAcceptedAddieTurn', () => {
     const events = [];
 
     for await (const event of orchestrateAcceptedAddieTurn({
-      turn: accept(response),
+      ...accept(response),
       provider: { id: 'anthropic' },
       executionMode: 'production',
       messages,
@@ -585,7 +604,7 @@ describe('orchestrateAcceptedAddieTurn', () => {
     expect(events[1]).toEqual({
       type: 'turn_decision',
       decision: {
-        action: 'execute_tools',
+        disposition: { type: 'continue', reason: 'execute_tools' },
         text: 'Checking both sources.',
         hasCustomToolCalls: true,
       },
@@ -625,7 +644,7 @@ describe('orchestrateAcceptedAddieTurn', () => {
     const events = [];
 
     for await (const event of orchestrateAcceptedAddieTurn({
-      turn: accept(response),
+      ...accept(response),
       provider: { id: 'anthropic' },
       executionMode: 'production',
       messages,
@@ -637,7 +656,11 @@ describe('orchestrateAcceptedAddieTurn', () => {
 
     expect(events).toEqual([{
       type: 'turn_decision',
-      decision: { action: 'continue', text: '', hasCustomToolCalls: false },
+      decision: {
+        disposition: { type: 'continue', reason: 'continue' },
+        text: '',
+        hasCustomToolCalls: false,
+      },
     }]);
     expect(execute).not.toHaveBeenCalled();
     expect(messages).toEqual([{ role: 'assistant', content: response.content }]);
@@ -654,18 +677,101 @@ describe('orchestrateAcceptedAddieTurn', () => {
       usage: { inputTokens: 3, outputTokens: 1 },
     };
     const messages: ModelMessage[] = [];
+    const events = [];
 
-    for await (const _event of orchestrateAcceptedAddieTurn({
-      turn: accept(response),
+    for await (const event of orchestrateAcceptedAddieTurn({
+      ...accept(response),
       provider: { id: 'anthropic' },
       executionMode: 'production',
       messages,
       ledger: new AddieToolExecutionLedger(),
       execute: vi.fn(),
     })) {
-      // Consume the shared boundary so its mutation policy is exercised.
+      events.push(event);
     }
 
+    expect(events).toEqual([{
+      type: 'turn_decision',
+      decision: {
+        disposition: { type: 'terminal', reason: 'complete' },
+        text: 'Done.',
+        hasCustomToolCalls: false,
+      },
+    }]);
     expect(messages).toEqual([]);
+  });
+
+  it('owns empty-terminal recovery selection before delivery handles the turn', async () => {
+    const response: ModelResponse = {
+      provider: 'anthropic',
+      model: 'test-model',
+      id: 'response_empty',
+      content: [],
+      finishReason: 'stop',
+      providerFinishReason: 'end_turn',
+      usage: { inputTokens: 3, outputTokens: 0 },
+    };
+    const accepted = accept(response, {
+      allowInitial: true,
+      initialEligible: true,
+      postToolEligible: false,
+    });
+    const events = [];
+
+    for await (const event of orchestrateAcceptedAddieTurn({
+      ...accepted,
+      provider: { id: 'anthropic' },
+      executionMode: 'production',
+      messages: [],
+      ledger: new AddieToolExecutionLedger(),
+      execute: vi.fn(),
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{
+      type: 'turn_decision',
+      decision: {
+        disposition: { type: 'recover', reason: 'initial' },
+        text: '',
+        hasCustomToolCalls: false,
+      },
+    }]);
+    expect(accepted.emptyResponseRecovery.loop.emptyResponseRecovery.pending).toBe(true);
+  });
+
+  it('keeps an empty terminal terminal when the shared iteration wall is exhausted', async () => {
+    const response: ModelResponse = {
+      provider: 'anthropic',
+      model: 'test-model',
+      id: 'response_empty_exhausted',
+      content: [],
+      finishReason: 'stop',
+      providerFinishReason: 'end_turn',
+      usage: { inputTokens: 3, outputTokens: 0 },
+    };
+    const events = [];
+
+    for await (const event of orchestrateAcceptedAddieTurn({
+      ...accept(response, {
+        allowInitial: true,
+        initialEligible: true,
+        postToolEligible: false,
+      }, 1),
+      provider: { id: 'anthropic' },
+      executionMode: 'production',
+      messages: [],
+      ledger: new AddieToolExecutionLedger(),
+      execute: vi.fn(),
+    })) {
+      events.push(event);
+    }
+
+    expect(events[0]).toMatchObject({
+      type: 'turn_decision',
+      decision: {
+        disposition: { type: 'terminal', reason: 'complete' },
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add one provider-neutral accepted-turn disposition for custom-tool continuation, same-provider continuation, empty-response recovery, terminal completion, and truncation
- route streaming and non-streaming delivery through that shared decision while preserving each surfaces existing delivery and recovery eligibility evidence
- keep continuation mutation, exactly-once post-tool recovery, event delivery, billing, logging, and persistence behavior unchanged
- bump the Addie code version and refresh the runtime registration hash

## Safety

- no provider selection, canary, environment, or production rollout change
- no paid or stochastic model calls
- post-tool recovery remains permanently text-only and provider continuation remains pinned
- no protocol surface change; no changeset required

## Verification

- 133 focused orchestration, terminal, empty-recovery, fallback, replay-safety, provider-health, and partial-stream tests passed
- 7,737 server unit tests passed (30 skipped)
- root unit suite and exact pre-commit suite passed
- TypeScript typecheck passed
- Addie inventory/reference checks passed (249 tools, 37 sets)
- production build passed
- independent code and security reviews reported no findings

Related to #6844
