### PR TITLE
feat(auth): add pending join request count canary

### DIFF
--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -405,6 +405,10 @@
                 <input type="checkbox" id="organizationAuthorizationDomainsRead">
                 Domains read (<code>organization_domains_read</code>)
               </label>
+              <label>
+                <input type="checkbox" id="organizationAuthorizationPendingJoinRequestCountRead">
+                Pending join request count read (<code>organization_pending_join_request_count_read</code>)
+              </label>
               <small>Only deployment-staged boundaries can be selected. Disable here for rollback within five seconds.</small>
             </div>
             <button class="btn btn-primary" id="saveOrganizationAuthorizationBtn" onclick="saveOrganizationAuthorizationEnforcement()" disabled>
@@ -1141,6 +1145,11 @@ loadAuditHistory();
           label: 'domains read',
           checkboxId: 'organizationAuthorizationDomainsRead',
         },
+        {
+          value: 'organization_pending_join_request_count_read',
+          label: 'pending join request count read',
+          checkboxId: 'organizationAuthorizationPendingJoinRequestCountRead',
+        },
       ];
       const configuredBoundaries = new Set(Array.isArray(setting.boundaries) ? setting.boundaries : []);
       const stagedBoundaries = new Set(
@@ -1185,6 +1194,10 @@ loadAuditHistory();
       const boundaries = [
         ['organization_roles_read', 'organizationAuthorizationRolesRead'],
         ['organization_domains_read', 'organizationAuthorizationDomainsRead'],
+        [
+          'organization_pending_join_request_count_read',
+          'organizationAuthorizationPendingJoinRequestCountRead',
+        ],
       ]
         .filter(([, checkboxId]) => document.getElementById(checkboxId).checked)
         .map(([boundary]) => boundary);

--- a/server/src/auth/organization-authorization-boundaries.ts
+++ b/server/src/auth/organization-authorization-boundaries.ts
@@ -2,6 +2,7 @@
 export const ORGANIZATION_AUTHORIZATION_BOUNDARIES = {
   ORGANIZATION_ROLES_READ: 'organization_roles_read',
   ORGANIZATION_DOMAINS_READ: 'organization_domains_read',
+  ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ: 'organization_pending_join_request_count_read',
 } as const;
 
 export type OrganizationAuthorizationBoundary =

--- a/server/src/routes/organizations.ts
+++ b/server/src/routes/organizations.ts
@@ -260,16 +260,45 @@ export function createOrganizationsRouter(): Router {
       const user = req.user!;
       const { orgId } = req.params;
 
-      // Verify user is admin/owner of this organization
-      const membership = await resolveUserOrgMembership(workos, user.id, orgId);
-      if (!membership) {
-        return res.status(403).json({
-          error: 'Access denied',
-          message: 'You are not a member of this organization',
-        });
+      const canaryDecision = await evaluateOrganizationAuthorizationCanary({
+        boundary:
+          ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ,
+        principal: user,
+        organizationId: orgId,
+        getWorkos: getAuthorizationEnforcementWorkos,
+      });
+
+      let userRole: string;
+      if (canaryDecision.enforced) {
+        recordOrganizationAuthorizationCanaryDecision(
+          ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ,
+          canaryDecision,
+        );
+        if (canaryDecision.status === 'unavailable') {
+          return res.status(503).json({
+            error: 'Authorization temporarily unavailable',
+            message: 'Organization access could not be verified. Please retry.',
+          });
+        }
+        if (canaryDecision.status === 'forbidden') {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
+        userRole = canaryDecision.membership.role;
+      } else {
+        // Kill-switch/default path: retain the shipped canonical-user decision.
+        const membership = await resolveUserOrgMembership(workos, user.id, orgId);
+        if (!membership) {
+          return res.status(403).json({
+            error: 'Access denied',
+            message: 'You are not a member of this organization',
+          });
+        }
+        userRole = membership.role;
       }
 
-      const userRole = membership.role;
       if (userRole !== 'admin' && userRole !== 'owner') {
         return res.json({ count: 0 }); // Non-admins see 0
       }

--- a/server/tests/unit/admin-organization-authorization-setting.test.ts
+++ b/server/tests/unit/admin-organization-authorization-setting.test.ts
@@ -35,6 +35,8 @@ vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
   ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
     ORGANIZATION_ROLES_READ: "organization_roles_read",
     ORGANIZATION_DOMAINS_READ: "organization_domains_read",
+    ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ:
+      "organization_pending_join_request_count_read",
   },
   isOrganizationAuthorizationBoundaryAllowedByEnvironment: environmentAllowsBoundaryMock,
   invalidateOrganizationAuthorizationRuntimeSettingCache: invalidateCacheMock,
@@ -149,14 +151,14 @@ describe("organization authorization runtime admin setting", () => {
 
   it("reports the environment ceiling independently for each supported boundary", async () => {
     environmentAllowsBoundaryMock.mockImplementation(
-      (boundary: string) => boundary === "organization_domains_read",
+      (boundary: string) => boundary === "organization_pending_join_request_count_read",
     );
 
     const response = await request(createApp()).get("/api/admin/settings");
 
     expect(response.status).toBe(200);
     expect(response.body.organization_authorization_environment_ceiling).toEqual({
-      boundaries: ["organization_domains_read"],
+      boundaries: ["organization_pending_join_request_count_read"],
     });
   });
 
@@ -176,6 +178,91 @@ describe("organization authorization runtime admin setting", () => {
       },
       "user_authenticated_admin",
     );
+  });
+
+  it("persists the pending-count boundary independently", async () => {
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: ["organization_pending_join_request_count_read"],
+      });
+
+    expect(response.status).toBe(200);
+    expect(setSettingMock).toHaveBeenCalledWith(
+      {
+        enabled: true,
+        boundaries: ["organization_pending_join_request_count_read"],
+      },
+      "user_authenticated_admin",
+    );
+  });
+
+  it("supports all-three activation and pending-count-only rollback", async () => {
+    const app = createApp();
+    const activation = await request(app)
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: [
+          "organization_roles_read",
+          "organization_domains_read",
+          "organization_pending_join_request_count_read",
+        ],
+      });
+
+    expect(activation.status).toBe(200);
+    expect(setSettingMock).toHaveBeenNthCalledWith(
+      1,
+      {
+        enabled: true,
+        boundaries: [
+          "organization_roles_read",
+          "organization_domains_read",
+          "organization_pending_join_request_count_read",
+        ],
+      },
+      "user_authenticated_admin",
+    );
+
+    const rollback = await request(app)
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      });
+
+    expect(rollback.status).toBe(200);
+    expect(setSettingMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        enabled: true,
+        boundaries: ["organization_roles_read", "organization_domains_read"],
+      },
+      "user_authenticated_admin",
+    );
+    expect(invalidateCacheMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("will not arm pending-count enforcement before its ceiling is staged", async () => {
+    environmentAllowsBoundaryMock.mockImplementation(
+      (boundary: string) => boundary !== "organization_pending_join_request_count_read",
+    );
+
+    const response = await request(createApp())
+      .put("/api/admin/settings/organization-authorization-enforcement")
+      .send({
+        enabled: true,
+        boundaries: [
+          "organization_roles_read",
+          "organization_domains_read",
+          "organization_pending_join_request_count_read",
+        ],
+      });
+
+    expect(response.status).toBe(409);
+    expect(setSettingMock).not.toHaveBeenCalled();
+    expect(invalidateCacheMock).not.toHaveBeenCalled();
   });
 
   it("rejects a mixed selection when any boundary is outside the environment ceiling", async () => {

--- a/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
+++ b/server/tests/unit/admin-settings-organization-authorization-ui.test.ts
@@ -23,6 +23,7 @@ function loadControls(currentSettings: Record<string, unknown>) {
     </select>
     <input type="checkbox" id="organizationAuthorizationRolesRead">
     <input type="checkbox" id="organizationAuthorizationDomainsRead">
+    <input type="checkbox" id="organizationAuthorizationPendingJoinRequestCountRead">
     <button id="saveOrganizationAuthorizationBtn" disabled>Save</button>
   `);
   const fetchMock = vi.fn();
@@ -89,6 +90,12 @@ describe("admin organization authorization runtime control", () => {
       .toBe(false);
     expect((document.getElementById("organizationAuthorizationDomainsRead") as HTMLInputElement).disabled)
       .toBe(true);
+    expect((document.getElementById(
+      "organizationAuthorizationPendingJoinRequestCountRead",
+    ) as HTMLInputElement).checked).toBe(false);
+    expect((document.getElementById(
+      "organizationAuthorizationPendingJoinRequestCountRead",
+    ) as HTMLInputElement).disabled).toBe(true);
     expect(document.getElementById("currentOrganizationAuthorizationStatus")?.textContent)
       .toContain("roles read");
 
@@ -163,6 +170,44 @@ describe("admin organization authorization runtime control", () => {
     expect(JSON.parse(String(init.body))).toEqual({
       enabled: true,
       boundaries: ["organization_domains_read"],
+    });
+
+    controls.dom.window.close();
+  });
+
+  it("saves a pending-count-only staged selection independently", async () => {
+    const controls = loadControls({
+      organization_authorization_enforcement: {
+        enabled: false,
+        boundaries: [],
+      },
+      organization_authorization_environment_ceiling: {
+        boundaries: ["organization_pending_join_request_count_read"],
+      },
+    });
+    controls.updateOrganizationAuthorizationDisplay();
+    const document = controls.dom.window.document;
+    expect((document.getElementById(
+      "organizationAuthorizationPendingJoinRequestCountRead",
+    ) as HTMLInputElement).disabled).toBe(false);
+    (document.getElementById("organizationAuthorizationEnabled") as HTMLSelectElement).value = "true";
+    (document.getElementById(
+      "organizationAuthorizationPendingJoinRequestCountRead",
+    ) as HTMLInputElement).checked = true;
+
+    controls.fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      organization_authorization_enforcement: {
+        enabled: true,
+        boundaries: ["organization_pending_join_request_count_read"],
+      },
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    await controls.saveOrganizationAuthorizationEnforcement();
+
+    const [, init] = controls.fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      enabled: true,
+      boundaries: ["organization_pending_join_request_count_read"],
     });
 
     controls.dom.window.close();

--- a/server/tests/unit/organization-authorization-canary.test.ts
+++ b/server/tests/unit/organization-authorization-canary.test.ts
@@ -36,6 +36,8 @@ import {
 const BOUNDARY = ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_ROLES_READ;
 const DOMAINS_BOUNDARY =
   ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_DOMAINS_READ;
+const PENDING_COUNT_BOUNDARY =
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES.ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ;
 
 describe("organization authorization canary", () => {
   beforeEach(() => {
@@ -165,12 +167,16 @@ describe("organization authorization canary", () => {
   it.each([
     [BOUNDARY, DOMAINS_BOUNDARY],
     [DOMAINS_BOUNDARY, BOUNDARY],
+    [PENDING_COUNT_BOUNDARY, BOUNDARY],
+    [BOUNDARY, PENDING_COUNT_BOUNDARY],
+    [PENDING_COUNT_BOUNDARY, DOMAINS_BOUNDARY],
+    [DOMAINS_BOUNDARY, PENDING_COUNT_BOUNDARY],
   ])(
     "does not enforce %s when runtime enables only %s",
     async (requestedBoundary, enabledBoundary) => {
       process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
       process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES =
-        `${BOUNDARY},${DOMAINS_BOUNDARY}`;
+        `${BOUNDARY},${DOMAINS_BOUNDARY},${PENDING_COUNT_BOUNDARY}`;
       const getWorkos = vi.fn();
 
       const decision = await evaluateOrganizationAuthorizationCanary({
@@ -189,6 +195,56 @@ describe("organization authorization canary", () => {
       expect(resolveUserOrgAuthorizationMock).not.toHaveBeenCalled();
     },
   );
+
+  it("enforces the pending-count boundary when both rollout gates select it", async () => {
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";
+    process.env.ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES =
+      PENDING_COUNT_BOUNDARY;
+    const getRuntimeSetting = vi.fn().mockResolvedValue({
+      enabled: true,
+      boundaries: [PENDING_COUNT_BOUNDARY],
+    });
+    const workos = { userManagement: {} };
+    resolveUserOrgAuthorizationMock.mockResolvedValue({ status: "authorized" });
+    evaluateUserOrgRoleAuthorizationMock.mockReturnValue({
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "member",
+        source: "workos",
+      },
+    });
+
+    const decision = await evaluateOrganizationAuthorizationCanary({
+      boundary: PENDING_COUNT_BOUNDARY,
+      principal: {
+        id: "user_canonical",
+        authWorkosUserId: "user_authenticated",
+      },
+      organizationId: "org_test",
+      getWorkos: () => workos as never,
+      getRuntimeSetting,
+    });
+
+    expect(decision).toEqual({
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "member",
+        source: "workos",
+      },
+    });
+    expect(getRuntimeSetting).toHaveBeenCalledOnce();
+    expect(resolveUserOrgAuthorizationMock).toHaveBeenCalledWith(
+      workos,
+      {
+        id: "user_canonical",
+        authWorkosUserId: "user_authenticated",
+      },
+      "org_test",
+    );
+  });
 
   it("fails closed when the environment is staged but runtime configuration is unavailable", async () => {
     process.env.ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true";

--- a/server/tests/unit/organization-authorization-setting-db.test.ts
+++ b/server/tests/unit/organization-authorization-setting-db.test.ts
@@ -130,13 +130,17 @@ describe("organization authorization system setting", () => {
     ]);
   });
 
-  it("accepts both supported read boundaries", async () => {
+  it("accepts all supported read boundaries", async () => {
     queryMock.mockResolvedValueOnce({ rows: [] });
 
     await setOrganizationAuthorizationEnforcement(
       {
         enabled: true,
-        boundaries: ["organization_roles_read", "organization_domains_read"],
+        boundaries: [
+          "organization_roles_read",
+          "organization_domains_read",
+          "organization_pending_join_request_count_read",
+        ],
       },
       "user_authenticated_admin",
     );
@@ -145,7 +149,11 @@ describe("organization authorization system setting", () => {
       "organization_authorization_enforcement",
       JSON.stringify({
         enabled: true,
-        boundaries: ["organization_roles_read", "organization_domains_read"],
+        boundaries: [
+          "organization_roles_read",
+          "organization_domains_read",
+          "organization_pending_join_request_count_read",
+        ],
       }),
       "user_authenticated_admin",
     ]);

--- a/server/tests/unit/organization-pending-count-canary-route.test.ts
+++ b/server/tests/unit/organization-pending-count-canary-route.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+const {
+  evaluateCanaryMock,
+  recordCanaryDecisionMock,
+  getEnforcementWorkosMock,
+  legacyMembershipMock,
+  getPendingRequestCountMock,
+} = vi.hoisted(() => {
+  process.env.WORKOS_API_KEY ||= "sk_test_organization_pending_count_canary";
+  process.env.WORKOS_CLIENT_ID ||= "client_test_organization_pending_count_canary";
+  process.env.WORKOS_COOKIE_PASSWORD ||=
+    "test-cookie-password-32chars-min-len-1234";
+  return {
+    evaluateCanaryMock: vi.fn(),
+    recordCanaryDecisionMock: vi.fn(),
+    getEnforcementWorkosMock: vi.fn(() => ({ bounded: true })),
+    legacyMembershipMock: vi.fn(),
+    getPendingRequestCountMock: vi.fn(),
+  };
+});
+
+vi.mock("@workos-inc/node", () => ({ WorkOS: class {} }));
+
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/middleware/auth.js")>()),
+  requireAuth: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = {
+      id: "user_canonical",
+      authWorkosUserId: "user_authenticated",
+      email: "linked@example.test",
+      emailVerified: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    next();
+  },
+}));
+
+vi.mock("../../src/auth/workos-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/auth/workos-client.js")>()),
+  getAuthorizationEnforcementWorkos: getEnforcementWorkosMock,
+}));
+
+vi.mock("../../src/utils/resolve-user-org-membership.js", () => ({
+  resolveUserOrgMembership: legacyMembershipMock,
+}));
+
+vi.mock("../../src/middleware/organization-authorization-canary.js", () => ({
+  ORGANIZATION_AUTHORIZATION_BOUNDARIES: {
+    ORGANIZATION_ROLES_READ: "organization_roles_read",
+    ORGANIZATION_DOMAINS_READ: "organization_domains_read",
+    ORGANIZATION_PENDING_JOIN_REQUEST_COUNT_READ:
+      "organization_pending_join_request_count_read",
+  },
+  evaluateOrganizationAuthorizationCanary: evaluateCanaryMock,
+  recordOrganizationAuthorizationCanaryDecision: recordCanaryDecisionMock,
+}));
+
+vi.mock("../../src/db/join-request-db.js", () => ({
+  JoinRequestDatabase: class {
+    getPendingRequestCount = getPendingRequestCountMock;
+  },
+}));
+
+import { createOrganizationsRouter } from "../../src/routes/organizations.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/organizations", createOrganizationsRouter());
+  return app;
+}
+
+describe("GET organization pending join request count authorization canary", () => {
+  beforeEach(() => {
+    evaluateCanaryMock.mockReset().mockResolvedValue({ enforced: false });
+    recordCanaryDecisionMock.mockReset();
+    legacyMembershipMock.mockReset().mockResolvedValue({ role: "admin" });
+    getPendingRequestCountMock.mockReset().mockResolvedValue(4);
+  });
+
+  it("preserves canonical-user authorization and the count while disabled", async () => {
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ count: 4 });
+    expect(legacyMembershipMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "user_canonical",
+      "org_test",
+    );
+    expect(evaluateCanaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: "organization_pending_join_request_count_read",
+        principal: expect.objectContaining({
+          id: "user_canonical",
+          authWorkosUserId: "user_authenticated",
+        }),
+        organizationId: "org_test",
+        getWorkos: getEnforcementWorkosMock,
+      }),
+    );
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy denial without reading the count while disabled", async () => {
+    legacyMembershipMock.mockResolvedValueOnce(null);
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(403);
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
+    expect(getPendingRequestCountMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the legacy ordinary-member response at 200 and zero", async () => {
+    legacyMembershipMock.mockResolvedValueOnce({ role: "member" });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ count: 0 });
+    expect(recordCanaryDecisionMock).not.toHaveBeenCalled();
+    expect(getPendingRequestCountMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an authorized exact admin grant without legacy authority", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "admin",
+        source: "credential_grant",
+      },
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ count: 4 });
+    expect(getPendingRequestCountMock).toHaveBeenCalledOnce();
+    expect(getPendingRequestCountMock).toHaveBeenCalledWith("org_test");
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_pending_join_request_count_read",
+      expect.objectContaining({ enforced: true, status: "authorized" }),
+    );
+  });
+
+  it("keeps the ordinary exact-member response at 200 and zero", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "authorized",
+      membership: {
+        organizationId: "org_test",
+        role: "member",
+        source: "workos",
+      },
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ count: 0 });
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(getPendingRequestCountMock).not.toHaveBeenCalled();
+    expect(recordCanaryDecisionMock).toHaveBeenCalledOnce();
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_pending_join_request_count_read",
+      expect.objectContaining({ enforced: true, status: "authorized" }),
+    );
+  });
+
+  it("denies a linked credential before legacy authority or count reads", async () => {
+    evaluateCanaryMock.mockResolvedValue({ enforced: true, status: "forbidden" });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Access denied");
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_pending_join_request_count_read",
+      { enforced: true, status: "forbidden" },
+    );
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(getPendingRequestCountMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 before downstream reads when authority is unavailable", async () => {
+    evaluateCanaryMock.mockResolvedValue({
+      enforced: true,
+      status: "unavailable",
+      unavailableSources: ["workos"],
+    });
+
+    const response = await request(createApp()).get(
+      "/api/organizations/org_test/pending-count",
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toBe("Authorization temporarily unavailable");
+    expect(recordCanaryDecisionMock).toHaveBeenCalledWith(
+      "organization_pending_join_request_count_read",
+      {
+        enforced: true,
+        status: "unavailable",
+        unavailableSources: ["workos"],
+      },
+    );
+    expect(legacyMembershipMock).not.toHaveBeenCalled();
+    expect(getPendingRequestCountMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a default-off exact-credential authorization boundary for `GET /api/organizations/:orgId/pending-count`
- preserve the existing ordinary-member contract: `200 {count: 0}`
- expose independent audited admin controls for the new boundary
- add route, evaluator, persistence, API, and UI regression coverage

## Rollout safety

This PR does **not** change `fly.toml`, so the boundary cannot activate after merge. The rollout remains three separate gates:

1. merge and fully converge this default-off implementation
2. separately stage the environment ceiling while runtime remains roles+domains
3. after convergence and soak, add only this boundary to the audited runtime setting

Fast rollback after activation removes only this boundary and leaves roles+domains enabled.

## Verification

- 7 focused suites / 78 tests passed
- `npm run typecheck` passed
- `git diff --check` passed
- code, test, and security expert reviews found no remaining blocker

The full local pre-commit suite was stopped after encountering the known platform-local C2PA native-binary load failure; the clean GitHub matrix is the merge gate.

Part of #6827.