### PR TITLE
chore(auth): stage pending join count ceiling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -40,7 +40,7 @@ primary_region = 'iad'
   # Deployment-time ceiling for the issue #6827 read-only authorization canary.
   # The database runtime gate remains independently disabled until explicitly armed.
   ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true"
-  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read,organization_domains_read"
+  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read,organization_domains_read,organization_pending_join_request_count_read"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.


### PR DESCRIPTION
## Summary

- add `organization_pending_join_request_count_read` to the Fly deployment-time authorization ceiling
- preserve the existing roles and domains ceiling entries
- make no runtime-setting write and activate no new boundary

## Rollout safety

The ceiling is necessary but not sufficient for enforcement. Production runtime remains enabled for exactly roles+domains, so the pending-count endpoint stays on its legacy path after this release.

Merge is held until the currently deploying main release fully converges and completes a clean 15-minute production soak. After this PR deploys, another convergence/soak gate is required before the separate audited runtime activation.

Fast rollback removes only the new ceiling entry; after eventual activation, the faster kill switch removes only the pending-count boundary from the audited runtime setting while preserving roles+domains.

## Verification

- `fly config validate --strict -c fly.toml` passed
- focused authorization/admin tests: 37/37 passed
- `git diff --check` passed
- default-off implementation is already deployed and has soaked for more than four hours

Part of #6827.