### PR TITLE
fix(compliance): correct shadow rollout audit

### DIFF
--- a/.agents/shortcuts/verification-profile-shadow-rollout.md
+++ b/.agents/shortcuts/verification-profile-shadow-rollout.md
@@ -60,8 +60,18 @@ identity (`role` plus `adcp_version`), a separately flagged legacy-badge cohort,
 per-endpoint blocking reasons, and review reasons. Do not paste it into public
 issues, pull requests, or other unrestricted systems.
 
+Candidate transitions compare only the version, proposed Spec/Sandbox statuses,
+and recommendation. The repeat gate counts only complete, bundle-backed
+observations with no unattributed failures or Sandbox-applicable unresolved
+bundles. Evidence-count changes are reported separately for manual review;
+they do not by themselves mean that the candidate outcome flapped.
+Endpoints with no assessment are labeled `not_assessed` instead of being
+misreported as incomplete runs with missing bundle evidence.
+
 Before proceeding, require:
 
+- at least the requested observation window since the first assessment written
+  by the current policy version (the audit fails closed before that age);
 - at least 95% coverage, with both numerator and denominator limited to the
   currently eligible monitored endpoints;
 - stable repeat observations for at least 95% of eligible endpoints, with no
@@ -80,6 +90,11 @@ Before proceeding, require:
   unmonitored lifecycle stages.
 
 These are decision gates, not automatic migration rules.
+
+Any change to evaluator semantics must advance
+`VERIFICATION_PROFILE_SHADOW_POLICY_VERSION`. Re-enable the audited lease after
+deploying that change and start a new 48-hour window; never combine observations
+from two policy versions to satisfy coverage or stability gates.
 
 The shadow evaluator intentionally leaves mixed executed partial bundles
 unresolved, even when their visible steps include a controller omission. The

--- a/server/src/scripts/audit-verification-profile-shadow.ts
+++ b/server/src/scripts/audit-verification-profile-shadow.ts
@@ -46,7 +46,9 @@ export function buildDecisionGates(summary: Summary): {
   const eligible = numeric(summary, 'eligible_agents');
   const assessed = numeric(summary, 'assessed_agents');
   const coverage = calculateCoveragePercent(eligible, assessed);
-  const stableTwoRuns = numeric(summary, 'agents_with_stable_two_or_more_runs');
+  const requiredWindowHours = numeric(summary, 'window_hours');
+  const observedWindowHours = numeric(summary, 'policy_observation_age_hours');
+  const stableTwoRuns = numeric(summary, 'agents_with_stable_two_or_more_decision_ready_runs');
   const stableRepeatCoverage = calculateCoveragePercent(eligible, stableTwoRuns);
   const flapping = numeric(summary, 'flapping_agents');
   const incompleteRuns = numeric(summary, 'incomplete_latest_runs');
@@ -55,6 +57,11 @@ export function buildDecisionGates(summary: Summary): {
   const unattributedFailures = numeric(summary, 'unattributed_failures');
 
   const gates = {
+    minimum_observation_window: {
+      pass: requiredWindowHours > 0 && observedWindowHours >= requiredWindowHours,
+      actual_hours: Math.round(observedWindowHours * 100) / 100,
+      minimum_hours: requiredWindowHours,
+    },
     coverage: { pass: eligible > 0 && coverage >= 95, actual_percent: coverage, minimum_percent: 95 },
     stable_repeat_observations: {
       pass: eligible > 0 && stableRepeatCoverage >= 95 && flapping === 0,
@@ -92,6 +99,9 @@ export function buildDecisionGates(summary: Summary): {
   if (numeric(summary, 'ambiguous_mixed_phases') > 0) {
     manualReviewReasons.push('ambiguous_mixed_controller_failure_phases');
   }
+  if (numeric(summary, 'evidence_drift_agents') > 0) {
+    manualReviewReasons.push('evidence_changed_between_runs');
+  }
   if (numeric(summary, 'failing_bundles') > 0 || numeric(summary, 'incomplete_bundles') > 0) {
     manualReviewReasons.push('candidate_nonpassing_bundles');
   }
@@ -115,8 +125,13 @@ function agentReasons(agent: Record<string, unknown>): {
   blocking_reasons: string[];
   review_reasons: string[];
 } {
+  if (agent.evaluated_at == null) {
+    return { blocking_reasons: ['not_assessed'], review_reasons: [] };
+  }
   const blocking: string[] = [];
-  if (numeric(agent, 'run_count') < 2) blocking.push('fewer_than_two_runs');
+  if (numeric(agent, 'decision_ready_run_count') < 2) {
+    blocking.push('fewer_than_two_decision_ready_runs');
+  }
   if (numeric(agent, 'transition_count') > 0) blocking.push('candidate_outcome_flapping');
   if (agent.run_complete !== true) blocking.push('latest_run_incomplete');
   if (agent.bundle_evidence_present !== true) blocking.push('bundle_evidence_missing');
@@ -131,6 +146,9 @@ function agentReasons(agent: Record<string, unknown>): {
   }
   if (numeric(agent, 'mixed_controller_failure_phase_count') > 0) {
     review.push('ambiguous_mixed_controller_failure_phases');
+  }
+  if (numeric(agent, 'evidence_transition_count') > 0) {
+    review.push('evidence_changed_between_runs');
   }
   if (numeric(agent, 'failing_bundle_count') > 0 || numeric(agent, 'incomplete_bundle_count') > 0) {
     review.push('candidate_nonpassing_bundles');
@@ -151,14 +169,18 @@ function agentReasons(agent: Record<string, unknown>): {
   return { blocking_reasons: blocking, review_reasons: review };
 }
 
-export async function runAudit(args: string[]): Promise<Record<string, unknown>> {
+export async function runAudit(
+  args: string[],
+  poolOverride?: Pick<ReturnType<typeof getPool>, 'query'>,
+): Promise<Record<string, unknown>> {
   const hours = parseHours(args);
   const includeAgents = args.includes('--include-agents');
-  const dbConfig = getDatabaseConfig();
-  if (!dbConfig) throw new Error('DATABASE_URL is required');
-
-  initializeDatabase(dbConfig);
-  const pool = getPool();
+  if (!poolOverride) {
+    const dbConfig = getDatabaseConfig();
+    if (!dbConfig) throw new Error('DATABASE_URL is required');
+    initializeDatabase(dbConfig);
+  }
+  const pool = poolOverride ?? getPool();
   const aggregate = await pool.query(
     `WITH known_agents AS (
        SELECT agent_url FROM discovered_agents
@@ -178,43 +200,88 @@ export async function runAudit(args: string[]): Promise<Record<string, unknown>>
          AND COALESCE(m.compliance_opt_out, FALSE) = FALSE
          AND COALESCE(m.monitoring_paused, FALSE) = FALSE
      ),
+     policy_history AS (
+       SELECT MIN(s.evaluated_at) AS observation_started_at
+       FROM verification_profile_shadow_assessments s
+       JOIN eligible e ON e.agent_url = s.agent_url
+         AND e.lifecycle_stage = s.lifecycle_stage
+       WHERE s.policy_version = $1
+     ),
      windowed AS (
        SELECT s.*,
               ROW_NUMBER() OVER (PARTITION BY s.agent_url ORDER BY s.evaluated_at DESC, s.id DESC) AS recency,
               jsonb_build_array(
                 s.adcp_version, s.proposed_spec_status, s.proposed_sandbox_status,
-                s.recommended_profile, s.run_complete, s.bundle_evidence_present,
+                s.recommended_profile
+              ) AS outcome_fingerprint,
+              jsonb_build_array(
+                s.run_complete, s.bundle_evidence_present,
                 s.failing_bundle_count, s.incomplete_bundle_count,
-                s.sandbox_unresolved_bundle_count, s.unattributed_failure_count
-              ) AS outcome_fingerprint
+                s.sandbox_unresolved_bundle_count, s.unattributed_failure_count,
+                s.selected_storyboard_count, s.applicable_phase_count,
+                s.controller_gap_phase_count, s.controller_gap_step_count,
+                s.controller_cascade_step_count, s.observed_failure_count,
+                s.sandbox_observable_failure_count, s.non_controller_gap_step_count,
+                s.controller_missing_storyboard_count, s.other_missing_storyboard_count,
+                s.mixed_controller_failure_phase_count
+              ) AS evidence_fingerprint,
+              (
+                s.run_complete
+                AND s.bundle_evidence_present
+                AND s.unattributed_failure_count = 0
+                AND (NOT s.sandbox_eligible OR s.sandbox_unresolved_bundle_count = 0)
+              ) AS decision_ready
        FROM verification_profile_shadow_assessments s
        JOIN eligible e ON e.agent_url = s.agent_url
          AND e.lifecycle_stage = s.lifecycle_stage
        WHERE s.policy_version = $1
          AND s.evaluated_at >= NOW() - make_interval(hours => $2)
      ),
-     ordered AS (
+     evidence_ordered AS (
+       SELECT w.*,
+              LAG(evidence_fingerprint) OVER (
+                PARTITION BY agent_url ORDER BY evaluated_at, id
+              ) AS previous_evidence_fingerprint
+       FROM windowed w
+     ),
+     decision_ready_ordered AS (
        SELECT w.*,
               LAG(outcome_fingerprint) OVER (
                 PARTITION BY agent_url ORDER BY evaluated_at, id
               ) AS previous_outcome_fingerprint
        FROM windowed w
+       WHERE decision_ready
      ),
      stability AS (
        SELECT agent_url,
               COUNT(*)::int AS run_count,
+              COUNT(DISTINCT evidence_fingerprint)::int AS evidence_variant_count,
+              COUNT(*) FILTER (
+                WHERE previous_evidence_fingerprint IS NOT NULL
+                  AND previous_evidence_fingerprint IS DISTINCT FROM evidence_fingerprint
+              )::int AS evidence_transition_count
+       FROM evidence_ordered
+       GROUP BY agent_url
+     ),
+     decision_ready_stability AS (
+       SELECT agent_url,
+              COUNT(*)::int AS decision_ready_run_count,
               COUNT(DISTINCT outcome_fingerprint)::int AS outcome_variant_count,
               COUNT(*) FILTER (
                 WHERE previous_outcome_fingerprint IS NOT NULL
                   AND previous_outcome_fingerprint IS DISTINCT FROM outcome_fingerprint
               )::int AS transition_count
-       FROM ordered
+       FROM decision_ready_ordered
        GROUP BY agent_url
      ),
      latest AS (
-       SELECT w.*, s.run_count, s.outcome_variant_count, s.transition_count
-       FROM ordered w
+       SELECT w.*, s.run_count, s.evidence_variant_count, s.evidence_transition_count,
+              COALESCE(d.decision_ready_run_count, 0) AS decision_ready_run_count,
+              COALESCE(d.outcome_variant_count, 0) AS outcome_variant_count,
+              COALESCE(d.transition_count, 0) AS transition_count
+       FROM evidence_ordered w
        JOIN stability s USING (agent_url)
+       LEFT JOIN decision_ready_stability d USING (agent_url)
        WHERE w.recency = 1
      ),
      badge_impact AS (
@@ -249,13 +316,23 @@ export async function runAudit(args: string[]): Promise<Record<string, unknown>>
      SELECT
        $1::text AS policy_version,
        $2::int AS window_hours,
+       ph.observation_started_at AS policy_observation_started_at,
+       COALESCE(
+         EXTRACT(EPOCH FROM (NOW() - ph.observation_started_at)) / 3600.0,
+         0
+       )::double precision AS policy_observation_age_hours,
        COUNT(e.agent_url)::int AS eligible_agents,
        COUNT(l.agent_url)::int AS assessed_agents,
        COUNT(*) FILTER (WHERE l.run_count >= 2)::int AS agents_with_two_or_more_runs,
-       COUNT(*) FILTER (WHERE l.run_count >= 2 AND l.outcome_variant_count = 1)::int
-         AS agents_with_stable_two_or_more_runs,
+       COUNT(*) FILTER (WHERE l.decision_ready_run_count >= 2)::int
+         AS agents_with_two_or_more_decision_ready_runs,
+       COUNT(*) FILTER (
+         WHERE l.decision_ready_run_count >= 2 AND l.outcome_variant_count = 1
+       )::int AS agents_with_stable_two_or_more_decision_ready_runs,
        COUNT(*) FILTER (WHERE l.transition_count > 0)::int AS flapping_agents,
        COALESCE(SUM(l.transition_count), 0)::int AS candidate_outcome_transitions,
+       COUNT(*) FILTER (WHERE l.evidence_transition_count > 0)::int AS evidence_drift_agents,
+       COALESCE(SUM(l.evidence_transition_count), 0)::int AS evidence_transitions,
        COUNT(*) FILTER (WHERE l.current_public_status = 'passing' AND l.proposed_spec_status <> 'passing')::int
          AS public_passing_not_spec_passing,
        COUNT(*) FILTER (WHERE l.current_public_status <> 'passing' AND l.proposed_sandbox_status = 'passing')::int
@@ -285,11 +362,13 @@ export async function runAudit(args: string[]): Promise<Record<string, unknown>>
        lb.carrying_multiple_modes AS legacy_badges_carrying_multiple_modes,
        lb.active_on_unmonitored_lifecycle AS legacy_badges_active_on_unmonitored_lifecycle
      FROM (SELECT 1) anchor
+     CROSS JOIN policy_history ph
      CROSS JOIN badge_impact bi
      CROSS JOIN legacy_badges lb
      LEFT JOIN eligible e ON TRUE
      LEFT JOIN latest l ON l.agent_url = e.agent_url
-     GROUP BY bi.active_badges_not_spec_passing, bi.active_badges_not_sandbox_passing,
+     GROUP BY ph.observation_started_at,
+              bi.active_badges_not_spec_passing, bi.active_badges_not_sandbox_passing,
               lb.active_or_degraded, lb.carrying_retired_live,
               lb.carrying_multiple_modes, lb.active_on_unmonitored_lifecycle`,
     [VERIFICATION_PROFILE_SHADOW_POLICY_VERSION, hours],
@@ -330,32 +409,66 @@ export async function runAudit(args: string[]): Promise<Record<string, unknown>>
                 ROW_NUMBER() OVER (PARTITION BY s.agent_url ORDER BY s.evaluated_at DESC, s.id DESC) AS recency,
                 jsonb_build_array(
                   s.adcp_version, s.proposed_spec_status, s.proposed_sandbox_status,
-                  s.recommended_profile, s.run_complete, s.bundle_evidence_present,
+                  s.recommended_profile
+                ) AS outcome_fingerprint,
+                jsonb_build_array(
+                  s.run_complete, s.bundle_evidence_present,
                   s.failing_bundle_count, s.incomplete_bundle_count,
-                  s.sandbox_unresolved_bundle_count, s.unattributed_failure_count
-                ) AS outcome_fingerprint
+                  s.sandbox_unresolved_bundle_count, s.unattributed_failure_count,
+                  s.selected_storyboard_count, s.applicable_phase_count,
+                  s.controller_gap_phase_count, s.controller_gap_step_count,
+                  s.controller_cascade_step_count, s.observed_failure_count,
+                  s.sandbox_observable_failure_count, s.non_controller_gap_step_count,
+                  s.controller_missing_storyboard_count, s.other_missing_storyboard_count,
+                  s.mixed_controller_failure_phase_count
+                ) AS evidence_fingerprint,
+                (
+                  s.run_complete
+                  AND s.bundle_evidence_present
+                  AND s.unattributed_failure_count = 0
+                  AND (NOT s.sandbox_eligible OR s.sandbox_unresolved_bundle_count = 0)
+                ) AS decision_ready
          FROM verification_profile_shadow_assessments s
          JOIN eligible e ON e.agent_url = s.agent_url
            AND e.lifecycle_stage = s.lifecycle_stage
          WHERE s.policy_version = $1
            AND s.evaluated_at >= NOW() - make_interval(hours => $2)
        ),
-       ordered AS (
+       evidence_ordered AS (
+         SELECT r.*,
+                LAG(evidence_fingerprint) OVER (
+                  PARTITION BY agent_url ORDER BY evaluated_at, id
+                ) AS previous_evidence_fingerprint
+         FROM ranked r
+       ),
+       decision_ready_ordered AS (
          SELECT r.*,
                 LAG(outcome_fingerprint) OVER (
                   PARTITION BY agent_url ORDER BY evaluated_at, id
                 ) AS previous_outcome_fingerprint
          FROM ranked r
+         WHERE decision_ready
        ),
        stability AS (
          SELECT agent_url,
                 COUNT(*)::int AS run_count,
+                COUNT(DISTINCT evidence_fingerprint)::int AS evidence_variant_count,
+                COUNT(*) FILTER (
+                  WHERE previous_evidence_fingerprint IS NOT NULL
+                    AND previous_evidence_fingerprint IS DISTINCT FROM evidence_fingerprint
+                )::int AS evidence_transition_count
+         FROM evidence_ordered
+         GROUP BY agent_url
+       ),
+       decision_ready_stability AS (
+         SELECT agent_url,
+                COUNT(*)::int AS decision_ready_run_count,
                 COUNT(DISTINCT outcome_fingerprint)::int AS outcome_variant_count,
                 COUNT(*) FILTER (
                   WHERE previous_outcome_fingerprint IS NOT NULL
                     AND previous_outcome_fingerprint IS DISTINCT FROM outcome_fingerprint
                 )::int AS transition_count
-         FROM ordered
+         FROM decision_ready_ordered
          GROUP BY agent_url
        )
        SELECT e.agent_url, e.lifecycle_stage, r.adcp_version, r.current_public_status,
@@ -364,14 +477,19 @@ export async function runAudit(args: string[]): Promise<Record<string, unknown>>
               r.run_complete, r.bundle_evidence_present, r.failing_bundle_count,
               r.incomplete_bundle_count, r.sandbox_unresolved_bundle_count,
               r.unattributed_failure_count,
-              s.run_count, s.outcome_variant_count, s.transition_count,
+              s.run_count,
+              COALESCE(d.decision_ready_run_count, 0) AS decision_ready_run_count,
+              COALESCE(d.outcome_variant_count, 0) AS outcome_variant_count,
+              COALESCE(d.transition_count, 0) AS transition_count,
+              s.evidence_variant_count, s.evidence_transition_count,
               r.controller_gap_phase_count,
               r.controller_missing_storyboard_count, r.other_missing_storyboard_count,
               r.mixed_controller_failure_phase_count, r.evaluated_at,
               COALESCE(badges.active_badges, '[]'::jsonb) AS active_badges
        FROM eligible e
-       LEFT JOIN ordered r ON r.agent_url = e.agent_url AND r.recency = 1
+       LEFT JOIN evidence_ordered r ON r.agent_url = e.agent_url AND r.recency = 1
        LEFT JOIN stability s ON s.agent_url = e.agent_url
+       LEFT JOIN decision_ready_stability d ON d.agent_url = e.agent_url
        LEFT JOIN LATERAL (
          SELECT jsonb_agg(
            jsonb_build_object(

--- a/server/src/services/verification-profile-shadow.ts
+++ b/server/src/services/verification-profile-shadow.ts
@@ -2,7 +2,7 @@ import type { ComplianceResult, Storyboard, TestStepResult } from '@adcp/sdk/tes
 import type { LifecycleStage, OverallRunStatus } from '../db/compliance-db.js';
 import { getStoryboardsForVersion } from './storyboards.js';
 
-export const VERIFICATION_PROFILE_SHADOW_POLICY_VERSION = 'verification-profiles-v1';
+export const VERIFICATION_PROFILE_SHADOW_POLICY_VERSION = 'verification-profiles-v2';
 
 export type ShadowCandidateStatus = 'passing' | 'partial' | 'failing';
 export type ShadowRecommendedProfile = 'spec' | 'sandbox' | null;
@@ -169,7 +169,6 @@ export function deriveVerificationProfileShadowAssessment(
   let controllerGapStepCount = 0;
   let controllerCascadeStepCount = 0;
   let observedFailureCount = 0;
-  let observedFailedStepCount = 0;
   let sandboxObservableFailureCount = 0;
   let nonControllerGapStepCount = 0;
   let mixedControllerFailurePhaseCount = 0;
@@ -190,7 +189,6 @@ export function deriveVerificationProfileShadowAssessment(
       const phaseFailedWithoutStep = phase.overall_passed === false && phaseFailures === 0 && !inferredControllerPhase;
       controllerGapStepCount += directGaps.length;
       controllerCascadeStepCount += cascades.length;
-      observedFailedStepCount += phaseFailures;
       observedFailureCount += phaseFailures + (phaseFailedWithoutStep ? 1 : 0);
       if (phaseFailedWithoutStep) unexplainedPhaseFailureCount++;
 
@@ -254,8 +252,18 @@ export function deriveVerificationProfileShadowAssessment(
   const sandboxIncompleteBundleCount = incompleteBundles.filter((bundle) =>
     !sandboxBundleCanProjectPassing(bundle.storyboard_ids ?? [])).length;
 
-  const detachedFailureCount = Math.max(0, (result.failures?.length ?? 0) - observedFailedStepCount);
-  const unattributedFailureCount = detachedFailureCount + unexplainedPhaseFailureCount;
+  const flatFailures = result.failures ?? [];
+  // The SDK's flat failure list may contain detached assertion failures in
+  // addition to ordinary failed steps. Those entries are still attributable
+  // when they carry their storyboard and step identity, so a count mismatch
+  // with the summarized track steps is not itself missing evidence. Keep every
+  // flat failure fail-closed for candidate grading below, and reserve the
+  // integrity metric for malformed entries or phase failures with no step.
+  const unattributedFlatFailureCount = flatFailures.filter((failure) =>
+    typeof failure.storyboard_id !== 'string' || failure.storyboard_id.trim().length === 0 ||
+    typeof failure.step_id !== 'string' || failure.step_id.trim().length === 0).length;
+  const unattributedFailureCount = unattributedFlatFailureCount + unexplainedPhaseFailureCount;
+  const hasFlatFailureEvidence = flatFailures.length > 0;
   const runComplete = result.completeness === 'complete';
   const currentPublicStatus = candidateStatus(publicOverallStatus);
   const controllerExplainsPublicGap = controllerGapPhaseCount > 0 || controllerOnlyMissing.size > 0;
@@ -263,7 +271,7 @@ export function deriveVerificationProfileShadowAssessment(
   let proposedSpecStatus: ShadowCandidateStatus;
   if (
     observedFailureCount > 0 ||
-    detachedFailureCount > 0 ||
+    hasFlatFailureEvidence ||
     failingBundles.length > 0 ||
     currentPublicStatus === 'failing'
   ) {
@@ -286,7 +294,7 @@ export function deriveVerificationProfileShadowAssessment(
   if (sandboxEligible) {
     if (
       sandboxObservableFailureCount > 0 ||
-      detachedFailureCount > 0 ||
+      hasFlatFailureEvidence ||
       sandboxFailingBundleCount > 0
     ) {
       proposedSandboxStatus = 'failing';

--- a/server/tests/integration/verification-profile-shadow-migration.test.ts
+++ b/server/tests/integration/verification-profile-shadow-migration.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Pool, type PoolClient } from 'pg';
+import { runAudit } from '../../src/scripts/audit-verification-profile-shadow.js';
 
 const TEST_SCHEMA = `verification_profile_shadow_migration_test_${process.pid}`;
 const MIGRATION = readFileSync(
@@ -30,6 +31,21 @@ describe.skipIf(!process.env.DATABASE_URL)('migration 572: verification profile 
       );
       CREATE TABLE agent_compliance_runs (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+      );
+      CREATE TABLE discovered_agents (agent_url TEXT PRIMARY KEY);
+      CREATE TABLE agent_registry_metadata (
+        agent_url TEXT PRIMARY KEY,
+        lifecycle_stage TEXT,
+        compliance_opt_out BOOLEAN DEFAULT FALSE,
+        monitoring_paused BOOLEAN DEFAULT FALSE
+      );
+      CREATE TABLE member_profiles (agents JSONB NOT NULL DEFAULT '[]'::jsonb);
+      CREATE TABLE agent_verification_badges (
+        agent_url TEXT NOT NULL,
+        role TEXT NOT NULL,
+        adcp_version TEXT NOT NULL,
+        status TEXT NOT NULL,
+        verification_modes TEXT[] NOT NULL
       );
     `);
     const run = await client.query<{ id: string }>(
@@ -175,5 +191,50 @@ describe.skipIf(!process.env.DATABASE_URL)('migration 572: verification profile 
        WHERE evaluated_at >= NOW() - INTERVAL '90 days'`,
     );
     expect(recent.rows[0].count).toBe('1');
+  });
+
+  it('executes the audit SQL and excludes an incomplete row from decision-ready repeats', async () => {
+    await client.query(
+      `INSERT INTO agent_registry_metadata (agent_url, lifecycle_stage)
+       VALUES ('https://audit.example.test/mcp', 'production')`,
+    );
+    const firstRun = await client.query<{ id: string }>(
+      'INSERT INTO agent_compliance_runs DEFAULT VALUES RETURNING id',
+    );
+    const secondRun = await client.query<{ id: string }>(
+      'INSERT INTO agent_compliance_runs DEFAULT VALUES RETURNING id',
+    );
+    await client.query(
+      `INSERT INTO verification_profile_shadow_assessments (
+         source_run_id, agent_url, lifecycle_stage, adcp_version, policy_version,
+         current_public_status, proposed_spec_status, proposed_sandbox_status,
+         sandbox_eligible, recommended_profile, run_complete,
+         bundle_evidence_present, failing_bundle_count,
+         incomplete_bundle_count, sandbox_unresolved_bundle_count,
+         unattributed_failure_count,
+         selected_storyboard_count, applicable_phase_count,
+         controller_gap_phase_count, controller_gap_step_count,
+         controller_cascade_step_count, observed_failure_count,
+         sandbox_observable_failure_count, non_controller_gap_step_count,
+         controller_missing_storyboard_count, other_missing_storyboard_count,
+         mixed_controller_failure_phase_count
+       ) VALUES
+       ($1, 'https://audit.example.test/mcp', 'production', '3.1', 'verification-profiles-v2',
+        'partial', 'partial', 'partial', TRUE, NULL, FALSE,
+        TRUE, 0, 1, 0, 0,
+        10, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+       ($2, 'https://audit.example.test/mcp', 'production', '3.1', 'verification-profiles-v2',
+        'partial', 'partial', 'partial', TRUE, NULL, TRUE,
+        TRUE, 0, 1, 0, 0,
+        10, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0)`,
+      [firstRun.rows[0].id, secondRun.rows[0].id],
+    );
+
+    const report = await runAudit(['--hours=48'], client);
+
+    expect(report.assessed_agents).toBe(1);
+    expect(report.agents_with_two_or_more_runs).toBe(1);
+    expect(report.agents_with_two_or_more_decision_ready_runs).toBe(0);
+    expect(report.agents_with_stable_two_or_more_decision_ready_runs).toBe(0);
   });
 });

--- a/server/tests/unit/audit-verification-profile-shadow.test.ts
+++ b/server/tests/unit/audit-verification-profile-shadow.test.ts
@@ -34,13 +34,16 @@ describe('verification profile shadow audit', () => {
     const decision = buildDecisionGates({
       eligible_agents: 4,
       assessed_agents: 4,
-      agents_with_stable_two_or_more_runs: 3,
+      window_hours: 48,
+      policy_observation_age_hours: 48,
+      agents_with_stable_two_or_more_decision_ready_runs: 3,
       flapping_agents: 1,
       incomplete_latest_runs: 0,
       latest_runs_missing_bundle_evidence: 0,
       failing_bundles: 0,
       incomplete_bundles: 0,
       unattributed_failures: 2,
+      evidence_drift_agents: 1,
       public_passing_not_spec_passing: 1,
       active_badges_not_spec_passing: 1,
     });
@@ -53,6 +56,7 @@ describe('verification profile shadow audit', () => {
     expect(decision.manual_review_reasons).toEqual([
       'public_passing_not_spec_passing',
       'affected_active_or_degraded_badges',
+      'evidence_changed_between_runs',
     ]);
   });
 
@@ -60,7 +64,9 @@ describe('verification profile shadow audit', () => {
     const decision = buildDecisionGates({
       eligible_agents: 20,
       assessed_agents: 19,
-      agents_with_stable_two_or_more_runs: 19,
+      window_hours: 48,
+      policy_observation_age_hours: 49,
+      agents_with_stable_two_or_more_decision_ready_runs: 19,
       flapping_agents: 0,
     });
 
@@ -73,7 +79,9 @@ describe('verification profile shadow audit', () => {
     const decision = buildDecisionGates({
       eligible_agents: 1,
       assessed_agents: 1,
-      agents_with_stable_two_or_more_runs: 1,
+      window_hours: 48,
+      policy_observation_age_hours: 48,
+      agents_with_stable_two_or_more_decision_ready_runs: 1,
       flapping_agents: 0,
       incomplete_bundles: 4,
       sandbox_unresolved_bundles: 1,
@@ -88,7 +96,9 @@ describe('verification profile shadow audit', () => {
       rows: [{
         eligible_agents: 1,
         assessed_agents: 2,
-        agents_with_stable_two_or_more_runs: 1,
+        window_hours: 48,
+        policy_observation_age_hours: 48,
+        agents_with_stable_two_or_more_decision_ready_runs: 1,
         flapping_agents: 0,
       }],
     });
@@ -109,10 +119,13 @@ describe('verification profile shadow audit', () => {
       .mockResolvedValueOnce({
         rows: [{
           agent_url: 'https://seller.example.test/mcp',
+          evaluated_at: '2026-09-01T12:00:00.000Z',
           sandbox_eligible: true,
           run_count: 2,
+          decision_ready_run_count: 2,
           outcome_variant_count: 2,
           transition_count: 1,
+          evidence_transition_count: 1,
           run_complete: true,
           bundle_evidence_present: true,
           failing_bundle_count: 0,
@@ -129,11 +142,14 @@ describe('verification profile shadow audit', () => {
           }],
         }, {
           agent_url: 'https://testing.example.test/mcp',
+          evaluated_at: '2026-09-01T12:00:00.000Z',
           lifecycle_stage: 'testing',
           sandbox_eligible: false,
           run_count: 2,
+          decision_ready_run_count: 2,
           outcome_variant_count: 1,
           transition_count: 0,
+          evidence_transition_count: 0,
           run_complete: true,
           bundle_evidence_present: true,
           failing_bundle_count: 0,
@@ -168,6 +184,7 @@ describe('verification profile shadow audit', () => {
     expect(agents[0].blocking_reasons).toEqual(['candidate_outcome_flapping']);
     expect(agents[0].review_reasons).toEqual([
       'public_passing_not_spec_passing',
+      'evidence_changed_between_runs',
       'active_or_degraded_badge_affected',
     ]);
     expect(agents[0].active_badges).toEqual([
@@ -182,5 +199,63 @@ describe('verification profile shadow audit', () => {
         reason_flags: ['retired_live_mode', 'multiple_modes'],
       }),
     ]);
+    expect(poolQueryMock.mock.calls[0][0]).toContain('AS evidence_fingerprint');
+    expect(poolQueryMock.mock.calls[0][0]).toContain('AS evidence_transition_count');
+    expect(poolQueryMock.mock.calls[0][0]).toContain('AS decision_ready_run_count');
+  });
+
+  it('labels an eligible endpoint without a shadow row as unassessed only', async () => {
+    poolQueryMock
+      .mockResolvedValueOnce({ rows: [{ eligible_agents: 1, assessed_agents: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          agent_url: 'https://unassessed.example.test/mcp',
+          lifecycle_stage: 'production',
+          evaluated_at: null,
+          run_count: null,
+          run_complete: null,
+          bundle_evidence_present: null,
+          active_badges: [],
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const report = await runAudit(['--include-agents']);
+    const agents = report.agents as Array<Record<string, unknown>>;
+
+    expect(agents[0].blocking_reasons).toEqual(['not_assessed']);
+    expect(agents[0].review_reasons).toEqual([]);
+  });
+
+  it('requires two decision-ready observations even when raw candidate outcomes match', () => {
+    const decision = buildDecisionGates({
+      eligible_agents: 1,
+      assessed_agents: 1,
+      window_hours: 48,
+      policy_observation_age_hours: 48,
+      agents_with_stable_two_or_more_decision_ready_runs: 0,
+      flapping_agents: 0,
+      incomplete_latest_runs: 0,
+      latest_runs_missing_bundle_evidence: 0,
+      sandbox_unresolved_bundles: 0,
+      unattributed_failures: 0,
+    });
+
+    expect(decision.gates.stable_repeat_observations.pass).toBe(false);
+    expect(decision.blocking_reasons).toContain('stable_repeat_observations');
+  });
+
+  it('refuses a decision before the current policy has observed for the requested window', () => {
+    const decision = buildDecisionGates({
+      window_hours: 48,
+      policy_observation_age_hours: 12,
+      eligible_agents: 1,
+      assessed_agents: 1,
+      agents_with_stable_two_or_more_decision_ready_runs: 1,
+      flapping_agents: 0,
+    });
+
+    expect(decision.gates.minimum_observation_window.pass).toBe(false);
+    expect(decision.blocking_reasons).toContain('minimum_observation_window');
   });
 });

--- a/server/tests/unit/verification-profile-shadow.test.ts
+++ b/server/tests/unit/verification-profile-shadow.test.ts
@@ -83,6 +83,7 @@ describe('deriveVerificationProfileShadowAssessment', () => {
     const assessment = deriveVerificationProfileShadowAssessment(result, 'production', 'passing');
 
     expect(assessment).toMatchObject({
+      policy_version: 'verification-profiles-v2',
       proposed_spec_status: 'partial',
       proposed_sandbox_status: 'partial',
       recommended_profile: null,
@@ -469,7 +470,7 @@ describe('deriveVerificationProfileShadowAssessment', () => {
     expect(assessment.proposed_sandbox_status).toBe('partial');
   });
 
-  it('blocks detached failures not represented by track steps', () => {
+  it('blocks detached failures while treating their storyboard and step identity as attribution', () => {
     const result = resultWith([{
       scenario: 'media_buy_seller/observe',
       overall_passed: true,
@@ -482,6 +483,30 @@ describe('deriveVerificationProfileShadowAssessment', () => {
         step_title: 'Detached failure',
         task: 'get_products',
         error: 'failed outside the summarized track',
+        fix_command: 'storyboard run',
+      }],
+    });
+
+    const assessment = deriveVerificationProfileShadowAssessment(result, 'production', 'passing');
+
+    expect(assessment.unattributed_failure_count).toBe(0);
+    expect(assessment.proposed_spec_status).toBe('failing');
+    expect(assessment.proposed_sandbox_status).toBe('failing');
+  });
+
+  it('reports malformed flat failures as unattributed while remaining fail-closed', () => {
+    const result = resultWith([{
+      scenario: 'media_buy_seller/observe',
+      overall_passed: true,
+      steps: [passedStep],
+    }], {
+      failures: [{
+        track: 'media_buy',
+        storyboard_id: '',
+        step_id: '',
+        step_title: 'Malformed failure',
+        task: 'get_products',
+        error: 'missing evidence identity',
         fix_command: 'storyboard run',
       }],
     });


### PR DESCRIPTION
## Summary
- correct shadow audit attribution and separate candidate outcome stability from evidence drift
- require repeated decision-ready observations and a full current-policy observation window
- bump the shadow evaluator policy to v2 so earlier observations cannot contaminate the new window
- execute the aggregate audit query in PostgreSQL integration coverage

## Safety
- public compliance behavior and badges are unchanged
- no additional agent traffic is introduced
- Phase 2 remains disabled
- disable the existing v1 lease before deploy, then explicitly re-enable after deploy to start a fresh v2 48-hour window

## Verification
- focused shadow unit suite: 74 passed
- PostgreSQL shadow integration suite: 6 passed
- TypeScript typecheck passed
- migration and changeset-scope checks passed
- three independent expert reviews green
- repository pre-commit root suites passed; full server-unit suite exceeded its fixed 600-second local wrapper without reporting a test failure, so CI will run the authoritative full suite