### PR TITLE
fix(release): validate candidate bundles before publication

### DIFF
--- a/.changeset/fix-release-candidate-validation.md
+++ b/.changeset/fix-release-candidate-validation.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Allow release-only storyboard validation to resolve a generated candidate bundle against the training agent's current stable-line capability, while preserving the agent's advertised versions and wire version. Synchronize TypeScript SDK AdCP metadata before validating a schema candidate.
+Allow release-only storyboard validation to resolve a generated candidate bundle against the training agent's current stable-line capability, while preserving the agent's advertised versions and wire version. Synchronize TypeScript SDK AdCP metadata and Python SDK package manifests before validating a schema candidate.

--- a/.changeset/fix-release-candidate-validation.md
+++ b/.changeset/fix-release-candidate-validation.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Allow release-only storyboard validation to resolve a generated candidate bundle against the training agent's current stable-line capability, while preserving the agent's advertised versions and wire version. Synchronize TypeScript SDK AdCP metadata before validating a schema candidate.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Verify current storyboard coverage
         if: steps.release-relevance.outputs.relevant == 'true' && (github.ref_name == 'main' || github.ref_name == '3.1.x')
         run: npm run test:storyboards
+        env:
+          # A committed Version Packages bundle can lead the training agent's
+          # published SDK by one candidate. The runner keeps this relaxation
+          # scoped to a generated bundle matching package.json.
+          ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: '1'
 
       - name: Verify 3.0 storyboard compatibility
         if: steps.release-relevance.outputs.relevant == 'true' && (github.ref_name == 'main' || github.ref_name == '3.1.x' || github.ref_name == '3.0.x')

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -237,6 +237,7 @@ jobs:
           PUBLIC_TEST_AGENT_TOKEN: storyboard-ci-token
           ADCP_COMPLIANCE_DIR: ${{ matrix.surface == 'current' && 'dist/compliance/latest' || steps.compat-bundle.outputs.dir }}
           ADCP_SCHEMA_ROOT: ${{ matrix.surface == 'current' && 'dist/schemas/latest' || steps.compat-bundle.outputs.schema_dir }}
+          ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ matrix.surface == 'current' && github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main' && '1' || '0' }}
         run: |
           set -uo pipefail
           # Creative-builder retains a large generated-schema graph after its
@@ -472,6 +473,7 @@ jobs:
       SALES_ORCHESTRATOR_COUNT: 8
       ADCP_COMPLIANCE_DIR: dist/compliance/latest
       ADCP_SCHEMA_ROOT: dist/schemas/latest
+      ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main' && '1' || '0' }}
       # SDK beta.11 keeps each storyboard inside the 4 GiB RSS envelope, but
       # the heaviest lifecycle flows can approach two minutes on a loaded
       # runner. Preserve the hard memory bound and allow teardown headroom.

--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -132,6 +132,9 @@ jobs:
           cp bundle/latest.tgz "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz"
           cp bundle/latest.tgz.sha256 "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz.sha256"
           printf '%s\n' "${bundle_version}" > sdk/ADCP_VERSION
+          # This is a disposable candidate checkout: align the SDK's AdCP
+          # metadata without bumping its own package release number.
+          npm --prefix sdk run sync-version -- --force
 
           python3 -m http.server 8765 --directory "${RUNNER_TEMP}/protocol-host" > "${RUNNER_TEMP}/protocol-http.log" 2>&1 &
           server_pid=$!

--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -196,7 +196,24 @@ jobs:
           (cd bundle && shasum -a 256 -c latest.tgz.sha256)
           node -e "const fs=require('node:fs'); const p=require('./bundle/latest.tgz.provenance.json'); const digest=fs.readFileSync('./bundle/latest.tgz.sha256','utf8').trim().split(/\s+/)[0]; if (p.source_repository !== 'adcontextprotocol/adcp') throw new Error('Unexpected protocol provenance repository'); if (p.source_commit !== process.env.PR_HEAD_SHA) throw new Error('Protocol provenance does not match PR head'); if (p.bundle_sha256 !== digest) throw new Error('Protocol provenance digest does not match checksum')"
           bundle_version="$(node -p "require('./bundle/latest.tgz.provenance.json').published_version")"
+          sdk_version="$(cat sdk/src/adcp/ADCP_VERSION)"
           printf '%s\n' "${bundle_version}" > sdk/src/adcp/ADCP_VERSION
+          # The SDK deliberately packages only its current prerelease schema.
+          # Keep that disposable package-data allowlist aligned with the
+          # candidate pin before exercising its version consistency test.
+          SDK_VERSION="${sdk_version}" BUNDLE_VERSION="${bundle_version}" python - <<'PY'
+          import os
+          from pathlib import Path
+
+          old = f"_schemas/{os.environ['SDK_VERSION']}/"
+          new = f"_schemas/{os.environ['BUNDLE_VERSION']}/"
+          for filename in ("sdk/pyproject.toml", "sdk/MANIFEST.in"):
+              path = Path(filename)
+              source = path.read_text()
+              if old not in source:
+                  raise SystemExit(f"{filename} does not package the pinned SDK schema {old}")
+              path.write_text(source.replace(old, new))
+          PY
           mkdir -p "${RUNNER_TEMP}/protocol-host/protocol"
           cp bundle/latest.tgz "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz"
           cp bundle/latest.tgz.sha256 "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz.sha256"

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -108,6 +108,7 @@ const complianceOptions = {
   ...(process.env.ADCP_COMPLIANCE_DIR && { complianceDir: process.env.ADCP_COMPLIANCE_DIR }),
   ...(process.env.ADCP_SCHEMA_ROOT && { schemaRoot: process.env.ADCP_SCHEMA_ROOT }),
 };
+const candidateVersionMode = process.env.ADCP_STORYBOARD_CANDIDATE_VERSION_MODE === '1';
 const releasedComplianceVersion = complianceOptions.complianceDir
   ? loadComplianceIndex(complianceOptions).adcp_version
   : undefined;
@@ -117,6 +118,19 @@ const isCurrentSourceRun = releasedComplianceVersion === undefined
     && resolve(complianceOptions.complianceDir) === resolve('dist/compliance/latest')
   );
 const isThreeZeroCompatRun = releasedComplianceVersion !== undefined && /^3\.0\.\d+$/.test(releasedComplianceVersion);
+if (candidateVersionMode) {
+  const packageVersion = JSON.parse(readFileSync(resolve('package.json'), 'utf8')).version as unknown;
+  if (!isCurrentSourceRun || releasedComplianceVersion === undefined) {
+    throw new Error(
+      'ADCP_STORYBOARD_CANDIDATE_VERSION_MODE=1 requires the generated dist/compliance/latest bundle',
+    );
+  }
+  if (typeof packageVersion !== 'string' || packageVersion !== releasedComplianceVersion) {
+    throw new Error(
+      'ADCP_STORYBOARD_CANDIDATE_VERSION_MODE=1 requires the compliance bundle version to match package.json',
+    );
+  }
+}
 // Released compliance artifacts carry a patch version, while the frozen 3.0
 // wire contract negotiates the stable `3.0` selector. Keep the exact artifact
 // version for schema selection and override only the request envelope. Source
@@ -653,7 +667,15 @@ async function selectStoryboardsForTenant(
     specialisms: profile.specialisms ?? [],
     major_versions: profile.adcp_major_versions,
     supported_versions: profile.adcp_supported_versions,
-  }, complianceOptions);
+  }, {
+    ...complianceOptions,
+    // Version Packages builds the next exact schema/compliance bundle before
+    // the training agent's published SDK can advertise it. Keep ordinary
+    // local and hosted runs strict; release-candidate validation opts in to a
+    // resolver-scoped same-line alias while execution continues to speak the
+    // training agent's real wire version.
+    ...(candidateVersionMode && { hostedStableLineAlias: TRAINING_AGENT_CURRENT_ADCP_VERSION }),
+  });
   const inDeclaredScope = new Set(resolved.storyboards.map(sb => sb.id));
   const versionExcluded = new Set(resolved.not_applicable.map(entry => entry.storyboard_id));
   const selectedCorpus = everything.filter(matchesExplicitSelection);

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -22,6 +22,10 @@ const schemaPrWorkflowConfig = YAML.parse(fs.readFileSync(
   path.join(repoRoot, '.github/workflows/validate-schema-bundle.yml'),
   'utf8'
 ));
+const trainingAgentWorkflowConfig = YAML.parse(fs.readFileSync(
+  path.join(repoRoot, '.github/workflows/training-agent-storyboards.yml'),
+  'utf8'
+));
 const workflowConfig = YAML.parse(workflow);
 const eolReleaseBranches = ['2.5-maintenance', '2.6.x'];
 const activeWorkflowPaths = [
@@ -71,6 +75,30 @@ assert.deepStrictEqual(
   schemaPrWorkflowConfig.on.pull_request.paths,
   ['static/schemas/source/**'],
   'Schema PR bundle validation must run only for canonical schema source changes.'
+);
+
+const typescriptCandidateStep = schemaPrWorkflowConfig.jobs['typescript-sdk'].steps.find(
+  step => step.name === 'Generate and build from the PR bundle'
+).run;
+const candidatePinIndex = typescriptCandidateStep.indexOf('> sdk/ADCP_VERSION');
+const candidateSyncIndex = typescriptCandidateStep.indexOf('npm --prefix sdk run sync-version -- --force');
+const candidateSchemaSyncIndex = typescriptCandidateStep.indexOf('npm --prefix sdk run sync-schemas');
+assert(
+  candidatePinIndex !== -1 && candidatePinIndex < candidateSyncIndex && candidateSyncIndex < candidateSchemaSyncIndex,
+  'TypeScript candidate validation must sync package AdCP metadata after pinning ADCP_VERSION and before schema generation.'
+);
+assert(
+  !typescriptCandidateStep.includes('sync-version -- --auto-update'),
+  'Candidate validation must not bump the TypeScript SDK package release number.'
+);
+
+const storyboardCandidateMode = trainingAgentWorkflowConfig.jobs.storyboards.steps.find(
+  step => step.name === 'Run storyboards against /${{ matrix.tenant }}'
+).env.ADCP_STORYBOARD_CANDIDATE_VERSION_MODE;
+assert(
+  storyboardCandidateMode.includes("matrix.surface == 'current'") &&
+    storyboardCandidateMode.includes("github.head_ref == 'changeset-release/main'"),
+  'Only current-surface Version Packages PR jobs may enable candidate-version resolution.'
 );
 
 assert.strictEqual(

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -92,6 +92,23 @@ assert(
   'Candidate validation must not bump the TypeScript SDK package release number.'
 );
 
+const pythonCandidateStep = schemaPrWorkflowConfig.jobs['python-sdk'].steps.find(
+  step => step.name === 'Generate and test from the PR bundle'
+).run;
+const pythonCandidatePinIndex = pythonCandidateStep.indexOf('> sdk/src/adcp/ADCP_VERSION');
+const pythonCandidateManifestIndex = pythonCandidateStep.indexOf('SDK_VERSION="${sdk_version}"');
+const pythonCandidateRegenIndex = pythonCandidateStep.indexOf('make -C sdk regenerate-schemas');
+assert(
+  pythonCandidatePinIndex !== -1 &&
+    pythonCandidatePinIndex < pythonCandidateManifestIndex &&
+    pythonCandidateManifestIndex < pythonCandidateRegenIndex,
+  'Python candidate validation must align its disposable package-data allowlist after pinning ADCP_VERSION and before schema generation.'
+);
+assert(
+  pythonCandidateStep.includes('for filename in ("sdk/pyproject.toml", "sdk/MANIFEST.in")'),
+  'Python candidate validation must update both wheel and sdist schema allowlists.'
+);
+
 const storyboardCandidateMode = trainingAgentWorkflowConfig.jobs.storyboards.steps.find(
   step => step.name === 'Run storyboards against /${{ matrix.tenant }}'
 ).env.ADCP_STORYBOARD_CANDIDATE_VERSION_MODE;

--- a/tests/run-storyboards-schema-root-options.test.cjs
+++ b/tests/run-storyboards-schema-root-options.test.cjs
@@ -82,6 +82,28 @@ test('candidate-bundle capability discovery registers the external schema root',
   );
 });
 
+test('candidate-version compatibility is explicit and resolver-scoped', () => {
+  const source = fs.readFileSync(RUNNER_FILE, 'utf8');
+  assert.match(
+    source,
+    /const candidateVersionMode = process\.env\.ADCP_STORYBOARD_CANDIDATE_VERSION_MODE === '1'/,
+  );
+  assert.match(
+    source,
+    /candidateVersionMode[\s\S]*isCurrentSourceRun[\s\S]*releasedComplianceVersion[\s\S]*packageVersion !== releasedComplianceVersion/,
+    'candidate mode must be limited to the generated current bundle matching package.json',
+  );
+  assert.match(
+    source,
+    /resolveStoryboardsForCapabilities\([\s\S]*hostedStableLineAlias:\s*TRAINING_AGENT_CURRENT_ADCP_VERSION/,
+  );
+  assert.doesNotMatch(
+    source,
+    /supported_versions:\s*\[[^\]]*releasedComplianceVersion/,
+    'candidate mode must not rewrite the seller capability declaration',
+  );
+});
+
 test('storyboard runs use public roots and pin the intended wire surface', () => {
   const source = fs.readFileSync(RUNNER_FILE, 'utf8');
   assert.match(source, /import \{ TRAINING_AGENT_CURRENT_ADCP_VERSION \} from/);


### PR DESCRIPTION
## Summary

- add an explicit release-only storyboard candidate-version mode that resolves a generated next-candidate bundle against the training agent current stable line
- keep the relaxation resolver-scoped: advertised capabilities and the execution wire version remain unchanged
- enable candidate mode only for release verification and the current surface of the Version Packages PR
- synchronize TypeScript SDK AdCP metadata in its disposable candidate checkout
- synchronize Python wheel/sdist schema allowlists in its disposable candidate checkout

## Why

#7007 currently asks the beta.9 training agent to resolve a generated beta.10 bundle under strict exact-version capability matching. The runner aborts before executing storyboards. The SDK candidate checkouts also need their non-generated version metadata aligned before their normal validation steps can pass.

## Validation

- real #7007 beta.10 candidate bundle: 147 sales storyboards resolved without a capability error
- real candidate `capability_discovery` run: 1/1 clean, 2/2 steps passed
- TypeScript beta.10 scratch sync, schema generation, schema validation, and library build
- Python beta.10 scratch regeneration from #7007 current artifact: generated validation plus 49 codegen/version-pin and 3 webhook compatibility tests
- standard-mode local matrix floors cleared for signals, sales, governance, and creative before stopping the long redundant run; required sales exact/clean cases passed
- release workflow invariants, storyboard runner option tests, server typecheck, changeset scope/status, and commit test gates

## Dependency

The Python candidate generation path also requires adcontextprotocol/adcp-client-python#1111, which removes the two obsolete reporting webhook patches. That PR is green and automated-review approved, awaiting human review.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/860d46c8-f5b5-4007-9e16-c46f71956753)
