### PR TITLE
refactor(addie): neutralize prepared diagnostics

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -122,16 +122,6 @@ export interface InvocationPreparedSnapshot {
   provider_request_sha256: string;
 }
 
-interface PreparedProviderRequest {
-  model: string;
-  max_tokens: number;
-  output_config?: Anthropic.Beta.BetaOutputConfig;
-  system: Anthropic.TextBlockParam[];
-  tools: Array<Record<string, unknown>>;
-  messages: Anthropic.MessageParam[];
-  betas?: readonly string[];
-}
-
 const DEFAULT_MAX_OUTPUT_TOKENS = 8_192;
 const SONNET_5_MAX_OUTPUT_TOKENS = 32_768;
 // The Anthropic SDK rejects non-streaming requests whose calculated timeout
@@ -142,14 +132,22 @@ const SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS = 16_384;
 function addieModelOutputControls(
   model: string,
   maxOutputTokens?: number,
-): Pick<PreparedProviderRequest, 'max_tokens' | 'output_config'> {
+): { maxOutputTokens: number; reasoning?: { effort: 'medium' } } {
   if (/^claude-sonnet-5(?:-|$)/.test(model)) {
     return {
-      max_tokens: Math.min(SONNET_5_MAX_OUTPUT_TOKENS, maxOutputTokens ?? SONNET_5_MAX_OUTPUT_TOKENS),
-      output_config: { effort: 'medium' },
+      maxOutputTokens: Math.min(
+        SONNET_5_MAX_OUTPUT_TOKENS,
+        maxOutputTokens ?? SONNET_5_MAX_OUTPUT_TOKENS,
+      ),
+      reasoning: { effort: 'medium' },
     };
   }
-  return { max_tokens: Math.min(DEFAULT_MAX_OUTPUT_TOKENS, maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS) };
+  return {
+    maxOutputTokens: Math.min(
+      DEFAULT_MAX_OUTPUT_TOKENS,
+      maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    ),
+  };
 }
 
 function isIsolatedExecution(options?: ProcessMessageOptions): boolean {
@@ -1112,27 +1110,17 @@ export class AddieClaudeClient {
       options?.invocationHashDomain,
     );
     const providerRequest = preparedInvocation.providerRequest;
-    // Preserve the existing Anthropic envelope hashes byte-for-byte. Other
-    // adapters expose different SDK shapes, so their component hashes use the
-    // canonical ordered request while the full request hash always covers the
-    // exact provider SDK payload.
-    const anthropicRequest = preparedInvocation.provider === 'anthropic'
-      ? providerRequest as unknown as PreparedProviderRequest
-      : null;
-    const systemBlocks: readonly unknown[] = anthropicRequest?.system ?? modelRequest.system;
-    const toolPayloads: Array<{ name: string; payload: unknown }> = anthropicRequest
-      ? anthropicRequest.tools.map((tool, index) => ({
-          name: typeof tool.name === 'string' ? tool.name : `tool_${index}`,
-          payload: tool,
-        }))
-      : [
+    const diagnosticComponents = preparedInvocation.diagnosticComponents;
+    const systemBlocks = diagnosticComponents?.systemBlocks ?? modelRequest.system;
+    const toolPayloads = diagnosticComponents?.toolSchemas
+      ?? [
           ...modelRequest.tools.map((tool) => ({ name: tool.name, payload: tool })),
           ...(modelRequest.providerTools ?? []).map((tool) => ({
             name: `provider:${tool.type}`,
             payload: tool,
           })),
         ];
-    const messagePayloads: readonly unknown[] = anthropicRequest?.messages ?? modelRequest.messages;
+    const messagePayloads = diagnosticComponents?.messagePayloads ?? modelRequest.messages;
     return {
       execution_mode: executionMode,
       model: preparedInvocation.model,
@@ -1322,10 +1310,8 @@ export class AddieClaudeClient {
       tools,
       ...(toolChoice && { toolChoice }),
       ...(providerWebSearchEnabled && { providerTools: [{ type: 'web_search' as const }] }),
-      ...(controls.output_config?.effort === 'medium' && {
-        reasoning: { effort: 'medium' as const },
-      }),
-      maxOutputTokens: controls.max_tokens,
+      ...(controls.reasoning && { reasoning: controls.reasoning }),
+      maxOutputTokens: controls.maxOutputTokens,
     };
   }
 

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.2';
+export const CODE_VERSION = '2026.09.3';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "7e9dd345a7110d11fedc128a17745ce63cd1387a14dd84e117a750420c94bf47",
+    "server/src/addie/claude-client.ts": "fd6d1e1562c8249760bf741d21751520b332e600ec1f592d84c9162b805bf5c7",
     "server/src/addie/prompts.ts": "27be3d63dfaa3c0335f1ec2213c0ee81369e705f056a341f9bc25fd8800191e9",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/model-providers/anthropic-provider.ts
+++ b/server/src/addie/model-providers/anthropic-provider.ts
@@ -600,6 +600,14 @@ export class AnthropicModelProvider implements ModelProvider {
       messages: toAnthropicMessages(request.messages),
       betas: ['web-search-2025-03-05'],
     } satisfies AnthropicRequest));
+    const diagnosticComponents = deepFreeze({
+      systemBlocks: providerRequest.system,
+      toolSchemas: providerRequest.tools.map((tool, index) => ({
+        name: typeof tool.name === 'string' ? tool.name : `tool_${index}`,
+        payload: tool,
+      })),
+      messagePayloads: providerRequest.messages,
+    });
 
     return {
       provider: 'anthropic',
@@ -607,6 +615,7 @@ export class AnthropicModelProvider implements ModelProvider {
       capabilities: this.capabilities,
       requestMetadata: request.requestMetadata,
       providerRequest,
+      diagnosticComponents,
     };
   }
 

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -245,6 +245,12 @@ export type NormalizedModelEvent =
   | { type: 'provider_state'; index: number; state: ModelProviderStateContent }
   | { type: 'response_complete'; response: ModelResponse };
 
+export interface PreparedRequestDiagnosticComponents {
+  systemBlocks: readonly unknown[];
+  toolSchemas: ReadonlyArray<{ name: string; payload: unknown }>;
+  messagePayloads: readonly unknown[];
+}
+
 export interface PreparedModelInvocation {
   provider: ModelProviderId;
   model: string;
@@ -253,6 +259,12 @@ export interface PreparedModelInvocation {
   requestMetadata?: Readonly<Record<string, string | number | boolean>>;
   /** Exact object handed to the SDK, exposed for last-moment signed parity. */
   providerRequest: Readonly<Record<string, unknown>>;
+  /**
+   * Optional ordered SDK payload components for compatibility-sensitive
+   * diagnostics. Adapters whose translated SDK envelope diverges from the
+   * canonical request should provide these to preserve established hashes.
+   */
+  diagnosticComponents?: Readonly<PreparedRequestDiagnosticComponents>;
 }
 
 export interface ModelRespondOptions {

--- a/server/tests/unit/addie/model-provider-anthropic.test.ts
+++ b/server/tests/unit/addie/model-provider-anthropic.test.ts
@@ -180,6 +180,17 @@ describe('AnthropicModelProvider request translation', () => {
       ],
       betas: ['web-search-2025-03-05'],
     });
+    expect(prepared.diagnosticComponents?.systemBlocks)
+      .toEqual(prepared.providerRequest.system);
+    expect(prepared.diagnosticComponents?.toolSchemas.map(({ name }) => name))
+      .toEqual(['search_docs', 'web_search']);
+    expect(prepared.diagnosticComponents?.toolSchemas.map(({ payload }) => payload))
+      .toEqual(prepared.providerRequest.tools);
+    expect(prepared.diagnosticComponents?.messagePayloads)
+      .toEqual(prepared.providerRequest.messages);
+    expect(Object.isFrozen(prepared.diagnosticComponents)).toBe(true);
+    expect(Object.isFrozen(prepared.diagnosticComponents?.toolSchemas)).toBe(true);
+    expect(Object.isFrozen(prepared.diagnosticComponents?.toolSchemas[0])).toBe(true);
   });
 
   it('rejects continuation state from a different provider', () => {

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -85,6 +85,7 @@ import type {
   ModelRespondOptions,
   NormalizedModelEvent,
   PreparedModelInvocation,
+  PreparedRequestDiagnosticComponents,
 } from '../../src/addie/model-providers/model-provider.js';
 
 const usage = { input_tokens: 3, output_tokens: 2 };
@@ -140,6 +141,7 @@ function invocationHmac(key: string, domain: string, value: string): string {
 function fakeProvider(
   id: ModelProviderId,
   responseText: string,
+  diagnosticComponents?: PreparedRequestDiagnosticComponents,
 ): ModelProvider & {
   prepare: ReturnType<typeof vi.fn<(request: ModelRequest) => PreparedModelInvocation>>;
   respond: ReturnType<typeof vi.fn<(
@@ -168,6 +170,7 @@ function fakeProvider(
       tools: request.tools,
       maxOutputTokens: request.maxOutputTokens,
     }),
+    ...(diagnosticComponents && { diagnosticComponents }),
   }));
   const respond = vi.fn((request: ModelRequest, options?: ModelRespondOptions) => (async function* () {
     const prepared = prepare(request);
@@ -454,6 +457,57 @@ describe('AddieClaudeClient isolated execution policy', () => {
       JSON.stringify((captured.tools as Array<Record<string, unknown>>)[0]),
     );
     expect(snapshots[0].tool_schemas[0].sha256).toBe(expectedFirstToolHash);
+  });
+
+  it('uses adapter-provided diagnostic components without provider-specific branching', () => {
+    const diagnosticComponents = {
+      systemBlocks: [{ vendorSystem: 'translated system' }],
+      toolSchemas: [{
+        name: 'translated_tool',
+        payload: { vendorTool: 'translated schema' },
+      }],
+      messagePayloads: [{ vendorMessage: 'translated message' }],
+    } satisfies PreparedRequestDiagnosticComponents;
+    const provider = fakeProvider('google', 'unused', diagnosticComponents);
+    const client = new AddieClaudeClient(
+      'unused',
+      'gemini-test',
+      undefined,
+      { provider },
+    );
+    const options = {
+      executionMode: 'shadow' as const,
+      disableServerTools: true,
+      invocationHashKey: 'neutral-diagnostic-key',
+      invocationHashDomain: 'neutral-diagnostic-domain:v1',
+    };
+
+    const prepared = client.prepareMessageInvocation(
+      'canonical message',
+      undefined,
+      undefined,
+      { systemPrompt: 'canonical system' },
+      options,
+    );
+
+    const expectedHash = (value: unknown) => invocationHmac(
+      options.invocationHashKey,
+      options.invocationHashDomain,
+      JSON.stringify(value),
+    );
+    expect(prepared.system_blocks).toEqual([{
+      index: 0,
+      sha256: expectedHash(diagnosticComponents.systemBlocks[0]),
+    }]);
+    expect(prepared.tool_schemas).toEqual([{
+      index: 0,
+      name: 'translated_tool',
+      sha256: expectedHash(diagnosticComponents.toolSchemas[0].payload),
+    }]);
+    expect(prepared.message_payloads).toEqual([{
+      index: 0,
+      sha256: expectedHash(diagnosticComponents.messagePayloads[0]),
+    }]);
   });
 
   it('prepares the exact first non-streaming snapshot without calling the SDK', async () => {


### PR DESCRIPTION
## Summary

- replace the common Addie client's Anthropic prepared-envelope cast and provider branch with optional provider-neutral diagnostic components on `PreparedModelInvocation`
- have the Anthropic adapter expose frozen, ordered translated system/tool/message payloads so established replay component hashes remain byte-for-byte compatible
- express Addie's model output controls in canonical `maxOutputTokens` / `reasoning` terms, bump `CODE_VERSION` to `2026.09.3`, and refresh the generated tool inventory

## Safety

- the full provider request digest still hashes the exact frozen object handed to the SDK
- Anthropic diagnostic payloads reference that same frozen request; other adapters retain the existing canonical component fallback
- delivery logging, streaming, notifications, persistence, billing, retry/routing policy, provider activation, rollout configuration, environments, and secrets are unchanged
- no paid or stochastic model/API calls were made

## Verification

- focused Anthropic/replay regression tests: 2 files, 91 tests passed
- `npm run typecheck`
- Addie tool reference, inventory, and portability checks: 249 tools, 37 sets
- `npm run precommit` / commit hook, including full server unit suite: 538 files; 7,775 passed, 30 skipped
- `npm run build`
- changeset scope check and `git diff --check`
- independent repository code review: Ready to push
- independent security review: no findings

Related to #6844.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
