### PR TITLE
fix(addie): persist interaction usage

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -157,7 +157,7 @@ const STREAM_SOFT_CAP = (() => {
 const STREAM_CONTINUATION_TAIL = '\n\n_(continued in next message ↓)_';
 const STREAM_CONTINUATION_HEAD = '_(continued from above ↑)_\n\n';
 import type { RequestTools } from './claude-client.js';
-import type { SuggestedPrompt } from './types.js';
+import { toInteractionModelUsage, type SuggestedPrompt } from './types.js';
 import { DatabaseThreadContextStore } from './thread-context-store.js';
 import { getThreadService, type ThreadContext } from './thread-service.js';
 import {
@@ -2295,6 +2295,7 @@ async function handleUserMessage({
         requested_model: dmEffectiveModel,
         reason: 'stream_interrupted',
       },
+      usage: null,
       latency_ms: Date.now() - startTime,
       flagged: true,
       flag_reason: `stream_interrupted:${streamInterruptCategory}`,
@@ -2400,6 +2401,7 @@ async function handleUserMessage({
     tools_used: response.tools_used,
     model: dmEffectiveModel,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
@@ -2800,6 +2802,7 @@ async function handleAppMention({
     tools_used: response.tools_used,
     model: mentionEffectiveModel,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,
@@ -4136,6 +4139,7 @@ async function handleDirectMessage(
     tools_used: response.tools_used,
     model: directMessageEffectiveModel,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     delivery_status: delivery.delivered ? 'delivered' : 'failed',
     flagged: userMessageFlagged || assistantFlagged || !delivery.delivered,
@@ -4516,6 +4520,7 @@ async function handleActiveThreadReply({
     tools_used: response.tools_used,
     model: activeThreadEffectiveModel,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     flagged: userMessageFlagged || assistantFlagged,
     flag_reason: [inputValidation.reason, flagReason].filter(Boolean).join('; ') || undefined,

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -640,7 +640,7 @@ export interface AddieResponse {
     total_tool_execution_ms: number;
     iterations: number;
   };
-  /** Token usage from Claude API */
+  /** Provider-normalized token and cache usage for this delivered turn. */
   usage?: {
     input_tokens: number;
     output_tokens: number;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.3';
+export const CODE_VERSION = '2026.09.4';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,13 +12,13 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "fd6d1e1562c8249760bf741d21751520b332e600ec1f592d84c9162b805bf5c7",
+    "server/src/addie/claude-client.ts": "bf5cb67c4758273aea1674b88e1b8b765724d90d807ba1ab587892b9a72e03a9",
     "server/src/addie/prompts.ts": "27be3d63dfaa3c0335f1ec2213c0ee81369e705f056a341f9bc25fd8800191e9",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "60baa3c324eeb2600187b38bdf8dbda46dcade25eb68bf65a2c0a643c67b7a1b",
-    "server/src/addie/handler.ts": "cf9d66b7b2700cefd2811d2d9c627ea2683c556e6c3afd36ecc99cac12aa5407",
+    "server/src/addie/bolt-app.ts": "03eb87d6def523062bbdd790fa82a20314a9fb2d5d03672149e9d80820e15b8e",
+    "server/src/addie/handler.ts": "9df4a97138442abf71faf66b53d40ff433b2ac4580e2cebb899cdfe40bd67a84",
     "server/src/routes/addie-chat.ts": "7f5045189cb2cdff22a5e61cb4a0eeba1adcaf5828d97fce0f4024fcad6161f7",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",

--- a/server/src/addie/handler.ts
+++ b/server/src/addie/handler.ts
@@ -132,12 +132,13 @@ import * as relationshipDb from '../db/relationship-db.js';
 import { loadRelationshipContext, formatContextForPrompt } from './services/relationship-context.js';
 import * as personEvents from '../db/person-events-db.js';
 import type { RequestTools } from './claude-client.js';
-import type {
-  AssistantThreadStartedEvent,
-  AppMentionEvent,
-  AssistantMessageEvent,
-  CreateAddieInteractionLog,
-  SuggestedPrompt,
+import {
+  toInteractionModelUsage,
+  type AssistantThreadStartedEvent,
+  type AppMentionEvent,
+  type AssistantMessageEvent,
+  type CreateAddieInteractionLog,
+  type SuggestedPrompt,
 } from './types.js';
 
 /**
@@ -756,6 +757,7 @@ export async function handleAssistantMessage(
     tools_used: response.tools_used,
     model: AddieModelConfig.chat,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     flagged,
     flag_reason: flagReason || undefined,
@@ -940,6 +942,7 @@ export async function handleAppMention(event: AppMentionEvent): Promise<void> {
     tools_used: response.tools_used,
     model: AddieModelConfig.chat,
     model_execution: response.model_execution,
+    usage: toInteractionModelUsage(response.usage),
     latency_ms: Date.now() - startTime,
     flagged,
     flag_reason: flagReason || undefined,

--- a/server/src/addie/types.ts
+++ b/server/src/addie/types.ts
@@ -2,7 +2,27 @@
  * Types for Addie - AAO's Community Agent
  */
 
-import type { ModelExecution } from './model-providers/model-provider.js';
+import type { ModelExecution, ModelUsage } from './model-providers/model-provider.js';
+
+/** Translate the stable delivery response shape back to canonical model usage. */
+export function toInteractionModelUsage(usage: {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+} | undefined): ModelUsage | null {
+  if (!usage) return null;
+  return {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    ...(usage.cache_creation_input_tokens !== undefined && {
+      cacheWriteTokens: usage.cache_creation_input_tokens,
+    }),
+    ...(usage.cache_read_input_tokens !== undefined && {
+      cacheReadTokens: usage.cache_read_input_tokens,
+    }),
+  };
+}
 
 /**
  * Slack Assistant thread started event
@@ -82,6 +102,8 @@ export interface AddieInteractionLog {
   tools_used: string[];
   model: string;
   model_execution?: ModelExecution;
+  /** Null means no provider usage was available; zero is a measured value. */
+  usage: ModelUsage | null;
   latency_ms: number;
   delivery_status?: 'delivered' | 'failed';
   flagged: boolean;

--- a/server/src/db/addie-db.ts
+++ b/server/src/db/addie-db.ts
@@ -25,6 +25,10 @@ interface AddieInteractionRow {
   provider_model_resolution: 'exact' | 'provider_canonicalized' | 'fallback' | null;
   provider_fallback_reason: string | null;
   local_response_reason: string | null;
+  tokens_input: number | null;
+  tokens_output: number | null;
+  tokens_cache_creation: number | null;
+  tokens_cache_read: number | null;
   latency_ms: number;
   flagged: boolean;
   flag_reason: string | null;
@@ -996,14 +1000,18 @@ export class AddieDatabase {
    * Log an interaction
    */
   async logInteraction(log: CreateAddieInteractionLog, knowledgeIds?: number[]): Promise<void> {
+    if (log.model_execution.source === 'provider' && log.usage === null) {
+      throw new Error('Provider interaction requires normalized usage');
+    }
     await query(
       `INSERT INTO addie_interactions (
         id, event_type, channel_id, thread_ts, user_id,
         input_text, input_sanitized, output_text,
         tools_used, knowledge_ids, model, model_execution_source, requested_model_provider, requested_model,
         model_provider, provider_model, provider_model_resolution, provider_fallback_reason, local_response_reason,
+        tokens_input, tokens_output, tokens_cache_creation, tokens_cache_read,
         latency_ms, flagged, flag_reason
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)`,
       [
         log.id,
         log.event_type,
@@ -1024,6 +1032,10 @@ export class AddieDatabase {
         log.model_execution?.source === 'provider' ? log.model_execution.model_resolution : null,
         log.model_execution?.source === 'provider' ? log.model_execution.fallback_reason : null,
         log.model_execution?.source === 'local' ? log.model_execution.reason : null,
+        log.usage?.inputTokens ?? null,
+        log.usage?.outputTokens ?? null,
+        log.usage?.cacheWriteTokens ?? null,
+        log.usage?.cacheReadTokens ?? null,
         log.latency_ms,
         log.flagged,
         log.flag_reason || null,
@@ -1115,6 +1127,18 @@ export class AddieDatabase {
                 reason: row.local_response_reason as Extract<NonNullable<AddieInteractionLog['model_execution']>, { source: 'local' }>['reason'],
               }
             : undefined,
+      usage: row.tokens_input !== null && row.tokens_output !== null
+        ? {
+            inputTokens: row.tokens_input,
+            outputTokens: row.tokens_output,
+            ...(row.tokens_cache_creation !== null && {
+              cacheWriteTokens: row.tokens_cache_creation,
+            }),
+            ...(row.tokens_cache_read !== null && {
+              cacheReadTokens: row.tokens_cache_read,
+            }),
+          }
+        : null,
       latency_ms: row.latency_ms,
       flagged: row.flagged,
       flag_reason: row.flag_reason ?? undefined,

--- a/server/src/db/migrations/573_addie_interaction_usage.sql
+++ b/server/src/db/migrations/573_addie_interaction_usage.sql
@@ -1,0 +1,43 @@
+-- Persist provider-normalized usage in the legacy interaction audit sink.
+--
+-- The unified thread-message sink already retains these values. Keeping the
+-- audit sink aligned prevents provider/model provenance from being separated
+-- from its measured usage. Columns remain nullable for local responses,
+-- historical rows, and rolling deploys from older application replicas.
+
+ALTER TABLE addie_interactions
+  ADD COLUMN IF NOT EXISTS tokens_input INTEGER,
+  ADD COLUMN IF NOT EXISTS tokens_output INTEGER,
+  ADD COLUMN IF NOT EXISTS tokens_cache_creation INTEGER,
+  ADD COLUMN IF NOT EXISTS tokens_cache_read INTEGER;
+
+ALTER TABLE addie_interactions
+  ADD CONSTRAINT addie_interactions_usage_nonnegative
+    CHECK (
+      (tokens_input IS NULL OR tokens_input >= 0)
+      AND (tokens_output IS NULL OR tokens_output >= 0)
+      AND (tokens_cache_creation IS NULL OR tokens_cache_creation >= 0)
+      AND (tokens_cache_read IS NULL OR tokens_cache_read >= 0)
+    ) NOT VALID,
+  ADD CONSTRAINT addie_interactions_usage_atomic
+    CHECK (
+      (
+        tokens_input IS NULL
+        AND tokens_output IS NULL
+        AND tokens_cache_creation IS NULL
+        AND tokens_cache_read IS NULL
+      )
+      OR (
+        tokens_input IS NOT NULL
+        AND tokens_output IS NOT NULL
+      )
+    ) NOT VALID;
+
+COMMENT ON COLUMN addie_interactions.tokens_input IS
+  'Normalized provider input tokens; NULL when provider usage is unavailable or predates usage persistence.';
+COMMENT ON COLUMN addie_interactions.tokens_output IS
+  'Normalized provider output tokens; NULL when provider usage is unavailable or predates usage persistence.';
+COMMENT ON COLUMN addie_interactions.tokens_cache_creation IS
+  'Normalized provider cache-write tokens when reported; NULL means unavailable, not zero.';
+COMMENT ON COLUMN addie_interactions.tokens_cache_read IS
+  'Normalized provider cache-read tokens when reported; NULL means unavailable, not zero.';

--- a/server/tests/integration/thread-service.test.ts
+++ b/server/tests/integration/thread-service.test.ts
@@ -355,6 +355,8 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         'addie_interactions_local_response_reason_values',
         'addie_interactions_provider_execution_atomic',
         'addie_interactions_provider_fallback_consistent',
+        'addie_interactions_usage_nonnegative',
+        'addie_interactions_usage_atomic',
       ];
       const result = await pool.query<{ conname: string; convalidated: boolean }>(
         `SELECT conname, convalidated
@@ -507,6 +509,12 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
           model_resolution: 'fallback',
           fallback_reason: 'primary_unavailable',
         },
+        usage: {
+          inputTokens: 12,
+          outputTokens: 4,
+          cacheWriteTokens: 3,
+          cacheReadTokens: 2,
+        },
         latency_ms: 10,
         flagged: false,
       });
@@ -527,6 +535,7 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
           requested_model: 'claude-sonnet-5',
           reason: 'provider_error',
         },
+        usage: null,
         latency_ms: 5,
         flagged: true,
       });
@@ -550,6 +559,10 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
           model_resolution: 'fallback',
           fallback_reason: 'primary_unavailable',
         },
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+        },
         latency_ms: 7,
         flagged: false,
       });
@@ -564,12 +577,19 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         model_resolution: 'fallback',
         fallback_reason: 'primary_unavailable',
       });
+      expect(interactions.find((row) => row.id === 'provider-provenance-provider')?.usage).toEqual({
+        inputTokens: 12,
+        outputTokens: 4,
+        cacheWriteTokens: 3,
+        cacheReadTokens: 2,
+      });
       expect(interactions.find((row) => row.id === 'provider-provenance-local')?.model_execution).toEqual({
         source: 'local',
         requested_provider: 'anthropic',
         requested_model: 'claude-sonnet-5',
         reason: 'provider_error',
       });
+      expect(interactions.find((row) => row.id === 'provider-provenance-local')?.usage).toBeNull();
       expect(interactions.find((row) => row.id === 'provider-provenance-model-fallback')?.model_execution).toEqual({
         source: 'provider',
         requested_provider: 'anthropic',
@@ -579,6 +599,57 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
         model_resolution: 'fallback',
         fallback_reason: 'primary_unavailable',
       });
+      expect(interactions.find((row) => row.id === 'provider-provenance-model-fallback')?.usage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+      });
+
+      await expect(addieDb.logInteraction({
+        id: 'provider-provenance-missing-usage',
+        timestamp: new Date(),
+        event_type: 'dm',
+        channel_id: 'D_TEST',
+        user_id: userId,
+        input_text: 'question',
+        input_sanitized: 'question',
+        output_text: 'answer',
+        tools_used: [],
+        model: 'claude-sonnet-5',
+        model_execution: {
+          source: 'provider',
+          requested_provider: 'anthropic',
+          requested_model: 'claude-sonnet-5',
+          provider: 'anthropic',
+          model: 'claude-sonnet-5',
+          model_resolution: 'exact',
+          fallback_reason: null,
+        },
+        usage: null,
+        latency_ms: 1,
+        flagged: false,
+      })).rejects.toThrow('Provider interaction requires normalized usage');
+
+      await expect(pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms, tokens_input
+         ) VALUES (
+           'provider-provenance-partial-usage', 'dm', 'D_TEST', $1, 'q', 'q',
+           'a', 'claude-sonnet-5', 1, 1
+         )`,
+        [userId],
+      )).rejects.toThrow();
+
+      await expect(pool.query(
+        `INSERT INTO addie_interactions (
+           id, event_type, channel_id, user_id, input_text, input_sanitized,
+           output_text, model, latency_ms, tokens_input, tokens_output
+         ) VALUES (
+           'provider-provenance-negative-usage', 'dm', 'D_TEST', $1, 'q', 'q',
+           'a', 'claude-sonnet-5', 1, -1, 0
+         )`,
+        [userId],
+      )).rejects.toThrow();
 
       await expect(pool.query(
         `INSERT INTO addie_interactions (

--- a/server/tests/unit/addie-db-interaction-usage.test.ts
+++ b/server/tests/unit/addie-db-interaction-usage.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+}));
+
+import { AddieDatabase } from '../../src/db/addie-db.js';
+import { query } from '../../src/db/client.js';
+
+const queryMock = vi.mocked(query);
+
+function providerInteraction() {
+  return {
+    id: 'usage-provider',
+    timestamp: new Date('2026-09-01T00:00:00.000Z'),
+    event_type: 'dm' as const,
+    channel_id: 'D_TEST',
+    user_id: 'U_TEST',
+    input_text: 'question',
+    input_sanitized: 'question',
+    output_text: 'answer',
+    tools_used: [],
+    model: 'claude-sonnet-5',
+    model_execution: {
+      source: 'provider' as const,
+      requested_provider: 'anthropic' as const,
+      requested_model: 'claude-sonnet-5',
+      provider: 'anthropic' as const,
+      model: 'claude-sonnet-5',
+      model_resolution: 'exact' as const,
+      fallback_reason: null,
+    },
+    usage: {
+      inputTokens: 12,
+      outputTokens: 4,
+      cacheWriteTokens: 3,
+      cacheReadTokens: 2,
+    },
+    latency_ms: 10,
+    flagged: false,
+  };
+}
+
+describe('AddieDatabase interaction usage persistence', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  });
+
+  it('writes normalized token and cache usage with provider provenance', async () => {
+    await new AddieDatabase().logInteraction(providerInteraction());
+
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(String(sql)).toContain(
+      'tokens_input, tokens_output, tokens_cache_creation, tokens_cache_read',
+    );
+    expect(params?.slice(19, 23)).toEqual([12, 4, 3, 2]);
+  });
+
+  it('rejects provider provenance without normalized usage before persistence', async () => {
+    await expect(new AddieDatabase().logInteraction({
+      ...providerInteraction(),
+      usage: null,
+    })).rejects.toThrow('Provider interaction requires normalized usage');
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('round-trips measured zero while preserving unavailable cache metrics', async () => {
+    queryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'usage-zero',
+        event_type: 'dm',
+        channel_id: 'D_TEST',
+        thread_ts: null,
+        user_id: 'U_TEST',
+        input_text: 'question',
+        input_sanitized: 'question',
+        output_text: 'answer',
+        tools_used: [],
+        model: 'claude-sonnet-5',
+        model_execution_source: 'provider',
+        requested_model_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        model_provider: 'anthropic',
+        provider_model: 'claude-sonnet-5',
+        provider_model_resolution: 'exact',
+        provider_fallback_reason: null,
+        local_response_reason: null,
+        tokens_input: 0,
+        tokens_output: 0,
+        tokens_cache_creation: null,
+        tokens_cache_read: null,
+        latency_ms: 10,
+        flagged: false,
+        flag_reason: null,
+        created_at: new Date('2026-09-01T00:00:00.000Z'),
+      }],
+      rowCount: 1,
+    } as never);
+
+    const [interaction] = await new AddieDatabase().getInteractions();
+    expect(interaction.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

- persist normalized input/output and cache usage beside provider/model/fallback provenance in the legacy `addie_interactions` audit sink
- keep local and historical interactions nullable while rejecting new provider-backed audit writes that lack normalized usage
- preserve measured zero values and distinguish unreported cache metrics from zero
- add rolling-deploy-safe constraints plus focused unit and PostgreSQL integration coverage

## Safety

- provider selection, activation, rollout configuration, prompts, tool execution, retry policy, and mutation safety are unchanged
- the migration is additive: nullable columns support historical rows and older replicas, while `NOT VALID` constraints protect new writes without scanning existing data
- only numeric usage metadata is added; no prompts, model output, raw provider diagnostics, credentials, or tenant access paths are exposed
- no paid model/API calls were made; provider behavior is covered with deterministic mocks

## Verification

- focused Addie provider-neutral/parity suite: 224 tests passed
- focused interaction persistence unit suite: 3 tests passed
- clean PostgreSQL 16 migration run through migration 573: passed
- PostgreSQL interaction integration suite: 45 tests passed
- `npm run test:migrations`
- `npm run test:addie-tools` (249 tools, 37 sets; reference, inventory, and portability)
- `npm run typecheck`
- `npm run test:server-unit` (539 files; 7,778 passed, 30 skipped)
- `npm run precommit` (including the staged full server suite)
- `npm run build`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- `git diff --check`
- independent code review: clean
- independent security review: clean

Related to #6844.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
