### PR TITLE
fix(release): align Python candidate manifest syntax

### DIFF
--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -205,9 +205,19 @@ jobs:
           import os
           from pathlib import Path
 
-          old = f"_schemas/{os.environ['SDK_VERSION']}/"
-          new = f"_schemas/{os.environ['BUNDLE_VERSION']}/"
-          for filename in ("sdk/pyproject.toml", "sdk/MANIFEST.in"):
+          sdk_version = os.environ["SDK_VERSION"]
+          bundle_version = os.environ["BUNDLE_VERSION"]
+          replacements = {
+              "sdk/pyproject.toml": (
+                  f"_schemas/{sdk_version}/",
+                  f"_schemas/{bundle_version}/",
+              ),
+              "sdk/MANIFEST.in": (
+                  f"_schemas/{sdk_version} ",
+                  f"_schemas/{bundle_version} ",
+              ),
+          }
+          for filename, (old, new) in replacements.items():
               path = Path(filename)
               source = path.read_text()
               if old not in source:

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -105,8 +105,11 @@ assert(
   'Python candidate validation must align its disposable package-data allowlist after pinning ADCP_VERSION and before schema generation.'
 );
 assert(
-  pythonCandidateStep.includes('for filename in ("sdk/pyproject.toml", "sdk/MANIFEST.in")'),
-  'Python candidate validation must update both wheel and sdist schema allowlists.'
+  pythonCandidateStep.includes('"sdk/pyproject.toml": (') &&
+    pythonCandidateStep.includes('f"_schemas/{sdk_version}/"') &&
+    pythonCandidateStep.includes('"sdk/MANIFEST.in": (') &&
+    pythonCandidateStep.includes('f"_schemas/{sdk_version} "'),
+  'Python candidate validation must update the distinct wheel and sdist schema allowlist syntaxes.'
 );
 
 const storyboardCandidateMode = trainingAgentWorkflowConfig.jobs.storyboards.steps.find(


### PR DESCRIPTION
## Summary

- model Python wheel and sdist schema allowlists with their distinct delimiters
- fail closed if either pinned schema entry is absent
- lock the two syntaxes into the release workflow immutability test

## Why

Regenerated release PR #7007 reached Python candidate validation after #7135 and #1111 merged, but failed before regeneration because MANIFEST.in uses `_schemas/<version> *.json` while pyproject.toml uses `_schemas/<version>/**/*.json`. The original workflow assumed both used a trailing slash.

Failed job: https://github.com/adcontextprotocol/adcp/actions/runs/33510763391/job/99866515326

## Validation

- full commit hook: 1,056 unit tests plus dynamic-import, format-boundary, state-change, and TypeScript checks
- `node tests/release-workflow-immutability.test.cjs`
- exact #7007 head `56dfd839` bundle: checksum/provenance, beta.10 sync, 1,562 schemas regenerated, generated-code validation, and 49 codegen/version-pin tests passed
- `git diff --check`

No changeset: this is CI-only release harness behavior and does not change the protocol package surface.