### PR TITLE
fix(release): regenerate candidates after validator changes

### DIFF
--- a/.changeset/regenerate-after-validator.md
+++ b/.changeset/regenerate-after-validator.md
@@ -1,0 +1,4 @@
+---
+---
+
+Regenerate release candidates after candidate-validation workflow changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
           changed_files="$(git show --format= --name-only --no-renames "${GITHUB_SHA}")"
-          if grep -Eq '^(\.changeset/|package(-lock)?[.]json$|dist/(schemas|compliance|protocol)/|static/(schemas|compliance)/source/|server/src/training-agent/|scripts/(build-schemas[.]cjs|build-compliance[.]cjs|build-protocol-tarball[.]cjs|sign-protocol-tarball[.]sh|run-storyboards-([^/]+[.]sh|isolated[.]mjs))|[.]github/workflows/(release|training-agent-storyboards)[.]yml$)' <<< "${changed_files}"; then
+          if grep -Eq '^(\.changeset/|package(-lock)?[.]json$|dist/(schemas|compliance|protocol)/|static/(schemas|compliance)/source/|server/src/training-agent/|scripts/(build-schemas[.]cjs|build-compliance[.]cjs|build-protocol-tarball[.]cjs|sign-protocol-tarball[.]sh|run-storyboards-([^/]+[.]sh|isolated[.]mjs))|[.]github/workflows/(release|training-agent-storyboards|validate-schema-bundle)[.]yml$)' <<< "${changed_files}"; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "Release-relevant files changed."
             exit 0

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -71,6 +71,13 @@ const changesetsActionImplementation = fs.readFileSync(
 );
 const changesetsActionContract = YAML.parse(changesetsActionContractSource);
 
+assert(
+  releaseRelevance.includes(
+    '[.]github/workflows/(release|training-agent-storyboards|validate-schema-bundle)[.]yml$'
+  ),
+  'Candidate bundle validation workflow changes must trigger release PR regeneration.'
+);
+
 assert.deepStrictEqual(
   schemaPrWorkflowConfig.on.pull_request.paths,
   ['static/schemas/source/**'],


### PR DESCRIPTION
## Summary

- classify candidate-bundle validation workflow changes as release-relevant
- ensure fixes to candidate validation regenerate the Version Packages PR they validate
- add an immutability assertion for the trigger contract
- include the policy-required empty changeset without bumping a package

## Why

#7139 fixed Python candidate validation and merged cleanly, but Release run 33512319439 skipped its mutation job because `validate-schema-bundle.yml` was absent from the release-relevance allowlist. That left #7007 on the pre-fix head. This adds the missing workflow beside the existing release and storyboard workflow triggers.

Skipped run: https://github.com/adcontextprotocol/adcp/actions/runs/33512319439

## Validation

- full commit hook on both commits: 1,056 unit tests plus dynamic-import, format-boundary, state-change, and TypeScript checks
- `node tests/release-workflow-immutability.test.cjs`
- Changesets status accepts the empty changeset for this protocol-scoped orchestration change
- `git diff --check`