### PR TITLE
fix(addie): add exact provider cost accounting

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1390,28 +1390,29 @@ export class AddieClaudeClient {
       );
     }
 
-    // #2790: per-user Anthropic cost cap. Check at entry; when the
+    // #2790: per-user model cost cap. Check exact pricing at entry; when the
     // user has exhausted their daily budget, return a friendly
     // "try again later" response instead of firing another
     // (billable) Claude call. The caller's ProcessMessageOptions
     // carries both `userId` and `tier` so we don't have to resolve
     // the subscription tier here.
-    if (operationalExecution && options?.costScope) {
+    if (operationalExecution) {
       const capResult = await checkCostCap(
-        options.costScope.userId,
-        options.costScope.tier,
+        options?.costScope?.userId,
+        options?.costScope?.tier ?? 'anonymous',
+        { selection: { provider: this.modelProvider.id, model: requestedModel } },
       );
       if (!capResult.ok) {
         const message = formatCapExceededMessage(capResult)
-          + (options.costScope.certificationReserveUsd ? ' Your certification progress is saved.' : '');
+          + (options?.costScope?.certificationReserveUsd ? ' Your certification progress is saved.' : '');
         logger.warn(
           {
-            userId: options.costScope.userId,
-            tier: options.costScope.tier,
+            userId: options?.costScope?.userId,
+            tier: options?.costScope?.tier,
             spentCents: capResult.spentCents,
             retryAfterMs: capResult.retryAfterMs,
           },
-          'Addie cost cap exceeded — refusing Claude call',
+          'Addie cost admission refused — refusing model call',
         );
         return {
           text: message,
@@ -1494,6 +1495,12 @@ export class AddieClaudeClient {
       : await getCurrentConfigVersionId();
 
     const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    const recordAccumulatedCost = async () => {
+      if (!operationalExecution || !options?.costScope) return;
+      for (const event of modelLoop.accountedUsage) {
+        await recordCost(options.costScope.userId, event);
+      }
+    };
 
     // Log if using precision model
     if (options?.modelOverride && options.modelOverride !== this.model) {
@@ -1514,7 +1521,6 @@ export class AddieClaudeClient {
     let iteration = 0;
     let hasExecutedCustomTool = false;
     let activeModel = effectiveModel;
-    let costModel = options?.modelOverride ?? AddieModelConfig.chat;
     let modelFallbackReason: ModelFallbackReason | null = null;
 
     while (modelLoop.hasRemaining) {
@@ -1598,7 +1604,6 @@ export class AddieClaudeClient {
           const { decision: fallback } = fallbackAttempt;
           response = fallbackAttempt.response;
           activeModel = fallback.model;
-          costModel = fallback.model;
           modelFallbackReason = fallback.reason;
           modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
           if (operationalExecution) {
@@ -1806,11 +1811,7 @@ export class AddieClaudeClient {
           'Addie: Model provider stopped before response completion',
         );
         if (operationalExecution && options?.costScope) {
-          await recordCost(
-            options.costScope.userId,
-            costModel,
-            finalUsage,
-          );
+          await recordAccumulatedCost();
         }
         return terminal.response;
       }
@@ -1870,11 +1871,7 @@ export class AddieClaudeClient {
         // counts even if a downstream flag/logging failure occurs.
         // recordCost no-ops for missing userId / system users.
         if (operationalExecution && options?.costScope) {
-          await recordCost(
-            options.costScope.userId,
-            costModel,
-            finalUsage,
-          );
+          await recordAccumulatedCost();
         }
         return terminal.response;
       }
@@ -1908,11 +1905,7 @@ export class AddieClaudeClient {
     // Still charge the user for tokens actually consumed on the way to
     // hitting max-iterations. Production delivery is Anthropic-only here.
     if (operationalExecution && options?.costScope) {
-      await recordCost(
-        options.costScope.userId,
-        costModel,
-        maxIterationsUsage,
-      );
+      await recordAccumulatedCost();
     }
     return terminal.response;
   }
@@ -1948,32 +1941,35 @@ export class AddieClaudeClient {
       );
     }
 
-    // #2790: per-user Anthropic cost cap (streaming path). Same
+    // #2790: provider-neutral cost admission (streaming path). Same
     // contract as `processMessage` — yield a `done` event with the
     // friendly cap-exceeded text and return early instead of firing
     // another billable Claude call.
     let certificationReserveUsed = false;
     let certificationLeaseId: string | undefined;
     let certificationLeaseHeartbeat: ReturnType<typeof setInterval> | undefined;
-    if (operationalExecution && options?.costScope) {
+    if (operationalExecution) {
       const capResult = await checkCostCap(
-        options.costScope.userId,
-        options.costScope.tier,
-        { certificationReserveUsd: options.costScope.certificationReserveUsd },
+        options?.costScope?.userId,
+        options?.costScope?.tier ?? 'anonymous',
+        {
+          certificationReserveUsd: options?.costScope?.certificationReserveUsd,
+          selection: { provider: this.modelProvider.id, model: requestedModel },
+        },
       );
       certificationReserveUsed = capResult.usedCertificationReserve === true;
       certificationLeaseId = capResult.certificationLeaseId;
       if (!capResult.ok) {
         const message = formatCapExceededMessage(capResult)
-          + (options.costScope.certificationReserveUsd ? ' Your certification progress is saved.' : '');
+          + (options?.costScope?.certificationReserveUsd ? ' Your certification progress is saved.' : '');
         logger.warn(
           {
-            userId: options.costScope.userId,
-            tier: options.costScope.tier,
+            userId: options?.costScope?.userId,
+            tier: options?.costScope?.tier,
             spentCents: capResult.spentCents,
             retryAfterMs: capResult.retryAfterMs,
           },
-          'Addie cost cap exceeded — refusing Claude stream',
+          'Addie cost admission refused — refusing model stream',
         );
         yield {
           type: 'done',
@@ -2083,10 +2079,15 @@ export class AddieClaudeClient {
       );
     }
     const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    const recordAccumulatedCost = async () => {
+      if (!operationalExecution || !options?.costScope) return;
+      for (const event of modelLoop.accountedUsage) {
+        await recordCost(options.costScope.userId, event);
+      }
+    };
     let iteration = 0;
     let lastProviderModel: string | undefined;
     let activeModel = effectiveModel;
-    let costModel = options?.modelOverride ?? AddieModelConfig.chat;
     let modelFallbackReason: ModelFallbackReason | null = null;
 
       while (modelLoop.hasRemaining) {
@@ -2247,7 +2248,6 @@ export class AddieClaudeClient {
                 const { decision: fallback } = fallbackAttempt;
                 currentResponse = fallbackAttempt.response;
                 activeModel = fallback.model;
-                costModel = fallback.model;
                 modelFallbackReason = fallback.reason;
                 lastProviderModel = currentResponse.model;
                 modelLoop.emptyResponseRecovery.completeInvocation(recoveryInvocation);
@@ -2471,14 +2471,8 @@ export class AddieClaudeClient {
         // budget (#2790). Both stream terminal paths (end_turn and
         // no-tool-blocks) serialize the same normalized accumulator.
         const buildStreamUsage = () => toAddieUsage(modelLoop.usage);
-        const chargeStreamCost = async (usage: ReturnType<typeof buildStreamUsage>) => {
-          if (operationalExecution && options?.costScope) {
-            await recordCost(
-              options.costScope.userId,
-              costModel,
-              usage,
-            );
-          }
+        const chargeStreamCost = async () => {
+          await recordAccumulatedCost();
         };
 
         const iterationText = turnDecision.text;
@@ -2552,7 +2546,7 @@ export class AddieClaudeClient {
             },
             'Addie Stream: Response stopped before completion',
           );
-          await chargeStreamCost(streamUsage);
+          await chargeStreamCost();
           yield { type: 'text', text: terminal.response.text };
           yield {
             type: 'done',
@@ -2608,7 +2602,7 @@ export class AddieClaudeClient {
               'Addie Stream: Normally completed response exceeded output cap',
             );
           }
-          await chargeStreamCost(streamUsage);
+          await chargeStreamCost();
           yield { type: 'text', text: terminal.response.text };
           yield {
             type: 'done',
@@ -2646,11 +2640,7 @@ export class AddieClaudeClient {
       // Charge the tokens consumed up to the max-iteration wall —
       // the API calls happened regardless of whether we converged.
       if (operationalExecution && options?.costScope) {
-        await recordCost(
-          options.costScope.userId,
-          costModel,
-          maxIterUsage,
-        );
+        await recordAccumulatedCost();
       }
       if (terminal.finalized.lengthExceeded) {
         logger.error(

--- a/server/src/addie/claude-cost-tracker.ts
+++ b/server/src/addie/claude-cost-tracker.ts
@@ -1,9 +1,9 @@
 /**
- * Per-user Anthropic API cost cap (#2790).
+ * Per-user Addie model API cost cap (#2790).
  *
  * Tool-call frequency limits (#2784, #2789) bound OUR external API
  * spend (Google Docs, Gemini, Slack) but don't bound Anthropic spend.
- * Each Addie turn is a Claude API call, and an attacker with a
+ * Each Addie turn is a paid model API call, and an attacker with a
  * compromised account can keep a session running that stays under
  * the tool-call cap while steadily burning dollars on Claude.
  *
@@ -64,6 +64,11 @@ import { createLogger } from '../logger.js';
 import { query } from '../db/client.js';
 import { TIER_PRESERVING_STATUSES } from '../db/organization-db.js';
 import { costUsdMicros, type ClaudeUsage } from './claude-pricing.js';
+import {
+  hasCompleteModelUsage,
+  resolveModelCostPricing,
+} from './model-cost-pricing.js';
+import type { ModelProviderId, ModelUsage } from './model-providers/model-provider.js';
 import { SYSTEM_USER_IDS } from './system-identities.js';
 import type { MemberContext } from './member-context.js';
 
@@ -135,6 +140,8 @@ export type UserTier = CappedTier | 'aao_team';
 
 export interface CostCheckResult {
   ok: boolean;
+  /** No exact reviewed rate exists for the requested provider/model pair. */
+  pricingUnsupported?: boolean;
   /** Cents spent in the current UTC calendar day for the user (rounded from micros). */
   spentCents?: number;
   /** Remaining USD in the budget, floored to 2 decimals. 0 when blocked. */
@@ -159,7 +166,7 @@ export interface CostTrackerStore {
   /** Sum of cost_usd_micros for `key` recorded since the start of the current UTC calendar day. */
   sumSinceUtcMidnight(key: string): Promise<{ totalMicros: number }>;
   /** Persist one charge. */
-  record(key: string, costMicros: number, model: string, usage: ClaudeUsage): Promise<void>;
+  record(key: string, costMicros: number, event: CostEvent): Promise<void>;
   claimCertificationLease(key: string, leaseId: string): Promise<boolean>;
   renewCertificationLease(key: string, leaseId: string): Promise<boolean>;
   releaseCertificationLease(key: string, leaseId: string): Promise<void>;
@@ -186,11 +193,21 @@ class PostgresStore implements CostTrackerStore {
     return { totalMicros: Number(row.total_micros ?? 0) };
   }
 
-  async record(key: string, costMicros: number, model: string, usage: ClaudeUsage): Promise<void> {
+  async record(key: string, costMicros: number, event: CostEvent): Promise<void> {
     await query(
-      `INSERT INTO addie_token_cost_events (scope_key, cost_usd_micros, model, tokens_input, tokens_output)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [key, costMicros, model, usage.input_tokens, usage.output_tokens],
+      `INSERT INTO addie_token_cost_events
+         (scope_key, cost_usd_micros, provider, model, tokens_input, tokens_output, tokens_cache_creation, tokens_cache_read)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        key,
+        costMicros,
+        event.provider,
+        event.model,
+        event.usage.inputTokens,
+        event.usage.outputTokens,
+        event.usage.cacheWriteTokens ?? null,
+        event.usage.cacheReadTokens ?? null,
+      ],
     );
   }
 
@@ -270,8 +287,22 @@ class InMemoryStore implements CostTrackerStore {
 
 let store: CostTrackerStore = new PostgresStore();
 
+/** Canonical provider/model/usage identity for one live cost event. */
+export interface CostEvent {
+  provider: ModelProviderId;
+  model: string;
+  usage: ModelUsage;
+}
+
+function isCurrentPricing(
+  pricing: ReturnType<typeof resolveModelCostPricing>,
+): pricing is NonNullable<ReturnType<typeof resolveModelCostPricing>> {
+  return pricing !== null
+    && (pricing.validBefore === null || Date.now() < pricing.validBefore.getTime());
+}
+
 /**
- * Check whether a user has budget for another Claude call. Returns
+ * Check whether a user has budget for another model call. Returns
  * `{ ok: true }` when allowed. System users and callers without a
  * userId are always allowed — those paths represent system automation
  * or unauthenticated anonymous use that isn't a per-user concern.
@@ -282,8 +313,22 @@ let store: CostTrackerStore = new PostgresStore();
 export async function checkCostCap(
   userId: string | null | undefined,
   tier: UserTier,
-  options?: { certificationReserveUsd?: number },
+  options?: {
+    certificationReserveUsd?: number;
+    selection?: Pick<CostEvent, 'provider' | 'model'>;
+  },
 ): Promise<CostCheckResult> {
+  const pricing = options?.selection
+    ? resolveModelCostPricing(options.selection.provider, options.selection.model)
+    : null;
+  // Preserve Anthropic's established conservative Fable fallback for an
+  // unlisted model. Alternate providers never borrow that rate: they require
+  // an exact, currently reviewed provider/model rate before live dispatch.
+  if (options?.selection
+    && options.selection.provider !== 'anthropic'
+    && !isCurrentPricing(pricing)) {
+    return { ok: false, tier, pricingUnsupported: true };
+  }
   if (!userId) return { ok: true };
   if (SYSTEM_USER_IDS.has(userId)) return { ok: true };
   if (tier === 'aao_team') return { ok: true, tier };
@@ -342,6 +387,23 @@ export async function checkCostCap(
   };
 }
 
+/**
+ * Admit a live model call only when its provider/model pair has an exact,
+ * reviewed rate. This intentionally runs before the normal scope exemptions:
+ * an uncapped system identity must not become a way to dispatch a model whose
+ * spend cannot be accounted for.
+ */
+export async function checkModelCostCap(
+  userId: string | null | undefined,
+  tier: UserTier,
+  selection: Pick<CostEvent, 'provider' | 'model'>,
+  options?: { certificationReserveUsd?: number },
+): Promise<CostCheckResult> {
+  const pricing = resolveModelCostPricing(selection.provider, selection.model);
+  if (!isCurrentPricing(pricing)) return { ok: false, tier, pricingUnsupported: true };
+  return checkCostCap(userId, tier, options);
+}
+
 export async function releaseCertificationReserve(
   userId: string | null | undefined,
   leaseId: string | undefined,
@@ -368,20 +430,92 @@ export async function renewCertificationReserve(
 }
 
 /**
- * Record an invocation's cost to the user's daily accumulator. Safe
- * to call without a userId (no-op) so the caller can always invoke
- * it post-response without branching.
+ * Record one live provider-normalized usage event. Unsupported provider/model
+ * pairs and incomplete usage are intentionally rejected rather than guessed;
+ * callers have already completed cost admission before dispatch. It is safe
+ * to call without a userId, which remains a no-op.
  */
+export async function recordModelCost(
+  userId: string | null | undefined,
+  event: CostEvent,
+): Promise<boolean> {
+  const pricing = resolveModelCostPricing(event.provider, event.model);
+  if (!hasCompleteModelUsage(event.usage) || (event.provider !== 'anthropic' && !isCurrentPricing(pricing))) {
+    logger.error(
+      { provider: event.provider, model: event.model },
+      'Refusing to record Addie model cost without exact pricing and complete normalized usage',
+    );
+    return false;
+  }
+  if (!userId || SYSTEM_USER_IDS.has(userId)) return true;
+  // The legacy Anthropic Fable fallback is intentionally retained for
+  // unlisted Anthropic response models. It cannot be reached by any other
+  // provider, which must have an exact reviewed rate above.
+  const micros = isCurrentPricing(pricing)
+    ? pricing.estimateCostMicros(event.usage)
+    : costUsdMicros(event.model, {
+        input_tokens: event.usage.inputTokens,
+        output_tokens: event.usage.outputTokens,
+        cache_creation_input_tokens: event.usage.cacheWriteTokens,
+        cache_read_input_tokens: event.usage.cacheReadTokens,
+      });
+  try {
+    await store.record(userId, micros, event);
+    return true;
+  } catch (err) {
+    // Accounting failures shouldn't block the user's response — the call
+    // already happened. Keep the existing documented tolerance while logging
+    // enough provenance for operations to diagnose the missing event.
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      { error: message, userId, provider: event.provider, model: event.model, micros },
+      'Failed to record Addie model cost event',
+    );
+    return false;
+  }
+}
+
+/**
+ * Backwards-compatible overload for callers/tests that still supply
+ * Anthropic SDK-shaped usage. The event overload is the live delivery seam.
+ */
+export async function recordCost(
+  userId: string | null | undefined,
+  event: CostEvent,
+): Promise<void>;
 export async function recordCost(
   userId: string | null | undefined,
   model: string,
   usage: ClaudeUsage,
+): Promise<void>;
+export async function recordCost(
+  userId: string | null | undefined,
+  model: string | CostEvent,
+  usage?: ClaudeUsage,
 ): Promise<void> {
+  if (typeof model !== 'string') {
+    await recordModelCost(userId, model);
+    return;
+  }
+  if (!usage) return;
   if (!userId) return;
   if (SYSTEM_USER_IDS.has(userId)) return;
   const micros = costUsdMicros(model, usage);
   try {
-    await store.record(userId, micros, model, usage);
+    await store.record(userId, micros, {
+      provider: 'anthropic',
+      model,
+      usage: {
+        inputTokens: usage.input_tokens,
+        outputTokens: usage.output_tokens,
+        ...(usage.cache_creation_input_tokens !== undefined && {
+          cacheWriteTokens: usage.cache_creation_input_tokens,
+        }),
+        ...(usage.cache_read_input_tokens !== undefined && {
+          cacheReadTokens: usage.cache_read_input_tokens,
+        }),
+      },
+    });
   } catch (err) {
     // Accounting failures shouldn't block the user's response —
     // the call already happened and a dropped accounting row is
@@ -398,6 +532,9 @@ export async function recordCost(
  * understands what happened.
  */
 export function formatCapExceededMessage(result: CostCheckResult): string {
+  if (result.pricingUnsupported) {
+    return 'This conversation model is temporarily unavailable while its usage accounting is configured.';
+  }
   if (result.reserveBusy) {
     return 'A certification completion reply is already processing. Please wait a moment and reload this conversation.';
   }

--- a/server/src/addie/claude-pricing.ts
+++ b/server/src/addie/claude-pricing.ts
@@ -99,5 +99,19 @@ export function hasKnownClaudePricing(model: string): boolean {
   return Object.prototype.hasOwnProperty.call(PRICING_PER_MILLION_TOKENS, model);
 }
 
+/**
+ * Resolve a dated Anthropic response identifier to its reviewed canonical
+ * model family. Anthropic returns dated revisions such as
+ * `claude-sonnet-4-6-20260801`; each is priced at its explicit canonical
+ * model's reviewed rate, while unrelated/unknown families still use the
+ * legacy conservative fallback in `costUsdMicros`.
+ */
+export function resolveKnownClaudePricingModel(model: string): string | null {
+  if (hasKnownClaudePricing(model)) return model;
+  return Object.keys(PRICING_PER_MILLION_TOKENS)
+    .filter((knownModel) => new RegExp(`^${knownModel}-\\d{8}$`).test(model))
+    .sort((a, b) => b.length - a.length)[0] ?? null;
+}
+
 /** Backwards-compatible test helper. */
 export const __hasKnownPricing = hasKnownClaudePricing;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.5';
+export const CODE_VERSION = '2026.09.6';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -12,7 +12,7 @@
     "note": "Directional consolidation target; current exact baselines remain the enforced no-growth ceilings."
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "bf5cb67c4758273aea1674b88e1b8b765724d90d807ba1ab587892b9a72e03a9",
+    "server/src/addie/claude-client.ts": "59c7837d61651012d7c4362c962c527aaf4ae186ec4d55b9d6f7817a2d70d632",
     "server/src/addie/prompts.ts": "27be3d63dfaa3c0335f1ec2213c0ee81369e705f056a341f9bc25fd8800191e9",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/jobs/shadow-replay-pricing.ts
+++ b/server/src/addie/jobs/shadow-replay-pricing.ts
@@ -1,13 +1,11 @@
 import {
-  CLAUDE_PRICING_VERSION,
-  costUsdMicros,
-  hasKnownClaudePricing,
-} from '../claude-pricing.js';
+  GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION,
+  resolveModelCostPricing,
+} from '../model-cost-pricing.js';
 import type { ModelProviderId } from '../model-providers/model-provider.js';
-import { GOOGLE_ROUTER_MODEL } from '../model-providers/google-generate-content-provider.js';
 
 export const GOOGLE_SHADOW_REPLAY_PRICING_VERSION =
-  'google-gemini-3.7-flash-through-2026-12-31' as const;
+  GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION;
 
 export interface ShadowReplayUsage {
   inputTokens: number;
@@ -29,43 +27,10 @@ export function resolveShadowReplayPricing(
   provider: ModelProviderId,
   model: string,
 ): ShadowReplayPricing | null {
-  if (provider === 'anthropic' && hasKnownClaudePricing(model)) {
-    return {
-      provider,
-      model,
-      version: `${CLAUDE_PRICING_VERSION}:${model}`,
-      validBefore: null,
-      estimateCostMicros: (usage) => costUsdMicros(model, {
-        input_tokens: usage.inputTokens,
-        output_tokens: usage.outputTokens,
-        cache_read_input_tokens: usage.cacheReadTokens,
-        cache_creation_input_tokens: usage.cacheWriteTokens,
-      }),
-    };
-  }
-  if (provider === 'google' && model === GOOGLE_ROUTER_MODEL) {
-    return {
-      provider,
-      model,
-      version: GOOGLE_SHADOW_REPLAY_PRICING_VERSION,
-      validBefore: new Date('2027-01-01T00:00:00.000Z'),
-      // Official standard pricing checked 2026-08-30: $0.75/M input,
-      // $0.075/M cached input, and $3.75/M output (including thought tokens).
-      // A malformed cache count is conservatively charged in addition to the
-      // full input count instead of allowing a negative uncached denominator.
-      estimateCostMicros: (usage) => {
-        const cacheWithinInput = usage.cacheReadTokens <= usage.inputTokens;
-        const uncachedInput = cacheWithinInput
-          ? usage.inputTokens - usage.cacheReadTokens
-          : usage.inputTokens;
-        return Math.ceil(
-          uncachedInput * 0.75
-          + usage.cacheReadTokens * 0.075
-          + usage.cacheWriteTokens * 0.75
-          + usage.outputTokens * 3.75,
-        );
-      },
-    };
-  }
-  return null;
+  const pricing = resolveModelCostPricing(provider, model);
+  if (!pricing) return null;
+  return {
+    ...pricing,
+    estimateCostMicros: (usage) => pricing.estimateCostMicros(usage),
+  };
 }

--- a/server/src/addie/model-cost-pricing.ts
+++ b/server/src/addie/model-cost-pricing.ts
@@ -1,0 +1,104 @@
+/**
+ * Reviewed live pricing for provider-normalized Addie model usage.
+ *
+ * This is deliberately a static, exact provider/model registry. A provider
+ * activation must add its rate here in the same reviewed change; it must not
+ * inherit another provider's fallback rate.
+ */
+
+import {
+  CLAUDE_PRICING_VERSION,
+  costUsdMicros,
+  resolveKnownClaudePricingModel,
+} from './claude-pricing.js';
+import {
+  GOOGLE_ROUTER_MODEL,
+  isGoogleRouterModelRevision,
+} from './model-providers/google-generate-content-provider.js';
+import type { ModelProviderId, ModelUsage } from './model-providers/model-provider.js';
+
+export const GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION =
+  'google-gemini-3.7-flash-through-2026-12-31' as const;
+
+export interface ModelCostPricing {
+  provider: ModelProviderId;
+  model: string;
+  version: string;
+  validBefore: Date | null;
+  estimateCostMicros: (usage: ModelUsage) => number;
+}
+
+/** A complete provider-normalized usage tuple is required for live charging. */
+export function hasCompleteModelUsage(usage: unknown): usage is ModelUsage {
+  if (!usage || typeof usage !== 'object') return false;
+  const value = usage as Record<string, unknown>;
+  const isSafeCount = (count: unknown): count is number =>
+    typeof count === 'number' && Number.isSafeInteger(count) && count >= 0;
+  return isSafeCount(value.inputTokens)
+    && isSafeCount(value.outputTokens)
+    && (value.cacheReadTokens === undefined || isSafeCount(value.cacheReadTokens))
+    && (value.cacheWriteTokens === undefined || isSafeCount(value.cacheWriteTokens));
+}
+
+/**
+ * Resolve only reviewed provider/model rates. Provider adapters may return an
+ * explicitly accepted dated revision of their requested canonical model; that
+ * revision is recorded verbatim, while this registry prices it by the one
+ * reviewed canonical rate. No other provider/model family is inferred.
+ */
+export function resolveModelCostPricing(
+  provider: ModelProviderId | string,
+  model: string,
+): ModelCostPricing | null {
+  const canonicalAnthropicModel = provider === 'anthropic'
+    ? resolveKnownClaudePricingModel(model)
+    : null;
+  if (provider === 'anthropic' && canonicalAnthropicModel) {
+    return {
+      provider: 'anthropic',
+      model,
+      version: `${CLAUDE_PRICING_VERSION}:${canonicalAnthropicModel}`,
+      validBefore: null,
+      estimateCostMicros: (usage) => costUsdMicros(canonicalAnthropicModel, {
+        input_tokens: usage.inputTokens,
+        output_tokens: usage.outputTokens,
+        cache_read_input_tokens: usage.cacheReadTokens,
+        cache_creation_input_tokens: usage.cacheWriteTokens,
+      }),
+    };
+  }
+  // Google Generate Content accepts this canonical router model and its
+  // provider-returned eight-digit dated revisions (for example `...-20260801`). Keep this
+  // mapping here, beside the reviewed rate, rather than falling back to any
+  // other model or provider price.
+  const canonicalGoogleModel = provider === 'google'
+    && isGoogleRouterModelRevision(model)
+    ? GOOGLE_ROUTER_MODEL
+    : null;
+  if (canonicalGoogleModel) {
+    return {
+      provider: 'google',
+      model,
+      version: GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION,
+      validBefore: new Date('2027-01-01T00:00:00.000Z'),
+      // Official standard pricing checked 2026-08-30: $0.75/M input,
+      // $0.075/M cached input, and $3.75/M output (including thought tokens).
+      // A cache-read count above input is charged in addition to all input,
+      // rather than deriving a negative uncached-input count.
+      estimateCostMicros: (usage) => {
+        const cacheReadTokens = usage.cacheReadTokens ?? 0;
+        const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
+        const uncachedInput = cacheReadTokens <= usage.inputTokens
+          ? usage.inputTokens - cacheReadTokens
+          : usage.inputTokens;
+        return Math.ceil(
+          uncachedInput * 0.75
+          + cacheReadTokens * 0.075
+          + cacheWriteTokens * 0.75
+          + usage.outputTokens * 3.75,
+        );
+      },
+    };
+  }
+  return null;
+}

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -24,6 +24,11 @@ import { validateNormalizedModelResponse } from './events.js';
 
 export const GOOGLE_ROUTER_MODEL = 'gemini-3.7-flash';
 
+/** Provider-returned dated revisions accepted for the frozen router model. */
+export function isGoogleRouterModelRevision(model: string): boolean {
+  return model === GOOGLE_ROUTER_MODEL || /^gemini-3\.7-flash-\d{8}$/.test(model);
+}
+
 export interface GoogleGenerateContentTransport {
   models: {
     generateContent(
@@ -405,7 +410,7 @@ export class GoogleGenerateContentProvider implements ModelProvider {
       { signal: options.signal },
     );
     const normalized = normalizeGoogleResponse(response);
-    if (normalized.model !== request.model && !normalized.model.startsWith(`${request.model}-`)) {
+    if (!isGoogleRouterModelRevision(normalized.model)) {
       throw new UnexpectedModelIdentityError('google', request.model, normalized.model);
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };

--- a/server/src/addie/model-providers/model-turn.ts
+++ b/server/src/addie/model-providers/model-turn.ts
@@ -34,6 +34,13 @@ export interface AcceptedModelTurn extends InspectedModelTurn {
   discardedRecoveryToolCalls: boolean;
 }
 
+/** Complete normalized usage grouped by the exact provider/model that produced it. */
+export interface AccountedModelUsage {
+  provider: ModelProviderId;
+  model: string;
+  usage: ModelUsage;
+}
+
 /** Append one canonical assistant continuation and any custom-tool results. */
 export function appendModelTurnContinuation(
   messages: ModelMessage[],
@@ -175,6 +182,7 @@ export class ModelTurnLoopState {
   readonly emptyResponseRecovery = new EmptyResponseRecoveryState();
   private readonly budget: ModelLoopBudget;
   private accumulatedUsage: ModelUsage = { inputTokens: 0, outputTokens: 0 };
+  private readonly usageByProviderModel = new Map<ModelProviderId, Map<string, ModelUsage>>();
   private awaitingResponse = false;
   private continuationProvider: ModelProviderId | null = null;
 
@@ -196,6 +204,21 @@ export class ModelTurnLoopState {
 
   get usage(): ModelUsage {
     return { ...this.accumulatedUsage };
+  }
+
+  /**
+   * Exact provider/model usage buckets for cost accounting. Same-identity
+   * turns stay aggregated to preserve established rounding behavior; a model
+   * change is never priced as though it were the previous model.
+   */
+  get accountedUsage(): AccountedModelUsage[] {
+    return [...this.usageByProviderModel.entries()].flatMap(([provider, byModel]) => (
+      [...byModel.entries()].map(([model, usage]) => ({
+        provider,
+        model,
+        usage: { ...usage },
+      }))
+    ));
   }
 
   /**
@@ -260,6 +283,12 @@ export class ModelTurnLoopState {
     }
     if (options.countUsage !== false) {
       this.accumulatedUsage = addModelUsage(this.accumulatedUsage, acceptedResponse.usage);
+      const byModel = this.usageByProviderModel.get(acceptedResponse.provider) ?? new Map<string, ModelUsage>();
+      byModel.set(
+        acceptedResponse.model,
+        addModelUsage(byModel.get(acceptedResponse.model) ?? { inputTokens: 0, outputTokens: 0 }, acceptedResponse.usage),
+      );
+      this.usageByProviderModel.set(acceptedResponse.provider, byModel);
     }
     this.awaitingResponse = false;
     return Object.freeze({

--- a/server/src/db/migrations/574_addie_token_cost_event_provider_usage.sql
+++ b/server/src/db/migrations/574_addie_token_cost_event_provider_usage.sql
@@ -1,0 +1,22 @@
+-- Provider-neutral provenance for the live Addie daily-cost ledger.
+--
+-- Existing rows and rolling writes from older replicas are Anthropic by
+-- construction, so the default preserves their meaning while new live calls
+-- persist the canonical provider/model and complete normalized cache usage.
+
+ALTER TABLE addie_token_cost_events
+  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'anthropic'
+    CHECK (provider IN ('anthropic', 'openai', 'google')),
+  ADD COLUMN IF NOT EXISTS tokens_cache_creation INTEGER
+    CHECK (tokens_cache_creation IS NULL OR tokens_cache_creation >= 0),
+  ADD COLUMN IF NOT EXISTS tokens_cache_read INTEGER
+    CHECK (tokens_cache_read IS NULL OR tokens_cache_read >= 0);
+
+COMMENT ON COLUMN addie_token_cost_events.provider IS
+  'Canonical model provider that incurred this live cost event; historical and rolling legacy rows default to anthropic.';
+COMMENT ON COLUMN addie_token_cost_events.model IS
+  'Exact reviewed model identifier used by the provider-neutral cost-pricing registry.';
+COMMENT ON COLUMN addie_token_cost_events.tokens_cache_creation IS
+  'Normalized cache-write tokens when reported; NULL means unavailable, not zero.';
+COMMENT ON COLUMN addie_token_cost_events.tokens_cache_read IS
+  'Normalized cache-read tokens when reported; NULL means unavailable, not zero.';

--- a/server/tests/unit/addie-empty-response-fallback.test.ts
+++ b/server/tests/unit/addie-empty-response-fallback.test.ts
@@ -674,7 +674,7 @@ describe('Addie empty-response fallback (#4430)', () => {
     expect(mocks.notifySystemError).not.toHaveBeenCalled();
   });
 
-  it('charges aggregate initial-recovery usage once per streaming and non-streaming interaction', async () => {
+  it('charges initial-recovery usage by exact provider/model identity', async () => {
     mocks.createMessage
       .mockResolvedValueOnce(emptyEndTurn)
       .mockResolvedValueOnce(recoveredEndTurn);
@@ -699,18 +699,42 @@ describe('Addie empty-response fallback (#4430)', () => {
       // Consume the complete response so terminal billing runs.
     }
 
-    expect(mocks.recordCost).toHaveBeenCalledTimes(2);
+    expect(mocks.recordCost).toHaveBeenCalledTimes(4);
     expect(mocks.recordCost).toHaveBeenNthCalledWith(
       1,
       'user-nonstream',
-      'claude-sonnet-5',
-      expect.objectContaining({ input_tokens: 22, output_tokens: 6 }),
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6-20260801',
+        usage: expect.objectContaining({ inputTokens: 10, outputTokens: 0 }),
+      }),
     );
     expect(mocks.recordCost).toHaveBeenNthCalledWith(
       2,
+      'user-nonstream',
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-5-20260801',
+        usage: expect.objectContaining({ inputTokens: 12, outputTokens: 6 }),
+      }),
+    );
+    expect(mocks.recordCost).toHaveBeenNthCalledWith(
+      3,
       'user-stream',
-      'claude-sonnet-5',
-      expect.objectContaining({ input_tokens: 22, output_tokens: 6 }),
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6-20260801',
+        usage: expect.objectContaining({ inputTokens: 10, outputTokens: 0 }),
+      }),
+    );
+    expect(mocks.recordCost).toHaveBeenNthCalledWith(
+      4,
+      'user-stream',
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-5-20260801',
+        usage: expect.objectContaining({ inputTokens: 12, outputTokens: 6 }),
+      }),
     );
   });
 

--- a/server/tests/unit/addie-response-truncation.test.ts
+++ b/server/tests/unit/addie-response-truncation.test.ts
@@ -658,8 +658,11 @@ describe('Addie response truncation (#4431)', () => {
     expect(mocks.recordCost).toHaveBeenCalledOnce();
     expect(mocks.recordCost).toHaveBeenCalledWith(
       'user-4431',
-      'claude-sonnet-5',
-      expect.objectContaining({ input_tokens: 8, output_tokens: 10 }),
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6-20260801',
+        usage: expect.objectContaining({ inputTokens: 8, outputTokens: 10 }),
+      }),
     );
   });
 });

--- a/server/tests/unit/addie/claude-client-model-fallback.test.ts
+++ b/server/tests/unit/addie/claude-client-model-fallback.test.ts
@@ -172,8 +172,11 @@ describe('Addie provider delivery runtime', () => {
     });
     expect(mocks.recordCost).toHaveBeenCalledWith(
       'fallback-user',
-      AddieModelConfig.chat,
-      expect.objectContaining({ input_tokens: 12, output_tokens: 4 }),
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: AddieModelConfig.chat,
+        usage: expect.objectContaining({ inputTokens: 12, outputTokens: 4 }),
+      }),
     );
   });
 

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -15,6 +15,7 @@ import {
   type GoogleGenerateContentTransport,
 } from '../../../src/addie/model-providers/google-generate-content-provider.js';
 import {
+  UnexpectedModelIdentityError,
   UnsupportedModelCapabilityError,
   type ModelRequest,
 } from '../../../src/addie/model-providers/model-provider.js';
@@ -327,6 +328,17 @@ describe('OpenAIResponsesProvider', () => {
     await expect(collectModelResponse(
       provider.respond(request(OPENAI_ROUTER_MODEL), { stream: true }),
     )).rejects.toBeInstanceOf(UnsupportedModelCapabilityError);
+  });
+
+  it('rejects a non-dated returned Google model suffix', async () => {
+    const transport: GoogleGenerateContentTransport = {
+      models: { generateContent: vi.fn().mockResolvedValue(googleResponse({
+        modelVersion: 'gemini-3.7-flash-preview',
+      })) },
+    };
+    const provider = new GoogleGenerateContentProvider('unused', transport);
+    await expect(collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL))))
+      .rejects.toBeInstanceOf(UnexpectedModelIdentityError);
   });
 
   it('omits unavailable optional cache usage fields', () => {

--- a/server/tests/unit/claude-cost-tracker.test.ts
+++ b/server/tests/unit/claude-cost-tracker.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   checkCostCap,
+  checkModelCostCap,
   recordCost,
+  recordModelCost,
   formatCapExceededMessage,
   releaseCertificationReserve,
   resolveUserTier,
@@ -148,6 +150,121 @@ describe('recordCost', () => {
     // Sonnet: 10_000*3 + 5000*15 = 105_000 micros
     // Total = 140_000 micros = $0.14 = 14 cents
     expect(result.spentCents).toBe(14);
+  });
+});
+
+describe('provider-neutral live cost accounting', () => {
+  it('admits and records a reviewed Anthropic model with the established price', async () => {
+    const admission = await checkModelCostCap('u-live-anthropic', 'member_free', {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(admission.ok).toBe(true);
+
+    expect(await recordModelCost('u-live-anthropic', {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      usage: { inputTokens: 10_000, outputTokens: 5_000 },
+    })).toBe(true);
+
+    expect((await checkCostCap('u-live-anthropic', 'member_free')).spentCents).toBe(11);
+  });
+
+  it('admits and records the explicit reviewed Gemini price against the same daily cap', async () => {
+    const admission = await checkModelCostCap('u-live-gemini', 'anonymous', {
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+    });
+    expect(admission.ok).toBe(true);
+
+    expect(await recordModelCost('u-live-gemini', {
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+      usage: { inputTokens: 4_000_000, outputTokens: 0 },
+    })).toBe(true);
+
+    expect((await checkCostCap('u-live-gemini', 'anonymous')).ok).toBe(false);
+  });
+
+  it('records an explicitly accepted dated Gemini revision at its canonical reviewed rate', async () => {
+    // The Google provider contract accepts dated response model revisions for
+    // this configured router model. They must resolve to the same reviewed
+    // rate used by admission, while the exact returned identifier is retained.
+    expect(await recordModelCost('u-live-gemini-revision', {
+      provider: 'google',
+      model: 'gemini-3.7-flash-20260801',
+      usage: { inputTokens: 1_000_000, outputTokens: 0 },
+    })).toBe(true);
+
+    expect((await checkCostCap('u-live-gemini-revision', 'member_free')).spentCents).toBe(75);
+  });
+
+  it('rejects unreviewed same-family model suffixes rather than guessing their rate', async () => {
+    const selection = { provider: 'google' as const, model: 'gemini-3.7-flash-preview' };
+    await expect(checkModelCostCap('u-unreviewed-suffix', 'member_free', selection))
+      .resolves.toMatchObject({ ok: false, pricingUnsupported: true });
+    expect(await recordModelCost('u-unreviewed-suffix', {
+      ...selection,
+      usage: { inputTokens: 1_000, outputTokens: 1_000 },
+    })).toBe(false);
+  });
+
+  it('rejects unknown provider/model pairs before admission and does not record them', async () => {
+    const selection = { provider: 'openai', model: 'gpt-unreviewed' } as const;
+    const admission = await checkModelCostCap('u-unknown-provider', 'member_free', selection);
+    expect(admission).toMatchObject({ ok: false, pricingUnsupported: true });
+    await expect(checkModelCostCap('u-unknown-model', 'member_free', {
+      provider: 'google',
+      model: 'gemini-unreviewed',
+    })).resolves.toMatchObject({ ok: false, pricingUnsupported: true });
+    expect(await recordModelCost('u-unknown-provider', {
+      ...selection,
+      usage: { inputTokens: 1_000, outputTokens: 1_000 },
+    })).toBe(false);
+    expect((await checkCostCap('u-unknown-provider', 'member_free')).spentCents).toBe(0);
+  });
+
+  it('rejects incomplete normalized usage without silently recording zero cost', async () => {
+    expect(await recordModelCost('u-incomplete-usage', {
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+      usage: { inputTokens: 1_000 } as never,
+    })).toBe(false);
+    expect((await checkCostCap('u-incomplete-usage', 'member_free')).spentCents).toBe(0);
+  });
+
+  it('fails closed when the reviewed Gemini price expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2027-01-01T00:00:00.000Z'));
+    try {
+      const event = {
+        provider: 'google' as const,
+        model: 'gemini-3.7-flash',
+        usage: { inputTokens: 1_000, outputTokens: 0 },
+      };
+      await expect(checkModelCostCap('u-expired-gemini', 'member_free', event))
+        .resolves.toMatchObject({ ok: false, pricingUnsupported: true });
+      await expect(recordModelCost('u-expired-gemini', event)).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('accumulates Anthropic and Gemini spend in one user/day budget', async () => {
+    await recordModelCost('u-mixed-provider', {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      usage: { inputTokens: 1_000_000, outputTokens: 0 },
+    });
+    await recordModelCost('u-mixed-provider', {
+      provider: 'google',
+      model: 'gemini-3.7-flash',
+      usage: { inputTokens: 1_000_000, outputTokens: 0 },
+    });
+
+    const result = await checkCostCap('u-mixed-provider', 'member_free');
+    expect(result.spentCents).toBe(375);
+    expect(result.remainingUsd).toBeCloseTo(1.25, 4);
   });
 });
 


### PR DESCRIPTION
## Summary
- Make the live Addie daily-cost ledger record canonical provider, exact returned model identity, and normalized cache usage.
- Add a static reviewed provider/model pricing registry shared with shadow replay; Gemini 3.7 Flash is explicit, expires on 2027-01-01, and unsupported or incomplete non-Anthropic usage fails closed.
- Preserve existing Anthropic pricing and its documented conservative unknown-model fallback; all providers accumulate against the existing per-user UTC-day cap.

## Rollout boundary
This is a future Gemini full-response rollout prerequisite only. It does **not** activate Gemini, change provider selection/fallback, or modify environments, secrets, or the existing $25 member-paid daily cap. Gemini's lower reviewed price may increase request headroom, but it does not remove that hard daily cap.

## Validation
- Clean-environment `npm run precommit` (with `ADCP_TIMEOUT_SCALE=2` after the normal repository timeout expired without a test failure): 68 root files / 1,056 root tests, plus 540 server files / 7,796 passed / 30 skipped
- `npm run build`
- Normal clean-environment commit hook
- Focused provider-accounting tests (154 tests), migration validation, generated Addie inventory/reference/portability checks, and diff check
- Independent code and security reviews

Related to #6844.