### PR TITLE
fix(addie): add long-form incident evaluations

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.6';
+export const CODE_VERSION = '2026.09.7';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-incident-eval.ts
+++ b/server/src/addie/eval/fixed-trace-incident-eval.ts
@@ -1,0 +1,338 @@
+import { createHash } from 'node:crypto';
+import type { GenerateContentResponse } from '@google/genai';
+import {
+  AddieClaudeClient,
+  type AddieResponse,
+  type StreamEvent,
+} from '../claude-client.js';
+import {
+  MAX_INPUT_LENGTH,
+  MAX_OUTPUT_LENGTH,
+  OUTPUT_TRUNCATION_SUFFIX,
+  sanitizeInput,
+} from '../security.js';
+import type {
+  ModelProvider,
+  ModelProviderId,
+  ModelRequest,
+  ModelRespondOptions,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../model-providers/model-provider.js';
+import {
+  AnthropicModelProvider,
+  type AnthropicMessagesTransport,
+} from '../model-providers/anthropic-provider.js';
+import {
+  GoogleGenerateContentProvider,
+  GOOGLE_ROUTER_MODEL,
+  type GoogleGenerateContentTransport,
+} from '../model-providers/google-generate-content-provider.js';
+import {
+  FIXED_TRACE_SUITE,
+  FIXED_TRACE_SUITE_VERSION,
+  fixedTraceSuiteSha256,
+  type FixedTraceCase,
+} from './fixed-trace-suite.js';
+
+export const FIXED_TRACE_INCIDENT_EVAL_VERSION = 'addie-fixed-trace-incidents-v1';
+
+const LEGACY_INPUT_BOUNDARY = 4_000;
+const PROVIDERS = ['anthropic', 'google'] as const satisfies readonly ModelProviderId[];
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function responseFixture(): string {
+  return [
+    '## Long-form delivery fixture',
+    '',
+    'The cobalt release gate requires an owner approval. Retain the evidence appendix for 48 hours. The final recommendation names the verified handoff.',
+    '',
+    ...Array.from(
+      { length: 360 },
+      (_, index) => `- [Delivery checkpoint ${String(index + 1).padStart(3, '0')}](https://fixture.test/checkpoint/${index + 1}): synthetic evidence, accountable owner, review status, and implementation handoff`,
+    ),
+  ].join('\n');
+}
+
+const LONG_FORM_RESPONSE_FIXTURE = responseFixture();
+
+/**
+ * Captures a real adapter's exact prepared request while its injected transport
+ * supplies deterministic, no-network responses.
+ */
+class CapturingProvider implements ModelProvider {
+  readonly prepared: PreparedModelInvocation[] = [];
+
+  constructor(
+    private readonly delegate: ModelProvider,
+  ) {}
+
+  get id(): ModelProviderId { return this.delegate.id; }
+  get capabilities() { return this.delegate.capabilities; }
+
+  prepare(request: ModelRequest): PreparedModelInvocation {
+    return this.delegate.prepare(request);
+  }
+
+  async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    for await (const event of this.delegate.respond(request, {
+      ...options,
+      beforeDispatch: async (prepared) => {
+        this.prepared.push(prepared);
+        await options.beforeDispatch?.(prepared);
+      },
+    })) {
+      yield event;
+    }
+  }
+}
+
+function anthropicProvider(): CapturingProvider {
+  const response = {
+    id: 'fixed-trace-anthropic-response',
+    model: 'claude-fixed-trace-eval',
+    content: [{ type: 'text', text: LONG_FORM_RESPONSE_FIXTURE }],
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1_000, output_tokens: 2_000 },
+  };
+  const transport: AnthropicMessagesTransport = {
+    beta: {
+      messages: {
+        create: async () => response,
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            for (const text of [
+              LONG_FORM_RESPONSE_FIXTURE.slice(0, 2_000),
+              LONG_FORM_RESPONSE_FIXTURE.slice(2_000, 7_000),
+              LONG_FORM_RESPONSE_FIXTURE.slice(7_000),
+            ]) {
+              if (text) yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } };
+            }
+          },
+          finalMessage: async () => response,
+        }),
+      },
+    },
+  };
+  return new CapturingProvider(new AnthropicModelProvider('', transport, { transportMaxRetries: 0 }));
+}
+
+function googleProvider(): CapturingProvider {
+  const response = {
+    responseId: 'fixed-trace-google-response',
+    modelVersion: GOOGLE_ROUTER_MODEL,
+    usageMetadata: { promptTokenCount: 1_000, candidatesTokenCount: 2_000 },
+    candidates: [{
+      finishReason: 'STOP',
+      content: { role: 'model', parts: [{ text: LONG_FORM_RESPONSE_FIXTURE }] },
+    }],
+  } as GenerateContentResponse;
+  const transport: GoogleGenerateContentTransport = {
+    models: {
+      generateContent: async () => response,
+    },
+  };
+  return new CapturingProvider(new GoogleGenerateContentProvider('', transport));
+}
+
+interface DeliveryObservation {
+  response: AddieResponse;
+  emittedText: string;
+  prepared: PreparedModelInvocation;
+}
+
+async function deliver(
+  trace: FixedTraceCase,
+  provider: ModelProviderId,
+  delivery: 'json' | 'stream',
+): Promise<DeliveryObservation> {
+  const adapter = provider === 'anthropic' ? anthropicProvider() : googleProvider();
+  const model = provider === 'anthropic' ? 'claude-fixed-trace-eval' : GOOGLE_ROUTER_MODEL;
+  const client = new AddieClaudeClient('', model, undefined, {
+    provider: adapter,
+  });
+  const sanitized = sanitizeInput(trace.request.message).sanitized;
+  if (delivery === 'json') {
+    const response = await client.processMessage(sanitized, undefined, undefined, undefined, {
+      executionMode: 'evaluation',
+    });
+    const prepared = adapter.prepared.at(-1);
+    if (!prepared) throw new Error('Fixed trace incident provider was not dispatched');
+    return { response, emittedText: response.text, prepared };
+  }
+
+  const events: StreamEvent[] = [];
+  for await (const event of client.processMessageStream(sanitized, undefined, undefined, {
+    executionMode: 'evaluation',
+  })) events.push(event);
+  const response = events.find((event): event is Extract<StreamEvent, { type: 'done' }> => event.type === 'done')?.response;
+  if (!response) throw new Error('Fixed trace incident stream did not terminate');
+  const prepared = adapter.prepared.at(-1);
+  if (!prepared) throw new Error('Fixed trace incident provider was not dispatched');
+  return {
+    response,
+    emittedText: events
+      .filter((event): event is Extract<StreamEvent, { type: 'text' }> => event.type === 'text')
+      .map((event) => event.text)
+      .join(''),
+    prepared,
+  };
+}
+
+function providerRequestContains(
+  prepared: PreparedModelInvocation,
+  markers: readonly string[],
+): boolean {
+  const serialized = JSON.stringify(prepared.providerRequest);
+  return markers.every((marker) => serialized.includes(marker));
+}
+
+function validMarkdownDeliveryBoundary(text: string): boolean {
+  const suffix = `\n\n${OUTPUT_TRUNCATION_SUFFIX}`;
+  if (!text.endsWith(suffix) || text.includes('\uFFFD')) return false;
+  const body = text.slice(0, -suffix.length);
+  let cursor = 0;
+  while (true) {
+    const open = body.indexOf('[', cursor);
+    if (open === -1) break;
+    const labelEnd = body.indexOf('](', open + 1);
+    const destinationEnd = labelEnd === -1 ? -1 : body.indexOf(')', labelEnd + 2);
+    if (labelEnd === -1 || destinationEnd === -1) return false;
+    cursor = destinationEnd + 1;
+  }
+  return /^- \[Delivery checkpoint \d{3}\]\(https:\/\/fixture\.test\/checkpoint\/\d+\): synthetic evidence, accountable owner, review status, and implementation handoff$/.test(body.split('\n').at(-1) ?? '');
+}
+
+function terminalProjection(response: AddieResponse) {
+  return {
+    text: response.text,
+    toolsUsed: response.tools_used,
+    toolExecutions: response.tool_executions,
+    flagged: response.flagged,
+    flagReason: response.flag_reason,
+    activeRuleIds: response.active_rule_ids,
+    modelExecution: response.model_execution,
+    usage: response.usage,
+    // Capacity/reserve fields are operational-admission metadata. Isolated
+    // evaluation intentionally does not exercise that production-only path.
+  };
+}
+
+function providerNeutralProjection(response: AddieResponse) {
+  const { modelExecution, ...terminal } = terminalProjection(response);
+  return {
+    ...terminal,
+    modelExecution: modelExecution.source === 'provider'
+      ? {
+          source: modelExecution.source,
+          modelResolution: modelExecution.model_resolution,
+          fallbackReason: modelExecution.fallback_reason,
+        }
+      : { source: modelExecution.source, reason: modelExecution.reason },
+  };
+}
+
+export interface FixedTraceIncidentEvalArtifact {
+  artifactVersion: typeof FIXED_TRACE_INCIDENT_EVAL_VERSION;
+  traceSuiteVersion: typeof FIXED_TRACE_SUITE_VERSION;
+  traceSuiteSha256: string;
+  fixtureSha256: string;
+  traceId: string;
+  noNetwork: true;
+  passed: boolean;
+  dimensions: {
+    inputAboveLegacyBoundary: boolean;
+    inputWithinCurrentBoundary: boolean;
+    inputPreservedBySanitizer: boolean;
+    latePromptCoverage: boolean;
+    retainedCoverage: boolean;
+    retainedLength: boolean;
+    markdownBoundary: boolean;
+    jsonStreamParity: boolean;
+    providerParity: boolean;
+  };
+  deliveries: Array<{
+    provider: ModelProviderId;
+    json: { outputLength: number; outputSha256: string; providerRequestSha256: string };
+    stream: { outputLength: number; outputSha256: string; providerRequestSha256: string } | null;
+  }>;
+}
+
+/** Run the known incident through real adapters backed by deterministic transports. */
+export async function runFixedTraceIncidentEval(): Promise<FixedTraceIncidentEvalArtifact> {
+  const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'long-form-deck-delivery');
+  if (!trace?.incident) throw new Error('Missing long-form fixed trace incident fixture');
+  const sanitized = sanitizeInput(trace.request.message);
+  const deliveries: FixedTraceIncidentEvalArtifact['deliveries'] = [];
+  const perProvider: Array<{
+    provider: ModelProviderId;
+    json: DeliveryObservation;
+    stream: DeliveryObservation | null;
+  }> = [];
+
+  for (const provider of PROVIDERS) {
+    const json = await deliver(trace, provider, 'json');
+    const stream = provider === 'anthropic' ? await deliver(trace, provider, 'stream') : null;
+    perProvider.push({ provider, json, stream });
+    deliveries.push({
+      provider,
+      json: {
+        outputLength: json.response.text.length,
+        outputSha256: sha256(json.response.text),
+        providerRequestSha256: sha256(JSON.stringify(json.prepared.providerRequest)),
+      },
+      stream: stream ? {
+        outputLength: stream.response.text.length,
+        outputSha256: sha256(stream.response.text),
+        providerRequestSha256: sha256(JSON.stringify(stream.prepared.providerRequest)),
+      } : null,
+    });
+  }
+
+  const jsonStreamParity = perProvider.filter(({ stream }) => stream !== null).every(({ json, stream }) => (
+    stream !== null
+    && json.emittedText === json.response.text
+    && stream.emittedText === stream.response.text
+    && JSON.stringify(terminalProjection(json.response)) === JSON.stringify(terminalProjection(stream.response))
+  ));
+  const providerParity = perProvider.every(({ provider, json }) => (
+    json.response.model_execution.source === 'provider'
+    && json.response.model_execution.requested_provider === provider
+    && json.response.model_execution.provider === provider
+    && JSON.stringify(providerNeutralProjection(json.response))
+      === JSON.stringify(providerNeutralProjection(perProvider[0].json.response))
+  ));
+  const forwarded = perProvider.every(({ json, stream }) => (
+    providerRequestContains(json.prepared, trace.incident!.latePromptMarkers)
+    && (stream === null || providerRequestContains(stream.prepared, trace.incident!.latePromptMarkers))
+  ));
+  const delivered = perProvider.flatMap(({ json, stream }) => [json.response.text, ...(stream ? [stream.response.text] : [])]);
+  const dimensions = {
+    inputAboveLegacyBoundary: trace.request.message.length > LEGACY_INPUT_BOUNDARY,
+    inputWithinCurrentBoundary: trace.request.message.length <= MAX_INPUT_LENGTH,
+    inputPreservedBySanitizer: sanitized.sanitized === trace.request.message && !sanitized.flagged,
+    latePromptCoverage: forwarded,
+    retainedCoverage: delivered.every((text) => trace.incident!.requiredDeliveredMarkers.every((marker) => text.includes(marker))),
+    retainedLength: delivered.every((text) => text.length >= trace.incident!.minimumDeliveredCharacters && text.length <= MAX_OUTPUT_LENGTH),
+    markdownBoundary: delivered.every(validMarkdownDeliveryBoundary),
+    jsonStreamParity,
+    providerParity,
+  };
+  return {
+    artifactVersion: FIXED_TRACE_INCIDENT_EVAL_VERSION,
+    traceSuiteVersion: FIXED_TRACE_SUITE_VERSION,
+    traceSuiteSha256: fixedTraceSuiteSha256(),
+    fixtureSha256: sha256(LONG_FORM_RESPONSE_FIXTURE),
+    traceId: trace.id,
+    noNetwork: true,
+    passed: Object.values(dimensions).every(Boolean),
+    dimensions,
+    deliveries,
+  };
+}

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -7,7 +7,7 @@ import type {
 } from '../model-providers/model-provider.js';
 import type { RouterAction } from '../router.js';
 
-export const FIXED_TRACE_SUITE_VERSION = 'addie-fixed-traces-v7';
+export const FIXED_TRACE_SUITE_VERSION = 'addie-fixed-traces-v8';
 
 export type FixedTraceCategory =
   | 'surface_policy'
@@ -19,6 +19,7 @@ export type FixedTraceCategory =
   | 'prompt_injection'
   | 'date_sensitive'
   | 'truncation'
+  | 'long_form_incident'
   | 'provider_degradation';
 
 export type FixedTraceTerminalStatus =
@@ -88,6 +89,16 @@ export interface FixedTraceCase {
   };
   /** Subjective criteria are intentionally not used by the deterministic gate. */
   answerRubric?: ReadonlyArray<string>;
+  /**
+   * Extra deterministic evidence for a known incident shape. This remains
+   * synthetic and provider-neutral; the no-network incident runner exercises
+   * it through the isolated full-response client seam.
+   */
+  incident?: {
+    latePromptMarkers: ReadonlyArray<string>;
+    requiredDeliveredMarkers: ReadonlyArray<string>;
+    minimumDeliveredCharacters: number;
+  };
 }
 
 export interface FixedTraceToolObservation {
@@ -174,6 +185,21 @@ export interface FixedTraceGrade {
 }
 
 const NOW = '2026-08-28T12:00:00.000Z';
+
+/**
+ * A realistic deck-sized request whose decision facts intentionally appear
+ * after the legacy 4k sanitizer boundary. It contains no production data.
+ */
+export const LONG_FORM_INCIDENT_QUESTION = [
+  'Prepare a detailed implementation review from this synthetic planning deck.',
+  ...Array.from(
+    { length: 155 },
+    (_, index) => `Background slide ${String(index + 1).padStart(3, '0')}: synthetic planning context and supporting detail for the implementation review`,
+  ),
+  'Late decision fact: cobalt release gate requires an owner approval.',
+  'Late decision fact: retain the evidence appendix for 48 hours.',
+  'Late decision fact: the final recommendation must name the verified handoff.',
+].join('\n');
 
 function deepFreeze<T>(value: T): T {
   if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
@@ -350,6 +376,45 @@ export const FIXED_TRACE_SUITE: ReadonlyArray<FixedTraceCase> = deepFreeze([
     toolFixtures: [],
     expectation: {
       terminalStatuses: ['truncated'], requiredTools: [], allowedTools: [], forbiddenTools: [], mutationAuthorization: 'none', requireFlagged: true,
+    },
+  },
+  {
+    id: 'long-form-deck-delivery',
+    category: 'long_form_incident',
+    privacy: 'synthetic',
+    request: {
+      source: 'dm',
+      message: LONG_FORM_INCIDENT_QUESTION,
+      nowUtc: NOW,
+      isAdmin: false,
+    },
+    routing: { action: 'respond', toolSets: [] },
+    toolFixtures: [],
+    expectation: {
+      terminalStatuses: ['complete'], requiredTools: [], allowedTools: [], forbiddenTools: [], mutationAuthorization: 'none',
+      requiredTextAny: [
+        ['cobalt release gate'],
+        ['48 hours'],
+        ['verified handoff'],
+      ],
+    },
+    answerRubric: [
+      'Uses all three decision facts that occur after the legacy input boundary.',
+      'Retains a useful, Markdown-valid long-form delivery rather than collapsing to its opening sentence.',
+    ],
+    incident: {
+      latePromptMarkers: [
+        'cobalt release gate requires an owner approval',
+        'retain the evidence appendix for 48 hours',
+        'final recommendation must name the verified handoff',
+      ],
+      requiredDeliveredMarkers: [
+        'cobalt release gate',
+        '48 hours',
+        'verified handoff',
+        'Delivery checkpoint 060',
+      ],
+      minimumDeliveredCharacters: 9_500,
     },
   },
   {

--- a/server/src/addie/security.ts
+++ b/server/src/addie/security.ts
@@ -43,6 +43,7 @@ function findSafeOutputBoundary(text: string, maxLength: number): number {
 
   let lastSentenceBoundary = -1;
   let lastWhitespaceBoundary = -1;
+  let lastLineBoundary = -1;
   let pendingSentenceBoundary: number | null = null;
   let skipUntil = 0;
 
@@ -205,6 +206,7 @@ function findSafeOutputBoundary(text: string, maxLength: number): number {
         pendingSentenceBoundary = null;
       }
       if (index > 0) lastWhitespaceBoundary = index;
+      if (/[\r\n]/u.test(grapheme)) lastLineBoundary = end;
     } else if (
       pendingSentenceBoundary !== null
       && SENTENCE_CLOSERS.has(grapheme)
@@ -245,7 +247,12 @@ function findSafeOutputBoundary(text: string, maxLength: number): number {
   if (lastSentenceBoundary >= minimumUsefulSentenceBoundary) {
     return lastSentenceBoundary;
   }
-  return Math.max(lastSentenceBoundary, lastWhitespaceBoundary);
+  // A line boundary is still Markdown-neutral, and avoids cutting an outline
+  // or deck list after its marker (for example, a trailing `-`). Only use an
+  // in-line whitespace boundary when there is no later complete line.
+  return lastLineBoundary >= 0
+    ? Math.max(lastSentenceBoundary, lastLineBoundary)
+    : Math.max(lastSentenceBoundary, lastWhitespaceBoundary);
 }
 
 function truncateAtGraphemeBoundary(text: string, maxLength: number): string {

--- a/server/tests/manual/fixed-trace-incident-eval.ts
+++ b/server/tests/manual/fixed-trace-incident-eval.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic, no-network regression evaluation for the observed Addie
+ * long-question / long-answer incident shape.
+ *
+ * Example:
+ * npx tsx server/tests/manual/fixed-trace-incident-eval.ts --output=.context/evals/addie-long-form.json
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import {
+  FIXED_TRACE_INCIDENT_EVAL_VERSION,
+  runFixedTraceIncidentEval,
+} from '../../src/addie/eval/fixed-trace-incident-eval.js';
+
+function argument(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  return process.argv.find((value) => value.startsWith(prefix))?.slice(prefix.length);
+}
+
+const outputArgument = argument('output');
+if (!outputArgument?.trim()) throw new Error('--output is required');
+const outputPath = resolve(outputArgument);
+const sourceFiles = [
+  'server/src/addie/eval/fixed-trace-incident-eval.ts',
+  'server/src/addie/eval/fixed-trace-suite.ts',
+  'server/src/addie/claude-client.ts',
+  'server/src/addie/security.ts',
+  'server/tests/manual/fixed-trace-incident-eval.ts',
+];
+const sourceBundleSha256 = createHash('sha256')
+  .update(sourceFiles.map((file) => `${file}\0${readFileSync(file, 'utf8')}`).join('\0'), 'utf8')
+  .digest('hex');
+const artifact = {
+  ...(await runFixedTraceIncidentEval()),
+  sourceBundleSha256,
+  gitCommit: execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+  gitDirty: execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim().length > 0,
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+console.log(JSON.stringify({
+  outputPath,
+  artifactVersion: FIXED_TRACE_INCIDENT_EVAL_VERSION,
+  traceSuiteVersion: artifact.traceSuiteVersion,
+  traceSuiteSha256: artifact.traceSuiteSha256,
+  sourceBundleSha256,
+  passed: artifact.passed,
+  dimensions: artifact.dimensions,
+}, null, 2));
+if (!artifact.passed) process.exitCode = 1;

--- a/server/tests/unit/addie/fixed-trace-incident-eval.test.ts
+++ b/server/tests/unit/addie/fixed-trace-incident-eval.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FIXED_TRACE_INCIDENT_EVAL_VERSION,
+  runFixedTraceIncidentEval,
+} from '../../../src/addie/eval/fixed-trace-incident-eval.js';
+
+describe('fixed trace long-form incident evaluation', () => {
+  it('reports complete no-network long-input, delivery, and provider-parity evidence', async () => {
+    const artifact = await runFixedTraceIncidentEval();
+
+    expect(artifact).toMatchObject({
+      artifactVersion: FIXED_TRACE_INCIDENT_EVAL_VERSION,
+      traceSuiteVersion: 'addie-fixed-traces-v8',
+      traceId: 'long-form-deck-delivery',
+      noNetwork: true,
+      passed: true,
+      dimensions: {
+        inputAboveLegacyBoundary: true,
+        inputWithinCurrentBoundary: true,
+        inputPreservedBySanitizer: true,
+        latePromptCoverage: true,
+        retainedCoverage: true,
+        retainedLength: true,
+        markdownBoundary: true,
+        jsonStreamParity: true,
+        providerParity: true,
+      },
+    });
+    expect(artifact.traceSuiteSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(artifact.fixtureSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(artifact.deliveries).toHaveLength(2);
+    for (const delivery of artifact.deliveries) {
+      expect(delivery.json.outputLength).toBeGreaterThanOrEqual(9_500);
+      expect(delivery.json.providerRequestSha256).toMatch(/^[a-f0-9]{64}$/);
+      if (delivery.provider === 'anthropic') {
+        expect(delivery.stream).not.toBeNull();
+        expect(delivery.stream?.outputLength).toBe(delivery.json.outputLength);
+        expect(delivery.stream?.outputSha256).toBe(delivery.json.outputSha256);
+        expect(delivery.stream?.providerRequestSha256).toMatch(/^[a-f0-9]{64}$/);
+      } else {
+        expect(delivery.stream).toBeNull();
+      }
+    }
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -128,12 +128,12 @@ function passingObservation(trace: FixedTraceCase): FixedTraceObservation {
 
 describe('fixed cross-provider trace suite', () => {
   it('is a fixed synthetic corpus covering every required risk category', () => {
-    expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v7');
-    expect(FIXED_TRACE_SUITE).toHaveLength(11);
+    expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v8');
+    expect(FIXED_TRACE_SUITE).toHaveLength(12);
     expect(new Set(FIXED_TRACE_SUITE.map((trace) => trace.id)).size).toBe(FIXED_TRACE_SUITE.length);
     expect(new Set(FIXED_TRACE_SUITE.map((trace) => trace.category))).toEqual(new Set([
       'surface_policy', 'knowledge', 'member_context', 'admin_read', 'safe_mutation',
-      'tool_error', 'prompt_injection', 'date_sensitive', 'truncation', 'provider_degradation',
+      'tool_error', 'prompt_injection', 'date_sensitive', 'truncation', 'long_form_incident', 'provider_degradation',
     ]));
     expect(FIXED_TRACE_SUITE.every((trace) => trace.privacy === 'synthetic')).toBe(true);
     const serialized = JSON.stringify(FIXED_TRACE_SUITE);
@@ -164,8 +164,8 @@ describe('fixed cross-provider trace suite', () => {
     const { grades, summary } = summarizeFixedTraceRun(observations);
     expect(grades.every((grade) => grade.deterministicPass)).toBe(true);
     expect(summary).toMatchObject({
-      expected: 11,
-      observed: 11,
+      expected: 12,
+      observed: 12,
       omitted: 0,
       complete: true,
       deterministicPassRate: 1,
@@ -176,11 +176,11 @@ describe('fixed cross-provider trace suite', () => {
       metadataPassRate: 1,
       latencyP95Ms: 10,
     });
-    expect(summary.terminalFailureRate).toBeCloseTo(2 / 11);
-    expect(summary.totalEstimatedCostUsd).toBeCloseTo(0.01);
+    expect(summary.terminalFailureRate).toBeCloseTo(2 / 12);
+    expect(summary.totalEstimatedCostUsd).toBeCloseTo(0.0105);
     expect(summary.comparisonEligible).toBe(true);
     expect(summary.terminalStatusCounts).toMatchObject({
-      complete: 8,
+      complete: 9,
       ignored: 1,
       truncated: 1,
       provider_error: 1,
@@ -329,7 +329,7 @@ describe('fixed cross-provider trace suite', () => {
 
   it('reports omissions instead of silently shrinking the requested matrix', () => {
     const { summary } = summarizeFixedTraceRun(FIXED_TRACE_SUITE.slice(0, 3).map(passingObservation));
-    expect(summary).toMatchObject({ expected: 11, observed: 3, omitted: 8, complete: false });
+    expect(summary).toMatchObject({ expected: 12, observed: 3, omitted: 9, complete: false });
   });
 
   it('rejects duplicate and unknown observations', () => {

--- a/server/tests/unit/addie/security-boundaries.test.ts
+++ b/server/tests/unit/addie/security-boundaries.test.ts
@@ -87,4 +87,20 @@ describe('Addie long-form input and output boundaries', () => {
       reason: 'Output truncated due to length',
     });
   });
+
+  it('prefers a complete Markdown list line over a later in-line whitespace boundary', () => {
+    const text = [
+      'Opening sentence.',
+      ...Array.from(
+        { length: 360 },
+        (_, index) => `- [Delivery checkpoint ${String(index + 1).padStart(3, '0')}](https://fixture.test/checkpoint/${index + 1}): synthetic evidence, accountable owner, review status, and implementation handoff`,
+      ),
+    ].join('\n');
+
+    const output = validateOutput(text).sanitized;
+    const body = output.slice(0, -(`\n\n${OUTPUT_TRUNCATION_SUFFIX}`).length);
+
+    expect(output).toContain('Delivery checkpoint 060');
+    expect(body.split('\n').at(-1)).toMatch(/^\- \[Delivery checkpoint \d{3}\]\(https:\/\/fixture\.test\/checkpoint\/\d+\): synthetic evidence, accountable owner, review status, and implementation handoff$/);
+  });
 });


### PR DESCRIPTION
## Summary
- add a versioned synthetic fixed-trace incident for a deck-sized (>4k) prompt and a detailed punctuation-light Markdown answer
- add a deterministic, machine-readable no-network evaluator that drives the real Anthropic and Google adapters through injected local transports, checks late-prompt request coverage, retained coverage/length/Markdown boundary, Anthropic JSON/stream terminal parity, and normalized provider parity
- preserve complete Markdown lines when output truncation cannot use a useful sentence boundary

## Evaluation evidence
- `npx tsx server/tests/manual/fixed-trace-incident-eval.ts --output=.context/evals/addie-long-form-incident-post-scope.json` passed all 9 dimensions
- trace suite: `addie-fixed-traces-v8`; SHA-256: `fad720df5cf3ff6f6f305f4109d571153702ea6dd2673bd2047425f40bfb674d`
- evaluator source bundle SHA-256: `95d2380854009e51acd53c91b072c4b0bd424a6ba7d24bbf112b3410c1180b97`

## Verification
- `npm run precommit` passed before staging; `npm run test:server-unit` passed independently (68 files, 1056 tests); `npm run typecheck`, `npm run build`, Addie tool inventory/reference/portability checks, and `git diff --check` passed
- independent Codex Sol/medium code-quality review: approved
- repository security review: approved

## Safety
No paid or live provider calls. The evaluator uses immutable synthetic fixtures, injected deterministic local transports, and `executionMode: evaluation`; it does not load/print keys or change provider selection, rollout, Gemini activation, billing/cap, or the $25 cap.

Related to #6844.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dbc0ffb9-13ce-4cf3-aeee-bad39e0f44fd)
