### PR TITLE
refactor(addie): bound authenticated web chat tools

### DIFF
--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
-  "profile_ids_sha256": "11ade6dfd79fbd345386fd20b109f09910974aca106672821f732f3e16e68e64",
-  "profile_contract_sha256": "dbaf9ab25e087710b422226201e2a7c2401832cbd8b1621dd44902ba7c143e0f",
+  "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
+  "profile_contract_sha256": "20d6a28e6134a976f436d427b9b3074fc6245e51321b9eb84e1e7e7ed3fd61cb",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {
@@ -45,7 +45,7 @@
     "maximum_slack_public_schema_bytes": 164359,
     "legacy_slack_member_tools": 138,
     "web_anonymous_tools": 13,
-    "web_authenticated_admin_tools": 232
+    "web_authenticated_admin_tools": 39
   },
   "surface_maximums": {
     "email_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
@@ -72,7 +72,7 @@
     "tavus_voice:committee_leader": { "custom_tool_count": 132, "wire_schema_bytes": 106023, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "tavus_voice:member": { "custom_tool_count": 121, "wire_schema_bytes": 95906, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "web_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "web_chat:authenticated_admin": { "custom_tool_count": 232, "wire_schema_bytes": 177151, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "web_chat:authenticated_member": { "custom_tool_count": 152, "wire_schema_bytes": 125514, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 }
+    "web_chat:authenticated_admin": { "custom_tool_count": 39, "wire_schema_bytes": 39768, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "web_chat:authenticated_member": { "custom_tool_count": 37, "wire_schema_bytes": 37474, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 }
   }
 }

--- a/scripts/build-addie-tool-surface-inventory.ts
+++ b/scripts/build-addie-tool-surface-inventory.ts
@@ -591,24 +591,105 @@ function buildWebProfiles(defs: Awaited<ReturnType<typeof loadDefinitions>>): Pr
       ...memberTools,
     ];
   };
-  const authenticatedMemberRequest = buildAuthenticatedRequest(false);
-  const authenticatedAdminRequest = buildAuthenticatedRequest(true);
+  const buildRoutedAuthenticatedProfiles = (isAdmin: boolean): Profile[] => {
+    const audience = isAdmin ? 'authenticated_admin' : 'authenticated_member';
+    const authenticatedRequest = buildAuthenticatedRequest(isAdmin);
+    const selectedFor = (routerSelectedSets: string[], hasSponsoredIntelligenceContext = false) => selectSlackToolSets({
+      routerSelectedSets,
+      routerAvailable: true,
+      source: 'dm',
+      isAdmin,
+      hasSponsoredIntelligenceContext,
+    });
+    const profileFor = (
+      id: string,
+      selectedToolSets: string[],
+      conditionalMaximums: string[],
+      safeFallback = false,
+    ) =>
+      profile({
+        id: `web_chat:${audience}:${id}`,
+        runtime: 'web_chat',
+        audience,
+        globalTools,
+        requestTools: authenticatedRequest,
+        allowedToolNames: safeFallback
+          ? defs.toolSets.getSafeReadOnlyFallbackTools()
+          : defs.toolSets.getToolsForSets(selectedToolSets, isAdmin),
+        selectedToolSets,
+        providerToolCount: 1,
+        conditionalMaximums,
+      });
+    const routerVisibleSetNames = Object.values(defs.toolSets.TOOL_SETS)
+      .filter((set) => set.routerVisible !== false && (isAdmin || !set.adminOnly))
+      .map((set) => set.name);
+    const routed = routerVisibleSetNames.map((setName) => profileFor(
+        `routed:${setName}`,
+        selectedFor([setName]),
+        ['router_selected_bounded_domain', 'nonstreaming_web_search'],
+      ));
+    const boundedDomainCombinations = routerVisibleSetNames.map((setName) => [setName]);
+    for (let first = 0; first < routerVisibleSetNames.length; first += 1) {
+      for (let second = first + 1; second < routerVisibleSetNames.length; second += 1) {
+        boundedDomainCombinations.push([routerVisibleSetNames[first], routerVisibleSetNames[second]]);
+      }
+    }
+    const boundedRouteCandidates = boundedDomainCombinations.flatMap((setNames) => [
+      profileFor(
+        `routed_combination:${setNames.join('+')}`,
+        selectedFor(setNames),
+        ['router_selected_up_to_two_bounded_domains', 'nonstreaming_web_search'],
+      ),
+      profileFor(
+        `routed_combination:${setNames.join('+')}:si_context`,
+        selectedFor(setNames, true),
+        ['router_selected_up_to_two_bounded_domains', 'active_sponsored_intelligence_session', 'nonstreaming_web_search'],
+      ),
+    ]);
+    // The runtime accepts at most two routed domains and can add SI only from
+    // trusted session/retrieval context. Retain the exact profiles that
+    // establish each generated maximum without checking in every combination.
+    const boundedRouteMaximums = new Map<string, Profile>();
+    for (const metric of ['custom_tool_count', 'wire_schema_bytes', 'tool_reference_bytes'] as const) {
+      const maximum = Math.max(...boundedRouteCandidates.map((candidate) => candidate[metric]));
+      for (const candidate of boundedRouteCandidates) {
+        if (candidate[metric] === maximum) {
+          boundedRouteMaximums.set(candidate.id, candidate);
+          break;
+        }
+      }
+    }
+    const fallback = profileFor(
+      'safe_fallback',
+      selectSlackToolSets({ routerAvailable: false, source: 'dm', isAdmin }),
+      ['router_unavailable', 'nonstreaming_web_search'],
+      true,
+    );
+    const activeCertification = ([
+      ['active_certification_learning', 'learning'],
+      ['active_certification_assessment', 'assessment'],
+      ['active_certification_mixed', 'mixed'],
+    ] as const).map(([id, activeCertificationKind]) => profileFor(
+      id,
+      selectSlackToolSets({
+        routerAvailable: true,
+        source: 'dm',
+        isAdmin,
+        activeCertificationKind,
+      }),
+      ['active_certification_session', 'nonstreaming_web_search'],
+    ));
+    return [...routed, ...boundedRouteMaximums.values(), fallback, ...activeCertification];
+  };
+
   return [
     profile({
       id: 'web_chat:anonymous:maximum', runtime: 'web_chat', audience: 'anonymous',
       globalTools, providerToolCount: 1,
       conditionalMaximums: ['nonstreaming_web_search'],
     }),
-    profile({
-      id: 'web_chat:authenticated_member:maximum', runtime: 'web_chat', audience: 'authenticated_member',
-      globalTools, requestTools: authenticatedMemberRequest, providerToolCount: 1,
-      conditionalMaximums: ['moltbook_configured', 'event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
-    profile({
-      id: 'web_chat:authenticated_admin:maximum', runtime: 'web_chat', audience: 'authenticated_admin',
-      globalTools, requestTools: authenticatedAdminRequest, providerToolCount: 1,
-      conditionalMaximums: ['moltbook_configured', 'admin_event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
+    ...buildRoutedAuthenticatedProfiles(false),
+    ...buildRoutedAuthenticatedProfiles(true),
   ];
 }
 

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.8';
+export const CODE_VERSION = '2026.09.9';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -19,12 +19,12 @@
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "03eb87d6def523062bbdd790fa82a20314a9fb2d5d03672149e9d80820e15b8e",
     "server/src/addie/handler.ts": "9df4a97138442abf71faf66b53d40ff433b2ac4580e2cebb899cdfe40bd67a84",
-    "server/src/routes/addie-chat.ts": "167204f0bd61a4d12e8e04464b65e46d489044a6961f5ad60fb9a1d375f4ae86",
+    "server/src/routes/addie-chat.ts": "4a188abe0bcf2ac486899ed586d855fd79451c4e0d37eda11a770b600429dcd3",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",
     "server/src/addie/jobs/shadow-replay-cohort.ts": "316d0764cd65e4c631d6efef7d090fd46a6a8fff22d4c917a40b44a7a69eee1f",
-    "server/src/addie/tool-sets.ts": "071010dcbcc098ef9f7bd12b8b3490b49b7267de7e3554bdff7f7c5e88525951"
+    "server/src/addie/tool-sets.ts": "536bd46058260d529f7def823a96966e9fb80f8d9fa120c99a7e63d43b5106e3"
   },
   "routed": {
     "tool_set_count": 37,
@@ -16936,91 +16936,229 @@
       "wire_schema_sha256": "b957bec348aef0ec96d8c6d3d286b85f89ddec537374760cdb80f4b68780dbbc"
     },
     {
-      "id": "web_chat:authenticated_admin:maximum",
+      "id": "web_chat:authenticated_admin:active_certification_assessment",
       "runtime": "web_chat",
       "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_assessment",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
       "conditional_maximums": [
-        "moltbook_configured",
-        "admin_event_and_meeting_permissions",
+        "active_certification_session",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 232,
+      "custom_tool_count": 28,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 177025,
-      "tool_reference_bytes": 34727,
-      "tool_reference_sha256": "ec9f17d2bdcd331f213f02c0fce5b3c41eb953b23be1f7513a80823d02535fac",
-      "overridden_tool_count": 8,
+      "wire_schema_bytes": 30501,
+      "tool_reference_bytes": 10366,
+      "tool_reference_sha256": "a219e487880587994b46462d6a15b21622541645a10de8900d137f9d0ab771b8",
+      "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
-        "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "search_members",
         "search_docs",
         "get_doc",
         "search_repos",
         "search_resources",
         "get_recent_news",
-        "bookmark_resource",
         "validate_json",
         "get_schema",
         "list_schemas",
         "compare_schema_versions",
-        "research_brand",
-        "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "validate_adagents",
-        "resolve_property",
-        "save_property",
-        "list_properties",
-        "list_missing_properties",
-        "check_property_list",
-        "enhance_property",
-        "resolve_catalog",
-        "browse_catalog",
-        "dispute_catalog_entry",
-        "list_working_groups",
-        "get_working_group",
-        "join_working_group",
-        "request_working_group_invitation",
-        "get_my_working_groups",
-        "express_council_interest",
-        "withdraw_council_interest",
-        "get_my_council_interests",
-        "get_my_profile",
         "set_my_name",
-        "update_my_profile",
-        "get_company_listing",
-        "update_company_listing",
-        "update_company_logo",
-        "request_brand_domain_challenge",
-        "verify_brand_domain_challenge",
-        "list_perspectives",
-        "create_working_group_post",
-        "propose_content",
-        "attach_content_asset",
-        "get_my_content",
-        "list_pending_content",
-        "approve_content",
-        "reject_content",
-        "request_revisions",
-        "add_committee_document",
-        "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "get_learner_progress",
+        "check_credentials",
+        "test_out_modules",
+        "start_certification_exam",
+        "complete_certification_exam",
+        "checkpoint_teaching_progress",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "bd72ada800be89b75c9934f22d39da2716d408cfd7082d78250a5d8ba518170c",
+      "wire_schema_sha256": "c0d5089b506971f109afb97b5268d6220e1c5656d5148d7a622f5a2e9cc8afee"
+    },
+    {
+      "id": "web_chat:authenticated_admin:active_certification_learning",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_learning",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
+      "conditional_maximums": [
+        "active_certification_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 29,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 31404,
+      "tool_reference_bytes": 11603,
+      "tool_reference_sha256": "d76dcf7d3aa954a2b242983315175a0912bddfcb244c420a0db39009b9ea4596",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "35d65076ecee4d988204088ee64422da183fe75da2c59e606217e62e228e1024",
+      "wire_schema_sha256": "28a7df77c6e854525eb331383b62ef17b3fc50c9f608f37aab519b7309a44db5"
+    },
+    {
+      "id": "web_chat:authenticated_admin:active_certification_mixed",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_learning",
+        "certification_assessment",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
+      "conditional_maximums": [
+        "active_certification_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 32,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 33853,
+      "tool_reference_bytes": 13758,
+      "tool_reference_sha256": "8d038a023dcccc7137b07e92d399808cb6c4ee256aa089bc8fc26f60aae826eb",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "test_out_modules",
+        "start_certification_exam",
+        "complete_certification_exam",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "6c5ec13ab1e04229284b2416d75b4b9ad7f06ff570821cea95cffa4c972ff8c6",
+      "wire_schema_sha256": "e1ee2accd5aed081439952ca1f560ae81ad0f93a41eae3f402705bedf21bdee3"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed_combination:agent_validation+adcp_operations:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 35,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 39768,
+      "tool_reference_bytes": 9709,
+      "tool_reference_sha256": "a8bcfc2eb50c8c0103a385d315f2b4e6aa539c3725323b0aec76561819034e10",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "resolve_brand",
+        "validate_adagents",
         "get_account_link",
         "get_agent_status",
         "check_publisher_authorization",
@@ -17029,22 +17167,10 @@
         "compare_media_kit",
         "test_rfp_response",
         "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
         "save_agent",
         "list_saved_agents",
         "remove_saved_agent",
         "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -17058,117 +17184,1432 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "1eacb60df1ca04a1a0d245ba05db752c5d077e1c6df298e782bba19099b503df",
+      "wire_schema_sha256": "c73356386d20044f41dbe2e50db9b5c1386a13c71e7a4d87fbf166a27edcac09"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed_combination:community_groups+agent_validation:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 39,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 32375,
+      "tool_reference_bytes": 9073,
+      "tool_reference_sha256": "29ae66a0c92c80fcc06ffbdd90742c75e1c9dac6514533494e8a997a09750b2e",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "bookmark_resource",
+        "resolve_brand",
+        "validate_adagents",
+        "list_working_groups",
+        "get_working_group",
+        "join_working_group",
+        "request_working_group_invitation",
+        "get_my_working_groups",
+        "express_council_interest",
+        "withdraw_council_interest",
+        "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "d8b0476c2af24262cc910ca088fec79a2373f8e7d59d81f0b38909cb657e6edf",
+      "wire_schema_sha256": "9bcb1702017f4322a668e724e28a9e6fcda10d6ec9d84b1ba30906a21ddd45aa"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed_combination:member_profile+certification_learning:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 33,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 34167,
+      "tool_reference_bytes": 13117,
+      "tool_reference_sha256": "39402d244d7826e4c65fe9af830da88e29aad58c6a380f57cfd3b969e84f49ae",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_my_profile",
+        "set_my_name",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "find_membership_products",
-        "create_payment_link",
-        "send_invoice",
-        "confirm_send_invoice",
-        "get_billing_portal",
-        "search_image_library",
-        "search_slack",
-        "get_channel_activity",
-        "list_certification_tracks",
-        "get_certification_module",
         "start_certification_module",
         "complete_certification_module",
         "get_learner_progress",
         "check_credentials",
-        "test_out_modules",
-        "start_certification_exam",
-        "complete_certification_exam",
         "checkpoint_teaching_progress",
         "get_build_phase_instructions",
         "save_learner_feedback",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "dd808b87ef78eda527f0b6c53e3185f67a74866decc7be13e934973ab7846ccc",
+      "wire_schema_sha256": "e8e949385d90fc2e12e1d8d037e0592d2f089e9fdb2e39965b85e665fcb8fb22"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:adcp_operations",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "adcp_operations",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 24094,
+      "tool_reference_bytes": 7532,
+      "tool_reference_sha256": "03fea349a1ff2eb8a964b256e72ba4bf10504c7bbef3f6e0813a9fafabdc0f33",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "ask_about_adcp_task",
+        "call_adcp_task",
+        "get_adcp_capabilities",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "9f28a693476baff5aefec20b2db206b558bbcb79597c3bc265e241d7ed2751d2",
+      "wire_schema_sha256": "6b7a2e58fbe2f0cbfffe87a60affec9e06b0206a5b800add73ae66e79176fafc"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_brands",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_brands",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 18,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 16077,
+      "tool_reference_bytes": 6628,
+      "tool_reference_sha256": "9f69ee1339b62c53c82c227f4bb682d7bb39d588379f780da47ca32f5a8573d6",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_missing_brands",
+        "list_missing_properties",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation",
+        "list_pending_brand_logos",
+        "list_brand_logos",
+        "review_brand_logo",
+        "list_pending_community_mirrors",
+        "transfer_brand_ownership",
+        "list_orphaned_brands"
+      ],
+      "ordered_tool_names_sha256": "b8ac4dc5a2cfe6493a8a33ba081f7c5af00bb972fb3e2beaadab67b18310e1e5",
+      "wire_schema_sha256": "b41c1d06922b909c87e66a7dbc7be8632ad50cfc49e3083f9bf3a4832fe04ebd"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_events",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_events",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 17908,
+      "tool_reference_bytes": 6552,
+      "tool_reference_sha256": "b021bf13d29d91c5ca15ddb0dda20d57f7a485a7170d22cb7aa8aa0b1c284f99",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation",
+        "create_event",
+        "manage_event_registrations",
+        "update_event",
+        "check_person_event_status",
+        "invite_to_event"
+      ],
+      "ordered_tool_names_sha256": "4bcfc903a63cf59dc51f5dcc4623bff98f5b411fb1aecf853b2ba7a07b16a3c3",
+      "wire_schema_sha256": "41d7bb27c799b0dd6147922dd0855f14b619388531d01682b4944d3a2b6ff2e7"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_feeds",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_feeds",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15049,
+      "tool_reference_bytes": 6583,
+      "tool_reference_sha256": "d63830f2e9d8b8840500c2687a66b9f7f3b0009623b36f6d88da14b14fbdf1e4",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "search_industry_feeds",
+        "add_industry_feed",
+        "get_feed_stats",
+        "list_feed_proposals",
+        "approve_feed_proposal",
+        "reject_feed_proposal",
+        "add_media_contact",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "b5e0ced21d7989e346a4c6d9ac63b576e6e4c7055b870f929d8b2fc991aa7380",
+      "wire_schema_sha256": "0db6fd6025b298c1bbc92cea9730f6e17bcfa90b6f0b7bd7e6ffacf682a43cb1"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_group_leadership",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_group_leadership",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14061,
+      "tool_reference_bytes": 6548,
+      "tool_reference_sha256": "f9b77eb5ea31ad48f30740b01666af66f88286407f0e7ede9659e0f045168229",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_working_groups",
+        "get_working_group",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "add_committee_leader",
+        "remove_committee_leader",
+        "list_committee_leaders",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "573dbdf5e1c394439468279576c89f2f19b40261bcb8a066c877ef7d5760a9f0",
+      "wire_schema_sha256": "69fe61e093b61698282b283cd981d6fa467bc8ff45d47fd9ddd3315f9125ee82"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_group_membership",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_group_membership",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13967,
+      "tool_reference_bytes": 6524,
+      "tool_reference_sha256": "6c2c887d9e588890d96571062490988658b6bf41134804cb27d444da0a69a0f3",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_working_groups",
+        "get_working_group",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "add_working_group_member",
+        "remove_working_group_member",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "3cf11b7f4fbdab0f4c6aecf0c1d6e65ff4c08831aafd9549f4087d795a94d53d",
+      "wire_schema_sha256": "bd8730a03f95d574a211a50cd3da019aeceec0792969447aa3cad1b6460a89cf"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_group_structure",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_group_structure",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14030,
+      "tool_reference_bytes": 6541,
+      "tool_reference_sha256": "b428c07455ff710a3f7f6075df380e86f41cc047a065a25f2fcb5e26ed62b8e9",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "create_chapter",
+        "list_chapters",
+        "create_industry_gathering",
+        "list_industry_gatherings",
+        "rename_working_group",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "932f8cd1a9646cc0969efaf9cb5a5ead8e0d7acd64472cb755c01ddfecc2880b",
+      "wire_schema_sha256": "e9cacf86c97431ae1c95132f699fd685260d685b3f0bac479dfe6e20c72f02dd"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_organizations",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_organizations",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 19044,
+      "tool_reference_bytes": 6760,
+      "tool_reference_sha256": "e5bf5d828008e2e118ce43858c9ab9bb83a19b75a34d75511a834609b526fe6b",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "merge_organizations",
+        "find_duplicate_orgs",
+        "check_domain_health",
+        "manage_organization_domains",
+        "update_org_member_role",
+        "list_slack_users_by_org",
+        "list_paying_members",
+        "list_escalations",
+        "resolve_escalation",
+        "update_member_logo",
+        "update_member_profile"
+      ],
+      "ordered_tool_names_sha256": "ba014e1b08eec51d38d4570c9578a5477d17888b8c74d45c5a3355da04b50cd7",
+      "wire_schema_sha256": "ce776ba2661a22f0cddb71ce3ddab41033f4bb93590dac0e77ad7067252d1364"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_prospects",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_prospects",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 18,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 18153,
+      "tool_reference_bytes": 6599,
+      "tool_reference_sha256": "0323f88c0618b54abfc82d7d7273e30e531c236e682518980272e2352c4622fc",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "add_prospect",
+        "update_prospect",
+        "enrich_company",
+        "query_prospects",
+        "prospect_search_lusha",
+        "claim_prospect",
+        "suggest_prospects",
+        "list_escalations",
+        "resolve_escalation",
+        "triage_prospect_domain"
+      ],
+      "ordered_tool_names_sha256": "5d9877b49ca445e919836f4034c8505d2260a6fdd2d23074df5c7e00b094df51",
+      "wire_schema_sha256": "f1eaf33d175e2e3a521248c49335949a4519c13efecdd8c875baaa15d8fc74cf"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:admin_workflows",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "admin_workflows",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 16034,
+      "tool_reference_bytes": 6609,
+      "tool_reference_sha256": "a97e33a9c38b07ea16c4b2b16c2c56b1529a1819f450ae1804a4d2ccb0b6de82",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "query_admin_analytics",
+        "list_flagged_conversations",
+        "review_flagged_conversation",
+        "set_reminder",
+        "my_upcoming_tasks",
+        "complete_task",
+        "log_conversation",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "20079d8c0068a93bd9d50640bf66019447a83ee2bfbb9655ece3b7e2498929ba",
+      "wire_schema_sha256": "bde7345cad6bc2bf4e7513fe6ba0407376bce546a8d740e45ad8b96c3bd6fa1e"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:agent_conformance",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "agent_conformance",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 10,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11878,
+      "tool_reference_bytes": 6272,
+      "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
+      "wire_schema_sha256": "d2a474f24f6641717710b15e04eaedd6e9d2b35d7701eccd6e1e5c95bff2d55f"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:agent_validation",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "agent_validation",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 22,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 24801,
+      "tool_reference_bytes": 7542,
+      "tool_reference_sha256": "a4237f9b0e994369fa03a394d0b262c58c43fa9693ea2760897e22b63d252d9a",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "resolve_brand",
+        "validate_adagents",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "grade_agent_signing",
         "diagnose_agent_auth",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "9491d3f05dbebed17b6f268df43e73e2df76ab05cf475e016bf95c9e4e37e101",
+      "wire_schema_sha256": "5294d9ba0bcfe1c1045db5f16bd8e3033f2988eb69d8b1a6f762e6c9aa6bd009"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:billing",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "billing",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 21,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 19572,
+      "tool_reference_bytes": 6813,
+      "tool_reference_sha256": "24f094e68f2b2471c39f2edfce0ce5effeec0f74512f7c66a2173621a61932c4",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "list_pending_invoices",
         "get_account",
         "resend_invoice",
         "update_billing_email",
         "preview_org_stripe_customer_update",
         "confirm_org_stripe_customer_update",
-        "add_prospect",
-        "update_prospect",
-        "enrich_company",
-        "research_domain",
-        "query_prospects",
         "send_payment_request",
-        "prospect_search_lusha",
-        "diagnose_signin_block",
-        "list_invites_for_org",
-        "resend_invite",
-        "revoke_invite",
-        "add_member_to_org",
-        "search_industry_feeds",
-        "add_industry_feed",
-        "get_feed_stats",
-        "query_admin_analytics",
-        "list_feed_proposals",
-        "approve_feed_proposal",
-        "reject_feed_proposal",
-        "add_media_contact",
-        "list_flagged_conversations",
-        "review_flagged_conversation",
         "grant_discount",
         "remove_discount",
         "list_discounts",
         "create_promotion_code",
-        "create_chapter",
-        "list_chapters",
-        "create_industry_gathering",
-        "list_industry_gatherings",
-        "create_committee",
-        "add_committee_leader",
-        "remove_committee_leader",
-        "list_committee_leaders",
-        "add_working_group_member",
-        "remove_working_group_member",
-        "merge_organizations",
-        "find_duplicate_orgs",
-        "check_domain_health",
-        "manage_organization_domains",
-        "update_org_member_role",
-        "update_user_name",
-        "rename_working_group",
-        "claim_prospect",
-        "suggest_prospects",
-        "set_reminder",
-        "my_upcoming_tasks",
-        "complete_task",
-        "log_conversation",
-        "list_slack_users_by_org",
-        "list_paying_members",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "5d5fef9eebed15ba28873d4f57d88ddf0f5d4660760f5af34dd4ca726e6c1d05",
+      "wire_schema_sha256": "60ca0cbb9ee400750ff1ec13abf80f9e77c6f0b20e741c2e69dc581d4fdaa43b"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:brand_registry",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "brand_registry",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 16,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15387,
+      "tool_reference_bytes": 6964,
+      "tool_reference_sha256": "e5aad1046c709b30c04436b82406956d5e6e313af5c334554d227fac2bc5dcda",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "research_brand",
+        "resolve_brand",
+        "save_brand",
+        "list_brands",
+        "list_missing_brands",
+        "upload_brand_logo",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "c86c7ca79d9a95e4aaeb0e56ed58d44f06d0120a6e1588aac522f8c23b5ff979",
+      "wire_schema_sha256": "453fed25309f55a3868b20a010aa47b86fb132992bd6588bab1bab35b9279183"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:certification_assessment",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_assessment",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 23018,
+      "tool_reference_bytes": 8427,
+      "tool_reference_sha256": "c57880703e4da6d502c0759be6e8db3a2960574fd4d28dc912f68bd82be5fa42",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "get_learner_progress",
+        "check_credentials",
+        "test_out_modules",
+        "start_certification_exam",
+        "complete_certification_exam",
+        "checkpoint_teaching_progress",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "d8b86e295f66994bc40de7e65e7e187dabfaf6960fabeb90c079dc71327a31ca",
+      "wire_schema_sha256": "5db5cf82dd6dc8246435bfba3266a6c5a4808ff1c9e9a586f5f75e2d7f770462"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:certification_learning",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_learning",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 20,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 23921,
+      "tool_reference_bytes": 9664,
+      "tool_reference_sha256": "e5df3c57cd24d3eb8389c2c18149210815b4157f24531c441c79e79e4aae89a1",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "6545bd72e52fb34c1f5ff0f5673a29a73703b9903437288c9e8d0404d1c13389",
+      "wire_schema_sha256": "faa566769822619cb0a6f8bff75fc49777e433b32471380b7b6d3dff2d9b1214"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:certification_overview",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "certification_overview",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13922,
+      "tool_reference_bytes": 7221,
+      "tool_reference_sha256": "9d376bbcb1caa28c0389d6ca8da2a483883c37c1027a36d247fa4f645bf7de0d",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_certification_tracks",
+        "get_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "06a46b681a948b3358ca6147d77cfbd1794ff8e0e64da0298983969a3b7120a0",
+      "wire_schema_sha256": "eea736b83acc1af91f6ad808ecf3e5fd56281bde9acdb7af31661ce4fdceefd3"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:collaboration",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "collaboration",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13132,
+      "tool_reference_bytes": 6488,
+      "tool_reference_sha256": "bb912a28e2090154ed28d363858c5b5a324c3ee6cac04c65492e682e1c544675",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "list_escalations",
         "resolve_escalation",
-        "ban_entity",
-        "unban_entity",
-        "list_bans",
-        "update_member_logo",
-        "update_member_profile",
-        "triage_prospect_domain",
-        "get_outreach_stats",
-        "get_outreach_history",
-        "send_outreach",
-        "lookup_person",
-        "create_contact",
-        "get_person_memory",
-        "get_engagement_plan",
-        "get_outreach_health",
-        "get_action_items",
-        "list_pending_brand_logos",
-        "list_brand_logos",
-        "review_brand_logo",
-        "list_pending_community_mirrors",
-        "transfer_brand_ownership",
-        "list_orphaned_brands",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
+        "send_member_dm"
+      ],
+      "ordered_tool_names_sha256": "b3203fd33a4230acca878aef71eac0b1a04ba753819fc954eb93e5a321b7024d",
+      "wire_schema_sha256": "6b9bba7440eebd293ab28cbcc41dce136ead68ab4455179acfa1f15d156081ee"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:committee_leadership",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "committee_leadership",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 20492,
+      "tool_reference_bytes": 6824,
+      "tool_reference_sha256": "2bd731a12a87d5c0b27ec4d6922bd0fedc5ca93fdf68aa07c623afea2d415b75",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_working_groups",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation",
         "create_event",
         "manage_event_registrations",
         "update_event",
         "check_person_event_status",
         "invite_to_event",
+        "add_committee_co_leader",
+        "remove_committee_co_leader",
+        "list_committee_co_leaders"
+      ],
+      "ordered_tool_names_sha256": "670b3b670ad1470b4bf60d897f1574b5c0e7019797bd6ebd373c82bc6b5d39d4",
+      "wire_schema_sha256": "4cb922c626ecbdedc4da37a789c1334297dac9f6f9914ce1ebdc8b5834429f7d"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:community_groups",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "community_groups",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 21,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 16701,
+      "tool_reference_bytes": 6896,
+      "tool_reference_sha256": "845ce5a190f163a60f5940c72cff2fc6bf05ea2d56fd57352e75d9c81eeed374",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "bookmark_resource",
+        "list_working_groups",
+        "get_working_group",
+        "join_working_group",
+        "request_working_group_invitation",
+        "get_my_working_groups",
+        "express_council_interest",
+        "withdraw_council_interest",
+        "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "f193e90e1b990924a5b04adc740864636c2fd045e7617fbc5da63f5c2b84d29f",
+      "wire_schema_sha256": "11ec21f80c76838d1140911173cf4fa91b0ebe05300ea34f5c09aa78eb5c4bc5"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:community_research",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "community_research",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15219,
+      "tool_reference_bytes": 6701,
+      "tool_reference_sha256": "7a12fbc2c59f48e9c4a87b12c760fa544fb683f0b5c68899e355fb75b0f4b72e",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "search_slack",
+        "get_channel_activity",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "4ad544d3e8030fefbae749f253a52caac87f684ce8580521f4535d5ed3a3c1d3",
+      "wire_schema_sha256": "5a6d0498e21ecd40f215b3893f42614e4dee0118b66e2a6b32c8cd40fa8acf30"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:content",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "content",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14429,
+      "tool_reference_bytes": 6590,
+      "tool_reference_sha256": "7b3a3f79148efabc619eae2fb4a02f6f11a2702a1917437c5eb954d68a07dd70",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "add_committee_document",
+        "update_committee_document",
+        "delete_committee_document",
+        "get_account_link",
+        "propose_news_source",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "82334054b3aedc5da5543e63969de89ea35efd03a4adebb79becbddac6082662",
+      "wire_schema_sha256": "2a5a62ca6b00d87c2477f649e202c3c3b00177ab89f6dc7391316e8e572be5bc"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:directory",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "directory",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 16814,
+      "tool_reference_bytes": 7056,
+      "tool_reference_sha256": "35a1f783beaca11c98df4515caca8f515208fadca6af4a148b9b5ce3e27e555c",
+      "overridden_tool_count": 7,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "list_members",
+        "get_member",
+        "list_agents",
+        "get_agent",
+        "lookup_domain",
+        "list_publishers",
+        "search_members",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "request_introduction",
+        "get_my_search_analytics",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "9cc8ca5444d3a345db423145a683c443ea3f3ed5b3b3c57e74999f6f89f24c24",
+      "wire_schema_sha256": "1041fd631c16bff057ba15ebae2f8d36e71dc8d158a98ba125571a9736637ecc"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:events",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "events",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14357,
+      "tool_reference_bytes": 6597,
+      "tool_reference_sha256": "6549145ecf88e7eb5c3325ed3576179d102e8bfdeaf0be661adb5bf30bf9f59f",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation",
+        "list_events",
+        "get_event_details",
+        "register_event_interest",
+        "list_event_attendees"
+      ],
+      "ordered_tool_names_sha256": "bcf30892b66587ef40bbbb866e8e9439e639a63c284ca59ca683f42a35944e48",
+      "wire_schema_sha256": "a09a062cc5ab1629c82916717919679419c5841a71f1dcaf438217d6bfb1a809"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:github",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "github",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 16002,
+      "tool_reference_bytes": 7580,
+      "tool_reference_sha256": "5c5d46e6a5311faf597d3f94e4bf85ad9f36f2a9dfb6ef6219c1130fed86e4f6",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "draft_github_issue",
+        "create_github_issue",
+        "get_github_issue",
+        "list_github_issues",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "8706bf5913fcb25554d883060b001228c7ff776f2630ce3ffa9dde92f9c968fb",
+      "wire_schema_sha256": "1cd86477c71629e830be99611594409d038d9666b0fcbc31f027518de3d25ce9"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:illustrations",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "illustrations",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12811,
+      "tool_reference_bytes": 7193,
+      "tool_reference_sha256": "d3b525e96cb03ffc4699ae4dd848f5ffa8274ca0f4092ac9a988bf64d47e9f19",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "search_image_library",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "afe357cf6743bf5e9b51249a1c98cf3857be4f4c61746e25abdaf891c38b1bb1",
+      "wire_schema_sha256": "e334e08f98bfc3135fa81028d3bc2a8d3f8059ba933c4e3618bda55f9c7267ee"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:knowledge",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 10,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11878,
+      "tool_reference_bytes": 6272,
+      "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
+      "wire_schema_sha256": "d2a474f24f6641717710b15e04eaedd6e9d2b35d7701eccd6e1e5c95bff2d55f"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:meetings",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "meetings",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 21,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 21995,
+      "tool_reference_bytes": 7293,
+      "tool_reference_sha256": "d1e6253780e0d555e9e2713dbf5d388f8f181a143150c39d542ef723b7867302",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation",
         "schedule_meeting",
         "list_upcoming_meetings",
         "get_my_meetings",
@@ -17179,69 +18620,179 @@
         "update_meeting",
         "add_meeting_attendee",
         "update_topic_subscriptions",
-        "manage_committee_topics",
-        "send_member_dm",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "search_moltbook",
-        "get_moltbook_thread",
-        "post_to_moltbook",
-        "comment_on_moltbook",
-        "get_moltbook_stats",
-        "get_moltbook_feed"
+        "manage_committee_topics"
       ],
-      "ordered_tool_names_sha256": "60c1bf349d4a8bc228804867d449a574dee4951878ba6176c7c9a1eb14821e0c",
-      "wire_schema_sha256": "42b6953e132f97483461fcd37818c7608d5b124cc9cad296efb10261fa87639d"
+      "ordered_tool_names_sha256": "f0f43bf9f6366992fdc6ba29fb2d42b72e02f7e7a0d43be728ab0c805721e795",
+      "wire_schema_sha256": "aa5f421509559f72455ddab310b6e3c3c45a8bb17d8de4d524c55ab2cf2b7a82"
     },
     {
-      "id": "web_chat:authenticated_member:maximum",
+      "id": "web_chat:authenticated_admin:routed:member_billing",
       "runtime": "web_chat",
-      "audience": "authenticated_member",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "member_billing",
+        "knowledge"
+      ],
       "conditional_maximums": [
-        "moltbook_configured",
-        "event_and_meeting_permissions",
+        "router_selected_bounded_domain",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 152,
+      "custom_tool_count": 15,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 125388,
-      "tool_reference_bytes": 31540,
-      "tool_reference_sha256": "83792e71e03edd0b1a329fe60c8b7f7f1384e3768748a84f1a85b97f5b3fd63f",
-      "overridden_tool_count": 8,
+      "wire_schema_bytes": 15359,
+      "tool_reference_bytes": 7176,
+      "tool_reference_sha256": "cac7b49c2dec292a34f2c6925939362b75d3d2295301ef12b8bca648d3b0c5df",
+      "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
-        "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "search_members",
         "search_docs",
         "get_doc",
         "search_repos",
-        "search_resources",
-        "get_recent_news",
-        "bookmark_resource",
-        "validate_json",
-        "get_schema",
-        "list_schemas",
-        "compare_schema_versions",
-        "research_brand",
-        "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "validate_adagents",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "create_payment_link",
+        "send_invoice",
+        "confirm_send_invoice",
+        "get_billing_portal",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "8b15286fb91325747e3349524dc3cc3041668a407170595955f72745ddc8d86a",
+      "wire_schema_sha256": "5d96cc5f09c9caba4f6bd5851bd8ea44486e8f77df8f2dce09111aedea1500e1"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:member_profile",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "member_profile",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 19373,
+      "tool_reference_bytes": 8818,
+      "tool_reference_sha256": "be8f36482ddcc141de84a7ac2032dabacd277a0462149f415f856a730ce4008a",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_my_profile",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "06e591d53346dc47c0dc4c0bd7c4ea4aead8573b5fdd849d65c8336405ae6da8",
+      "wire_schema_sha256": "ffade93f3144b9929e81b33659e543b0d3683f3bf6b769c0934fdda071a2f5f6"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:outreach",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "outreach",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15473,
+      "tool_reference_bytes": 6604,
+      "tool_reference_sha256": "14d6564095b0b6e82cabaa5c7a9742a273f3f0049b616bcb3a27b60752a91808",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "get_account",
+        "list_escalations",
+        "resolve_escalation",
+        "get_outreach_stats",
+        "get_outreach_history",
+        "send_outreach",
+        "lookup_person",
+        "create_contact",
+        "get_action_items"
+      ],
+      "ordered_tool_names_sha256": "9c0b32db88df14bbf37a756927002992d88a597451f23d11a2427340a08767a1",
+      "wire_schema_sha256": "240574a0e4a31729eea51c0a92c13845f8d3f9f309a8bc7e662e591bbe6f931f"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:property_catalog",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "property_catalog",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 17872,
+      "tool_reference_bytes": 7790,
+      "tool_reference_sha256": "e725afdc590b98aab6bbaeac2a0aa7be7cd0a17790d0a634a5fbd8e01ff3a6d4",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
         "resolve_property",
         "save_property",
         "list_properties",
@@ -17251,35 +18802,495 @@
         "resolve_catalog",
         "browse_catalog",
         "dispute_catalog_entry",
-        "list_working_groups",
-        "get_working_group",
-        "join_working_group",
-        "request_working_group_invitation",
-        "get_my_working_groups",
-        "express_council_interest",
-        "withdraw_council_interest",
-        "get_my_council_interests",
-        "get_my_profile",
-        "set_my_name",
-        "update_my_profile",
-        "get_company_listing",
-        "update_company_listing",
-        "update_company_logo",
-        "request_brand_domain_challenge",
-        "verify_brand_domain_challenge",
-        "list_perspectives",
-        "create_working_group_post",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "c98e03a94a78f006869c3353ee604a7590c3fb8f94b78124af30fa5ae7632283",
+      "wire_schema_sha256": "c60857626cc730bc95fd434e0dbc0e9bc256bb49be96e66f6a027ad4d977ba76"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:publishing_author",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "publishing_author",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15135,
+      "tool_reference_bytes": 6472,
+      "tool_reference_sha256": "7a4659f475332084989a1d826180909c0bf5da81acedc2b3a97d57b31842911e",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
         "propose_content",
         "attach_content_asset",
         "get_my_content",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "88eef0953102ecab38c1a9d99d30bcbbe0f41f417403369abf793359f9d334bc",
+      "wire_schema_sha256": "1c7796653174afc940d591254294bd244ef19fd3084a0b8b9882031e456c1ad1"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:publishing_promotion",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "publishing_promotion",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12185,
+      "tool_reference_bytes": 6321,
+      "tool_reference_sha256": "388376d355541b6842a7853bc24e20bcf7ffb99ddd7c407abf8d351955425a35",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_perspectives",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "7528a5b3768856fa348e70aae06945e434bb0e33197e6f4151799bdc724d5354",
+      "wire_schema_sha256": "e52754075b05bde94ef55b1611c7e6c291cfb72a40d566923d752057fca08666"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:publishing_review",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "publishing_review",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13530,
+      "tool_reference_bytes": 6664,
+      "tool_reference_sha256": "de5892316884a9a7288cd1a4c079ba7454b8a09561141fadea63c67c6256bc5e",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
         "list_pending_content",
         "approve_content",
         "reject_content",
         "request_revisions",
-        "add_committee_document",
-        "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "da59b5b65a273573d1f498797b643d1411cef3da428d227ba40fe312838503fe",
+      "wire_schema_sha256": "ee66ba412433825cc9fb5a5ccb71872a74ba4c895bbf5673790c7747a4e2421a"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:schema_reference",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "schema_reference",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15087,
+      "tool_reference_bytes": 6861,
+      "tool_reference_sha256": "c8be8f92486324ce39f9bed199d73802ee78c7347223e7c1fe7b51ab1a3d91db",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "b9a369aced7f69958d3abce09c0719fe1dbd4e36bd1ca5faced3cd0c0a929de9",
+      "wire_schema_sha256": "0d96f0e213a44f4ceecb4ed1b87f8089a02bca4a5904ab3cbffd9e4822d6c633"
+    },
+    {
+      "id": "web_chat:authenticated_admin:routed:sponsored_intelligence",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "sponsored_intelligence",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 16,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14629,
+      "tool_reference_bytes": 7179,
+      "tool_reference_sha256": "c7386ead3d69c23bbec3a88d4aed2cd0b3ae92c382a15d103d612c571d496ecc",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_escalations",
+        "resolve_escalation"
+      ],
+      "ordered_tool_names_sha256": "0a0f58bf7eeb5f256ec47e69b670c7fcaf3d99cbd41470b8631986f3f4338f9b",
+      "wire_schema_sha256": "6d0c9c977388c947ff69cb5e8c8ad6ad0af52c38e7fd0a19dee94bdd774cfa21"
+    },
+    {
+      "id": "web_chat:authenticated_admin:safe_fallback",
+      "runtime": "web_chat",
+      "audience": "authenticated_admin",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 9889,
+      "tool_reference_bytes": 7097,
+      "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
+      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
+    },
+    {
+      "id": "web_chat:authenticated_member:active_certification_assessment",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_assessment",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
+      "conditional_maximums": [
+        "active_certification_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 26,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 28207,
+      "tool_reference_bytes": 10298,
+      "tool_reference_sha256": "a4cf746de6ff6b2d705c89744d5a0fe9e62e0d4aa907a2c69effe43b4dc3a600",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "get_learner_progress",
+        "check_credentials",
+        "test_out_modules",
+        "start_certification_exam",
+        "complete_certification_exam",
+        "checkpoint_teaching_progress"
+      ],
+      "ordered_tool_names_sha256": "d5fede9abe22dc9e9881c02a0273f7c97d12f14b898f6a95124633edf174fb03",
+      "wire_schema_sha256": "23c8e7ed45dd022edb1966609ef40428cf1e4c8630f76a03562b99d91061a7e6"
+    },
+    {
+      "id": "web_chat:authenticated_member:active_certification_learning",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_learning",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
+      "conditional_maximums": [
+        "active_certification_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 27,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 29110,
+      "tool_reference_bytes": 11535,
+      "tool_reference_sha256": "3b6270c3d17733243ba13d975ed10e2f95f8dfa8584da7ca2618225210aeebca",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "bab8226b2b5de31430f15b50111a74fb4c48b6c740a6acb7cd827244d1f65c6e",
+      "wire_schema_sha256": "5e19bbfc48273bf70e749297fd3b9ab5c5aaf9b08bb8af8bd86325623c9f04e1"
+    },
+    {
+      "id": "web_chat:authenticated_member:active_certification_mixed",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_learning",
+        "certification_assessment",
+        "knowledge",
+        "community_research",
+        "schema_reference",
+        "illustrations"
+      ],
+      "conditional_maximums": [
+        "active_certification_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 30,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 31559,
+      "tool_reference_bytes": 13690,
+      "tool_reference_sha256": "dda898eb7b32d395561f645aab4404c8a5b6ea14be882d5dd142c12b8ebee308",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "search_image_library",
+        "search_slack",
+        "get_channel_activity",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "test_out_modules",
+        "start_certification_exam",
+        "complete_certification_exam",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "409043ee299e0fb5f20b8a94de341fc6e92f1dc0c6f010a74777841984b8542b",
+      "wire_schema_sha256": "6438078f7b960ea8c2ddd2acc89e7d8026cfdb675fd1c0956f6c746a9bbbb2a5"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed_combination:agent_validation+adcp_operations:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 33,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 37474,
+      "tool_reference_bytes": 9641,
+      "tool_reference_sha256": "c93e3fc58d318e0db3f177206d84185942338f619843e3627a359e6321f57211",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "resolve_brand",
+        "validate_adagents",
         "get_account_link",
         "get_agent_status",
         "check_publisher_authorization",
@@ -17288,22 +19299,10 @@
         "compare_media_kit",
         "test_rfp_response",
         "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
         "save_agent",
         "list_saved_agents",
         "remove_saved_agent",
         "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -17317,37 +19316,921 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth"
+      ],
+      "ordered_tool_names_sha256": "c96c5ea6aba257c440dc2ff7a9acf2817a02307703702c81a2288f7430b5b45c",
+      "wire_schema_sha256": "26a6321f24c94f3e90a93b8fabeb1b89cfb69a0eb026f90d391621587e858e82"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed_combination:community_groups+agent_validation:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 37,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 30081,
+      "tool_reference_bytes": 9005,
+      "tool_reference_sha256": "46b1f946f5ae8b417b11782f352eccdc517837fd3abda87d570882d14e50e559",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "bookmark_resource",
+        "resolve_brand",
+        "validate_adagents",
+        "list_working_groups",
+        "get_working_group",
+        "join_working_group",
+        "request_working_group_invitation",
+        "get_my_working_groups",
+        "express_council_interest",
+        "withdraw_council_interest",
+        "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth"
+      ],
+      "ordered_tool_names_sha256": "982cbe48db8f739bbe9eccb008e503def15690919fac44de905d4a561ffc4cbe",
+      "wire_schema_sha256": "ab97dc715d8db760510b59a7490a4f8c0319ab9c2b281c9777ff14e45a3eb06c"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed_combination:member_profile+certification_learning:si_context",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "knowledge",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 31,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 31873,
+      "tool_reference_bytes": 13049,
+      "tool_reference_sha256": "8eeb65e92ad2e7d683157592a8e01acd8514bb4d3f99f1eb2478d9d967943ea7",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_my_profile",
+        "set_my_name",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "find_membership_products",
-        "create_payment_link",
-        "send_invoice",
-        "confirm_send_invoice",
-        "get_billing_portal",
-        "search_image_library",
-        "search_slack",
-        "get_channel_activity",
-        "list_certification_tracks",
-        "get_certification_module",
         "start_certification_module",
         "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "d8c66d37d6df48413a3b7b5a276769d648c2c624653502a53387f24da0384142",
+      "wire_schema_sha256": "a7d56c4a8d22fddb68dfc93e7c27f859f65d1448966a074255ad2865e232cd97"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:adcp_operations",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "adcp_operations",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 21800,
+      "tool_reference_bytes": 7464,
+      "tool_reference_sha256": "3385748df4d82728ff435822b89289e6a79cc3808a0cbaafa04d580d5bf4b21e",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "ask_about_adcp_task",
+        "call_adcp_task",
+        "get_adcp_capabilities",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "bfc83c6d48f46068f0f72a53bde488954ce10b62a5413a4161001c1c00f91ae2",
+      "wire_schema_sha256": "ff1ef77cb525e20d05d42c8b1f1f1aea2958e036bd9ad9abfda770666b40a5a9"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:agent_conformance",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "agent_conformance",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 8,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 9584,
+      "tool_reference_bytes": 6204,
+      "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
+      "wire_schema_sha256": "794297396f878654e94a25ad546001e08efbed278e56ff5fba79d6ff3e42d2c8"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:agent_validation",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "agent_validation",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 20,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 22507,
+      "tool_reference_bytes": 7474,
+      "tool_reference_sha256": "93902dac0be0731281c2e756452ff648708c23b36f5ffa7e7861b6770de6af48",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "resolve_brand",
+        "validate_adagents",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth"
+      ],
+      "ordered_tool_names_sha256": "9b5a7dcdd38c145f0fe4401eda4fa72b0d19948e7e378f354c64b9a6c5e422bd",
+      "wire_schema_sha256": "94b8d4806785dfb1b52bf6ad021a9d84f1e436909581337466e1b561ae4b1067"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:brand_registry",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "brand_registry",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13093,
+      "tool_reference_bytes": 6896,
+      "tool_reference_sha256": "e12c44434293c6b0dc7916e267e8243cbb9ec94f9fef84d5d561077f7a1c98d8",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "research_brand",
+        "resolve_brand",
+        "save_brand",
+        "list_brands",
+        "list_missing_brands",
+        "upload_brand_logo",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "b6435c3530033076496004a285593e6fe2c340d24a50cc3db408540adcdb026e",
+      "wire_schema_sha256": "f55493bc080d32608ac0388bfe983063aa89904f2736eb070cc31c3c6685181a"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:certification_assessment",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_assessment",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 20724,
+      "tool_reference_bytes": 8359,
+      "tool_reference_sha256": "27c2d10ad9cc0361785648f2297400debd7111290670a3d33f99bccca5d8964e",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
         "get_learner_progress",
         "check_credentials",
         "test_out_modules",
         "start_certification_exam",
         "complete_certification_exam",
+        "checkpoint_teaching_progress"
+      ],
+      "ordered_tool_names_sha256": "f560a7034716e30e165e088d98817f599254c01e14772e5e8317ba9a2b6fcf01",
+      "wire_schema_sha256": "a7d63006b5ef73a9af4f1235b1362b00c251b00e21aeae2b845f0d718310fd6b"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:certification_learning",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_learning",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 18,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 21627,
+      "tool_reference_bytes": 9596,
+      "tool_reference_sha256": "89dea497c4b9e8a13d6c85d57fc2a43f0ce6952ad5a4c3257fc8fbf0c693d956",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "call_adcp_task",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
         "checkpoint_teaching_progress",
         "get_build_phase_instructions",
-        "save_learner_feedback",
-        "grade_agent_signing",
-        "diagnose_agent_auth",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "fc4e265a83cd21d6af1c81c276d7355dd1c48df1f474fdcd15eb6dec87a22236",
+      "wire_schema_sha256": "fbf03650eaf9491a6d51ae6ad457e047d109d8ab799272d70466034a4cf8aee6"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:certification_overview",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "certification_overview",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11628,
+      "tool_reference_bytes": 7153,
+      "tool_reference_sha256": "5e453a96c89d9b0819cf05a967ba2f583bbb3dfb731e2b26df1498564f399f0b",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "set_my_name",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_certification_tracks",
+        "get_certification_module",
+        "get_learner_progress",
+        "check_credentials"
+      ],
+      "ordered_tool_names_sha256": "ca55070d4e842ea56d5331afdc93fb57ea4e09ac2bbefccfc4e24403903cc278",
+      "wire_schema_sha256": "4c459fa4af4eddecffd4b06f2622e1764271448bf5c936e54ebb3d7aa3a37c3a"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:collaboration",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "collaboration",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 9,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 10838,
+      "tool_reference_bytes": 6420,
+      "tool_reference_sha256": "3cda1deaa09dbedc854c68426f8d020c3a7c397cc198c84fa6d788a83606ca29",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "send_member_dm"
+      ],
+      "ordered_tool_names_sha256": "047276a55405c438e9d2a95835549c6a759739534c4f480679474d2d9e5057d5",
+      "wire_schema_sha256": "3f9854986f8f3109b97cb3e5cc05cb616428bb4fbfd72f06fe21aa555bdc4f04"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:committee_leadership",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "committee_leadership",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 18198,
+      "tool_reference_bytes": 6756,
+      "tool_reference_sha256": "80cc1524392e82d48bf381113a8ca29e02753c09d9ed12251c808783c1693615",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_working_groups",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "create_event",
         "manage_event_registrations",
         "update_event",
         "check_person_event_status",
         "invite_to_event",
+        "add_committee_co_leader",
+        "remove_committee_co_leader",
+        "list_committee_co_leaders"
+      ],
+      "ordered_tool_names_sha256": "f5c61d7c78d6dd43d97b73d411bfa30298a47165a6c2f5134dc9c35d4bae6b20",
+      "wire_schema_sha256": "d528786da1aa28cf148a0997d7ba3c37363e153c40f0fcd7d54e87181b14a986"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:community_groups",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "community_groups",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14407,
+      "tool_reference_bytes": 6828,
+      "tool_reference_sha256": "92a437bfa3535c33410f0307540123120f010441072f5681180819b758c4ddee",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "bookmark_resource",
+        "list_working_groups",
+        "get_working_group",
+        "join_working_group",
+        "request_working_group_invitation",
+        "get_my_working_groups",
+        "express_council_interest",
+        "withdraw_council_interest",
+        "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "62f60eac619dba015eb6c318d5d830439768c30f1287fa70e5df8551b06102f7",
+      "wire_schema_sha256": "31b83530f95de0a6fac56b198cfec98d8d2a1a51c1da1965bbbc7eaa0c16c755"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:community_research",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "community_research",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12925,
+      "tool_reference_bytes": 6633,
+      "tool_reference_sha256": "4ebd97a82ba5ed5e88f8b9c7c68486c8e81573ab6df849e5f63b50e9c88db803",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "60aed27ddfc51b427a77fef035c6540b466731ea0c9f31d0c091a6ace3c786fc",
+      "wire_schema_sha256": "6f671561a84ec5e68ce4c4694146b6cdee8d464a81d3cb3f6aeca76c900addfd"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:content",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "content",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12135,
+      "tool_reference_bytes": 6522,
+      "tool_reference_sha256": "368474d5b48fb00b3496e657ae57a05c670790a9abddd0453b0cbf83e1211528",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "add_committee_document",
+        "update_committee_document",
+        "delete_committee_document",
+        "get_account_link",
+        "propose_news_source",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "8e432367f76670bf947b853da758b22f3f0092d440797831027fd64b95915976",
+      "wire_schema_sha256": "adcceece2987aec6089a8cef894de1869648cd46ba6a27094d9f78cee12be300"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:directory",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "directory",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 14520,
+      "tool_reference_bytes": 6988,
+      "tool_reference_sha256": "350eb55bd5a8c7f9ec8515eaf5c6c438f8348668333769961b099024b8c90f14",
+      "overridden_tool_count": 7,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "list_members",
+        "get_member",
+        "list_agents",
+        "get_agent",
+        "lookup_domain",
+        "list_publishers",
+        "search_members",
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "request_introduction",
+        "get_my_search_analytics",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "06210f0b4cc1324a597562c5df847b6711821d1819858e6ae18a60cec137fea1",
+      "wire_schema_sha256": "f029c91d2b8f78fd7f78301579d1398e75f6ffa07a83726a14e2dc07c9ee4c22"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:events",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "events",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12063,
+      "tool_reference_bytes": 6529,
+      "tool_reference_sha256": "053730f00e37ba1615adcaafe3475f73f0c303135ec62d399f2064b9ba7e4807",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "list_events",
+        "get_event_details",
+        "register_event_interest",
+        "list_event_attendees"
+      ],
+      "ordered_tool_names_sha256": "0fde87b1571ac73f28511df5c8b9aa2d55f4596e0b239491b1172b4bbb2d1189",
+      "wire_schema_sha256": "5e13a1b5bd8b6390cd9b241d52e7ab1682bf61cefe385cd6927d51e77fbd27c6"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:github",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "github",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13708,
+      "tool_reference_bytes": 7512,
+      "tool_reference_sha256": "9303b977f057804221df18fcf5394a23cddcbf80dbe417a0b7382fe579d2721b",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "draft_github_issue",
+        "create_github_issue",
+        "get_github_issue",
+        "list_github_issues",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "44d5a4c62f20347dc45db4a6db581c8fb13537ba989c9ad02dc140dec7aa1772",
+      "wire_schema_sha256": "f7387d30624470220c487e35888416e81175e3101bcc30d8f7dcbcd814fec698"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:illustrations",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "illustrations",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 9,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 10517,
+      "tool_reference_bytes": 7125,
+      "tool_reference_sha256": "9f88115b0cef18d69339cdedbf39e1625a9a5acda4ea1ccd54853e3dbe516329",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "search_image_library"
+      ],
+      "ordered_tool_names_sha256": "ee88e3252d793c582cb0d66af17d4d7d51c8052f413501715136123f89afa185",
+      "wire_schema_sha256": "16473100cc5d561d5765a246f4d854b718aabd4091b48955507c4860db46c135"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:knowledge",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 8,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 9584,
+      "tool_reference_bytes": 6204,
+      "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
+      "wire_schema_sha256": "794297396f878654e94a25ad546001e08efbed278e56ff5fba79d6ff3e42d2c8"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:meetings",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "meetings",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 19,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 19701,
+      "tool_reference_bytes": 7225,
+      "tool_reference_sha256": "eb78a269dacec491112dc3c085db3fc1ba577887ab67b9f040f3b3b64c253964",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "schedule_meeting",
         "list_upcoming_meetings",
         "get_my_meetings",
@@ -17358,20 +20241,395 @@
         "update_meeting",
         "add_meeting_attendee",
         "update_topic_subscriptions",
-        "manage_committee_topics",
-        "send_member_dm",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "search_moltbook",
-        "get_moltbook_thread",
-        "post_to_moltbook",
-        "comment_on_moltbook",
-        "get_moltbook_stats",
-        "get_moltbook_feed"
+        "manage_committee_topics"
       ],
-      "ordered_tool_names_sha256": "ba3b0ba34ca3982d006f0b9e069c3d411d4b2ecb543039b6099d6ed9135b8aca",
-      "wire_schema_sha256": "ff6eaf3d3afeaa64f4226997799afa7fd3551e4df31f0d60cdb8d32836811a71"
+      "ordered_tool_names_sha256": "312722fb59708da8d8d7421a8e459d5e4cdd0238afc1087aae8aee4bcee3d0d9",
+      "wire_schema_sha256": "fbc82a7637a2f79f52b7f8dbe7aee945991a95a34f9adbf187ffa663852f3b16"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:member_billing",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "member_billing",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 13065,
+      "tool_reference_bytes": 7108,
+      "tool_reference_sha256": "270db71df0c99e66cc50c6124e2d7dbda5fadd6eb54562ab21996c0eb5b25419",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "find_membership_products",
+        "create_payment_link",
+        "send_invoice",
+        "confirm_send_invoice",
+        "get_billing_portal"
+      ],
+      "ordered_tool_names_sha256": "b324e3dd51b9640389168ef3a4e709cd2c27e47427d7352229627861781108b8",
+      "wire_schema_sha256": "37893a795faf715b284336c7beada0cdc385080fbbff0e94ee0094eeb01b1602"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:member_profile",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "member_profile",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 15,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 17079,
+      "tool_reference_bytes": 8750,
+      "tool_reference_sha256": "2fd463a775b09815d175f6b4dac1ca45f0b9301cda5305447e9e08e2295700dc",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_my_profile",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "e7d3efe2eca5a246cf6ef99cf7a297b1583adebe6e68cbcc23d454c70624e5d9",
+      "wire_schema_sha256": "b5e75daf6f1a8add1fdf58383b37b5188e09aed0ee3d2fd7a9f9b0f5b6a602fb"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:property_catalog",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "property_catalog",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 17,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 15578,
+      "tool_reference_bytes": 7722,
+      "tool_reference_sha256": "61a0709c99ef0167d4d42cd73528959c1c6776a4d2048e59711319e15e873d47",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "resolve_property",
+        "save_property",
+        "list_properties",
+        "list_missing_properties",
+        "check_property_list",
+        "enhance_property",
+        "resolve_catalog",
+        "browse_catalog",
+        "dispute_catalog_entry",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "1e13c3c04582db2e20d3c2232db1179e5b9558f45c9f540b4b9673fab830d29f",
+      "wire_schema_sha256": "4f2e8921e874f5c2c2e9e027c953f6e1442bb8cda482a3ed1562557b03270d43"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:publishing_author",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "publishing_author",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12841,
+      "tool_reference_bytes": 6404,
+      "tool_reference_sha256": "a6c79c0c96fcf511e2dc0dc27cc6ec8fcda07b111ed1dd99d903b69d99d9e8f3",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "propose_content",
+        "attach_content_asset",
+        "get_my_content",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "5ff202716eb2e96f09fd7ccb51c0214ac22ee6309d87e4913cc3d011a56c8572",
+      "wire_schema_sha256": "556dad233fbe882e066b0cc76823e483b70101c999c028ca87140e64bcbaa978"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:publishing_promotion",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "publishing_promotion",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 9,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 9891,
+      "tool_reference_bytes": 6253,
+      "tool_reference_sha256": "8d0d16535ce27054c2b43c26ae5186898d3bf57651b718ebcbd14c3ac1cbf67d",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_perspectives",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "a692d943e6821afd0b483e4e40378ac4c6ec2bb95293491b2dcb7f709ffee862",
+      "wire_schema_sha256": "df97f90ed90c30a62b72043ca25db81b519f2ed950b777653da3f2f40211b5ab"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:publishing_review",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "publishing_review",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11236,
+      "tool_reference_bytes": 6596,
+      "tool_reference_sha256": "09c154e8bd60a690ea286ee84fe4c4216fe198b7a48680291888d3b222ccd5c1",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "list_pending_content",
+        "approve_content",
+        "reject_content",
+        "request_revisions",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "756126a02cbee1a579bbfeaaab41e64873ad1f5d45ecc8f4a00b5c2f70fb0bbc",
+      "wire_schema_sha256": "5db3236b42332f41db8f334b73849fd7b330ca55c712e1d84dd38c3a8f83516e"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:schema_reference",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "schema_reference",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 12,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12793,
+      "tool_reference_bytes": 6793,
+      "tool_reference_sha256": "ca32a251214b1b83f7762242f92ee9bb0dfcb6bea0ec43d443aae7a1f801a3e1",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "get_account_link",
+        "set_outreach_preference",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "74740d71b620fb902938bec28560ab71f5233be2d9af7ba9b9ce495da18b2a12",
+      "wire_schema_sha256": "004461998e57fdaf62f2350527e49acafe5246048e1da2b7933753049a0d51a7"
+    },
+    {
+      "id": "web_chat:authenticated_member:routed:sponsored_intelligence",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "sponsored_intelligence",
+        "knowledge"
+      ],
+      "conditional_maximums": [
+        "router_selected_bounded_domain",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 14,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 12335,
+      "tool_reference_bytes": 7111,
+      "tool_reference_sha256": "8def28d7f77e2ffee3327eb453b02a12093edd8ac2a3ad18ac5dbfb61a84a6e2",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning"
+      ],
+      "ordered_tool_names_sha256": "830f35a23b149b015139431b9b4353b78e44504240ab652ef1c77caea66f09e2",
+      "wire_schema_sha256": "80eb27efbdd38b112286c9bf4e86128fe6a2c17c853f02a4c52482cb311d9cd4"
+    },
+    {
+      "id": "web_chat:authenticated_member:safe_fallback",
+      "runtime": "web_chat",
+      "audience": "authenticated_member",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 11,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 9889,
+      "tool_reference_bytes": 7097,
+      "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
+      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
     }
   ],
   "baseline": {
@@ -17416,7 +20674,7 @@
       "maximum_slack_public_schema_bytes": 2655,
       "legacy_slack_member_tools": -83,
       "web_anonymous_tools": 0,
-      "web_authenticated_admin_tools": -3
+      "web_authenticated_admin_tools": -196
     }
   },
   "budgets": {
@@ -17439,7 +20697,7 @@
       "maximum_slack_public_schema_bytes": 164359,
       "legacy_slack_member_tools": 138,
       "web_anonymous_tools": 13,
-      "web_authenticated_admin_tools": 232
+      "web_authenticated_admin_tools": 39
     },
     "surface_maximums": {
       "email_chat:anonymous": {
@@ -17587,24 +20845,24 @@
         "maximum_provider_tool_wire_bytes": 52
       },
       "web_chat:authenticated_admin": {
-        "custom_tool_count": 232,
-        "wire_schema_bytes": 177151,
+        "custom_tool_count": 39,
+        "wire_schema_bytes": 39768,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "web_chat:authenticated_member": {
-        "custom_tool_count": 152,
-        "wire_schema_bytes": 125514,
+        "custom_tool_count": 37,
+        "wire_schema_bytes": 37474,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       }
     },
-    "profile_ids_sha256": "11ade6dfd79fbd345386fd20b109f09910974aca106672821f732f3e16e68e64",
-    "profile_contract_sha256": "dbaf9ab25e087710b422226201e2a7c2401832cbd8b1621dd44902ba7c143e0f",
+    "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
+    "profile_contract_sha256": "20d6a28e6134a976f436d427b9b3074fc6245e51321b9eb84e1e7e7ed3fd61cb",
     "status": "within_budget"
   },
   "profile_contract": {
-    "profile_ids_sha256": "11ade6dfd79fbd345386fd20b109f09910974aca106672821f732f3e16e68e64",
-    "profile_contract_sha256": "dbaf9ab25e087710b422226201e2a7c2401832cbd8b1621dd44902ba7c143e0f"
+    "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
+    "profile_contract_sha256": "20d6a28e6134a976f436d427b9b3074fc6245e51321b9eb84e1e7e7ed3fd61cb"
   }
 }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -19,7 +19,7 @@
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "03eb87d6def523062bbdd790fa82a20314a9fb2d5d03672149e9d80820e15b8e",
     "server/src/addie/handler.ts": "9df4a97138442abf71faf66b53d40ff433b2ac4580e2cebb899cdfe40bd67a84",
-    "server/src/routes/addie-chat.ts": "4a188abe0bcf2ac486899ed586d855fd79451c4e0d37eda11a770b600429dcd3",
+    "server/src/routes/addie-chat.ts": "684a6cadb71464f1331be1257d29f0cdabea62bba6ebef1534a05f7593d76d89",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/slack-tool-selection.ts
+++ b/server/src/addie/slack-tool-selection.ts
@@ -99,6 +99,12 @@ export function selectSlackToolSets(input: SlackToolSetSelectionInput): string[]
   return selected;
 }
 
+/**
+ * Delivery-neutral name for the bounded direct-interaction selection policy.
+ * Slack retains its established export while web chat shares the exact policy.
+ */
+export const selectRoutedToolSets = selectSlackToolSets;
+
 /** Normalize Slack conversation privacy, including DM shapes that omit is_private. */
 export function resolveSlackChannelPrivacy(channel: {
   is_im?: boolean;

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -64,6 +64,12 @@ export const SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS = [
 ] as const;
 
 /**
+ * Direct chat may combine a primary and a closely related follow-up domain,
+ * but never receives an unbounded router-selected union.
+ */
+export const MAX_DIRECT_ROUTED_TOOL_SET_COUNT = 2;
+
+/**
  * Tools excluded from ALWAYS_AVAILABLE in public channels
  * to prevent enrollment pitching where it doesn't belong
  */
@@ -674,6 +680,19 @@ export const TOOL_SETS: Record<string, ToolSet> = {
 export function getToolsInSet(setName: string): string[] {
   const set = TOOL_SETS[setName];
   return set ? set.tools : [];
+}
+
+/**
+ * The explicit read-only surface available when a direct-chat router result
+ * cannot be trusted. This deliberately excludes the normal "always" tools:
+ * several of those write user preferences, create escalations, or resolve
+ * admin work and are appropriate only after a valid route has been selected.
+ */
+export function getSafeReadOnlyFallbackTools(): string[] {
+  return Array.from(new Set([
+    ...SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS.flatMap(getToolsInSet),
+    'web_search',
+  ]));
 }
 
 /**

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -355,7 +355,8 @@ export async function selectRoutedWebTools(input: {
       threadMessages: input.threadMessages,
     };
     try {
-      plan = input.router.quickMatch(routingContext) ?? await input.router.route(routingContext);
+      plan = input.router.quickMatch(routingContext)
+        ?? await input.router.route(routingContext, { failureMode: 'throw' });
     } catch (error) {
       routerAvailable = false;
       logger.warn({ error, threadId: input.threadId }, 'Addie Chat: Router unavailable; using safe read-only fallback');

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -17,6 +17,25 @@ import { CachedPostgresStore } from "../middleware/pg-rate-limit-store.js";
 import { optionalAuth } from "../middleware/auth.js";
 import { serveHtmlWithConfig } from "../utils/html-config.js";
 import { AddieClaudeClient, type AddieResponse, type RequestTools } from "../addie/claude-client.js";
+import {
+  AddieRouter,
+  type ExecutionPlan,
+  type RoutingContext,
+} from "../addie/router.js";
+import { createProductionRouter } from "../addie/router-runtime.js";
+import {
+  buildUnavailableSetsHint,
+  getSafeReadOnlyFallbackTools,
+  getToolsForSets,
+  getValidToolSetNames,
+  MAX_DIRECT_ROUTED_TOOL_SET_COUNT,
+  SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS,
+} from "../addie/tool-sets.js";
+import {
+  classifyActiveCertificationProgress,
+  selectRoutedToolSets,
+  type ActiveCertificationKind,
+} from "../addie/slack-tool-selection.js";
 import { classifyLocalModelExecution } from "../addie/model-providers/model-provider.js";
 import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
@@ -43,6 +62,7 @@ import {
 import {
   SI_HOST_TOOLS,
   createSiHostToolHandlers,
+  hasCachedSiSession,
 } from "../addie/mcp/si-host-tools.js";
 import {
   ADCP_TOOLS,
@@ -160,6 +180,7 @@ export const EMPTY_ASSISTANT_RESPONSE_FALLBACK =
 const logger = createLogger("addie-chat-routes");
 
 let claudeClient: AddieClaudeClient | null = null;
+let webChatRouter: AddieRouter | null = null;
 let initialized = false;
 
 function readAnonymousThreadOwner(req: Request): string | null {
@@ -292,6 +313,114 @@ export function buildTieredAccess(memberTools: RequestTools, isAuth: boolean, is
   return { requestTools, processOptions, effectiveModel };
 }
 
+type WebChatRouter = Pick<AddieRouter, 'quickMatch' | 'route'>;
+type WebChatClient = Pick<AddieClaudeClient, 'processMessage' | 'processMessageStream'>
+  & Partial<Pick<AddieClaudeClient, 'getRegisteredTools'>>;
+
+export interface RoutedWebTools {
+  requestTools: RequestTools;
+  selectedToolSets: string[];
+  allowedToolNames: string[];
+  unavailableHint: string;
+}
+
+/**
+ * Apply the same bounded router selection used by direct Slack conversations
+ * to an authenticated web request. Definitions and handlers are intersected
+ * before dispatch, so an incomplete request-local registration fails closed.
+ */
+export async function selectRoutedWebTools(input: {
+  message: string;
+  memberContext: MemberContext | null;
+  threadId: string;
+  isAAOAdmin: boolean;
+  requestTools: RequestTools;
+  router: WebChatRouter | null;
+  /** Globally registered definitions whose handlers were paired at registration time. */
+  globalToolNames?: readonly string[];
+  activeCertificationKind?: ActiveCertificationKind | null;
+  hasSponsoredIntelligenceContext?: boolean;
+  threadMessages?: string[];
+}): Promise<RoutedWebTools> {
+  let plan: ExecutionPlan | null = null;
+  let routerAvailable = input.router !== null;
+
+  if (input.router) {
+    const routingContext: RoutingContext = {
+      message: input.message,
+      source: 'dm',
+      memberContext: input.memberContext,
+      isThread: true,
+      isAAOAdmin: input.isAAOAdmin,
+      threadMessages: input.threadMessages,
+    };
+    try {
+      plan = input.router.quickMatch(routingContext) ?? await input.router.route(routingContext);
+    } catch (error) {
+      routerAvailable = false;
+      logger.warn({ error, threadId: input.threadId }, 'Addie Chat: Router unavailable; using safe read-only fallback');
+    }
+  }
+
+  const validToolSets = getValidToolSetNames(input.isAAOAdmin);
+  const respondPlan = plan?.action === 'respond' ? plan : null;
+  const hasValidRespondPlan = respondPlan !== null
+    && Array.isArray(respondPlan.tool_sets)
+    && respondPlan.tool_sets.length <= MAX_DIRECT_ROUTED_TOOL_SET_COUNT
+    && respondPlan.tool_sets.every((name) => typeof name === 'string' && validToolSets.has(name));
+  const useSafeFallback = !routerAvailable || !hasValidRespondPlan;
+
+  // Web chat is a direct interaction. An ignore/react, malformed, stale, or
+  // unauthorized plan cannot be delivered safely, so use the explicit
+  // read-only fallback rather than the normal always-available escape hatches.
+  const routerSelectedSets = hasValidRespondPlan
+    ? respondPlan.tool_sets
+    : [...SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS];
+  const selectedToolSets = selectRoutedToolSets({
+    routerSelectedSets,
+    routerAvailable: !useSafeFallback,
+    source: 'dm',
+    isAdmin: input.isAAOAdmin,
+    activeCertificationKind: useSafeFallback ? null : input.activeCertificationKind,
+    hasSponsoredIntelligenceContext: useSafeFallback
+      ? false
+      : input.hasSponsoredIntelligenceContext,
+  });
+  const allowedToolNames = useSafeFallback
+    ? getSafeReadOnlyFallbackTools()
+    : getToolsForSets(selectedToolSets, input.isAAOAdmin);
+  const definitions = new Map(input.requestTools.tools.map((tool) => [tool.name, tool]));
+  const globalToolNames = new Set(input.globalToolNames ?? []);
+  const matchedToolNames = allowedToolNames.filter((name) =>
+    (definitions.has(name) || globalToolNames.has(name))
+    && (input.requestTools.handlers.has(name) || globalToolNames.has(name)),
+  );
+  const incompleteToolNames = allowedToolNames.filter((name) =>
+    name !== 'web_search' && !matchedToolNames.includes(name),
+  );
+  if (incompleteToolNames.length > 0) {
+    logger.warn(
+      { threadId: input.threadId, incompleteToolNames },
+      'Addie Chat: Excluded incomplete routed tool registrations',
+    );
+  }
+  const matched = new Set(matchedToolNames);
+
+  return {
+    requestTools: {
+      tools: input.requestTools.tools.filter((tool) => matched.has(tool.name)),
+      handlers: new Map(
+        [...input.requestTools.handlers].filter(([name]) => matched.has(name)),
+      ),
+    },
+    selectedToolSets,
+    // Keep provider-managed web_search in the allowlist even though it has no
+    // custom handler. The client applies this list to global definitions too.
+    allowedToolNames,
+    unavailableHint: buildUnavailableSetsHint(selectedToolSets, input.isAAOAdmin),
+  };
+}
+
 /**
  * Initialize the chat client
  *
@@ -309,6 +438,7 @@ async function initializeChatClient(): Promise<void> {
 
   // Client defaults to Sonnet; anonymous requests override to Haiku per-request
   claudeClient = new AddieClaudeClient(apiKey, AddieModelConfig.chat);
+  webChatRouter = createProductionRouter(apiKey, process.env.OPENAI_API_KEY?.trim()).router;
 
   // Initialize knowledge search
   await initializeKnowledgeSearch();
@@ -556,6 +686,7 @@ export interface PreparedRequest {
   certificationModuleContext: { moduleId?: string };
   certificationProgress: certDb.LearnerProgress[];
   threadExternalId: string;
+  isAAOAdmin: boolean;
 }
 
 export function resolveThreadCertificationProgress(
@@ -733,6 +864,7 @@ export async function prepareRequestWithMemberTools(
   let hasThreadCertificationContext = false;
   let certificationModuleId: string | undefined;
   let certificationProgress: certDb.LearnerProgress[] = [];
+  let isAAOAdmin = false;
   if (memberContext?.workos_user?.workos_user_id) {
     try {
       const progress = await certDb.getProgress(memberContext.workos_user.workos_user_id);
@@ -787,6 +919,7 @@ export async function prepareRequestWithMemberTools(
       certificationModuleContext: trainingModuleContext,
       certificationProgress,
       threadExternalId,
+      isAAOAdmin: false,
     };
   }
 
@@ -850,6 +983,7 @@ export async function prepareRequestWithMemberTools(
     ]);
 
     if (userIsAdmin) {
+      isAAOAdmin = true;
       allTools.push(...ADMIN_TOOLS);
       for (const [name, handler] of createAdminToolHandlers(memberContext)) {
         combinedHandlers.set(name, handler);
@@ -921,6 +1055,7 @@ export async function prepareRequestWithMemberTools(
     certificationModuleContext: trainingModuleContext,
     certificationProgress,
     threadExternalId,
+    isAAOAdmin,
   };
 }
 
@@ -943,11 +1078,18 @@ const chatCorsOptions: cors.CorsOptions = {
 };
 
 export function createAddieChatRouter(options?: {
-  chatClient?: Pick<AddieClaudeClient, 'processMessage' | 'processMessageStream'>;
+  chatClient?: WebChatClient;
+  router?: WebChatRouter | null;
 }): { pageRouter: Router; apiRouter: Router } {
   const pageRouter = Router();
   const apiRouter = Router();
   const injectedChatClient = options?.chatClient;
+  // An explicit null is a deterministic test/replay choice: do not replace it
+  // with the process-wide production router. Injected clients otherwise use a
+  // safe fallback unless their test supplies a router fixture.
+  const resolveRouter = (): WebChatRouter | null => Object.hasOwn(options ?? {}, 'router')
+    ? options?.router ?? null
+    : (injectedChatClient ? null : webChatRouter);
 
   // Enable CORS for all API routes (for native app support)
   apiRouter.use(cors(chatCorsOptions));
@@ -1150,6 +1292,10 @@ export function createAddieChatRouter(options?: {
         messageToProcess,
         requestContext,
         requestTools: memberTools,
+        memberContext,
+        siAgents,
+        certificationProgress,
+        isAAOAdmin,
         hasThreadCertificationContext,
       } = await prepareRequestWithMemberTools(
         inputValidation.sanitized,
@@ -1159,11 +1305,33 @@ export function createAddieChatRouter(options?: {
         thread.thread_id,
         typeof organization_id === 'string' ? organization_id : null
       );
-      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(
+      const tieredAccess = buildTieredAccess(
         memberTools,
         isAuth,
         hasThreadCertificationContext,
       );
+      const activeCertificationKind = classifyActiveCertificationProgress(
+        certificationProgress.filter((entry) =>
+          entry.addie_thread_id === externalId || entry.addie_thread_id === thread.thread_id,
+        ),
+      );
+      const routedWebTools = isAuth
+        ? await selectRoutedWebTools({
+            message: messageToProcess,
+            memberContext,
+            threadId: thread.thread_id,
+            isAAOAdmin,
+            requestTools: tieredAccess.requestTools,
+            router: resolveRouter(),
+            globalToolNames: activeChatClient.getRegisteredTools?.(),
+            activeCertificationKind,
+            hasSponsoredIntelligenceContext:
+              hasCachedSiSession(externalId) || siAgents.length > 0,
+            threadMessages: contextMessages.slice(-6).map((turn) => `${turn.user}: ${turn.text}`),
+          })
+        : null;
+      const { processOptions, effectiveModel } = tieredAccess;
+      const requestTools = routedWebTools?.requestTools ?? tieredAccess.requestTools;
 
       // Cost-cap scope (#2790 / #2945 f/u). Authenticated callers key
       // off the WorkOS user ID and resolve their tier from
@@ -1183,7 +1351,9 @@ export function createAddieChatRouter(options?: {
       try {
         response = await activeChatClient.processMessage(messageToProcess, contextMessages, requestTools, undefined, {
           ...processOptions,
-          requestContext,
+          requestContext: [requestContext, routedWebTools?.unavailableHint].filter(Boolean).join('\n\n'),
+          selectedToolSetNames: routedWebTools?.selectedToolSets,
+          allowedToolNames: routedWebTools?.allowedToolNames,
           threadId: thread.thread_id,
           userDisplayName: displayName || undefined,
           currentSpeakerName: displayName || undefined,
@@ -1613,10 +1783,12 @@ export function createAddieChatRouter(options?: {
         messageToProcess,
         requestContext,
         requestTools: memberTools,
+        memberContext,
         siAgents,
         hasThreadCertificationContext: hasThreadCertCtx,
         certificationModuleContext,
         certificationProgress,
+        isAAOAdmin,
       } = await prepareRequestWithMemberTools(
         messageForModel,
         req.user?.id,
@@ -1625,7 +1797,29 @@ export function createAddieChatRouter(options?: {
         thread.thread_id,
         typeof organization_id === 'string' ? organization_id : null
       );
-      const { requestTools, processOptions, effectiveModel } = buildTieredAccess(memberTools, isAuth, hasThreadCertCtx);
+      const tieredAccess = buildTieredAccess(memberTools, isAuth, hasThreadCertCtx);
+      const activeCertificationKind = classifyActiveCertificationProgress(
+        certificationProgress.filter((entry) =>
+          entry.addie_thread_id === externalId || entry.addie_thread_id === thread.thread_id,
+        ),
+      );
+      const routedWebTools = isAuth
+        ? await selectRoutedWebTools({
+            message: messageToProcess,
+            memberContext,
+            threadId: thread.thread_id,
+            isAAOAdmin,
+            requestTools: tieredAccess.requestTools,
+            router: resolveRouter(),
+            globalToolNames: activeChatClient.getRegisteredTools?.(),
+            activeCertificationKind,
+            hasSponsoredIntelligenceContext:
+              hasCachedSiSession(externalId) || siAgents.length > 0,
+            threadMessages: contextMessages.slice(-6).map((turn) => `${turn.user}: ${turn.text}`),
+          })
+        : null;
+      const { processOptions, effectiveModel } = tieredAccess;
+      const requestTools = routedWebTools?.requestTools ?? tieredAccess.requestTools;
       requestedModelForAttempt = effectiveModel;
       const preTurnCertification = userId && certificationModuleContext.moduleId
         ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
@@ -1668,7 +1862,9 @@ export function createAddieChatRouter(options?: {
       for await (const event of activeChatClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
         ...processOptions,
         ...(completionReserveEligible ? { maxIterations: 3, maxMessages: 12 } : {}),
-        requestContext,
+        requestContext: [requestContext, routedWebTools?.unavailableHint].filter(Boolean).join('\n\n'),
+        selectedToolSetNames: routedWebTools?.selectedToolSets,
+        allowedToolNames: routedWebTools?.allowedToolNames,
         threadId: thread.thread_id,
         userDisplayName: displayName || undefined,
         currentSpeakerName: displayName || undefined,

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -119,6 +119,7 @@ vi.mock('../../src/addie/mcp/property-tools.js', () => ({
 vi.mock('../../src/addie/mcp/si-host-tools.js', () => ({
   SI_HOST_TOOLS: [],
   createSiHostToolHandlers: () => new Map(),
+  hasCachedSiSession: () => false,
 }));
 
 vi.mock('../../src/addie/mcp/adcp-tools.js', () => ({
@@ -261,7 +262,7 @@ function successfulModelResponse(text = 'Allowed response') {
 
 function mountChatRouter() {
   const timeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation((() => 0) as typeof setTimeout);
-  const { apiRouter } = createAddieChatRouter();
+  const { apiRouter } = createAddieChatRouter({ router: null });
   timeoutSpy.mockRestore();
 
   const app = express();

--- a/server/tests/unit/addie-chat-org-selection.test.ts
+++ b/server/tests/unit/addie-chat-org-selection.test.ts
@@ -12,6 +12,10 @@ const siMocks = vi.hoisted(() => ({
   formatContext: vi.fn(),
 }));
 
+const siHostMocks = vi.hoisted(() => ({
+  hasCachedSiSession: vi.fn(),
+}));
+
 const directoryMocks = vi.hoisted(() => ({
   createHandlers: vi.fn(),
 }));
@@ -47,6 +51,12 @@ vi.mock('../../src/addie/mcp/directory-tools.js', () => ({
     directoryMocks.createHandlers(context);
     return new Map([['list_agents', async () => JSON.stringify({ scoped: true })]]);
   },
+}));
+
+vi.mock('../../src/addie/mcp/si-host-tools.js', () => ({
+  SI_HOST_TOOLS: [],
+  createSiHostToolHandlers: () => new Map(),
+  hasCachedSiSession: siHostMocks.hasCachedSiSession,
 }));
 
 vi.mock('../../src/db/certification-db.js', () => ({
@@ -96,6 +106,8 @@ describe('prepareRequestWithMemberTools organization selection', () => {
     siMocks.retrieve.mockReset();
     siMocks.retrieve.mockResolvedValue({ agents: [], retrieval_time_ms: 0 });
     siMocks.formatContext.mockReset();
+    siHostMocks.hasCachedSiSession.mockReset();
+    siHostMocks.hasCachedSiSession.mockReturnValue(false);
     directoryMocks.createHandlers.mockClear();
   });
 
@@ -157,7 +169,7 @@ describe('mounted Addie web-thread ownership', () => {
     })()),
   } as any;
 
-  function app() {
+  function app(router?: any) {
     const instance = express();
     instance.use(express.json());
     instance.use((req, _res, next) => {
@@ -170,7 +182,7 @@ describe('mounted Addie web-thread ownership', () => {
         : {};
       next();
     });
-    instance.use('/api/addie/chat', createAddieChatRouter({ chatClient }).apiRouter);
+    instance.use('/api/addie/chat', createAddieChatRouter({ chatClient, router }).apiRouter);
     return instance;
   }
 
@@ -243,6 +255,75 @@ describe('mounted Addie web-thread ownership', () => {
       expect(processMessage.mock.calls[0]?.[0]).toBe(message);
     },
   );
+
+  it('uses identical routed tools and prompt modules for authenticated JSON and streaming requests', async () => {
+    const router = {
+      quickMatch: vi.fn().mockReturnValue(null),
+      route: vi.fn().mockResolvedValue({
+        action: 'respond',
+        tool_sets: ['directory'],
+        confidence: 'high',
+        reason: 'directory lookup',
+        decision_method: 'llm',
+      }),
+    };
+    chatClient.processMessage.mockClear();
+    chatClient.processMessageStream.mockClear();
+
+    await request(app(router))
+      .post('/api/addie/chat')
+      .set('x-test-user-id', 'user_123')
+      .send({ message: 'Find an agent' })
+      .expect(200);
+    await request(app(router))
+      .post('/api/addie/chat/stream')
+      .set('x-test-user-id', 'user_123')
+      .send({ message: 'Find an agent' })
+      .expect(200);
+
+    const jsonTools = chatClient.processMessage.mock.calls[0]?.[2]?.tools.map((tool: { name: string }) => tool.name);
+    const jsonOptions = chatClient.processMessage.mock.calls[0]?.[4];
+    const streamTools = chatClient.processMessageStream.mock.calls[0]?.[2]?.tools.map((tool: { name: string }) => tool.name);
+    const streamOptions = chatClient.processMessageStream.mock.calls[0]?.[3];
+
+    expect(jsonTools).toEqual(streamTools);
+    expect(jsonOptions.selectedToolSetNames).toEqual(['directory', 'knowledge']);
+    expect(streamOptions.selectedToolSetNames).toEqual(jsonOptions.selectedToolSetNames);
+    expect(streamOptions.allowedToolNames).toEqual(jsonOptions.allowedToolNames);
+  });
+
+  it.each([
+    ['JSON', '/api/addie/chat', chatClient.processMessage, 4],
+    ['streaming', '/api/addie/chat/stream', chatClient.processMessageStream, 3],
+  ])('keeps sponsored-intelligence routing scoped to the external thread id on %s', async (
+    _label,
+    path,
+    processMessage,
+    optionsArgument,
+  ) => {
+    const conversationId = '11111111-1111-4111-8111-111111111111';
+    const router = {
+      quickMatch: vi.fn().mockReturnValue(null),
+      route: vi.fn().mockResolvedValue({
+        action: 'respond', tool_sets: ['directory'], confidence: 'high', reason: 'test', decision_method: 'llm',
+      }),
+    };
+    siHostMocks.hasCachedSiSession.mockReturnValue(true);
+    threadMocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread-internal-id', user_type: 'workos', user_id: 'user_123', message_count: 1,
+    });
+    processMessage.mockClear();
+
+    await request(app(router))
+      .post(path)
+      .set('x-test-user-id', 'user_123')
+      .send({ message: 'Continue SI work', conversation_id: conversationId })
+      .expect(200);
+
+    expect(siHostMocks.hasCachedSiSession).toHaveBeenCalledWith(conversationId);
+    expect(processMessage.mock.calls[0]?.[optionsArgument]?.selectedToolSetNames)
+      .toEqual(['directory', 'knowledge', 'sponsored_intelligence']);
+  });
 
   it('issues an HttpOnly owner capability cookie when an anonymous POST creates a thread', async () => {
     const response = await request(app())

--- a/server/tests/unit/addie/web-tool-selection.test.ts
+++ b/server/tests/unit/addie/web-tool-selection.test.ts
@@ -61,12 +61,15 @@ describe('authenticated web Addie tool routing', () => {
       'search_docs',
       'create_payment_link',
     ]);
-    expect(router.route).toHaveBeenCalledWith(expect.objectContaining({
-      source: 'dm',
-      isThread: true,
-      isAAOAdmin: false,
-      threadMessages: ['User: Earlier request'],
-    }));
+    expect(router.route).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'dm',
+        isThread: true,
+        isAAOAdmin: false,
+        threadMessages: ['User: Earlier request'],
+      }),
+      { failureMode: 'throw' },
+    );
   });
 
   it('allows an authorized admin domain but rejects it for a member', async () => {
@@ -146,6 +149,36 @@ describe('authenticated web Addie tool routing', () => {
     ]) {
       expect(selected.allowedToolNames).not.toContain(mutation);
     }
+  });
+
+  it('forces router outages into the safe fallback instead of accepting a returned fallback plan', async () => {
+    const router = {
+      quickMatch: vi.fn().mockReturnValue(null),
+      route: vi.fn().mockImplementation(async (_context, options) => {
+        // This is deliberately a single, otherwise-authorized admin domain:
+        // without failureMode: throw it would evade a set-count guard.
+        if (options?.failureMode !== 'throw') {
+          return {
+            action: 'respond' as const,
+            tool_sets: ['admin_prospects'],
+            confidence: 'high' as const,
+            reason: 'internal router fallback',
+            decision_method: 'llm' as const,
+          };
+        }
+        throw new Error('provider outage');
+      }),
+    };
+
+    const selected = await select(router, true);
+
+    expect(router.route).toHaveBeenCalledWith(expect.any(Object), { failureMode: 'throw' });
+    expect(selected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(selected.allowedToolNames).not.toContain('add_prospect');
   });
 
   it('never returns a definition or handler without its counterpart', async () => {

--- a/server/tests/unit/addie/web-tool-selection.test.ts
+++ b/server/tests/unit/addie/web-tool-selection.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AddieTool } from '../../../src/addie/types.js';
+import {
+  selectRoutedWebTools,
+} from '../../../src/routes/addie-chat.js';
+
+const tools: AddieTool[] = [
+  { name: 'search_docs', description: 'Search docs', input_schema: { type: 'object', properties: {} } },
+  { name: 'create_payment_link', description: 'Create payment link', input_schema: { type: 'object', properties: {} } },
+  { name: 'add_prospect', description: 'Add prospect', input_schema: { type: 'object', properties: {} } },
+  { name: 'orphaned_definition', description: 'Must not reach the model', input_schema: { type: 'object', properties: {} } },
+];
+const handlers = new Map(tools
+  .filter((tool) => tool.name !== 'orphaned_definition')
+  .map((tool) => [tool.name, async () => '{}']));
+handlers.set('orphaned_handler', async () => '{}');
+
+function routerFor(toolSets: string[]) {
+  return {
+    quickMatch: vi.fn().mockReturnValue(null),
+    route: vi.fn().mockResolvedValue({
+      action: 'respond' as const,
+      tool_sets: toolSets,
+      confidence: 'high' as const,
+      reason: 'test',
+      decision_method: 'llm' as const,
+    }),
+  };
+}
+
+async function select(
+  router: Parameters<typeof selectRoutedWebTools>[0]['router'],
+  isAAOAdmin = false,
+  requestTools = { tools, handlers },
+  globalToolNames?: string[],
+) {
+  return selectRoutedWebTools({
+    message: 'Test message',
+    memberContext: null,
+    threadId: 'thread-1',
+    isAAOAdmin,
+    requestTools,
+    router,
+    globalToolNames,
+    threadMessages: ['User: Earlier request'],
+  });
+}
+
+describe('authenticated web Addie tool routing', () => {
+  it('selects bounded member tools with request-scoped prompt modules', async () => {
+    const router = routerFor(['member_billing']);
+    const selected = await select(router);
+
+    expect(selected.selectedToolSets).toEqual(['member_billing', 'knowledge']);
+    expect(selected.allowedToolNames).toContain('create_payment_link');
+    expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual([
+      'search_docs',
+      'create_payment_link',
+    ]);
+    expect([...selected.requestTools.handlers.keys()]).toEqual([
+      'search_docs',
+      'create_payment_link',
+    ]);
+    expect(router.route).toHaveBeenCalledWith(expect.objectContaining({
+      source: 'dm',
+      isThread: true,
+      isAAOAdmin: false,
+      threadMessages: ['User: Earlier request'],
+    }));
+  });
+
+  it('allows an authorized admin domain but rejects it for a member', async () => {
+    const adminSelected = await select(routerFor(['admin_prospects']), true);
+    expect(adminSelected.selectedToolSets).toContain('admin_prospects');
+    expect(adminSelected.requestTools.tools.map((tool) => tool.name)).toContain('add_prospect');
+
+    const memberSelected = await select(routerFor(['admin_prospects']));
+    expect(memberSelected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(memberSelected.requestTools.tools.map((tool) => tool.name)).not.toContain('add_prospect');
+  });
+
+  it('fails closed to the safe read-only fallback for invalid router output', async () => {
+    const selected = await select(routerFor(['obsolete_router_alias']));
+
+    expect(selected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual(['search_docs']);
+    expect(selected.allowedToolNames).not.toContain('create_payment_link');
+    expect(selected.allowedToolNames).not.toContain('add_prospect');
+  });
+
+  it('fails closed when a router plan exceeds the two-domain direct-chat bound', async () => {
+    const selected = await select(routerFor(['member_billing', 'directory', 'events']));
+
+    expect(selected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(selected.allowedToolNames).not.toContain('create_payment_link');
+    expect(selected.allowedToolNames).not.toContain('capture_learning');
+  });
+
+  it('does not add sponsored-intelligence prompt scope to a safe fallback', async () => {
+    const selected = await selectRoutedWebTools({
+      message: 'Continue SI work',
+      memberContext: null,
+      threadId: 'thread-1',
+      isAAOAdmin: false,
+      requestTools: { tools, handlers },
+      router: null,
+      hasSponsoredIntelligenceContext: true,
+    });
+
+    expect(selected.selectedToolSets).not.toContain('sponsored_intelligence');
+    expect(selected.allowedToolNames).not.toContain('send_to_si_agent');
+  });
+
+  it('fails closed to the safe read-only fallback when the router fails', async () => {
+    const router = {
+      quickMatch: vi.fn().mockReturnValue(null),
+      route: vi.fn().mockRejectedValue(new Error('router unavailable')),
+    };
+    const selected = await select(router);
+
+    expect(selected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual(['search_docs']);
+    for (const mutation of [
+      'capture_learning',
+      'set_outreach_preference',
+      'escalate_to_admin',
+      'resolve_escalation',
+      'create_payment_link',
+      'add_prospect',
+    ]) {
+      expect(selected.allowedToolNames).not.toContain(mutation);
+    }
+  });
+
+  it('never returns a definition or handler without its counterpart', async () => {
+    const selected = await select(routerFor(['member_billing']));
+    const definitionNames = selected.requestTools.tools.map((tool) => tool.name).sort();
+    const handlerNames = [...selected.requestTools.handlers.keys()].sort();
+
+    expect(definitionNames).toEqual(handlerNames);
+    expect(definitionNames).not.toContain('orphaned_definition');
+    expect(handlerNames).not.toContain('orphaned_handler');
+  });
+
+  it('retains authenticated handlers that override a paired global definition', async () => {
+    const localTools = tools.filter((tool) => tool.name === 'create_payment_link');
+    const localHandlers = new Map([
+      ['search_docs', async () => '{"scope":"authenticated"}'],
+      ['create_payment_link', async () => '{}'],
+    ]);
+    const selected = await select(
+      routerFor(['member_billing']),
+      false,
+      { tools: localTools, handlers: localHandlers },
+      ['search_docs'],
+    );
+
+    // The definition is paired in the global registry; the request-local
+    // handler shadows its anonymous-safe counterpart for authenticated users.
+    expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual(['create_payment_link']);
+    expect([...selected.requestTools.handlers.keys()]).toEqual([
+      'search_docs',
+      'create_payment_link',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Moves authenticated web chat (JSON and SSE) to the bounded provider-neutral router selection and request-scoped prompt path. Router output is validated and capped at two direct domains; trusted Sponsored Intelligence context remains a server-owned overlay.
- Fails closed for malformed, stale, unauthorized, over-cap, unavailable, or failed routing with an explicit named, read-only fallback (including web search) that excludes mutation handlers.
- Preserves the global-definition/request-local authenticated-handler pairing, admin filtering, thread continuity, and JSON/SSE selected-tool and prompt-module parity.

## Surface metrics

| Authenticated web profile | Custom tools | Wire schema bytes | Prompt/reference bytes |
| --- | ---: | ---: | ---: |
| Member before | 152 | 125,388 | 31,540 |
| Member after | 37 | 37,474 | 13,690 |
| Admin before | 232 | 177,025 | 34,727 |
| Admin after | 39 | 39,768 | 13,758 |

Anonymous web chat remains at 13 tools. Addie code/config version is `2026.09.9`; generated inventory and surface-budget artifacts are regenerated. No changeset is required for this Addie-only change under repository policy.

## Safety and tests

- Added deterministic member/admin routing, unauthorized mutation, invalid/over-cap output, router failure/fallback, handler-definition parity, request prompt scoping, SI continuity, and JSON/SSE parity coverage. Tests inject a mocked router or explicit `null`; final focused logs contain no AddieRouter/model execution entries, so no paid/live provider call is made by the committed tests.
- Focused web tests: 49 passed; broader deterministic coverage: 171 passed.
- Passed `npm run typecheck`, `npm run test:addie-tools`, `npm run build`, and `git diff --check`.
- Normalized scaled precommit hook and standalone server-unit both passed: 542 files / 7,797 passed, 30 skipped. Independent code and security review approved the final diff.
- Environment baseline: this workspace’s `.env.local` sets `DEV_USER_EMAIL` and `DEV_USER_ID`, which enables development auth at module load and causes four normal-auth baseline failures on clean `origin/main`. All full-suite verification exports both as empty values; repository configuration is unchanged.

Related to #6845

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ce97f149-fd91-4a33-96b7-ef44139c23ff)
