### PR TITLE
refactor(addie): bound Slack reaction tools

### DIFF
--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
-  "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
-  "profile_contract_sha256": "9805570b53d3f4a405a1c39d027733b11db5860fb947e29d6abdb1d4921ab992",
+  "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
+  "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {
@@ -55,10 +55,10 @@
     "legacy_slack:member_mention": { "custom_tool_count": 133, "wire_schema_bytes": 117335, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "mcp_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "official_docs_replay:evaluation_only": { "custom_tool_count": 2, "wire_schema_bytes": 1873, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
-    "slack_bolt_reaction:admin": { "custom_tool_count": 243, "wire_schema_bytes": 191322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:member": { "custom_tool_count": 163, "wire_schema_bytes": 139685, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:public_channel": { "custom_tool_count": 162, "wire_schema_bytes": 137874, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:public_channel_admin": { "custom_tool_count": 242, "wire_schema_bytes": 189511, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:admin": { "custom_tool_count": 36, "wire_schema_bytes": 36467, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:member": { "custom_tool_count": 34, "wire_schema_bytes": 34173, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:public_channel": { "custom_tool_count": 33, "wire_schema_bytes": 33700, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:public_channel_admin": { "custom_tool_count": 33, "wire_schema_bytes": 33700, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:admin_dm": { "custom_tool_count": 219, "wire_schema_bytes": 173278, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:admin_working_group": { "custom_tool_count": 219, "wire_schema_bytes": 173278, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:member_dm": { "custom_tool_count": 153, "wire_schema_bytes": 131695, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },

--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-  "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce",
+  "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {

--- a/scripts/build-addie-tool-surface-inventory.ts
+++ b/scripts/build-addie-tool-surface-inventory.ts
@@ -15,6 +15,7 @@ import { assembleAddieSystemPrompt } from '../server/src/addie/prompt-assembly.j
 import { buildAddieToolReference } from '../server/src/addie/prompts.js';
 import {
   ADMIN_CHANNEL_WG_SLUG,
+  selectBoundedRoutedToolSets,
   selectSlackToolSets,
   SYSTEM_CHANNEL_TOOL_SETS,
   type SlackToolSource,
@@ -456,28 +457,99 @@ function buildSlackBoltProfiles(defs: Awaited<ReturnType<typeof loadDefinitions>
       conditionalMaximums: ['server_configured_system_channel', 'router_returns_all_valid_tool_sets', 'google_docs_configured', 'nonstreaming_web_search'],
     }));
   }
-  profiles.push(
-    profile({
-      id: 'slack_bolt_reaction:member:maximum', runtime: 'slack_bolt_reaction', audience: 'member',
-      globalTools, requestTools: memberRequest, providerToolCount: 1,
-      conditionalMaximums: ['google_docs_configured', 'member_event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
-    profile({
-      id: 'slack_bolt_reaction:admin:maximum', runtime: 'slack_bolt_reaction', audience: 'admin',
-      globalTools, requestTools: adminRequest, providerToolCount: 1,
-      conditionalMaximums: ['google_docs_configured', 'admin_event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
-    profile({
-      id: 'slack_bolt_reaction:public_channel:maximum', runtime: 'slack_bolt_reaction', audience: 'public_channel',
-      globalTools, requestTools: publicRequest, providerToolCount: 1,
-      conditionalMaximums: ['google_docs_configured', 'event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
-    profile({
-      id: 'slack_bolt_reaction:public_channel_admin:maximum', runtime: 'slack_bolt_reaction', audience: 'public_channel_admin',
-      globalTools, requestTools: buildRequest(true, true), providerToolCount: 1,
-      conditionalMaximums: ['google_docs_configured', 'admin_event_and_meeting_permissions', 'nonstreaming_web_search'],
-    }),
-  );
+  // Reaction-triggered replies use the same bounded response-plan policy as
+  // other direct, user-visible routes. Record each metric's actual maximum,
+  // plus the explicit router-failure surface, rather than modeling the old
+  // unrestricted request registry as reachable at runtime.
+  const reactionSurfaces = [
+    { audience: 'member', isAdmin: false, isPublic: false, available: memberRequest },
+    { audience: 'admin', isAdmin: true, isPublic: false, available: adminRequest },
+    { audience: 'public_channel', isAdmin: false, isPublic: true, available: publicRequest },
+    { audience: 'public_channel_admin', isAdmin: true, isPublic: true, available: buildRequest(true, true) },
+  ];
+  for (const surface of reactionSurfaces) {
+    const availableReactionToolNames = new Set([
+      ...globalTools,
+      ...surface.available,
+    ].map((tool) => tool.name));
+    const routerVisibleSetNames = Object.values(toolSets.TOOL_SETS)
+      .filter((set) => set.routerVisible !== false && (surface.isAdmin || !set.adminOnly))
+      .map((set) => set.name);
+    const combinations = routerVisibleSetNames.map((setName) => [setName]);
+    for (let first = 0; first < routerVisibleSetNames.length; first += 1) {
+      for (let second = first + 1; second < routerVisibleSetNames.length; second += 1) {
+        combinations.push([routerVisibleSetNames[first], routerVisibleSetNames[second]]);
+      }
+    }
+    const candidates = combinations.flatMap((toolSetsForPlan) => [false, true].map((hasSponsoredIntelligenceContext) => {
+      const selection = selectBoundedRoutedToolSets({
+        plan: {
+          action: 'respond',
+          tool_sets: toolSetsForPlan,
+          confidence: 'high',
+          reason: 'inventory bounded reaction route',
+          decision_method: 'quick_match',
+        },
+        routerAvailable: true,
+        source: 'channel',
+        isAdmin: surface.isAdmin,
+        isPublicChannel: surface.isPublic,
+        hasSponsoredIntelligenceContext,
+        isToolAvailable: (name) => availableReactionToolNames.has(name),
+      });
+      return profile({
+        id: `slack_bolt_reaction:${surface.audience}:candidate:${toolSetsForPlan.join('+')}${hasSponsoredIntelligenceContext ? ':si_context' : ''}`,
+        runtime: 'slack_bolt_reaction',
+        audience: surface.audience,
+        route: toolSetsForPlan.join('+'),
+        selectedToolSets: selection.selectedToolSets,
+        allowedToolNames: selection.allowedToolNames,
+        globalTools,
+        requestTools: surface.available,
+        providerToolCount: 1,
+        conditionalMaximums: [
+          'router_selected_up_to_two_bounded_domains',
+          ...(hasSponsoredIntelligenceContext ? ['active_sponsored_intelligence_session'] : []),
+          'google_docs_configured',
+          'nonstreaming_web_search',
+        ],
+      });
+    }));
+    const maximums = new Map<string, Profile>();
+    for (const metric of ['custom_tool_count', 'wire_schema_bytes', 'tool_reference_bytes'] as const) {
+      const maximum = Math.max(...candidates.map((candidate) => candidate[metric]));
+      const candidate = candidates.find((entry) => entry[metric] === maximum)!;
+      maximums.set(metric, {
+        ...candidate,
+        id: metric === 'custom_tool_count'
+          ? `slack_bolt_reaction:${surface.audience}:maximum`
+          : `slack_bolt_reaction:${surface.audience}:maximum_${metric}`,
+      });
+    }
+    const fallback = selectBoundedRoutedToolSets({
+      plan: null,
+      routerAvailable: false,
+      source: 'channel',
+      isAdmin: surface.isAdmin,
+      isPublicChannel: surface.isPublic,
+      hasSponsoredIntelligenceContext: true,
+      activeCertificationKind: 'mixed',
+      systemRole: 'billing',
+      isToolAvailable: (name) => availableReactionToolNames.has(name),
+    });
+    profiles.push(...maximums.values(), profile({
+      id: `slack_bolt_reaction:${surface.audience}:safe_fallback`,
+      runtime: 'slack_bolt_reaction',
+      audience: surface.audience,
+      route: 'safe_fallback',
+      selectedToolSets: fallback.selectedToolSets,
+      allowedToolNames: fallback.allowedToolNames,
+      globalTools,
+      requestTools: surface.available,
+      providerToolCount: 1,
+      conditionalMaximums: ['router_unavailable', 'nonstreaming_web_search'],
+    }));
+  }
   return profiles;
 }
 
@@ -1048,8 +1120,11 @@ async function buildSnapshot() {
   const runtimeToolsMissingFromCatalog = [...runtimeNames]
     .filter((name) => !catalogTokens.has(name))
     .sort();
+  // The catalog also documents conditionally registered, non-routed tools.
+  // Inventory parity is a runtime safety property: every tool a router can
+  // select must have a definition/handler on at least one modeled runtime.
   const catalogToolsMissingFromRuntime = [...catalogTokens]
-    .filter((name) => !runtimeNames.has(name))
+    .filter((name) => routedNames.has(name) && !runtimeNames.has(name))
     .sort();
 
   const snapshot = {

--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -252,6 +252,7 @@ import {
   classifyActiveCertificationProgress,
   resolveRequiredSlackChannelContext,
   resolveSlackChannelPrivacy,
+  selectBoundedRoutedToolSets,
   selectSlackToolSets,
   type ActiveCertificationKind,
   type SystemChannelRole,
@@ -1058,7 +1059,8 @@ async function setAgentViewSuggestedPrompts(client: any, userId: string, channel
 async function buildRequestContext(
   userId: string,
   threadContext?: ThreadContext,
-  existingMemberContext?: MemberContext | null
+  existingMemberContext?: MemberContext | null,
+  options?: { includeCertificationContext?: boolean },
 ): Promise<{ requestContext: string; memberContext: MemberContext | null; activeCertificationKind: ActiveCertificationKind | null }> {
   try {
     const memberContext = existingMemberContext !== undefined ? existingMemberContext : await getMemberContext(userId);
@@ -1097,7 +1099,7 @@ async function buildRequestContext(
     let certContextText = '';
     let activeCertificationKind: ActiveCertificationKind | null = null;
     const workosUserId = memberContext?.workos_user?.workos_user_id;
-    if (workosUserId) {
+    if (workosUserId && options?.includeCertificationContext !== false) {
       try {
         const progress = await certDb.getProgress(workosUserId);
         const inProgress = progress.filter(p => p.status === 'in_progress');
@@ -5730,6 +5732,7 @@ async function handleReactionAdded({
   if (!claudeClient || !boltApp) {
     return;
   }
+  const reactionClient = claudeClient;
 
   // Use boltApp.client for API calls
   const client = boltApp.client;
@@ -5928,11 +5931,70 @@ async function handleReactionAdded({
   // Create user-scoped tools (pass channel context for working group auto-detection)
   const { tools: userTools, isAAOAdmin: userIsAdmin } = await createUserScopedTools(memberContext, reactingUserId, thread.thread_id, channelContext);
 
+  // Reactions are user-visible thread continuations, but selection is kept
+  // separate from the reaction trigger, persistence, audit, and delivery
+  // mechanics above. Invalid/non-response/over-broad router output receives
+  // the same explicit read-only fallback as authenticated web chat.
+  let reactionPlan: ExecutionPlan | null = null;
+  let reactionRouterAvailable = addieRouter !== null;
+  if (addieRouter) {
+    const routingContext: RoutingContext = {
+      message: userInput,
+      source: 'channel',
+      memberContext,
+      isThread: true,
+      isAAOAdmin: userIsAdmin,
+      channelName: channelContext.viewing_channel_name,
+      threadMessages: conversationHistory?.slice(-6).map((turn) => `${turn.user}: ${turn.text}`),
+    };
+    try {
+      reactionPlan = addieRouter.quickMatch(routingContext)
+        ?? await addieRouter.route(routingContext, { failureMode: 'throw' });
+    } catch (error) {
+      reactionRouterAvailable = false;
+      logger.warn({ error, threadId: thread.thread_id }, 'Addie Bolt: Reaction router unavailable; using safe read-only fallback');
+    }
+  }
+  const requestDefinitionNames = new Set(userTools.tools.map((tool) => tool.name));
+  const requestHandlerNames = new Set(userTools.handlers.keys());
+  const reactionSelection = selectBoundedRoutedToolSets({
+    plan: reactionPlan,
+    routerAvailable: reactionRouterAvailable,
+    source: 'channel',
+    isAdmin: userIsAdmin,
+    isPublicChannel: channelContext.viewing_channel_is_private === false,
+    hasSponsoredIntelligenceContext: hasCachedSiSession(thread.thread_id),
+    isToolAvailable: (name) => (
+      (requestDefinitionNames.has(name) && requestHandlerNames.has(name))
+      || reactionClient.hasRegisteredTools([name])
+    ),
+  });
+  const { filteredTools: reactionTools } = filterToolsBySet(
+    userTools,
+    reactionSelection.selectedToolSets,
+    userIsAdmin,
+    channelContext.viewing_channel_is_private === false,
+  );
+  if (reactionSelection.useSafeFallback) {
+    // The normal member context can contain a server-owned active-course
+    // overlay. Rebuild it without that elevated context for a router fallback.
+    const fallbackContext = await buildRequestContext(reactingUserId, channelContext, memberContext, {
+      includeCertificationContext: false,
+    });
+    requestContext = fallbackContext.requestContext;
+    if (historyUnavailable) requestContext += `\n\n${HISTORY_UNAVAILABLE_NOTE}`;
+  }
+  requestContext = [requestContext, reactionSelection.unavailableHint]
+    .filter(Boolean)
+    .join('\n\n');
+
   // Admin users get higher iteration limit for bulk operations.
   // Reactions can confirm tool actions, so they remain user-scoped.
   const processOptions = {
     ...(userIsAdmin ? { maxIterations: ADMIN_MAX_ITERATIONS } : {}),
     requestContext,
+    selectedToolSetNames: reactionSelection.selectedToolSets,
+    allowedToolNames: reactionSelection.allowedToolNames,
     slackUserId: reactingUserId,
     threadId: thread.thread_id,
     ...(await buildSlackCostOptions(memberContext, reactingUserId)),
@@ -5942,7 +6004,7 @@ async function handleReactionAdded({
   // Process with Claude
   let response: AddieResponse;
   try {
-    response = await claudeClient.processMessage(userInput, conversationHistory, userTools, undefined, processOptions);
+    response = await reactionClient.processMessage(userInput, conversationHistory, reactionTools, undefined, processOptions);
   } catch (error) {
     logger.error({ error }, 'Addie Bolt: Error processing reaction response');
     response = {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.9';
+export const CODE_VERSION = '2026.09.10';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -110,7 +110,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 172327,
+      "wire_schema_bytes": 172332,
       "tool_reference_bytes": 29572,
       "tool_reference_sha256": "4d90d8576f2f543ed2646294b69a7e0e08201b8efd312b904ea43baa3a2a83b5",
       "overridden_tool_count": 7,
@@ -337,7 +337,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "cc78806188aa3b7be55bba733abc1ecbf7b2eea9f83ae6068e5b97ef694eb072",
-      "wire_schema_sha256": "8d636c4512a5a13ee8a75bc6c64363212b2a50065c48cee1f4a775fef39a212b"
+      "wire_schema_sha256": "72589df4027d4d1ad75354b46aead59c4691c088c4a791636355d68bf0caa74f"
     },
     {
       "id": "legacy_slack:admin_mention:maximum",
@@ -355,7 +355,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 168846,
+      "wire_schema_bytes": 168851,
       "tool_reference_bytes": 28616,
       "tool_reference_sha256": "41b9d3e6692a8601f73deca9d90a76fcc100e1cde724e3d99c185ad4903c4ad1",
       "overridden_tool_count": 7,
@@ -577,7 +577,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "1d769dca5f53c7baee0102ce9e49384e23c11d51e1e44d65913124563c08e97c",
-      "wire_schema_sha256": "2802b8b4d53ed364f2666b8c6fb39188e1097d486bf7e9a942f458a929cda2a3"
+      "wire_schema_sha256": "377b10d7c32fbe77fd488626a84d3b608bc9c54d146ab551b2a80184c3ad8e13"
     },
     {
       "id": "legacy_slack:member_dm:maximum",
@@ -595,7 +595,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 120690,
+      "wire_schema_bytes": 120695,
       "tool_reference_bytes": 26385,
       "tool_reference_sha256": "993ca372acea9111b4ec3efc74d631c448e056613031d4fa975bc8c918763e68",
       "overridden_tool_count": 7,
@@ -742,7 +742,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "88484816c567cdded948a50c26649b061d39509263be69448049497bd93edc30",
-      "wire_schema_sha256": "007f09dbaf5d07d0a3681e568eb8060fc3e149d17deeecc7c031ab5426f63edb"
+      "wire_schema_sha256": "427e3383c3b8a39456ce1d035b2c85f9d3e35ce3928477d1aff474df188468cf"
     },
     {
       "id": "legacy_slack:member_mention:maximum",
@@ -760,7 +760,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 117209,
+      "wire_schema_bytes": 117214,
       "tool_reference_bytes": 25429,
       "tool_reference_sha256": "4306e0bb518b18dd5527a459b510b17cad6e720c4ec3e3e65b971de4c3ddfff4",
       "overridden_tool_count": 7,
@@ -902,7 +902,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "93d3ff44c928cde4c4b5e99b42fc7711177e21c39c2f1ce6e4c49d966d7fa241",
-      "wire_schema_sha256": "b59763ff737c756f78babffe9754e7b57b7f17733bc6f0b899c607214fbec6b1"
+      "wire_schema_sha256": "f34d19b8858d5cea3e249f2739a79132704c1a702f188f4e564ba285d112bf4e"
     },
     {
       "id": "mcp_chat:anonymous:exact",
@@ -1191,7 +1191,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11057,
+      "wire_schema_bytes": 11062,
       "tool_reference_bytes": 7204,
       "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
       "overridden_tool_count": 4,
@@ -1213,7 +1213,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
-      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
+      "wire_schema_sha256": "984db6c11e6d807a4817f48e164d850702e10e5b0d2bfdb86030a4ab60f3a7dd"
     },
     {
       "id": "slack_bolt_reaction:member:maximum",
@@ -1430,7 +1430,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11057,
+      "wire_schema_bytes": 11062,
       "tool_reference_bytes": 7204,
       "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
       "overridden_tool_count": 4,
@@ -1452,7 +1452,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
-      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
+      "wire_schema_sha256": "984db6c11e6d807a4817f48e164d850702e10e5b0d2bfdb86030a4ab60f3a7dd"
     },
     {
       "id": "slack_bolt_reaction:public_channel_admin:maximum",
@@ -1666,7 +1666,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11057,
+      "wire_schema_bytes": 11062,
       "tool_reference_bytes": 7204,
       "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
       "overridden_tool_count": 4,
@@ -1688,7 +1688,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
-      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
+      "wire_schema_sha256": "984db6c11e6d807a4817f48e164d850702e10e5b0d2bfdb86030a4ab60f3a7dd"
     },
     {
       "id": "slack_bolt_reaction:public_channel:maximum",
@@ -1902,7 +1902,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11057,
+      "wire_schema_bytes": 11062,
       "tool_reference_bytes": 7204,
       "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
       "overridden_tool_count": 4,
@@ -1924,7 +1924,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
-      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
+      "wire_schema_sha256": "984db6c11e6d807a4817f48e164d850702e10e5b0d2bfdb86030a4ab60f3a7dd"
     },
     {
       "id": "slack_bolt:admin_dm:adcp_operations",
@@ -2591,7 +2591,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -2819,7 +2819,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:admin_dm:billing",
@@ -3007,7 +3007,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31669,
+      "wire_schema_bytes": 31674,
       "tool_reference_bytes": 10473,
       "tool_reference_sha256": "c17a79f052b027016aaa5928c0ab13631784eddaa6ffc57e69a935d9e2ab7734",
       "overridden_tool_count": 4,
@@ -3046,7 +3046,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "21e70235e9926708cae72c4a9dc96ce633dfce1a5da5fa3afed7c9689d1994c0",
-      "wire_schema_sha256": "e28e3f567c5d6e1f494c7e394f80a4a65ad9f8423c60453e5999bc401df7b430"
+      "wire_schema_sha256": "b245fcc9d033c21477099cee7a730c1385c7d084163c55fc8a3b8331574c91cc"
     },
     {
       "id": "slack_bolt:admin_dm:certification_learning",
@@ -3126,7 +3126,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32572,
+      "wire_schema_bytes": 32577,
       "tool_reference_bytes": 11710,
       "tool_reference_sha256": "d9f7808652561728b725a03420ceb80db6a2cce7d96af678c4317aa96b4f1e75",
       "overridden_tool_count": 4,
@@ -3166,7 +3166,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c3aea0dcbab6e98c77df077d96b724466d2c6987bc8bf0e5ba75fb5d286eddde",
-      "wire_schema_sha256": "70000bd6d60d90821805edcb8725e8dd44f02093d043c329fa77c099d8f2fba9"
+      "wire_schema_sha256": "87847e832af66eabec2076ecb727282880231795769f6a4347cb162c387c2b92"
     },
     {
       "id": "slack_bolt:admin_dm:certification_mixed_session",
@@ -3193,7 +3193,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 35021,
+      "wire_schema_bytes": 35026,
       "tool_reference_bytes": 13865,
       "tool_reference_sha256": "4474b32bda402e11d5060db402b2c98e68d17af0fe2ac11aaebdddbf60af43d2",
       "overridden_tool_count": 4,
@@ -3236,7 +3236,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "2188ff25e360a838ca7f609753e1fa05b04925711d41dffa10d1b2c2c463af6c",
-      "wire_schema_sha256": "b3c497be485d3f22896d169190619078be81938d5a4ad070a5eb7a8010cc656c"
+      "wire_schema_sha256": "8ae29527f0862ee7ea54514a14a945632c39be6ca00ebdbb498189ab1cb6d83c"
     },
     {
       "id": "slack_bolt:admin_dm:certification_overview",
@@ -4200,7 +4200,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19596,
+      "wire_schema_bytes": 19601,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -4229,7 +4229,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
+      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
     },
     {
       "id": "slack_bolt:admin_dm:schema_reference",
@@ -4254,7 +4254,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15087,
+      "wire_schema_bytes": 15092,
       "tool_reference_bytes": 6861,
       "tool_reference_sha256": "c8be8f92486324ce39f9bed199d73802ee78c7347223e7c1fe7b51ab1a3d91db",
       "overridden_tool_count": 4,
@@ -4277,7 +4277,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b9a369aced7f69958d3abce09c0719fe1dbd4e36bd1ca5faced3cd0c0a929de9",
-      "wire_schema_sha256": "0d96f0e213a44f4ceecb4ed1b87f8089a02bca4a5904ab3cbffd9e4822d6c633"
+      "wire_schema_sha256": "2f5e3103b00b4b0bde92cb877d83e29386cb1be3b3b8499b581708afb10d02a4"
     },
     {
       "id": "slack_bolt:admin_dm:sponsored_intelligence",
@@ -4946,7 +4946,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -5174,7 +5174,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:admin_working_group:billing",
@@ -6266,7 +6266,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19596,
+      "wire_schema_bytes": 19601,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -6295,7 +6295,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
+      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
     },
     {
       "id": "slack_bolt:admin_working_group:schema_reference",
@@ -6319,7 +6319,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11786,
+      "wire_schema_bytes": 11791,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -6339,7 +6339,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "7430850dc24b9a251b6bca8738229f4c7c65f607a804a28a601b48b751922d1c"
+      "wire_schema_sha256": "b86578395ee8e980a49142c6acb6575078b69e80e787dc7d5bc3ba944b15a4fb"
     },
     {
       "id": "slack_bolt:admin_working_group:sponsored_intelligence",
@@ -6581,7 +6581,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131569,
+      "wire_schema_bytes": 131574,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -6743,7 +6743,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "03975b259175aea4e90618b0ff8300bd839a0063078fe8b6daf450aa68b50fe5"
+      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
     },
     {
       "id": "slack_bolt:member_dm:brand_registry",
@@ -6872,7 +6872,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29375,
+      "wire_schema_bytes": 29380,
       "tool_reference_bytes": 10405,
       "tool_reference_sha256": "4eb6007132d73841d11f5bfe99fbe7276adf9ee71757a64a414cf1e95754b1cb",
       "overridden_tool_count": 4,
@@ -6909,7 +6909,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "26b6cc3a42587a710c7baa1a374ce45cfe41c97040fffeebc1c464c7a8e2f415",
-      "wire_schema_sha256": "5cd83295b6d2ef7c56d51601a06b8f94eb99f558e2f30c04a88e2f42c7fe85f4"
+      "wire_schema_sha256": "698cb1200d80161890fb5217f82b2f779bb111af0af8d3882c956e961fbead91"
     },
     {
       "id": "slack_bolt:member_dm:certification_learning",
@@ -6987,7 +6987,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30278,
+      "wire_schema_bytes": 30283,
       "tool_reference_bytes": 11642,
       "tool_reference_sha256": "238c631f89502b86952ce5f789e532444ff3a30a872b5ed4126ed143807ed8ec",
       "overridden_tool_count": 4,
@@ -7025,7 +7025,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "3fea176c7247ff2d3f96cfbc3bb1d8586d83c37c1dc090253111c1fa67c78d06",
-      "wire_schema_sha256": "83a5003de721c47200ee92714942d858e4f5452cd07ea08d442cb94b0211f8e5"
+      "wire_schema_sha256": "a35fcf3152b63a327745bf0cb647e17b562f337f43a8b03539f7ff753949c382"
     },
     {
       "id": "slack_bolt:member_dm:certification_mixed_session",
@@ -7052,7 +7052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32727,
+      "wire_schema_bytes": 32732,
       "tool_reference_bytes": 13797,
       "tool_reference_sha256": "2fdd41a8d8aeee68941f05a5803de2b290941788dab72b9aacecc1c41e2c8c70",
       "overridden_tool_count": 4,
@@ -7093,7 +7093,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "ecb4a361ac31c3fdca960be469fd56589b0538d5c5e135811326b45943f17cf2",
-      "wire_schema_sha256": "7d5c1a7d6a418e671bfc4d29d32ed8fde96c3c4837615f78ffeac5dd6d562e1d"
+      "wire_schema_sha256": "de3768a640442cf4df7631b59e5e9540ed41baf18252d58d817666fa0ad7504b"
     },
     {
       "id": "slack_bolt:member_dm:certification_overview",
@@ -7970,7 +7970,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17302,
+      "wire_schema_bytes": 17307,
       "tool_reference_bytes": 7329,
       "tool_reference_sha256": "7e2d632bc91a830d1a6051d5fee175602da3e185fcf5d0790efb105fe7ef22ae",
       "overridden_tool_count": 4,
@@ -7997,7 +7997,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "7771bc4ccaf1f93b1c16b3e86054c10b50ce447dd631c5e161eb035c1462741a",
-      "wire_schema_sha256": "d225aa765c080662b214c9c5384a8686bae7b8e523eebe6e185efa9fa47f54a4"
+      "wire_schema_sha256": "63a2e4bd7e45e333d387f416fab6b441aa168babdb75088cc810f5da0bad69b1"
     },
     {
       "id": "slack_bolt:member_dm:schema_reference",
@@ -8022,7 +8022,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12793,
+      "wire_schema_bytes": 12798,
       "tool_reference_bytes": 6793,
       "tool_reference_sha256": "ca32a251214b1b83f7762242f92ee9bb0dfcb6bea0ec43d443aae7a1f801a3e1",
       "overridden_tool_count": 4,
@@ -8043,7 +8043,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "74740d71b620fb902938bec28560ab71f5233be2d9af7ba9b9ce495da18b2a12",
-      "wire_schema_sha256": "004461998e57fdaf62f2350527e49acafe5246048e1da2b7933753049a0d51a7"
+      "wire_schema_sha256": "558680828d978fb6e8555c838e2252311c0ed7a53df9f0ed7db65e963d879e4d"
     },
     {
       "id": "slack_bolt:member_dm:sponsored_intelligence",
@@ -8710,7 +8710,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -8938,7 +8938,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:private_channel_admin:billing",
@@ -10030,7 +10030,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19596,
+      "wire_schema_bytes": 19601,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -10059,7 +10059,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
+      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
     },
     {
       "id": "slack_bolt:private_channel_admin:schema_reference",
@@ -10083,7 +10083,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11786,
+      "wire_schema_bytes": 11791,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -10103,7 +10103,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "7430850dc24b9a251b6bca8738229f4c7c65f607a804a28a601b48b751922d1c"
+      "wire_schema_sha256": "b86578395ee8e980a49142c6acb6575078b69e80e787dc7d5bc3ba944b15a4fb"
     },
     {
       "id": "slack_bolt:private_channel_admin:sponsored_intelligence",
@@ -10333,7 +10333,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131569,
+      "wire_schema_bytes": 131574,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -10495,7 +10495,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "03975b259175aea4e90618b0ff8300bd839a0063078fe8b6daf450aa68b50fe5"
+      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
     },
     {
       "id": "slack_bolt:private_channel_member:brand_registry",
@@ -11447,7 +11447,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17302,
+      "wire_schema_bytes": 17307,
       "tool_reference_bytes": 7329,
       "tool_reference_sha256": "7e2d632bc91a830d1a6051d5fee175602da3e185fcf5d0790efb105fe7ef22ae",
       "overridden_tool_count": 4,
@@ -11474,7 +11474,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "7771bc4ccaf1f93b1c16b3e86054c10b50ce447dd631c5e161eb035c1462741a",
-      "wire_schema_sha256": "d225aa765c080662b214c9c5384a8686bae7b8e523eebe6e185efa9fa47f54a4"
+      "wire_schema_sha256": "63a2e4bd7e45e333d387f416fab6b441aa168babdb75088cc810f5da0bad69b1"
     },
     {
       "id": "slack_bolt:private_channel_member:schema_reference",
@@ -11498,7 +11498,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9492,
+      "wire_schema_bytes": 9497,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 4,
@@ -11516,7 +11516,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "89a32ba5abd9e5f4ad3f5fe2e2056eaf80e049a646d888e1e71c20634806c582"
+      "wire_schema_sha256": "0a1d8e725c67d799200bf75b76898dc1c13f9c26b18717fc986a57a64433b92f"
     },
     {
       "id": "slack_bolt:private_channel_member:sponsored_intelligence",
@@ -12143,7 +12143,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 160478,
+      "wire_schema_bytes": 160483,
       "tool_reference_bytes": 34474,
       "tool_reference_sha256": "082f5b11955ea3225ca39699e70870cc46423164601c030617038945c8d3852c",
       "overridden_tool_count": 11,
@@ -12354,7 +12354,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "93f092a464d52d315e0f74c3e6290de1078619517d88839984c9b6aa584c5e44",
-      "wire_schema_sha256": "374d37b2aee7ca0e0728f5f90931ac3052b7566b517f73d08787a32bb4b34b29"
+      "wire_schema_sha256": "b41017eb96d2ecca23c6cb16eca9cd7bbd3784d8d851547ded26796772856d3d"
     },
     {
       "id": "slack_bolt:public_channel_admin:billing",
@@ -13361,7 +13361,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16829,
+      "wire_schema_bytes": 16834,
       "tool_reference_bytes": 7311,
       "tool_reference_sha256": "21e09979964c84fda582577a89ae18eb1657c2f4bac3f25820bc76ab41a75ce3",
       "overridden_tool_count": 4,
@@ -13387,7 +13387,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
-      "wire_schema_sha256": "8cf5bc03c91028ba2f5d916ef5526500728d05d0938216914b9b64fedd47eb7d"
+      "wire_schema_sha256": "1b4a4a050058c4d9af4ef7b26f64793bccaa4e7d51aea3f3e4951fc4abc29cce"
     },
     {
       "id": "slack_bolt:public_channel_admin:schema_reference",
@@ -13411,7 +13411,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9019,
+      "wire_schema_bytes": 9024,
       "tool_reference_bytes": 5268,
       "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
@@ -13428,7 +13428,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
-      "wire_schema_sha256": "de935d7a3943637a8a1e624dc718df8d39297c6f7a6c18e34df43c55f7f5efce"
+      "wire_schema_sha256": "aac6d356aba4f213f23acd38b8ffe7b130880de5588c51a602c11fc90961b6bf"
     },
     {
       "id": "slack_bolt:public_channel_admin:sponsored_intelligence",
@@ -13652,7 +13652,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 128296,
+      "wire_schema_bytes": 128301,
       "tool_reference_bytes": 30932,
       "tool_reference_sha256": "4a7ee9b4c10b4d565eeef851cb294ea5528500b6bb4c8560325442eb065834eb",
       "overridden_tool_count": 11,
@@ -13809,7 +13809,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "57f0ef7a602f90ab6060dc9e8d6315a975f1b693244e2beb790ee8f9666e1748",
-      "wire_schema_sha256": "9e90e097d7d9a933ab2374e66f4f14b6ec96ca03f162dd2b391066645ac56cc4"
+      "wire_schema_sha256": "61881c75ab90ab1154b7721e561ad9ee56efdb972b321aef7887c4f738040158"
     },
     {
       "id": "slack_bolt:public_channel_member:brand_registry",
@@ -14735,7 +14735,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16829,
+      "wire_schema_bytes": 16834,
       "tool_reference_bytes": 7311,
       "tool_reference_sha256": "21e09979964c84fda582577a89ae18eb1657c2f4bac3f25820bc76ab41a75ce3",
       "overridden_tool_count": 4,
@@ -14761,7 +14761,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
-      "wire_schema_sha256": "8cf5bc03c91028ba2f5d916ef5526500728d05d0938216914b9b64fedd47eb7d"
+      "wire_schema_sha256": "1b4a4a050058c4d9af4ef7b26f64793bccaa4e7d51aea3f3e4951fc4abc29cce"
     },
     {
       "id": "slack_bolt:public_channel_member:schema_reference",
@@ -14785,7 +14785,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9019,
+      "wire_schema_bytes": 9024,
       "tool_reference_bytes": 5268,
       "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
@@ -14802,7 +14802,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
-      "wire_schema_sha256": "de935d7a3943637a8a1e624dc718df8d39297c6f7a6c18e34df43c55f7f5efce"
+      "wire_schema_sha256": "aac6d356aba4f213f23acd38b8ffe7b130880de5588c51a602c11fc90961b6bf"
     },
     {
       "id": "slack_bolt:public_channel_member:sponsored_intelligence",
@@ -14904,7 +14904,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15132,7 +15132,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:system_channel_admin:billing:all_valid_sets_maximum",
@@ -15191,7 +15191,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15419,7 +15419,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:system_channel_admin:error:all_valid_sets_maximum",
@@ -15478,7 +15478,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15706,7 +15706,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:system_channel_admin:escalation:all_valid_sets_maximum",
@@ -15765,7 +15765,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15993,7 +15993,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "slack_bolt:system_channel_admin:prospect:all_valid_sets_maximum",
@@ -16052,7 +16052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173152,
+      "wire_schema_bytes": 173157,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -16280,7 +16280,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
+      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
     },
     {
       "id": "tavus_voice:admin:maximum",
@@ -16295,7 +16295,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 163564,
+      "wire_schema_bytes": 163569,
       "tool_reference_bytes": 27489,
       "tool_reference_sha256": "53966de22812288edef87880ee78ec6a5ba985cf49615d3c2bbea38195e500c8",
       "overridden_tool_count": 0,
@@ -16521,7 +16521,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ee026b5c5493eecf66980d8bc45d13bca576838fd1e56d46a225d8c0a8fc735a",
-      "wire_schema_sha256": "e0250902f2dfefc845775f38cce7e7c872ffb656af4413b662f4b15f871f4edb"
+      "wire_schema_sha256": "23cbb026612362ba72d81d6473b35c39bdbca5634c04b37db99e2ad2d7c7a68e"
     },
     {
       "id": "tavus_voice:baseline:exact",
@@ -16578,7 +16578,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 105897,
+      "wire_schema_bytes": 105902,
       "tool_reference_bytes": 23922,
       "tool_reference_sha256": "3325db8b4c0e632e29f6310065b1d6ba66eba31d5292b7f3c4852e3e041c5a79",
       "overridden_tool_count": 0,
@@ -16719,7 +16719,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "1014ec0f38456600ea98be64558e693f91e59d9f0c9a9802743152bb36a42710",
-      "wire_schema_sha256": "647fd9dc64eb674d752d7658532f66b2ed2a6d676d1163c359448014cb66c686"
+      "wire_schema_sha256": "999861a9182626c246dc4296060f3c0353db71f9f5cb499d2f4c62d88e9570ef"
     },
     {
       "id": "tavus_voice:member:maximum",
@@ -16733,7 +16733,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 95780,
+      "wire_schema_bytes": 95785,
       "tool_reference_bytes": 22901,
       "tool_reference_sha256": "1626c891eac9cef4f152d07c383ff695b93150c9bf4d2206c6385e70aed48c0f",
       "overridden_tool_count": 0,
@@ -16863,7 +16863,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "777fd9afbfea06766211ff5d208c0e612bbfdc08756213f9ea1501efdf9dd33b",
-      "wire_schema_sha256": "79ab26d706e2f3e0781273da8a97e22e9c849150c65a5012c9b90f2e6cf405f8"
+      "wire_schema_sha256": "e5b9169f6282de09fa80cc58f4a0bba46ad06069eb4e7c97e931f5fed30f8096"
     },
     {
       "id": "web_chat:anonymous:maximum",
@@ -16925,7 +16925,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30501,
+      "wire_schema_bytes": 30506,
       "tool_reference_bytes": 10366,
       "tool_reference_sha256": "a219e487880587994b46462d6a15b21622541645a10de8900d137f9d0ab771b8",
       "overridden_tool_count": 0,
@@ -16962,7 +16962,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bd72ada800be89b75c9934f22d39da2716d408cfd7082d78250a5d8ba518170c",
-      "wire_schema_sha256": "c0d5089b506971f109afb97b5268d6220e1c5656d5148d7a622f5a2e9cc8afee"
+      "wire_schema_sha256": "cef030c8537758cb77ee289bfa123494a87af371eba2ac87e0610123ee042ebc"
     },
     {
       "id": "web_chat:authenticated_admin:active_certification_learning",
@@ -16986,7 +16986,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31404,
+      "wire_schema_bytes": 31409,
       "tool_reference_bytes": 11603,
       "tool_reference_sha256": "d76dcf7d3aa954a2b242983315175a0912bddfcb244c420a0db39009b9ea4596",
       "overridden_tool_count": 0,
@@ -17024,7 +17024,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "35d65076ecee4d988204088ee64422da183fe75da2c59e606217e62e228e1024",
-      "wire_schema_sha256": "28a7df77c6e854525eb331383b62ef17b3fc50c9f608f37aab519b7309a44db5"
+      "wire_schema_sha256": "4daeda93f7ddd5a50f8067da981a592e8efef04efac487c48c5c219338ffe4ea"
     },
     {
       "id": "web_chat:authenticated_admin:active_certification_mixed",
@@ -17049,7 +17049,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 33853,
+      "wire_schema_bytes": 33858,
       "tool_reference_bytes": 13758,
       "tool_reference_sha256": "8d038a023dcccc7137b07e92d399808cb6c4ee256aa089bc8fc26f60aae826eb",
       "overridden_tool_count": 0,
@@ -17090,7 +17090,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "6c5ec13ab1e04229284b2416d75b4b9ad7f06ff570821cea95cffa4c972ff8c6",
-      "wire_schema_sha256": "e1ee2accd5aed081439952ca1f560ae81ad0f93a41eae3f402705bedf21bdee3"
+      "wire_schema_sha256": "448607a32c2bb972a06460a4747338fb9fd532d3ddfa7819f8c152bfffb421ba"
     },
     {
       "id": "web_chat:authenticated_admin:routed_combination:agent_validation+adcp_operations:si_context",
@@ -18928,7 +18928,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15087,
+      "wire_schema_bytes": 15092,
       "tool_reference_bytes": 6861,
       "tool_reference_sha256": "c8be8f92486324ce39f9bed199d73802ee78c7347223e7c1fe7b51ab1a3d91db",
       "overridden_tool_count": 0,
@@ -18951,7 +18951,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b9a369aced7f69958d3abce09c0719fe1dbd4e36bd1ca5faced3cd0c0a929de9",
-      "wire_schema_sha256": "0d96f0e213a44f4ceecb4ed1b87f8089a02bca4a5904ab3cbffd9e4822d6c633"
+      "wire_schema_sha256": "2f5e3103b00b4b0bde92cb877d83e29386cb1be3b3b8499b581708afb10d02a4"
     },
     {
       "id": "web_chat:authenticated_admin:routed:sponsored_intelligence",
@@ -19019,7 +19019,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9889,
+      "wire_schema_bytes": 9894,
       "tool_reference_bytes": 7097,
       "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
       "overridden_tool_count": 0,
@@ -19039,7 +19039,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
-      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
+      "wire_schema_sha256": "c62875c292b24c0e30cb62209c1a9d5b3163fb492b4c4c76f79b146c7e79b883"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_assessment",
@@ -19063,7 +19063,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28207,
+      "wire_schema_bytes": 28212,
       "tool_reference_bytes": 10298,
       "tool_reference_sha256": "a4cf746de6ff6b2d705c89744d5a0fe9e62e0d4aa907a2c69effe43b4dc3a600",
       "overridden_tool_count": 0,
@@ -19098,7 +19098,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "d5fede9abe22dc9e9881c02a0273f7c97d12f14b898f6a95124633edf174fb03",
-      "wire_schema_sha256": "23c8e7ed45dd022edb1966609ef40428cf1e4c8630f76a03562b99d91061a7e6"
+      "wire_schema_sha256": "84d0fef2f62ab92692b2462edb992cd0697fa9dc44958b458148bcbd55754984"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_learning",
@@ -19122,7 +19122,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29110,
+      "wire_schema_bytes": 29115,
       "tool_reference_bytes": 11535,
       "tool_reference_sha256": "3b6270c3d17733243ba13d975ed10e2f95f8dfa8584da7ca2618225210aeebca",
       "overridden_tool_count": 0,
@@ -19158,7 +19158,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bab8226b2b5de31430f15b50111a74fb4c48b6c740a6acb7cd827244d1f65c6e",
-      "wire_schema_sha256": "5e19bbfc48273bf70e749297fd3b9ab5c5aaf9b08bb8af8bd86325623c9f04e1"
+      "wire_schema_sha256": "b88eb7d2218d905dfdae788ca6f865ad9144d4559617a31ccceaeed68a1a062f"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_mixed",
@@ -19183,7 +19183,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31559,
+      "wire_schema_bytes": 31564,
       "tool_reference_bytes": 13690,
       "tool_reference_sha256": "dda898eb7b32d395561f645aab4404c8a5b6ea14be882d5dd142c12b8ebee308",
       "overridden_tool_count": 0,
@@ -19222,7 +19222,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "409043ee299e0fb5f20b8a94de341fc6e92f1dc0c6f010a74777841984b8542b",
-      "wire_schema_sha256": "6438078f7b960ea8c2ddd2acc89e7d8026cfdb675fd1c0956f6c746a9bbbb2a5"
+      "wire_schema_sha256": "f74cf9697eefe8f7c6061fb6007e0a486dad4dae42a187b967b7dbb612b1c257"
     },
     {
       "id": "web_chat:authenticated_member:routed_combination:agent_validation+adcp_operations:si_context",
@@ -20490,7 +20490,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12793,
+      "wire_schema_bytes": 12798,
       "tool_reference_bytes": 6793,
       "tool_reference_sha256": "ca32a251214b1b83f7762242f92ee9bb0dfcb6bea0ec43d443aae7a1f801a3e1",
       "overridden_tool_count": 0,
@@ -20511,7 +20511,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "74740d71b620fb902938bec28560ab71f5233be2d9af7ba9b9ce495da18b2a12",
-      "wire_schema_sha256": "004461998e57fdaf62f2350527e49acafe5246048e1da2b7933753049a0d51a7"
+      "wire_schema_sha256": "558680828d978fb6e8555c838e2252311c0ed7a53df9f0ed7db65e963d879e4d"
     },
     {
       "id": "web_chat:authenticated_member:routed:sponsored_intelligence",
@@ -20577,7 +20577,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9889,
+      "wire_schema_bytes": 9894,
       "tool_reference_bytes": 7097,
       "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
       "overridden_tool_count": 0,
@@ -20597,7 +20597,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
-      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
+      "wire_schema_sha256": "c62875c292b24c0e30cb62209c1a9d5b3163fb492b4c4c76f79b146c7e79b883"
     }
   ],
   "baseline": {
@@ -20637,9 +20637,9 @@
       "maximum_slack_member_tools": 6,
       "maximum_slack_admin_tools": 3,
       "maximum_slack_public_tools": -6,
-      "maximum_slack_member_schema_bytes": 7407,
-      "maximum_slack_admin_schema_bytes": 7032,
-      "maximum_slack_public_schema_bytes": 361,
+      "maximum_slack_member_schema_bytes": 7412,
+      "maximum_slack_admin_schema_bytes": 7037,
+      "maximum_slack_public_schema_bytes": 366,
       "legacy_slack_member_tools": -83,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -196
@@ -20826,11 +20826,11 @@
       }
     },
     "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-    "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce",
+    "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-    "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce"
+    "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af"
   }
 }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -17,14 +17,14 @@
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "03eb87d6def523062bbdd790fa82a20314a9fb2d5d03672149e9d80820e15b8e",
+    "server/src/addie/bolt-app.ts": "6f6a3a80180c3312d510e51c0da9582fcc336754a5823bbfe2f1cabeb1de6447",
     "server/src/addie/handler.ts": "9df4a97138442abf71faf66b53d40ff433b2ac4580e2cebb899cdfe40bd67a84",
-    "server/src/routes/addie-chat.ts": "684a6cadb71464f1331be1257d29f0cdabea62bba6ebef1534a05f7593d76d89",
+    "server/src/routes/addie-chat.ts": "42330b3540843faaca0e893d1fa2a01712165523b811673482b70ff0c83eb2e0",
     "server/src/routes/tavus.ts": "640e818f0ecd4da6c72f310b7582f7bc1f2c00fd77dbe0dc521f53459e31003f",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",
     "server/src/addie/jobs/shadow-replay-cohort.ts": "316d0764cd65e4c631d6efef7d090fd46a6a8fff22d4c917a40b44a7a69eee1f",
-    "server/src/addie/tool-sets.ts": "536bd46058260d529f7def823a96966e9fb80f8d9fa120c99a7e63d43b5106e3"
+    "server/src/addie/tool-sets.ts": "2654c1e17b44299cde229e01ff28ca22cd549ba920c78b3ec97850eb25c27322"
   },
   "routed": {
     "tool_set_count": 37,
@@ -36,18 +36,18 @@
     "missing_runtime_definitions": []
   },
   "runtime": {
-    "unique_tool_count": 249,
+    "unique_tool_count": 248,
     "not_declared_to_router_count": 0,
     "not_declared_to_router": [],
     "not_declared_to_router_scope": "Modern routed Slack Bolt profiles only"
   },
   "prompt": {
     "rules_bytes": 154049,
-    "tool_reference_bytes": 37017,
+    "tool_reference_bytes": 35641,
     "complete_offline_tool_reference_bytes": 37305,
     "response_style_bytes": 9053,
-    "system_prompt_bytes": 200133,
-    "system_prompt_sha256": "547534517f14a16dda5a98e0ce2da073e5c18615c5612df76f8190a62710adc1"
+    "system_prompt_bytes": 198757,
+    "system_prompt_sha256": "8b7f460bb2dbfcf069949de39ea6ce4716bcdeaad4e093c3a945a27f43f66003"
   },
   "catalog": {
     "missing_runtime_tool_count": 0,
@@ -110,7 +110,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 172332,
+      "wire_schema_bytes": 172327,
       "tool_reference_bytes": 29572,
       "tool_reference_sha256": "4d90d8576f2f543ed2646294b69a7e0e08201b8efd312b904ea43baa3a2a83b5",
       "overridden_tool_count": 7,
@@ -337,7 +337,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "cc78806188aa3b7be55bba733abc1ecbf7b2eea9f83ae6068e5b97ef694eb072",
-      "wire_schema_sha256": "72589df4027d4d1ad75354b46aead59c4691c088c4a791636355d68bf0caa74f"
+      "wire_schema_sha256": "8d636c4512a5a13ee8a75bc6c64363212b2a50065c48cee1f4a775fef39a212b"
     },
     {
       "id": "legacy_slack:admin_mention:maximum",
@@ -355,7 +355,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 168851,
+      "wire_schema_bytes": 168846,
       "tool_reference_bytes": 28616,
       "tool_reference_sha256": "41b9d3e6692a8601f73deca9d90a76fcc100e1cde724e3d99c185ad4903c4ad1",
       "overridden_tool_count": 7,
@@ -577,7 +577,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "1d769dca5f53c7baee0102ce9e49384e23c11d51e1e44d65913124563c08e97c",
-      "wire_schema_sha256": "377b10d7c32fbe77fd488626a84d3b608bc9c54d146ab551b2a80184c3ad8e13"
+      "wire_schema_sha256": "2802b8b4d53ed364f2666b8c6fb39188e1097d486bf7e9a942f458a929cda2a3"
     },
     {
       "id": "legacy_slack:member_dm:maximum",
@@ -595,7 +595,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 120695,
+      "wire_schema_bytes": 120690,
       "tool_reference_bytes": 26385,
       "tool_reference_sha256": "993ca372acea9111b4ec3efc74d631c448e056613031d4fa975bc8c918763e68",
       "overridden_tool_count": 7,
@@ -742,7 +742,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "88484816c567cdded948a50c26649b061d39509263be69448049497bd93edc30",
-      "wire_schema_sha256": "427e3383c3b8a39456ce1d035b2c85f9d3e35ce3928477d1aff474df188468cf"
+      "wire_schema_sha256": "007f09dbaf5d07d0a3681e568eb8060fc3e149d17deeecc7c031ab5426f63edb"
     },
     {
       "id": "legacy_slack:member_mention:maximum",
@@ -760,7 +760,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 117214,
+      "wire_schema_bytes": 117209,
       "tool_reference_bytes": 25429,
       "tool_reference_sha256": "4306e0bb518b18dd5527a459b510b17cad6e720c4ec3e3e65b971de4c3ddfff4",
       "overridden_tool_count": 7,
@@ -902,7 +902,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "93d3ff44c928cde4c4b5e99b42fc7711177e21c39c2f1ce6e4c49d966d7fa241",
-      "wire_schema_sha256": "f34d19b8858d5cea3e249f2739a79132704c1a702f188f4e564ba285d112bf4e"
+      "wire_schema_sha256": "b59763ff737c756f78babffe9754e7b57b7f17733bc6f0b899c607214fbec6b1"
     },
     {
       "id": "mcp_chat:anonymous:exact",
@@ -974,45 +974,34 @@
       "id": "slack_bolt_reaction:admin:maximum",
       "runtime": "slack_bolt_reaction",
       "audience": "admin",
+      "route": "community_groups+agent_validation",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "sponsored_intelligence"
+      ],
       "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
         "google_docs_configured",
-        "admin_event_and_meeting_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 243,
+      "custom_tool_count": 36,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 191201,
-      "tool_reference_bytes": 37017,
-      "tool_reference_sha256": "87c2721104b647744944b2f875b72ff9ace6ee4597e6dc23e9fa4745abd85b12",
-      "overridden_tool_count": 11,
+      "wire_schema_bytes": 29074,
+      "tool_reference_bytes": 8507,
+      "tool_reference_sha256": "e996a1b244cbc2e866b8ae58e8b904656b42a19cedbb738a8cb9cd5ea49dc423",
+      "overridden_tool_count": 1,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "search_docs",
-        "get_doc",
-        "search_repos",
-        "search_resources",
         "bookmark_resource",
-        "get_recent_news",
-        "validate_json",
-        "get_schema",
-        "list_schemas",
-        "compare_schema_versions",
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
         "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "fetch_url",
-        "read_slack_file",
-        "read_google_doc",
         "list_working_groups",
         "get_working_group",
         "join_working_group",
@@ -1021,27 +1010,8 @@
         "express_council_interest",
         "withdraw_council_interest",
         "get_my_council_interests",
-        "get_my_profile",
-        "set_my_name",
-        "update_my_profile",
-        "get_company_listing",
-        "update_company_listing",
-        "update_company_logo",
-        "request_brand_domain_challenge",
-        "verify_brand_domain_challenge",
-        "list_perspectives",
         "create_working_group_post",
-        "propose_content",
-        "attach_content_asset",
-        "get_my_content",
-        "list_pending_content",
-        "approve_content",
-        "reject_content",
-        "request_revisions",
-        "add_committee_document",
         "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
         "get_account_link",
         "get_agent_status",
         "check_publisher_authorization",
@@ -1050,23 +1020,6 @@
         "compare_media_kit",
         "test_rfp_response",
         "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
-        "save_agent",
-        "list_saved_agents",
-        "remove_saved_agent",
-        "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "search_members",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -1074,215 +1027,226 @@
         "send_to_si_agent",
         "end_si_session",
         "get_si_session_status",
-        "search_slack",
-        "get_channel_activity",
-        "check_illustration_status",
-        "generate_perspective_illustration",
-        "find_membership_products",
-        "create_payment_link",
-        "send_invoice",
-        "confirm_send_invoice",
-        "get_billing_portal",
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "suggest_newsletter_content",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "list_escalations",
+        "resolve_escalation",
+        "resolve_brand",
+        "validate_adagents"
+      ],
+      "ordered_tool_names_sha256": "86130ab62c490cabceb3407d6753d9ad1e34e2f75a0ad9ba3576de5f6c4a9225",
+      "wire_schema_sha256": "ae11adc0fa71a792667e7fdbaf3c75ee93eab29e7359cb04c2ad0f1be5fc91b9"
+    },
+    {
+      "id": "slack_bolt_reaction:admin:maximum_tool_reference_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "admin",
+      "route": "member_profile+certification_learning",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 30,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 30866,
+      "tool_reference_bytes": 11610,
+      "tool_reference_sha256": "d599773628e7687ba8a7bf55788ce6efb37d4cd52f34e7a28b1fe1afa682c1e9",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "get_my_profile",
+        "set_my_name",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "find_membership_products",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "call_adcp_task",
+        "list_escalations",
+        "resolve_escalation",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "e0df1d9dc0f33a947082f19991f7fefc496b01741abec5e5c005a1b12b834cdf",
+      "wire_schema_sha256": "3f547a38bc35e28503a344f01a516000f1e6d68034ae0145710cd752277c4d01"
+    },
+    {
+      "id": "slack_bolt_reaction:admin:maximum_wire_schema_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "admin",
+      "route": "agent_validation+adcp_operations",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 32,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 36467,
+      "tool_reference_bytes": 9143,
+      "tool_reference_sha256": "7265966088c7621da96f67f87c11c31918a85b1c0600cce078a96ac9081007aa",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "ask_about_adcp_task",
         "call_adcp_task",
         "get_adcp_capabilities",
         "grade_agent_signing",
         "diagnose_agent_auth",
-        "issue_conformance_token",
-        "run_conformance_against_my_agent",
-        "list_pending_invoices",
-        "get_account",
-        "resend_invoice",
-        "update_billing_email",
-        "preview_org_stripe_customer_update",
-        "confirm_org_stripe_customer_update",
-        "add_prospect",
-        "update_prospect",
-        "enrich_company",
-        "research_domain",
-        "query_prospects",
-        "send_payment_request",
-        "prospect_search_lusha",
-        "diagnose_signin_block",
-        "list_invites_for_org",
-        "resend_invite",
-        "revoke_invite",
-        "add_member_to_org",
-        "search_industry_feeds",
-        "add_industry_feed",
-        "get_feed_stats",
-        "query_admin_analytics",
-        "list_feed_proposals",
-        "approve_feed_proposal",
-        "reject_feed_proposal",
-        "add_media_contact",
-        "list_flagged_conversations",
-        "review_flagged_conversation",
-        "grant_discount",
-        "remove_discount",
-        "list_discounts",
-        "create_promotion_code",
-        "create_chapter",
-        "list_chapters",
-        "create_industry_gathering",
-        "list_industry_gatherings",
-        "create_committee",
-        "add_committee_leader",
-        "remove_committee_leader",
-        "list_committee_leaders",
-        "add_working_group_member",
-        "remove_working_group_member",
-        "merge_organizations",
-        "find_duplicate_orgs",
-        "check_domain_health",
-        "manage_organization_domains",
-        "update_org_member_role",
-        "update_user_name",
-        "rename_working_group",
-        "claim_prospect",
-        "suggest_prospects",
-        "set_reminder",
-        "my_upcoming_tasks",
-        "complete_task",
-        "log_conversation",
-        "list_slack_users_by_org",
-        "list_paying_members",
         "list_escalations",
         "resolve_escalation",
-        "ban_entity",
-        "unban_entity",
-        "list_bans",
-        "update_member_logo",
-        "update_member_profile",
-        "triage_prospect_domain",
-        "get_outreach_stats",
-        "get_outreach_history",
-        "send_outreach",
-        "lookup_person",
-        "create_contact",
-        "get_person_memory",
-        "get_engagement_plan",
-        "get_outreach_health",
-        "get_action_items",
-        "list_pending_brand_logos",
-        "list_brand_logos",
-        "review_brand_logo",
-        "list_pending_community_mirrors",
-        "transfer_brand_ownership",
-        "list_orphaned_brands",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
-        "create_event",
-        "manage_event_registrations",
-        "update_event",
-        "check_person_event_status",
-        "invite_to_event",
-        "schedule_meeting",
-        "list_upcoming_meetings",
-        "get_my_meetings",
-        "get_meeting_details",
-        "rsvp_to_meeting",
-        "cancel_meeting",
-        "cancel_meeting_series",
-        "update_meeting",
-        "add_meeting_attendee",
-        "update_topic_subscriptions",
-        "manage_committee_topics",
-        "research_brand",
         "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "publish_brand_canonical_document",
-        "add_to_brand_refs",
-        "check_mutual_assertion",
-        "notify_pending_verification",
-        "parse_brand_properties",
-        "import_brand_properties",
-        "send_member_dm",
-        "draft_social_posts",
-        "check_portrait_status",
-        "offer_portrait_generation",
-        "search_image_library",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "validate_adagents",
-        "resolve_property",
-        "save_property",
-        "list_properties",
-        "list_missing_properties",
-        "check_property_list",
-        "enhance_property",
-        "resolve_catalog",
-        "browse_catalog",
-        "dispute_catalog_entry",
-        "list_certification_tracks",
-        "get_certification_module",
-        "start_certification_module",
-        "complete_certification_module",
-        "get_learner_progress",
-        "check_credentials",
-        "test_out_modules",
-        "start_certification_exam",
-        "complete_certification_exam",
-        "checkpoint_teaching_progress",
-        "get_build_phase_instructions",
-        "save_learner_feedback"
+        "validate_adagents"
       ],
-      "ordered_tool_names_sha256": "9f0fc2d5113bf561f9f02333f0a7380ce7f469bcd21d9b3d189fb8d5a5d060dc",
-      "wire_schema_sha256": "219988a6db00331e47ade435815b75805cc73b2a3f3741421ac849ffb93996c7"
+      "ordered_tool_names_sha256": "694b4ef9ca09500caa814228edba48db79937ad9c3a3dca6e24357e3f8732ba2",
+      "wire_schema_sha256": "77b176a4f175f09ac6ca5fa1fee886f4eae053aed0a4b576b29199da79a5a1ef"
+    },
+    {
+      "id": "slack_bolt_reaction:admin:safe_fallback",
+      "runtime": "slack_bolt_reaction",
+      "audience": "admin",
+      "route": "safe_fallback",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11057,
+      "tool_reference_bytes": 7204,
+      "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
+      "overridden_tool_count": 4,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "fetch_url",
+        "read_slack_file",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
+      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
     },
     {
       "id": "slack_bolt_reaction:member:maximum",
       "runtime": "slack_bolt_reaction",
       "audience": "member",
+      "route": "community_groups+agent_validation",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "sponsored_intelligence"
+      ],
       "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
         "google_docs_configured",
-        "member_event_and_meeting_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 163,
+      "custom_tool_count": 34,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 139564,
-      "tool_reference_bytes": 33830,
-      "tool_reference_sha256": "89e4f55a72589e235535109a3f13f9e08f1a95fa869f051b0ab1b0a7b68be902",
-      "overridden_tool_count": 11,
+      "wire_schema_bytes": 26780,
+      "tool_reference_bytes": 8439,
+      "tool_reference_sha256": "254bda47727d0a6f3986bea0f943e967ffa3e32ddbcdbe0be8f874117c807416",
+      "overridden_tool_count": 1,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "search_docs",
-        "get_doc",
-        "search_repos",
-        "search_resources",
         "bookmark_resource",
-        "get_recent_news",
-        "validate_json",
-        "get_schema",
-        "list_schemas",
-        "compare_schema_versions",
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
         "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "fetch_url",
-        "read_slack_file",
-        "read_google_doc",
         "list_working_groups",
         "get_working_group",
         "join_working_group",
@@ -1291,27 +1255,8 @@
         "express_council_interest",
         "withdraw_council_interest",
         "get_my_council_interests",
-        "get_my_profile",
-        "set_my_name",
-        "update_my_profile",
-        "get_company_listing",
-        "update_company_listing",
-        "update_company_logo",
-        "request_brand_domain_challenge",
-        "verify_brand_domain_challenge",
-        "list_perspectives",
         "create_working_group_post",
-        "propose_content",
-        "attach_content_asset",
-        "get_my_content",
-        "list_pending_content",
-        "approve_content",
-        "reject_content",
-        "request_revisions",
-        "add_committee_document",
         "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
         "get_account_link",
         "get_agent_status",
         "check_publisher_authorization",
@@ -1320,23 +1265,6 @@
         "compare_media_kit",
         "test_rfp_response",
         "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
-        "save_agent",
-        "list_saved_agents",
-        "remove_saved_agent",
-        "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "search_members",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -1344,135 +1272,220 @@
         "send_to_si_agent",
         "end_si_session",
         "get_si_session_status",
-        "search_slack",
-        "get_channel_activity",
-        "check_illustration_status",
-        "generate_perspective_illustration",
-        "find_membership_products",
-        "create_payment_link",
-        "send_invoice",
-        "confirm_send_invoice",
-        "get_billing_portal",
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "suggest_newsletter_content",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "resolve_brand",
+        "validate_adagents"
+      ],
+      "ordered_tool_names_sha256": "6bd5a97a43f02ed0eb8c8cc110f86af20179170ce0699758a4e211c818f7b52e",
+      "wire_schema_sha256": "dc1b9f61cd741d553055927273468e3c9f201486536cd3eaf7db1228c25f7fa9"
+    },
+    {
+      "id": "slack_bolt_reaction:member:maximum_tool_reference_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "member",
+      "route": "member_profile+certification_learning",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 28,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 28572,
+      "tool_reference_bytes": 11542,
+      "tool_reference_sha256": "73cae8597c0a984f419d8433a28f40aee6deba923a8b89991b8e52a7f92f2f94",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "get_my_profile",
+        "set_my_name",
+        "update_my_profile",
+        "get_company_listing",
+        "update_company_listing",
+        "update_company_logo",
+        "request_brand_domain_challenge",
+        "verify_brand_domain_challenge",
+        "get_account_link",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "find_membership_products",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "call_adcp_task",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "262ed3956fff85e46b61469256dd1fa742efe348ca54b0c767bc3349efcf032d",
+      "wire_schema_sha256": "560819e031bc52d9d09ee0efdc5fd403333e107c1ec2fbde0c5622f8fd827ed6"
+    },
+    {
+      "id": "slack_bolt_reaction:member:maximum_wire_schema_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "member",
+      "route": "agent_validation+adcp_operations",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 30,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 34173,
+      "tool_reference_bytes": 9075,
+      "tool_reference_sha256": "fd2ce66763a76a42309a4b32e8570dd292d6082c74e935cfd07d9cb927648c03",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "get_account_link",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "ask_about_adcp_task",
         "call_adcp_task",
         "get_adcp_capabilities",
         "grade_agent_signing",
         "diagnose_agent_auth",
-        "issue_conformance_token",
-        "run_conformance_against_my_agent",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
-        "create_event",
-        "manage_event_registrations",
-        "update_event",
-        "check_person_event_status",
-        "invite_to_event",
-        "schedule_meeting",
-        "list_upcoming_meetings",
-        "get_my_meetings",
-        "get_meeting_details",
-        "rsvp_to_meeting",
-        "cancel_meeting",
-        "cancel_meeting_series",
-        "update_meeting",
-        "add_meeting_attendee",
-        "update_topic_subscriptions",
-        "manage_committee_topics",
-        "research_brand",
         "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "publish_brand_canonical_document",
-        "add_to_brand_refs",
-        "check_mutual_assertion",
-        "notify_pending_verification",
-        "parse_brand_properties",
-        "import_brand_properties",
-        "send_member_dm",
-        "draft_social_posts",
-        "check_portrait_status",
-        "offer_portrait_generation",
-        "search_image_library",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "validate_adagents",
-        "resolve_property",
-        "save_property",
-        "list_properties",
-        "list_missing_properties",
-        "check_property_list",
-        "enhance_property",
-        "resolve_catalog",
-        "browse_catalog",
-        "dispute_catalog_entry",
-        "list_certification_tracks",
-        "get_certification_module",
-        "start_certification_module",
-        "complete_certification_module",
-        "get_learner_progress",
-        "check_credentials",
-        "test_out_modules",
-        "start_certification_exam",
-        "complete_certification_exam",
-        "checkpoint_teaching_progress",
-        "get_build_phase_instructions",
-        "save_learner_feedback"
+        "validate_adagents"
       ],
-      "ordered_tool_names_sha256": "11c9ae418da5fbf94790dbfd97ba9c85c9242d9ae04191500b464efa3f96c176",
-      "wire_schema_sha256": "d18f4c40dd07da9e25d1d899267380f2c983fc16713ae7d36c2e1479e663f4b9"
+      "ordered_tool_names_sha256": "43fe6d50fa4886c69cf0289b2bc50f75646e4d86f9af7baa7168cc9fc24e195b",
+      "wire_schema_sha256": "f2ab6776eed292ccca57dba528e6319c519e40dd0418c9a3f12bbb5176eeb0bb"
+    },
+    {
+      "id": "slack_bolt_reaction:member:safe_fallback",
+      "runtime": "slack_bolt_reaction",
+      "audience": "member",
+      "route": "safe_fallback",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11057,
+      "tool_reference_bytes": 7204,
+      "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
+      "overridden_tool_count": 4,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "fetch_url",
+        "read_slack_file",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
+      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
     },
     {
       "id": "slack_bolt_reaction:public_channel_admin:maximum",
       "runtime": "slack_bolt_reaction",
       "audience": "public_channel_admin",
+      "route": "community_groups+agent_validation",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "sponsored_intelligence"
+      ],
       "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
         "google_docs_configured",
-        "admin_event_and_meeting_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 238,
+      "custom_tool_count": 33,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 187928,
-      "tool_reference_bytes": 36145,
-      "tool_reference_sha256": "d42150044bc988d976df18d8602ef4a748c1c54ec07901de17c6b81a58acffd6",
-      "overridden_tool_count": 11,
+      "wire_schema_bytes": 26307,
+      "tool_reference_bytes": 8421,
+      "tool_reference_sha256": "021adc3cdbdbd32c38ed50230346a5d0e1f4ec590367d9636679378004cbb184",
+      "overridden_tool_count": 1,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "search_docs",
-        "get_doc",
-        "search_repos",
-        "search_resources",
         "bookmark_resource",
-        "get_recent_news",
-        "validate_json",
-        "get_schema",
-        "list_schemas",
-        "compare_schema_versions",
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
         "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "fetch_url",
-        "read_slack_file",
-        "read_google_doc",
         "list_working_groups",
         "get_working_group",
         "join_working_group",
@@ -1481,6 +1494,63 @@
         "express_council_interest",
         "withdraw_council_interest",
         "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "resolve_brand",
+        "validate_adagents"
+      ],
+      "ordered_tool_names_sha256": "9422ab4632b9f200a6cd25e590188b837392ed5b96176cc01090b321168d97a0",
+      "wire_schema_sha256": "91718ba688e302e1d2c568e408d8704a1bd3483b4b98c72813de18285d00fb30"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel_admin:maximum_tool_reference_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel_admin",
+      "route": "member_profile+certification_learning",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 27,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 28099,
+      "tool_reference_bytes": 11524,
+      "tool_reference_sha256": "f84784c2bc074cfb56a2d039abf948bd7cbaadbcc0c8992afa3d1c402810f840",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
         "get_my_profile",
         "set_my_name",
         "update_my_profile",
@@ -1489,43 +1559,6 @@
         "update_company_logo",
         "request_brand_domain_challenge",
         "verify_brand_domain_challenge",
-        "list_perspectives",
-        "create_working_group_post",
-        "propose_content",
-        "attach_content_asset",
-        "get_my_content",
-        "list_pending_content",
-        "approve_content",
-        "reject_content",
-        "request_revisions",
-        "add_committee_document",
-        "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
-        "get_agent_status",
-        "check_publisher_authorization",
-        "test_adcp_agent",
-        "evaluate_agent_quality",
-        "compare_media_kit",
-        "test_rfp_response",
-        "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
-        "save_agent",
-        "list_saved_agents",
-        "remove_saved_agent",
-        "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "search_members",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -1533,211 +1566,162 @@
         "send_to_si_agent",
         "end_si_session",
         "get_si_session_status",
-        "search_slack",
-        "get_channel_activity",
-        "check_illustration_status",
-        "generate_perspective_illustration",
         "find_membership_products",
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "suggest_newsletter_content",
+        "call_adcp_task",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "a43c0c20bb9431383eadb2d6c94296f9df929cb8b01c65fafbba4dc4b00fe9a2",
+      "wire_schema_sha256": "c82db0cbc751ae8c37a8e0b99500ffa3c39a9c47d124e5d2e75eaf963be04d27"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel_admin:maximum_wire_schema_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel_admin",
+      "route": "agent_validation+adcp_operations",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 29,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 33700,
+      "tool_reference_bytes": 9057,
+      "tool_reference_sha256": "cc5f9a748614b60e5a126dc349b8ebe3b4b446ec3c05eb9c3ac2bd5c47452ebc",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "ask_about_adcp_task",
         "call_adcp_task",
         "get_adcp_capabilities",
         "grade_agent_signing",
         "diagnose_agent_auth",
-        "issue_conformance_token",
-        "run_conformance_against_my_agent",
-        "list_pending_invoices",
-        "get_account",
-        "resend_invoice",
-        "update_billing_email",
-        "preview_org_stripe_customer_update",
-        "confirm_org_stripe_customer_update",
-        "add_prospect",
-        "update_prospect",
-        "enrich_company",
-        "research_domain",
-        "query_prospects",
-        "send_payment_request",
-        "prospect_search_lusha",
-        "diagnose_signin_block",
-        "list_invites_for_org",
-        "resend_invite",
-        "revoke_invite",
-        "add_member_to_org",
-        "search_industry_feeds",
-        "add_industry_feed",
-        "get_feed_stats",
-        "query_admin_analytics",
-        "list_feed_proposals",
-        "approve_feed_proposal",
-        "reject_feed_proposal",
-        "add_media_contact",
-        "list_flagged_conversations",
-        "review_flagged_conversation",
-        "grant_discount",
-        "remove_discount",
-        "list_discounts",
-        "create_promotion_code",
-        "create_chapter",
-        "list_chapters",
-        "create_industry_gathering",
-        "list_industry_gatherings",
-        "create_committee",
-        "add_committee_leader",
-        "remove_committee_leader",
-        "list_committee_leaders",
-        "add_working_group_member",
-        "remove_working_group_member",
-        "merge_organizations",
-        "find_duplicate_orgs",
-        "check_domain_health",
-        "manage_organization_domains",
-        "update_org_member_role",
-        "update_user_name",
-        "rename_working_group",
-        "claim_prospect",
-        "suggest_prospects",
-        "set_reminder",
-        "my_upcoming_tasks",
-        "complete_task",
-        "log_conversation",
-        "list_slack_users_by_org",
-        "list_paying_members",
-        "list_escalations",
-        "resolve_escalation",
-        "ban_entity",
-        "unban_entity",
-        "list_bans",
-        "update_member_logo",
-        "update_member_profile",
-        "triage_prospect_domain",
-        "get_outreach_stats",
-        "get_outreach_history",
-        "send_outreach",
-        "lookup_person",
-        "create_contact",
-        "get_person_memory",
-        "get_engagement_plan",
-        "get_outreach_health",
-        "get_action_items",
-        "list_pending_brand_logos",
-        "list_brand_logos",
-        "review_brand_logo",
-        "list_pending_community_mirrors",
-        "transfer_brand_ownership",
-        "list_orphaned_brands",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
-        "create_event",
-        "manage_event_registrations",
-        "update_event",
-        "check_person_event_status",
-        "invite_to_event",
-        "schedule_meeting",
-        "list_upcoming_meetings",
-        "get_my_meetings",
-        "get_meeting_details",
-        "rsvp_to_meeting",
-        "cancel_meeting",
-        "cancel_meeting_series",
-        "update_meeting",
-        "add_meeting_attendee",
-        "update_topic_subscriptions",
-        "manage_committee_topics",
-        "research_brand",
         "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "publish_brand_canonical_document",
-        "add_to_brand_refs",
-        "check_mutual_assertion",
-        "notify_pending_verification",
-        "parse_brand_properties",
-        "import_brand_properties",
-        "send_member_dm",
-        "draft_social_posts",
-        "check_portrait_status",
-        "offer_portrait_generation",
-        "search_image_library",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "validate_adagents",
-        "resolve_property",
-        "save_property",
-        "list_properties",
-        "list_missing_properties",
-        "check_property_list",
-        "enhance_property",
-        "resolve_catalog",
-        "browse_catalog",
-        "dispute_catalog_entry",
-        "list_certification_tracks",
-        "get_certification_module",
-        "start_certification_module",
-        "complete_certification_module",
-        "get_learner_progress",
-        "check_credentials",
-        "test_out_modules",
-        "start_certification_exam",
-        "complete_certification_exam",
-        "checkpoint_teaching_progress",
-        "get_build_phase_instructions",
-        "save_learner_feedback"
+        "validate_adagents"
       ],
-      "ordered_tool_names_sha256": "8c332ea390464f2c2f9faa37a47db4400c297989a06322db5c41b9d90fefe1b5",
-      "wire_schema_sha256": "6d429a4991ead9ca48aeaa53b562ef3f9b0540ae7499238d6d2b20bf47c012c2"
+      "ordered_tool_names_sha256": "58633158dd7801a0b0bfb7b66663e5901a35852f2379adaf65675268d5d6cb86",
+      "wire_schema_sha256": "fe78e547e7891e5a07fd21c93821d2102b1c2e9ba257dabf76b0193841646409"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel_admin:safe_fallback",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel_admin",
+      "route": "safe_fallback",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11057,
+      "tool_reference_bytes": 7204,
+      "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
+      "overridden_tool_count": 4,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "fetch_url",
+        "read_slack_file",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
+      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
     },
     {
       "id": "slack_bolt_reaction:public_channel:maximum",
       "runtime": "slack_bolt_reaction",
       "audience": "public_channel",
+      "route": "community_groups+agent_validation",
+      "selected_tool_sets": [
+        "community_groups",
+        "agent_validation",
+        "sponsored_intelligence"
+      ],
       "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
         "google_docs_configured",
-        "event_and_meeting_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 158,
+      "custom_tool_count": 33,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 136291,
-      "tool_reference_bytes": 32958,
-      "tool_reference_sha256": "5fa9a33c7ae5a966fb1b7d3b45d6a20659533e19eacff051e9694d6c2b08929b",
-      "overridden_tool_count": 11,
+      "wire_schema_bytes": 26307,
+      "tool_reference_bytes": 8421,
+      "tool_reference_sha256": "021adc3cdbdbd32c38ed50230346a5d0e1f4ec590367d9636679378004cbb184",
+      "overridden_tool_count": 1,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
       "ordered_tool_names": [
-        "search_docs",
-        "get_doc",
-        "search_repos",
-        "search_resources",
         "bookmark_resource",
-        "get_recent_news",
-        "validate_json",
-        "get_schema",
-        "list_schemas",
-        "compare_schema_versions",
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
         "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "fetch_url",
-        "read_slack_file",
-        "read_google_doc",
         "list_working_groups",
         "get_working_group",
         "join_working_group",
@@ -1746,6 +1730,63 @@
         "express_council_interest",
         "withdraw_council_interest",
         "get_my_council_interests",
+        "create_working_group_post",
+        "list_committee_documents",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
+        "grade_agent_signing",
+        "diagnose_agent_auth",
+        "resolve_brand",
+        "validate_adagents"
+      ],
+      "ordered_tool_names_sha256": "9422ab4632b9f200a6cd25e590188b837392ed5b96176cc01090b321168d97a0",
+      "wire_schema_sha256": "91718ba688e302e1d2c568e408d8704a1bd3483b4b98c72813de18285d00fb30"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel:maximum_tool_reference_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel",
+      "route": "member_profile+certification_learning",
+      "selected_tool_sets": [
+        "member_profile",
+        "certification_learning",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 27,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 28099,
+      "tool_reference_bytes": 11524,
+      "tool_reference_sha256": "f84784c2bc074cfb56a2d039abf948bd7cbaadbcc0c8992afa3d1c402810f840",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
         "get_my_profile",
         "set_my_name",
         "update_my_profile",
@@ -1754,43 +1795,6 @@
         "update_company_logo",
         "request_brand_domain_challenge",
         "verify_brand_domain_challenge",
-        "list_perspectives",
-        "create_working_group_post",
-        "propose_content",
-        "attach_content_asset",
-        "get_my_content",
-        "list_pending_content",
-        "approve_content",
-        "reject_content",
-        "request_revisions",
-        "add_committee_document",
-        "list_committee_documents",
-        "update_committee_document",
-        "delete_committee_document",
-        "get_agent_status",
-        "check_publisher_authorization",
-        "test_adcp_agent",
-        "evaluate_agent_quality",
-        "compare_media_kit",
-        "test_rfp_response",
-        "test_io_execution",
-        "recommend_storyboards",
-        "get_storyboard_detail",
-        "run_storyboard",
-        "run_storyboard_step",
-        "save_agent",
-        "list_saved_agents",
-        "remove_saved_agent",
-        "setup_test_agent",
-        "draft_github_issue",
-        "create_github_issue",
-        "get_github_issue",
-        "list_github_issues",
-        "propose_news_source",
-        "search_members",
-        "request_introduction",
-        "get_my_search_analytics",
-        "get_member_engagement",
         "set_outreach_preference",
         "get_si_availability",
         "list_si_agents",
@@ -1798,87 +1802,129 @@
         "send_to_si_agent",
         "end_si_session",
         "get_si_session_status",
-        "search_slack",
-        "get_channel_activity",
-        "check_illustration_status",
-        "generate_perspective_illustration",
         "find_membership_products",
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "suggest_newsletter_content",
+        "call_adcp_task",
+        "start_certification_module",
+        "complete_certification_module",
+        "get_learner_progress",
+        "check_credentials",
+        "checkpoint_teaching_progress",
+        "get_build_phase_instructions",
+        "save_learner_feedback"
+      ],
+      "ordered_tool_names_sha256": "a43c0c20bb9431383eadb2d6c94296f9df929cb8b01c65fafbba4dc4b00fe9a2",
+      "wire_schema_sha256": "c82db0cbc751ae8c37a8e0b99500ffa3c39a9c47d124e5d2e75eaf963be04d27"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel:maximum_wire_schema_bytes",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel",
+      "route": "agent_validation+adcp_operations",
+      "selected_tool_sets": [
+        "agent_validation",
+        "adcp_operations",
+        "sponsored_intelligence"
+      ],
+      "conditional_maximums": [
+        "router_selected_up_to_two_bounded_domains",
+        "active_sponsored_intelligence_session",
+        "google_docs_configured",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 29,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 33700,
+      "tool_reference_bytes": 9057,
+      "tool_reference_sha256": "cc5f9a748614b60e5a126dc349b8ebe3b4b446ec3c05eb9c3ac2bd5c47452ebc",
+      "overridden_tool_count": 1,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "validate_agent",
+        "get_agent_status",
+        "check_publisher_authorization",
+        "test_adcp_agent",
+        "evaluate_agent_quality",
+        "compare_media_kit",
+        "test_rfp_response",
+        "test_io_execution",
+        "save_agent",
+        "list_saved_agents",
+        "remove_saved_agent",
+        "setup_test_agent",
+        "set_outreach_preference",
+        "get_si_availability",
+        "list_si_agents",
+        "connect_to_si_agent",
+        "send_to_si_agent",
+        "end_si_session",
+        "get_si_session_status",
+        "escalate_to_admin",
+        "get_escalation_status",
+        "capture_learning",
         "ask_about_adcp_task",
         "call_adcp_task",
         "get_adcp_capabilities",
         "grade_agent_signing",
         "diagnose_agent_auth",
-        "issue_conformance_token",
-        "run_conformance_against_my_agent",
-        "list_events",
-        "get_event_details",
-        "register_event_interest",
-        "list_event_attendees",
-        "create_event",
-        "manage_event_registrations",
-        "update_event",
-        "check_person_event_status",
-        "invite_to_event",
-        "schedule_meeting",
-        "list_upcoming_meetings",
-        "get_my_meetings",
-        "get_meeting_details",
-        "rsvp_to_meeting",
-        "cancel_meeting",
-        "cancel_meeting_series",
-        "update_meeting",
-        "add_meeting_attendee",
-        "update_topic_subscriptions",
-        "manage_committee_topics",
-        "research_brand",
         "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo",
-        "publish_brand_canonical_document",
-        "add_to_brand_refs",
-        "check_mutual_assertion",
-        "notify_pending_verification",
-        "parse_brand_properties",
-        "import_brand_properties",
-        "send_member_dm",
-        "draft_social_posts",
-        "check_portrait_status",
-        "offer_portrait_generation",
-        "search_image_library",
-        "add_committee_co_leader",
-        "remove_committee_co_leader",
-        "list_committee_co_leaders",
-        "validate_adagents",
-        "resolve_property",
-        "save_property",
-        "list_properties",
-        "list_missing_properties",
-        "check_property_list",
-        "enhance_property",
-        "resolve_catalog",
-        "browse_catalog",
-        "dispute_catalog_entry",
-        "list_certification_tracks",
-        "get_certification_module",
-        "start_certification_module",
-        "complete_certification_module",
-        "get_learner_progress",
-        "check_credentials",
-        "test_out_modules",
-        "start_certification_exam",
-        "complete_certification_exam",
-        "checkpoint_teaching_progress",
-        "get_build_phase_instructions",
-        "save_learner_feedback"
+        "validate_adagents"
       ],
-      "ordered_tool_names_sha256": "a528cd7d63da0a6afc6244759698a662573e25962408eeae0b0506f18b8e31ac",
-      "wire_schema_sha256": "263eb651aa260016916afddbf71c77e45f1e652ed54c0e4f2dcef795ddd65c73"
+      "ordered_tool_names_sha256": "58633158dd7801a0b0bfb7b66663e5901a35852f2379adaf65675268d5d6cb86",
+      "wire_schema_sha256": "fe78e547e7891e5a07fd21c93821d2102b1c2e9ba257dabf76b0193841646409"
+    },
+    {
+      "id": "slack_bolt_reaction:public_channel:safe_fallback",
+      "runtime": "slack_bolt_reaction",
+      "audience": "public_channel",
+      "route": "safe_fallback",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "router_unavailable",
+        "nonstreaming_web_search"
+      ],
+      "custom_tool_count": 13,
+      "maximum_provider_tool_count": 1,
+      "maximum_provider_tool_names": [
+        "web_search"
+      ],
+      "maximum_provider_tool_wire_bytes": 52,
+      "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
+      "wire_schema_bytes": 11057,
+      "tool_reference_bytes": 7204,
+      "tool_reference_sha256": "8d9120b7048ba556b9877bcdea6510919ce24836d20617ec53263fd2a1e085ca",
+      "overridden_tool_count": 4,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news",
+        "validate_json",
+        "get_schema",
+        "list_schemas",
+        "compare_schema_versions",
+        "fetch_url",
+        "read_slack_file",
+        "search_slack",
+        "get_channel_activity"
+      ],
+      "ordered_tool_names_sha256": "d9cf1712c934eae3f991c8005a614f4360cc4bcbb0cb38a3e120595ca5437ec0",
+      "wire_schema_sha256": "6d775f49b5463ae8f91153ede29d7ef52d233e1533566eb7001c506a038f44c0"
     },
     {
       "id": "slack_bolt:admin_dm:adcp_operations",
@@ -2545,7 +2591,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -2773,7 +2819,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:admin_dm:billing",
@@ -2961,7 +3007,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31674,
+      "wire_schema_bytes": 31669,
       "tool_reference_bytes": 10473,
       "tool_reference_sha256": "c17a79f052b027016aaa5928c0ab13631784eddaa6ffc57e69a935d9e2ab7734",
       "overridden_tool_count": 4,
@@ -3000,7 +3046,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "21e70235e9926708cae72c4a9dc96ce633dfce1a5da5fa3afed7c9689d1994c0",
-      "wire_schema_sha256": "b245fcc9d033c21477099cee7a730c1385c7d084163c55fc8a3b8331574c91cc"
+      "wire_schema_sha256": "e28e3f567c5d6e1f494c7e394f80a4a65ad9f8423c60453e5999bc401df7b430"
     },
     {
       "id": "slack_bolt:admin_dm:certification_learning",
@@ -3080,7 +3126,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32577,
+      "wire_schema_bytes": 32572,
       "tool_reference_bytes": 11710,
       "tool_reference_sha256": "d9f7808652561728b725a03420ceb80db6a2cce7d96af678c4317aa96b4f1e75",
       "overridden_tool_count": 4,
@@ -3120,7 +3166,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c3aea0dcbab6e98c77df077d96b724466d2c6987bc8bf0e5ba75fb5d286eddde",
-      "wire_schema_sha256": "87847e832af66eabec2076ecb727282880231795769f6a4347cb162c387c2b92"
+      "wire_schema_sha256": "70000bd6d60d90821805edcb8725e8dd44f02093d043c329fa77c099d8f2fba9"
     },
     {
       "id": "slack_bolt:admin_dm:certification_mixed_session",
@@ -3147,7 +3193,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 35026,
+      "wire_schema_bytes": 35021,
       "tool_reference_bytes": 13865,
       "tool_reference_sha256": "4474b32bda402e11d5060db402b2c98e68d17af0fe2ac11aaebdddbf60af43d2",
       "overridden_tool_count": 4,
@@ -3190,7 +3236,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "2188ff25e360a838ca7f609753e1fa05b04925711d41dffa10d1b2c2c463af6c",
-      "wire_schema_sha256": "8ae29527f0862ee7ea54514a14a945632c39be6ca00ebdbb498189ab1cb6d83c"
+      "wire_schema_sha256": "b3c497be485d3f22896d169190619078be81938d5a4ad070a5eb7a8010cc656c"
     },
     {
       "id": "slack_bolt:admin_dm:certification_overview",
@@ -4154,7 +4200,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19601,
+      "wire_schema_bytes": 19596,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -4183,7 +4229,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
+      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
     },
     {
       "id": "slack_bolt:admin_dm:schema_reference",
@@ -4208,7 +4254,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15092,
+      "wire_schema_bytes": 15087,
       "tool_reference_bytes": 6861,
       "tool_reference_sha256": "c8be8f92486324ce39f9bed199d73802ee78c7347223e7c1fe7b51ab1a3d91db",
       "overridden_tool_count": 4,
@@ -4231,7 +4277,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b9a369aced7f69958d3abce09c0719fe1dbd4e36bd1ca5faced3cd0c0a929de9",
-      "wire_schema_sha256": "2f5e3103b00b4b0bde92cb877d83e29386cb1be3b3b8499b581708afb10d02a4"
+      "wire_schema_sha256": "0d96f0e213a44f4ceecb4ed1b87f8089a02bca4a5904ab3cbffd9e4822d6c633"
     },
     {
       "id": "slack_bolt:admin_dm:sponsored_intelligence",
@@ -4900,7 +4946,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -5128,7 +5174,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:admin_working_group:billing",
@@ -6220,7 +6266,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19601,
+      "wire_schema_bytes": 19596,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -6249,7 +6295,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
+      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
     },
     {
       "id": "slack_bolt:admin_working_group:schema_reference",
@@ -6273,7 +6319,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11791,
+      "wire_schema_bytes": 11786,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -6293,7 +6339,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "b86578395ee8e980a49142c6acb6575078b69e80e787dc7d5bc3ba944b15a4fb"
+      "wire_schema_sha256": "7430850dc24b9a251b6bca8738229f4c7c65f607a804a28a601b48b751922d1c"
     },
     {
       "id": "slack_bolt:admin_working_group:sponsored_intelligence",
@@ -6535,7 +6581,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131574,
+      "wire_schema_bytes": 131569,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -6697,7 +6743,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
+      "wire_schema_sha256": "03975b259175aea4e90618b0ff8300bd839a0063078fe8b6daf450aa68b50fe5"
     },
     {
       "id": "slack_bolt:member_dm:brand_registry",
@@ -6826,7 +6872,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29380,
+      "wire_schema_bytes": 29375,
       "tool_reference_bytes": 10405,
       "tool_reference_sha256": "4eb6007132d73841d11f5bfe99fbe7276adf9ee71757a64a414cf1e95754b1cb",
       "overridden_tool_count": 4,
@@ -6863,7 +6909,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "26b6cc3a42587a710c7baa1a374ce45cfe41c97040fffeebc1c464c7a8e2f415",
-      "wire_schema_sha256": "698cb1200d80161890fb5217f82b2f779bb111af0af8d3882c956e961fbead91"
+      "wire_schema_sha256": "5cd83295b6d2ef7c56d51601a06b8f94eb99f558e2f30c04a88e2f42c7fe85f4"
     },
     {
       "id": "slack_bolt:member_dm:certification_learning",
@@ -6941,7 +6987,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30283,
+      "wire_schema_bytes": 30278,
       "tool_reference_bytes": 11642,
       "tool_reference_sha256": "238c631f89502b86952ce5f789e532444ff3a30a872b5ed4126ed143807ed8ec",
       "overridden_tool_count": 4,
@@ -6979,7 +7025,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "3fea176c7247ff2d3f96cfbc3bb1d8586d83c37c1dc090253111c1fa67c78d06",
-      "wire_schema_sha256": "a35fcf3152b63a327745bf0cb647e17b562f337f43a8b03539f7ff753949c382"
+      "wire_schema_sha256": "83a5003de721c47200ee92714942d858e4f5452cd07ea08d442cb94b0211f8e5"
     },
     {
       "id": "slack_bolt:member_dm:certification_mixed_session",
@@ -7006,7 +7052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32732,
+      "wire_schema_bytes": 32727,
       "tool_reference_bytes": 13797,
       "tool_reference_sha256": "2fdd41a8d8aeee68941f05a5803de2b290941788dab72b9aacecc1c41e2c8c70",
       "overridden_tool_count": 4,
@@ -7047,7 +7093,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "ecb4a361ac31c3fdca960be469fd56589b0538d5c5e135811326b45943f17cf2",
-      "wire_schema_sha256": "de3768a640442cf4df7631b59e5e9540ed41baf18252d58d817666fa0ad7504b"
+      "wire_schema_sha256": "7d5c1a7d6a418e671bfc4d29d32ed8fde96c3c4837615f78ffeac5dd6d562e1d"
     },
     {
       "id": "slack_bolt:member_dm:certification_overview",
@@ -7924,7 +7970,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17307,
+      "wire_schema_bytes": 17302,
       "tool_reference_bytes": 7329,
       "tool_reference_sha256": "7e2d632bc91a830d1a6051d5fee175602da3e185fcf5d0790efb105fe7ef22ae",
       "overridden_tool_count": 4,
@@ -7951,7 +7997,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "7771bc4ccaf1f93b1c16b3e86054c10b50ce447dd631c5e161eb035c1462741a",
-      "wire_schema_sha256": "63a2e4bd7e45e333d387f416fab6b441aa168babdb75088cc810f5da0bad69b1"
+      "wire_schema_sha256": "d225aa765c080662b214c9c5384a8686bae7b8e523eebe6e185efa9fa47f54a4"
     },
     {
       "id": "slack_bolt:member_dm:schema_reference",
@@ -7976,7 +8022,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12798,
+      "wire_schema_bytes": 12793,
       "tool_reference_bytes": 6793,
       "tool_reference_sha256": "ca32a251214b1b83f7762242f92ee9bb0dfcb6bea0ec43d443aae7a1f801a3e1",
       "overridden_tool_count": 4,
@@ -7997,7 +8043,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "74740d71b620fb902938bec28560ab71f5233be2d9af7ba9b9ce495da18b2a12",
-      "wire_schema_sha256": "558680828d978fb6e8555c838e2252311c0ed7a53df9f0ed7db65e963d879e4d"
+      "wire_schema_sha256": "004461998e57fdaf62f2350527e49acafe5246048e1da2b7933753049a0d51a7"
     },
     {
       "id": "slack_bolt:member_dm:sponsored_intelligence",
@@ -8664,7 +8710,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -8892,7 +8938,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:private_channel_admin:billing",
@@ -9984,7 +10030,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19601,
+      "wire_schema_bytes": 19596,
       "tool_reference_bytes": 7397,
       "tool_reference_sha256": "52b9c5c3190c2d1bfb4afd920b762688c5c7b03ba8265ed2de184ee9432619e9",
       "overridden_tool_count": 4,
@@ -10013,7 +10059,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "27c18356c89e778e80cd2528a385d8d69b41931fb3b3d165e781dd9625fe9806"
+      "wire_schema_sha256": "47eef1f239eec6464f54a59d4167531bca31c11c60a4a49d3b08139dd1f0a35a"
     },
     {
       "id": "slack_bolt:private_channel_admin:schema_reference",
@@ -10037,7 +10083,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11791,
+      "wire_schema_bytes": 11786,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -10057,7 +10103,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "b86578395ee8e980a49142c6acb6575078b69e80e787dc7d5bc3ba944b15a4fb"
+      "wire_schema_sha256": "7430850dc24b9a251b6bca8738229f4c7c65f607a804a28a601b48b751922d1c"
     },
     {
       "id": "slack_bolt:private_channel_admin:sponsored_intelligence",
@@ -10287,7 +10333,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131574,
+      "wire_schema_bytes": 131569,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -10449,7 +10495,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
+      "wire_schema_sha256": "03975b259175aea4e90618b0ff8300bd839a0063078fe8b6daf450aa68b50fe5"
     },
     {
       "id": "slack_bolt:private_channel_member:brand_registry",
@@ -11401,7 +11447,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17307,
+      "wire_schema_bytes": 17302,
       "tool_reference_bytes": 7329,
       "tool_reference_sha256": "7e2d632bc91a830d1a6051d5fee175602da3e185fcf5d0790efb105fe7ef22ae",
       "overridden_tool_count": 4,
@@ -11428,7 +11474,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "7771bc4ccaf1f93b1c16b3e86054c10b50ce447dd631c5e161eb035c1462741a",
-      "wire_schema_sha256": "63a2e4bd7e45e333d387f416fab6b441aa168babdb75088cc810f5da0bad69b1"
+      "wire_schema_sha256": "d225aa765c080662b214c9c5384a8686bae7b8e523eebe6e185efa9fa47f54a4"
     },
     {
       "id": "slack_bolt:private_channel_member:schema_reference",
@@ -11452,7 +11498,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9497,
+      "wire_schema_bytes": 9492,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 4,
@@ -11470,7 +11516,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "0a1d8e725c67d799200bf75b76898dc1c13f9c26b18717fc986a57a64433b92f"
+      "wire_schema_sha256": "89a32ba5abd9e5f4ad3f5fe2e2056eaf80e049a646d888e1e71c20634806c582"
     },
     {
       "id": "slack_bolt:private_channel_member:sponsored_intelligence",
@@ -11531,16 +11577,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 13,
+      "custom_tool_count": 11,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20320,
-      "tool_reference_bytes": 6948,
-      "tool_reference_sha256": "66a4d0b64d0fb3b73ddab2ab24859ce2f36e9fe677651a5d16c2704823f0b318",
+      "wire_schema_bytes": 18026,
+      "tool_reference_bytes": 6880,
+      "tool_reference_sha256": "411901d7b513077b4eee7ba245a032ccf4add4fc2a505af0c0a4d2f2f8809dc1",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11555,12 +11601,10 @@
         "capture_learning",
         "ask_about_adcp_task",
         "call_adcp_task",
-        "get_adcp_capabilities",
-        "list_escalations",
-        "resolve_escalation"
+        "get_adcp_capabilities"
       ],
-      "ordered_tool_names_sha256": "dd031f0b8139947db1ef4558865f70da7e3b796b78e964ba7145e74d2fec8b77",
-      "wire_schema_sha256": "0ac22584221cdc5d0aaf51de20d8acaea42cb43d4405774fd156e7b39ddf09ae"
+      "ordered_tool_names_sha256": "15d16ceb1a9bc6265391d8fbe0006361afbb71c7acd797ca1ce5784454e31754",
+      "wire_schema_sha256": "aa05316da667aab159257729fb6f7e1c67e8a76dffc3bd478311f9f2dcf657cd"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_brands",
@@ -11577,16 +11621,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 14,
+      "custom_tool_count": 12,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12303,
-      "tool_reference_bytes": 5103,
-      "tool_reference_sha256": "c90efcda635291dc28329d1761744e22b210dc740baed9d615f0afa97be8c598",
+      "wire_schema_bytes": 10009,
+      "tool_reference_bytes": 5035,
+      "tool_reference_sha256": "87708641d86ca2923b23e024ea6c67746c3bbe1798629e8e522fd04d6c6f7d87",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11595,8 +11639,6 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "list_pending_brand_logos",
         "list_brand_logos",
         "review_brand_logo",
@@ -11606,8 +11648,8 @@
         "list_missing_brands",
         "list_missing_properties"
       ],
-      "ordered_tool_names_sha256": "0055d21f01d897e73a81aad97f9e300a62608d606818779323fb8fb2aea8ceea",
-      "wire_schema_sha256": "dc4c3369b0e596740ce42deddb5eca0c452128fd9c54998c26d1df4738bf4018"
+      "ordered_tool_names_sha256": "f335c3650ad5afe4a2221bca6b19b88542cedeb69bd9fb912e065ae63d41470e",
+      "wire_schema_sha256": "f104946b195c33dad92657f36e0d09d7d20283bc77fbd63d252c9c5bc955a2e0"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_events",
@@ -11624,16 +11666,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 11,
+      "custom_tool_count": 9,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14134,
-      "tool_reference_bytes": 5027,
-      "tool_reference_sha256": "e1e11f82a8e3071b8f3e0112fb4b5cebce606c84de2ee33c592dc76af3792438",
+      "wire_schema_bytes": 11840,
+      "tool_reference_bytes": 4959,
+      "tool_reference_sha256": "811c6c0fb4294b05ca52bdab60124a4b9a0b7321fbe01c02f10bfc43270dcedd",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11642,16 +11684,14 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "create_event",
         "manage_event_registrations",
         "update_event",
         "check_person_event_status",
         "invite_to_event"
       ],
-      "ordered_tool_names_sha256": "ec0c54b58b0bd381196a9ed3f043b7ac489ffd62a756014f355ebf6f9ceb471e",
-      "wire_schema_sha256": "4bcca59dd4b1c5d6cecc91f0f26389669b4248c1c920447f6c91df31fcd3c956"
+      "ordered_tool_names_sha256": "78fceac6fc5a984b5d0b66ae9e9beefa63774103c244635741cb1455ad9418f8",
+      "wire_schema_sha256": "392a39b1953b4c61808ce4ecee693888fe2504611170962bedd7d0af65b8e1a4"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_feeds",
@@ -11668,16 +11708,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 13,
+      "custom_tool_count": 11,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11275,
-      "tool_reference_bytes": 5058,
-      "tool_reference_sha256": "f5044560f7d86f7750bf9559ee6e5b43f66d60fc7820d8117bc68f540a3dd081",
+      "wire_schema_bytes": 8981,
+      "tool_reference_bytes": 4990,
+      "tool_reference_sha256": "bbe2ca0200e93db8902cb153d09c01744762284426a9b0d447edba23e78dee91",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11692,12 +11732,10 @@
         "list_feed_proposals",
         "approve_feed_proposal",
         "reject_feed_proposal",
-        "add_media_contact",
-        "list_escalations",
-        "resolve_escalation"
+        "add_media_contact"
       ],
-      "ordered_tool_names_sha256": "588979548c7664c19ffde54a55b6497636ab98b62ececd56a2a7e72efb4a9616",
-      "wire_schema_sha256": "4e70b79f8908479e6249de98dbc0b6b7641a17bce24fae5a7a135081065e0228"
+      "ordered_tool_names_sha256": "10feee0b9c04bab17a16f6a5ea33243119cdaaff3c60584cba4f4015c5ebd6b4",
+      "wire_schema_sha256": "888d77472284ce892358a2c7b151c04084f8f0b43c1844e65072d9d7df83bf51"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_leadership",
@@ -11714,16 +11752,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 11,
+      "custom_tool_count": 9,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10287,
-      "tool_reference_bytes": 5023,
-      "tool_reference_sha256": "2403faacf6697b1f4eea5167424281b0f93f710e8542e506f6d2e5556ced49b4",
+      "wire_schema_bytes": 7993,
+      "tool_reference_bytes": 4955,
+      "tool_reference_sha256": "3b6fc79f5405f85c4ac8fdc11c84447805d178349630465015dee92f2e5b58bd",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11736,12 +11774,10 @@
         "capture_learning",
         "add_committee_leader",
         "remove_committee_leader",
-        "list_committee_leaders",
-        "list_escalations",
-        "resolve_escalation"
+        "list_committee_leaders"
       ],
-      "ordered_tool_names_sha256": "bf55f22555afa324223e91621a34eb8aede0feb8bbd3808c9ca925c0b28bbb42",
-      "wire_schema_sha256": "94e628c30db7e28eb1482825d7038a38ad546ecf1832618842424d4a8f962132"
+      "ordered_tool_names_sha256": "1a7e4053773341480e40bf3d5719a92149f41f6907cec6255826c72ca8eaee71",
+      "wire_schema_sha256": "1c3d1f15a36a25939dfb0dd7a72798ad54f7945b6bb2d0d0644c8855915c9866"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_membership",
@@ -11758,16 +11794,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
-      "tool_reference_bytes": 4999,
-      "tool_reference_sha256": "f3bc970d4984f7e9293245a35bd53066aa6f9f421b4dbf35e364d2df94cfaf90",
+      "wire_schema_bytes": 7899,
+      "tool_reference_bytes": 4931,
+      "tool_reference_sha256": "4321359f37138d0ebc6423ecb922349c8f8e18e39e8b3603f85ec36c8bcfb1e9",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11779,12 +11815,10 @@
         "get_escalation_status",
         "capture_learning",
         "add_working_group_member",
-        "remove_working_group_member",
-        "list_escalations",
-        "resolve_escalation"
+        "remove_working_group_member"
       ],
-      "ordered_tool_names_sha256": "aa931e60f1755679a61de86cf247151b49ed2bce6cc4101a3126dde09b47a93d",
-      "wire_schema_sha256": "cf8352119cfd48c75ffffa09eaaa32ddc1179372472f98eefc1bf121b8a73167"
+      "ordered_tool_names_sha256": "26d7f34d6d73328f9c1b0408f02126cf96b685e649f7d79c8f0b19b4b3549933",
+      "wire_schema_sha256": "768655c2e80ea7f3a8da9586098700ed2a1568a8deb4ecfaab5509d060c2363c"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_structure",
@@ -11801,16 +11835,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 11,
+      "custom_tool_count": 9,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10256,
-      "tool_reference_bytes": 5016,
-      "tool_reference_sha256": "bf3f1c2e11293d0e7d3e5ab2f10ca53f53178360dd0c12beefb77b70e8770987",
+      "wire_schema_bytes": 7962,
+      "tool_reference_bytes": 4948,
+      "tool_reference_sha256": "335588e02a9a72b5cc803ed01c4c096be23d532b34c33c5d736368dcb856e061",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11823,12 +11857,10 @@
         "list_chapters",
         "create_industry_gathering",
         "list_industry_gatherings",
-        "rename_working_group",
-        "list_escalations",
-        "resolve_escalation"
+        "rename_working_group"
       ],
-      "ordered_tool_names_sha256": "f1708ba876bc9fd30c87d8a759821610e9e87b208fd60377792ee061251ad120",
-      "wire_schema_sha256": "506005402da4d7dcc94be7e50ae00c8e14fb1a9a89c5ed4869a2b2e7a516d1f5"
+      "ordered_tool_names_sha256": "d8bcae23edd575d85fc9e4111e78ad8f6a7b3de078c16e63811c77615666b8fc",
+      "wire_schema_sha256": "b96fee00d0b51273b91181ada9c4306cd8c81773aa926481d1a99ef969c85828"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_organizations",
@@ -11845,16 +11877,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 15,
+      "custom_tool_count": 13,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15270,
-      "tool_reference_bytes": 5235,
-      "tool_reference_sha256": "82ed038e33e6b94f7ea0259167f79b0b38e5912548ef588c4019f17734e4d4ff",
+      "wire_schema_bytes": 12976,
+      "tool_reference_bytes": 5167,
+      "tool_reference_sha256": "c351ffcbf05a7c2009727b7b8e6daee8d86c5cfa0eb00ae78611953b49167627",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11870,13 +11902,11 @@
         "update_org_member_role",
         "list_slack_users_by_org",
         "list_paying_members",
-        "list_escalations",
-        "resolve_escalation",
         "update_member_logo",
         "update_member_profile"
       ],
-      "ordered_tool_names_sha256": "28b0050e30b831f33e4d62fff6628278935c7c60ff0e951378b6745f4b29704f",
-      "wire_schema_sha256": "68b84846afa4da7c38b6670c9df5bd9dd7a30b08cd3007f6c38beae97faca89b"
+      "ordered_tool_names_sha256": "9fcad2f43ea932260038ce63cc830b778a805f30c7e707e047e96f92e95ee90f",
+      "wire_schema_sha256": "f1a4abae13464dd42f341531f5697a6c2af02be0cace56aa5b0dfa6c9de46f2a"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_prospects",
@@ -11893,16 +11923,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 14,
+      "custom_tool_count": 12,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14379,
-      "tool_reference_bytes": 5074,
-      "tool_reference_sha256": "940cd436bad1165be0fe52a28606b061763ddf2a7869370673eea1073382e9f5",
+      "wire_schema_bytes": 12085,
+      "tool_reference_bytes": 5006,
+      "tool_reference_sha256": "085833d09327aaae0b25b526600f592918ca7ca9a8952d69eda4329492fda1b2",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11918,12 +11948,10 @@
         "prospect_search_lusha",
         "claim_prospect",
         "suggest_prospects",
-        "list_escalations",
-        "resolve_escalation",
         "triage_prospect_domain"
       ],
-      "ordered_tool_names_sha256": "5cb4f3b56a157db1a95e31a6c44301310189221834ad634f5e117081a2065865",
-      "wire_schema_sha256": "09a46e048425e320c2260f304dc16a9a84346dfa1dfdbab7b2f716f9c8a8cbb3"
+      "ordered_tool_names_sha256": "b76e078305de1875a30f0e5d4b18bcd664e48972075323b873ec22817670f461",
+      "wire_schema_sha256": "f8026347f3b2b7fc612ee564e9249a8e6d60ca7dd39936b9631d1696fd247128"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_workflows",
@@ -11940,16 +11968,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 13,
+      "custom_tool_count": 11,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12260,
-      "tool_reference_bytes": 5084,
-      "tool_reference_sha256": "6d30d90f38a5fa490aa2b4e316ceaaa16fc12f7d646aecedf9fd55d9005e7465",
+      "wire_schema_bytes": 9966,
+      "tool_reference_bytes": 5016,
+      "tool_reference_sha256": "a4cc65ab4611bb3b1fb3cb42bea7fbbd3be10b0a9b3d7803bcf726dbc8a67ea2",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -11964,12 +11992,10 @@
         "set_reminder",
         "my_upcoming_tasks",
         "complete_task",
-        "log_conversation",
-        "list_escalations",
-        "resolve_escalation"
+        "log_conversation"
       ],
-      "ordered_tool_names_sha256": "4dc938a77db1fddfb45c586c2e5d0ad39d7bf9193c4c02c373f58c9fccd973cf",
-      "wire_schema_sha256": "bc673f4715c1c13a32b23a5392e83f21246c1c547b6c30927f272f0fe1d6c34b"
+      "ordered_tool_names_sha256": "8e474c411ddc319868bf5b1d3a4008457bba9462048c04763080a0c56f6ea347",
+      "wire_schema_sha256": "69ef6c4a72bff7168689f13021f900469d7857bb3cde6553842bb5aa0dc32a26"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_conformance",
@@ -11986,16 +12012,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 8,
+      "custom_tool_count": 6,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9505,
-      "tool_reference_bytes": 5774,
-      "tool_reference_sha256": "03196aefe354b33dbbbefe57ef82668f6ed7218bf5ccf7a050f7f33ea1204dc9",
+      "wire_schema_bytes": 7211,
+      "tool_reference_bytes": 5706,
+      "tool_reference_sha256": "d8f3e2e7bd71653c858614ef8b689d63957f45fe16c7a3e10bb069f0265e85e6",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12005,12 +12031,10 @@
         "get_escalation_status",
         "capture_learning",
         "issue_conformance_token",
-        "run_conformance_against_my_agent",
-        "list_escalations",
-        "resolve_escalation"
+        "run_conformance_against_my_agent"
       ],
-      "ordered_tool_names_sha256": "90136466ce3835fe18d718de5d0fee550f7f6c88274a128d2f219fd3754a0d59",
-      "wire_schema_sha256": "62e3678f8c9df767fdcdecd71c7bc1e319920144d91c4b39d37e22c1f5a8d8ba"
+      "ordered_tool_names_sha256": "0fa7c1408af4686efb4e6dbd59e7c48f5491ddd2efd4052b782ee854ae88f1a6",
+      "wire_schema_sha256": "6673bdac28443d4d60382dfbdc53ab839f22a164918e27a5e519c93014f12dda"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_validation",
@@ -12027,16 +12051,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 18,
+      "custom_tool_count": 16,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 21027,
-      "tool_reference_bytes": 6958,
-      "tool_reference_sha256": "98c1bd046bf036b3e2d56a450ebfe8878a9d77db5f4ded718458c9b86d0fddaf",
+      "wire_schema_bytes": 18733,
+      "tool_reference_bytes": 6890,
+      "tool_reference_sha256": "efd5041ba869695b5119965a360c59abc633175f7d9da6724ba9d40b14a498e7",
       "overridden_tool_count": 1,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12055,13 +12079,11 @@
         "capture_learning",
         "grade_agent_signing",
         "diagnose_agent_auth",
-        "list_escalations",
-        "resolve_escalation",
         "resolve_brand",
         "validate_adagents"
       ],
-      "ordered_tool_names_sha256": "67dfb93ca851f6f8327bbbb8cb7e717a28827b66788962c6fb51bf5b710555aa",
-      "wire_schema_sha256": "4809fe6e76ea9ebd30f6596af1a4055712c6805f3132b97fcaa07d445569e59a"
+      "ordered_tool_names_sha256": "4d409bfbf7ff2d0c7a6c77ac602eda38ec5b6b824196cfc6f170ccc5e02f01fd",
+      "wire_schema_sha256": "1b20245766776e2ac16c0f7f9189abecb6f6dc5c8c7f40f3a0a0f76a14508e96"
     },
     {
       "id": "slack_bolt:public_channel_admin:all_valid_sets_maximum",
@@ -12114,16 +12136,16 @@
         "all_role_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 204,
+      "custom_tool_count": 202,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 162777,
-      "tool_reference_bytes": 34542,
-      "tool_reference_sha256": "f8c256ee28fb1b74ab37e112d6f7ee70f62ef94d98c5530737f292ced3b26588",
+      "wire_schema_bytes": 160478,
+      "tool_reference_bytes": 34474,
+      "tool_reference_sha256": "082f5b11955ea3225ca39699e70870cc46423164601c030617038945c8d3852c",
       "overridden_tool_count": 11,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12257,8 +12279,6 @@
         "log_conversation",
         "list_slack_users_by_org",
         "list_paying_members",
-        "list_escalations",
-        "resolve_escalation",
         "update_member_logo",
         "update_member_profile",
         "triage_prospect_domain",
@@ -12333,8 +12353,8 @@
         "get_build_phase_instructions",
         "save_learner_feedback"
       ],
-      "ordered_tool_names_sha256": "9b06113b5f1ee13e46106296d0148df02da0827a6b5430477aca4ba369667521",
-      "wire_schema_sha256": "4d6e3a97006bc1cbfade947dc30090e1d1cb1621e7d9f068bfcacae7faabc87e"
+      "ordered_tool_names_sha256": "93f092a464d52d315e0f74c3e6290de1078619517d88839984c9b6aa584c5e44",
+      "wire_schema_sha256": "374d37b2aee7ca0e0728f5f90931ac3052b7566b517f73d08787a32bb4b34b29"
     },
     {
       "id": "slack_bolt:public_channel_admin:billing",
@@ -12351,16 +12371,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 6,
+      "custom_tool_count": 4,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8104,
-      "tool_reference_bytes": 4747,
-      "tool_reference_sha256": "b90d560f39a5d60c2d1bc6f564f3a48a7cef87f692804643f1e052b77b8b8321",
+      "wire_schema_bytes": 5810,
+      "tool_reference_bytes": 4679,
+      "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12368,12 +12388,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "04cddb556d1e8ef0f4e81ecd08195662371c709b521a38e4b65e99d75982b4f6",
-      "wire_schema_sha256": "5ffaee3c6743f491d2efa9b32282078f990dc87c4ce0b3c568ddd0c13feb2283"
+      "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
+      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
     },
     {
       "id": "slack_bolt:public_channel_admin:brand_registry",
@@ -12390,16 +12408,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 16,
+      "custom_tool_count": 14,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18174,
-      "tool_reference_bytes": 6063,
-      "tool_reference_sha256": "d90b2e224aae7db2c9495d3dc25e331d446f868d42ba1272fcd4335eae82343f",
+      "wire_schema_bytes": 15880,
+      "tool_reference_bytes": 5995,
+      "tool_reference_sha256": "78f5a3e227e801f64efeb77190b1d4306825ae634a634019ff1bbc5eb74fced8",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12408,8 +12426,6 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "research_brand",
         "resolve_brand",
         "save_brand",
@@ -12421,8 +12437,8 @@
         "check_mutual_assertion",
         "notify_pending_verification"
       ],
-      "ordered_tool_names_sha256": "d47f181054492b36c13e0dcb2a2292f3a528706c01badd4f109871329613d919",
-      "wire_schema_sha256": "2ebc8b2e5c36893f37a868a52aac78f43076383ab86557baae4de33d30fef145"
+      "ordered_tool_names_sha256": "51fa0d9b72207609010e7c395ad05fd9c64183267443ccf3dea5e7fc098a1e8c",
+      "wire_schema_sha256": "e4abdcdf4fb75bd3324651c0b88eb6e059f3a756d64b19a3445fe38d4b547af0"
     },
     {
       "id": "slack_bolt:public_channel_admin:certification_assessment",
@@ -12439,16 +12455,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 15,
+      "custom_tool_count": 13,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19244,
-      "tool_reference_bytes": 6902,
-      "tool_reference_sha256": "5499a5998f792c975cbc95670934c8113272690bc0c2ae058955f2deb91156d6",
+      "wire_schema_bytes": 16950,
+      "tool_reference_bytes": 6834,
+      "tool_reference_sha256": "00100bad072964a6ff52407a77807af70d49e3e3d7ad7a643578276cbed84f63",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12460,8 +12476,6 @@
         "get_escalation_status",
         "capture_learning",
         "call_adcp_task",
-        "list_escalations",
-        "resolve_escalation",
         "get_learner_progress",
         "check_credentials",
         "test_out_modules",
@@ -12469,8 +12483,8 @@
         "complete_certification_exam",
         "checkpoint_teaching_progress"
       ],
-      "ordered_tool_names_sha256": "361e2cb0eb257e0fd9856ff77c5700d4f1cbc115c4b227081f3d27ba2ad9ebe0",
-      "wire_schema_sha256": "7a8a7054cb0fd5e4f59cf2aec162911923b0f721111b20b7a6cc3b612e0c2b8a"
+      "ordered_tool_names_sha256": "8ac4c56c1525cdc7dc33c1dce45e8192c4e2ef35a3534be78ea1e573a45b7a51",
+      "wire_schema_sha256": "1e4390b1fea96985281ca194a8c65486f319c2e4afbcd4da57388f475acea9cc"
     },
     {
       "id": "slack_bolt:public_channel_admin:certification_learning",
@@ -12487,16 +12501,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 16,
+      "custom_tool_count": 14,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20147,
-      "tool_reference_bytes": 8139,
-      "tool_reference_sha256": "88b0a44dcdd2f5456d9494fd28630a3cd064a23cb4c9ee11a5425b83b8e8fb46",
+      "wire_schema_bytes": 17853,
+      "tool_reference_bytes": 8071,
+      "tool_reference_sha256": "09c17f2d7be8670598cee0d28be64d0030eeb7a23653120ad573ee12e0b1f602",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12508,8 +12522,6 @@
         "get_escalation_status",
         "capture_learning",
         "call_adcp_task",
-        "list_escalations",
-        "resolve_escalation",
         "start_certification_module",
         "complete_certification_module",
         "get_learner_progress",
@@ -12518,8 +12530,8 @@
         "get_build_phase_instructions",
         "save_learner_feedback"
       ],
-      "ordered_tool_names_sha256": "a14c202eb1ae19fea4132d03a4bda224d32195ac666670fb2ff01a4a80dac172",
-      "wire_schema_sha256": "0383441ed1a14edda91254a8b690ca7cd626b4aafd84f1977f5ce0073eeb7ca1"
+      "ordered_tool_names_sha256": "c48ea42b9e2155bd3f7e2071d4b9e0a73a62009e45239a0a93d2b1b1ad3fb904",
+      "wire_schema_sha256": "9322e31737e513b306f554a5600dff665dd30a7266779354451076d8eb83911f"
     },
     {
       "id": "slack_bolt:public_channel_admin:certification_overview",
@@ -12536,16 +12548,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 11,
+      "custom_tool_count": 9,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10148,
-      "tool_reference_bytes": 5696,
-      "tool_reference_sha256": "5dabf5eeeb8ccf10af7410ac1a2bacc8695f25cc08b0cb7842a4dc1f41532e6f",
+      "wire_schema_bytes": 7854,
+      "tool_reference_bytes": 5628,
+      "tool_reference_sha256": "49a0ad11f82bc0e092aaa06ef1a244ca15e5b0e896692835133a6ae0b4b85a88",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12555,15 +12567,13 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "list_certification_tracks",
         "get_certification_module",
         "get_learner_progress",
         "check_credentials"
       ],
-      "ordered_tool_names_sha256": "403e7e0ca2c4391b2be46973dcc0ae37b8825672fab2761c3723128d3cb3d02a",
-      "wire_schema_sha256": "08c614fced0e0f589d390b8f4363b5f8c14f7a28922d43729a2ff6f69ae8c26b"
+      "ordered_tool_names_sha256": "76d0045ed7ed72a0d064b425d402583e71d874e94a76722044d0fa92b4ce9b24",
+      "wire_schema_sha256": "635babec938811396f1e376045d5d0e0b73bb2d0acdb8331fd7fe78e5a720a44"
     },
     {
       "id": "slack_bolt:public_channel_admin:collaboration",
@@ -12580,16 +12590,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 7,
+      "custom_tool_count": 5,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9358,
-      "tool_reference_bytes": 4963,
-      "tool_reference_sha256": "3f4332e9cd84836a08686bdbe4f65644c379e63819419ec7c5b291e1674f8b4f",
+      "wire_schema_bytes": 7064,
+      "tool_reference_bytes": 4895,
+      "tool_reference_sha256": "10f61a027ef688857f3355342fa14e772d652fd15e70da96df88a418f99833b9",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12598,12 +12608,10 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "send_member_dm"
       ],
-      "ordered_tool_names_sha256": "911e2aa1d43d919d3f3a2cbc94d491c5c446c3ee5ac467eaa7059eab377a4c1a",
-      "wire_schema_sha256": "f32b474d593e9e3c81031c0728302b71cbc6c51c1ff36cc87ca8993b7f295988"
+      "ordered_tool_names_sha256": "4511d88caefcdce804d554bd69b578cf536f2f43618a951273e9ccb8d2f3c014",
+      "wire_schema_sha256": "9055537247ae12d2a027f65ee5403db037814ac6b44d7b98b2d4386031bd1cf4"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_leadership",
@@ -12620,16 +12628,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 15,
+      "custom_tool_count": 13,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16718,
-      "tool_reference_bytes": 5299,
-      "tool_reference_sha256": "4e4bb7cf774a3fa2c875c37e6fd9d040308289abb7d3ccfd2e4b3957ceb8827f",
+      "wire_schema_bytes": 14424,
+      "tool_reference_bytes": 5231,
+      "tool_reference_sha256": "49602033db04120cff2434db5556e22eecec8e29c76f2cc57a920a82f3086a0f",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12639,8 +12647,6 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "create_event",
         "manage_event_registrations",
         "update_event",
@@ -12650,8 +12656,8 @@
         "remove_committee_co_leader",
         "list_committee_co_leaders"
       ],
-      "ordered_tool_names_sha256": "f2a9ada88869494ee98ed6bdc39b6d853df3f6870a7a26b6b935b9cc7ddac6d2",
-      "wire_schema_sha256": "5c0e36d3ceca7de546d8c24eecc24904ad49fc67624724a1ba5d62fb44554ee5"
+      "ordered_tool_names_sha256": "63d3d934436b7b22c32804baf79a34407d7c63fd8b26eeae139925b4ef4cce40",
+      "wire_schema_sha256": "acc7dd198a71fc4f9816c15ba44b7a24fae583775deebb956796fe39fc13865c"
     },
     {
       "id": "slack_bolt:public_channel_admin:community_groups",
@@ -12668,16 +12674,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 17,
+      "custom_tool_count": 15,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12927,
-      "tool_reference_bytes": 5371,
-      "tool_reference_sha256": "5c7e78c6b545a0d6f8ece56c5de2581ccbd69c26d23b3d0f14d5c6acbce4685c",
+      "wire_schema_bytes": 10633,
+      "tool_reference_bytes": 5303,
+      "tool_reference_sha256": "352c91ad1f413626631ce78b3bbc0cd39d961fd2cdc77e7b61945d633b401eed",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12696,12 +12702,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "908bfee9cf955ce0091a69dfd3def659bdf544ea11bde52fd5280593a84b7fac",
-      "wire_schema_sha256": "8b6de5cb7656c83cd86bbc42b0a9fee81f1e9c7d3bd6ac56b47d17744550042d"
+      "ordered_tool_names_sha256": "91bf1372e425f64e3d7e018308e3e3e3c2fb10bc4e878920e102732ac79d3568",
+      "wire_schema_sha256": "8caa72c0c231415a0eb457ea33ac659606533b6af03338247dc2300c60796cbf"
     },
     {
       "id": "slack_bolt:public_channel_admin:community_research",
@@ -12718,16 +12722,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 12,
+      "custom_tool_count": 10,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12613,
-      "tool_reference_bytes": 5283,
-      "tool_reference_sha256": "a6ca8efa5f7db271202a1bc459d34d6d020cd3353eecbba20fc198aad08f7a1b",
+      "wire_schema_bytes": 10319,
+      "tool_reference_bytes": 5215,
+      "tool_reference_sha256": "59a2cc421790843be1fd58e6c0aa17159058628ccf3bdd916acdc7ae4b3cb2a3",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12741,12 +12745,10 @@
         "get_channel_activity",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "6d08f0c1e2900330e3f3cb75e1fbdfcb00337774c0de6c1a209668368eb9b4de",
-      "wire_schema_sha256": "d315ecb5d536e49bd24a8caa255f1df66aa325598c46ca54115b824b1be92062"
+      "ordered_tool_names_sha256": "691ac90ddfb60796c829aa740dbfae7cb695c4f3c9fd7f63e7ba349256cd2d4a",
+      "wire_schema_sha256": "336c0cd5a9069e23b9bea05e927e006c352d6b0537e91cc4c036b14db11e8588"
     },
     {
       "id": "slack_bolt:public_channel_admin:content",
@@ -12763,16 +12765,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10655,
-      "tool_reference_bytes": 5065,
-      "tool_reference_sha256": "a6a70eabf7d14a18fae6b1a9e171dcaff9540e34af511f43075a3b148f91db8b",
+      "wire_schema_bytes": 8361,
+      "tool_reference_bytes": 4997,
+      "tool_reference_sha256": "fae4e05a056314d2988fc31d178f7b1459929831b07856998d6f90d0b06b844a",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12784,12 +12786,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "ea7925b973d55fd1a153488de52d1b6188f1fbec3966f0e7b34e293e44daab56",
-      "wire_schema_sha256": "ee9f4b704c389508d13855db31a86ed8e21d8642216da69c4b00c6ad982e4139"
+      "ordered_tool_names_sha256": "bc3829064c2772b1c825a305b46be1ef2905e7a67ac5104a19cf76d91c259f7c",
+      "wire_schema_sha256": "1d8f7d65f8a818845c8c8e7a8e47027e3e0e0ec18db8fa4f1d12903365bd4e1a"
     },
     {
       "id": "slack_bolt:public_channel_admin:directory",
@@ -12806,16 +12806,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 15,
+      "custom_tool_count": 13,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13040,
-      "tool_reference_bytes": 5531,
-      "tool_reference_sha256": "cc6a11813a21052887ee43a8ed56d7dc51a1a78c9f6b55d49748df166d4e36ae",
+      "wire_schema_bytes": 10746,
+      "tool_reference_bytes": 5463,
+      "tool_reference_sha256": "15bf51b75b29232a182021c09c62ece5bac1c11d6f18940c219271fe0ec073bf",
       "overridden_tool_count": 6,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12832,12 +12832,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "3513264a0d68aa2e5a7d5af5adb1301894548d6cc71dd2366182bb3ca4597d10",
-      "wire_schema_sha256": "38e333f86720411277eff2638a899fdb044615ceb33e0902cd8b2501b4754b9b"
+      "ordered_tool_names_sha256": "34859b0cb6da0a3f68c3a296f21400a2ea1c5608b194941cb69dcf6c02dd96ed",
+      "wire_schema_sha256": "8785ef7308fc42f43f36b84ea685a12423bc1c40c5554f2574b4f1890de06a9d"
     },
     {
       "id": "slack_bolt:public_channel_admin:events",
@@ -12854,16 +12852,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10583,
-      "tool_reference_bytes": 5072,
-      "tool_reference_sha256": "bbabd0598e966083bdf143f2a544d3d8542a63dd8a2ac16d683668c27892ea5a",
+      "wire_schema_bytes": 8289,
+      "tool_reference_bytes": 5004,
+      "tool_reference_sha256": "9b575799940a8b63ab4d71e213b265c696166a661fe7ed83b1e63ffa389aa3d5",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12872,15 +12870,13 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "list_events",
         "get_event_details",
         "register_event_interest",
         "list_event_attendees"
       ],
-      "ordered_tool_names_sha256": "1bfc9763f2505cb5fc41118fb21609347fb6569938ff12ba520e804f8ced97a2",
-      "wire_schema_sha256": "770f74ad36a5d02269a3c0a6f3e3d11d2c80e66c2b9af8374cd2f1ee2903c229"
+      "ordered_tool_names_sha256": "921fdc7c56d62f0ad6eeef8ca78fb66df7512b19d01a596b946bd725789eec70",
+      "wire_schema_sha256": "1aa539dc1073e18a2e098498cc2557da3eacf93954e220652ea5a02b5b00b6a1"
     },
     {
       "id": "slack_bolt:public_channel_admin:github",
@@ -12897,16 +12893,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12228,
-      "tool_reference_bytes": 6055,
-      "tool_reference_sha256": "1d02af4620bfe277ed2d0f8d92fe5ae7153fc2b9957c8420040ad810fe590993",
+      "wire_schema_bytes": 9934,
+      "tool_reference_bytes": 5987,
+      "tool_reference_sha256": "1f39a7f444dae2a1907f5118c3549cf2c083fcfdbe5b0049db2675ecd21065a5",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12918,12 +12914,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "961f246e805feb7f58da1f14b0d993d4e42e52fdf9f855ab1bb06a74a2dcfe7a",
-      "wire_schema_sha256": "327e41ff8f26a0f73600a16475b5ad7edd4942785b641124e55aa39b86825000"
+      "ordered_tool_names_sha256": "1ab36f15b2f5563e9367dfe4489947d43fc4b5dfd950070be51b704acfe40fb2",
+      "wire_schema_sha256": "8be5c072cc64b4155e97561172ec8ce9f2ef2964c0db47d2cb7066f9ead4667f"
     },
     {
       "id": "slack_bolt:public_channel_admin:illustrations",
@@ -12940,16 +12934,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 7,
+      "custom_tool_count": 5,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9037,
-      "tool_reference_bytes": 5668,
-      "tool_reference_sha256": "26f4a0495d08ff847642f8d277ef90ad7e59af30c6768dad34ebe706ba4fb9d8",
+      "wire_schema_bytes": 6743,
+      "tool_reference_bytes": 5600,
+      "tool_reference_sha256": "a037859ae5edeacc387d5ed3cee34e55ee10b40a6086437979d63964c42a6943",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -12958,12 +12952,10 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "search_image_library"
       ],
-      "ordered_tool_names_sha256": "4a84d37fde850f9141fd7cfa8fdd9008b5f8b1207ae19e22ba6c7b20de48b422",
-      "wire_schema_sha256": "97ff7f9f123979590fa15982a6de8405cd9e7f2e8a55c62b142d37ec65c22efa"
+      "ordered_tool_names_sha256": "cd89f28f6579d916c36483c82e551a9c0b7dbc6fd28607ef058608030a87c469",
+      "wire_schema_sha256": "a4da5112c15e5cec6a754fb50481e54bf81d21ccfc6f95a6f64172bb8172fd8b"
     },
     {
       "id": "slack_bolt:public_channel_admin:knowledge",
@@ -12980,16 +12972,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 9,
+      "custom_tool_count": 7,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11405,
-      "tool_reference_bytes": 6254,
-      "tool_reference_sha256": "af4e022f14d28fac78db704847cb5225d29b76b8eb34a2f74b7092dbe5f11e25",
+      "wire_schema_bytes": 9111,
+      "tool_reference_bytes": 6186,
+      "tool_reference_sha256": "aef54854ee629e7e5fea9dd3b84d5de9acb8cda3847076d6647485fe3ea69ecf",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13000,12 +12992,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "a3caa039e681183d9bf223071df59376c7377c7b2be4bd598bc0718fbe762bae",
-      "wire_schema_sha256": "90dd9ed13cfb03cc22703d42bfe7717c5371acd953bed659f4fe335a266873e0"
+      "ordered_tool_names_sha256": "b50ed01628a8175d4cad4a3c7a9dd466c519165354b6a963a9e2522456ee2ca6",
+      "wire_schema_sha256": "1f23b9bc3ae365392ced3b0d5ef1f2c86d99a5da96df6ae062fde339d24a7301"
     },
     {
       "id": "slack_bolt:public_channel_admin:meetings",
@@ -13022,16 +13012,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 17,
+      "custom_tool_count": 15,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18221,
-      "tool_reference_bytes": 5768,
-      "tool_reference_sha256": "52e5a4021d3c168f84cde10df784e89a817e17a3505a3220c98c4b2f5b86c80c",
+      "wire_schema_bytes": 15927,
+      "tool_reference_bytes": 5700,
+      "tool_reference_sha256": "d8ca80030f6d041fcb2ce4b2a9ae0fbe53fac234746e52a8faeec013395412f3",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13040,8 +13030,6 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "schedule_meeting",
         "list_upcoming_meetings",
         "get_my_meetings",
@@ -13054,8 +13042,8 @@
         "update_topic_subscriptions",
         "manage_committee_topics"
       ],
-      "ordered_tool_names_sha256": "76034bae05d29f5488227e087450a01b7d9874eec7730f00daa158726ef385f4",
-      "wire_schema_sha256": "9b53f8463d3c8af9c3bd09b5ba2146b34fd57339211896b57fd633b51fa3e163"
+      "ordered_tool_names_sha256": "6a688c893300b6c9e954316fccf089ad30c48b7b26192b13ca3edfd28e90846c",
+      "wire_schema_sha256": "8bb4f6262591577fb3bfcbc96d9fbcc0cf3790393b75ff92f7145db4f5d65bf3"
     },
     {
       "id": "slack_bolt:public_channel_admin:member_billing",
@@ -13072,16 +13060,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 6,
+      "custom_tool_count": 4,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8104,
-      "tool_reference_bytes": 4747,
-      "tool_reference_sha256": "b90d560f39a5d60c2d1bc6f564f3a48a7cef87f692804643f1e052b77b8b8321",
+      "wire_schema_bytes": 5810,
+      "tool_reference_bytes": 4679,
+      "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13089,12 +13077,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "04cddb556d1e8ef0f4e81ecd08195662371c709b521a38e4b65e99d75982b4f6",
-      "wire_schema_sha256": "5ffaee3c6743f491d2efa9b32282078f990dc87c4ce0b3c568ddd0c13feb2283"
+      "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
+      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
     },
     {
       "id": "slack_bolt:public_channel_admin:member_profile",
@@ -13111,16 +13097,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 13,
+      "custom_tool_count": 11,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15599,
-      "tool_reference_bytes": 7293,
-      "tool_reference_sha256": "d3f76620b8fab5b5468876d2be77b5920b517ebcad96b12828b161e1ae636523",
+      "wire_schema_bytes": 13305,
+      "tool_reference_bytes": 7225,
+      "tool_reference_sha256": "ac5fc3a3a133f90ccaab5a6e525bb942bf7f0ab3c0fd9b313a5b7e3f3926de8e",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13135,12 +13121,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "9608ff8cff3f9642f802fc735b1471894f8d964a0cec4c632ebe0b24c720d061",
-      "wire_schema_sha256": "bf38100d24a2b3a553536be8a3e2782c0e9207d700d7166b643da8c9f911fdc5"
+      "ordered_tool_names_sha256": "b09955448a679aaca5d60e28c624703ca2017e21adaa3916f8f08bc4e3938e3e",
+      "wire_schema_sha256": "d905d17c8a80deed4bf4946f7ed0a214f5d834234ec139d26ac8075b4ac1c57d"
     },
     {
       "id": "slack_bolt:public_channel_admin:outreach",
@@ -13157,16 +13141,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 13,
+      "custom_tool_count": 11,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11699,
-      "tool_reference_bytes": 5079,
-      "tool_reference_sha256": "bf068045184b9e78fab2d363a3d704d5de2f16533b5ed94d407e5e3dff610964",
+      "wire_schema_bytes": 9405,
+      "tool_reference_bytes": 5011,
+      "tool_reference_sha256": "f2838ec9a1327a288a476d037e9401e55d4aa3a36bbd86af81d3c31fb5db8b9f",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13176,8 +13160,6 @@
         "get_escalation_status",
         "capture_learning",
         "get_account",
-        "list_escalations",
-        "resolve_escalation",
         "get_outreach_stats",
         "get_outreach_history",
         "send_outreach",
@@ -13185,8 +13167,8 @@
         "create_contact",
         "get_action_items"
       ],
-      "ordered_tool_names_sha256": "56dc91845a9ae87fa9e0241d099d41730a3a2297f7421bcf0776bdccdd5d1714",
-      "wire_schema_sha256": "7e6c56e4b8625e13a393c48687df5db7e6b8cda716c2593f364ad1c6d3a1dc5a"
+      "ordered_tool_names_sha256": "684564011603cee11e2a0dfe4d03c86af5a480128d13c17d15b2d24f3e7967d0",
+      "wire_schema_sha256": "9412c696c9b3411834ded398fd034a58326a7d260a462b3668b02419e9609be6"
     },
     {
       "id": "slack_bolt:public_channel_admin:property_catalog",
@@ -13203,16 +13185,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 15,
+      "custom_tool_count": 13,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14098,
-      "tool_reference_bytes": 6265,
-      "tool_reference_sha256": "36b9595ff7e3bc7223b50371a66c3eb1e259f385b39613dfa17455af8516c443",
+      "wire_schema_bytes": 11804,
+      "tool_reference_bytes": 6197,
+      "tool_reference_sha256": "02116eb06990bf6d119451af7d830174ed945dcf66b3ad84ec4f15bd9377ab52",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13221,8 +13203,6 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "resolve_property",
         "save_property",
         "list_properties",
@@ -13233,8 +13213,8 @@
         "browse_catalog",
         "dispute_catalog_entry"
       ],
-      "ordered_tool_names_sha256": "0194846897118dee95f4571f170c035740ef6594a172848892342d9e28b88ee7",
-      "wire_schema_sha256": "8f3af053661c3b87ae17be1767ab26b8efae591697fcf9f960ebbc9a5fc966ba"
+      "ordered_tool_names_sha256": "eb7d0302a30632f15314c6ee143c83048a41165c0a75a38c7474bdc06c2a3fdc",
+      "wire_schema_sha256": "0e14f1a470243359b3e0cf732bbb5663e2e9e91370d415161ffb0b099f4b1254"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_author",
@@ -13251,16 +13231,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 12,
+      "custom_tool_count": 10,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13198,
-      "tool_reference_bytes": 6247,
-      "tool_reference_sha256": "858d9598286bc82ab725c11fbecda8266e89b578fb7c4d171317fc913e2c5907",
+      "wire_schema_bytes": 10904,
+      "tool_reference_bytes": 6179,
+      "tool_reference_sha256": "1225ecdf6a37721fed2c187c54e76f1f5b7ac0c65045355c9a8f8cb6917504a9",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13274,12 +13254,10 @@
         "generate_perspective_illustration",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "da0e7d0a7e5a9cb2632271527b2b4613d02db86a9d444c524f3886d601b6e655",
-      "wire_schema_sha256": "fca2228003b70dd355d2239cb820aa92301d11e534d673fd87b257dd3eebde28"
+      "ordered_tool_names_sha256": "6d50901649abc163fa8869ab0a7a9c54770166030303bd1d51ae29e0057f4856",
+      "wire_schema_sha256": "e6f84d196418ff5bf8b7fc99f5645261ffa8d03a813ab8f4bb7e533dd1b94c14"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_promotion",
@@ -13296,16 +13274,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 8,
+      "custom_tool_count": 6,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9912,
-      "tool_reference_bytes": 4958,
-      "tool_reference_sha256": "6e6beab3000c11e50dba697bf7a59210adf88fbbf5c60aba277cc0681d95fbbb",
+      "wire_schema_bytes": 7618,
+      "tool_reference_bytes": 4890,
+      "tool_reference_sha256": "63844236d8b4fc32eace11c1a05b363295cdf7e7a21f9dba208494c8a8ca037d",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13315,12 +13293,10 @@
         "escalate_to_admin",
         "get_escalation_status",
         "capture_learning",
-        "list_escalations",
-        "resolve_escalation",
         "draft_social_posts"
       ],
-      "ordered_tool_names_sha256": "031896adc8527b06abb89f07fec3eb3cc51e6c4106eed27d7cebb3d8a8091233",
-      "wire_schema_sha256": "d345c062d6ca49ac7af7ec7c4c34a928f9fffd897144fcf9eab2713b9e85ffb2"
+      "ordered_tool_names_sha256": "77444af6faddc476c3d5b7d4c187d13ca3f9f0cc376abb7a5ef29a1c0e9d99eb",
+      "wire_schema_sha256": "a2db2492c6f81398b324a7f598ae4abf3ea1ade88547cf4149650a895d14c44e"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_review",
@@ -13337,16 +13313,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9756,
-      "tool_reference_bytes": 5139,
-      "tool_reference_sha256": "26a5e5a6818a9ea78745dac264a25f900a09bbf3d7232cf1c8384b5f24983ed3",
+      "wire_schema_bytes": 7462,
+      "tool_reference_bytes": 5071,
+      "tool_reference_sha256": "e622e4729cac9277baee6ba3dda72ab0ac460f4c8a9a55bdd36e05886d14895f",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13358,12 +13334,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "04e0658c134fc6590928e64e914e6a1017d4c82a42dc8beb2679ae23be657ff9",
-      "wire_schema_sha256": "aaecd3a3a3b4b76fd60920f1fefdaf8f3f5a683c62ee32825f2cfddce4615a76"
+      "ordered_tool_names_sha256": "853dc8d9f0ae66e04744148486b180e9fe12294a4cc6331c12d1731888c051e7",
+      "wire_schema_sha256": "39c2d7af0ea491b0692583223e554127e76d2341b7c591ccc46265bb5cfda402"
     },
     {
       "id": "slack_bolt:public_channel_admin:router_unavailable",
@@ -13380,16 +13354,16 @@
         "google_docs_configured",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 19,
+      "custom_tool_count": 17,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19128,
-      "tool_reference_bytes": 7379,
-      "tool_reference_sha256": "d00f9a7467397856685af9c9bb2706b24ae8bfa248c70e33a3bdbab35041a5bb",
+      "wire_schema_bytes": 16829,
+      "tool_reference_bytes": 7311,
+      "tool_reference_sha256": "21e09979964c84fda582577a89ae18eb1657c2f4bac3f25820bc76ab41a75ce3",
       "overridden_tool_count": 4,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13410,12 +13384,10 @@
         "get_channel_activity",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "3e30e2e06b4c8a025fe2f0da884dc3808a29bea27e88b7b98cb33204ac4337e4",
-      "wire_schema_sha256": "70a1d2eb38982a0bf10463dbd5508c881ceea09f2d7249583c4e56cb16df3730"
+      "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
+      "wire_schema_sha256": "8cf5bc03c91028ba2f5d916ef5526500728d05d0938216914b9b64fedd47eb7d"
     },
     {
       "id": "slack_bolt:public_channel_admin:schema_reference",
@@ -13432,16 +13404,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 10,
+      "custom_tool_count": 8,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11318,
-      "tool_reference_bytes": 5336,
-      "tool_reference_sha256": "7f13e74e09b5cda2e1bba6152a6395c52d89ed1b2d839f8a19c8c50a94b32bb2",
+      "wire_schema_bytes": 9019,
+      "tool_reference_bytes": 5268,
+      "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13453,12 +13425,10 @@
         "set_outreach_preference",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "c7eb156ec8236921a4ab024924138526051f1e9fd4f17aa69ac2a28be31ca7bb",
-      "wire_schema_sha256": "9ee148e41124c9384aeaf3fadd4306001e8be28cef93fd3da36c93650b4a5759"
+      "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
+      "wire_schema_sha256": "de935d7a3943637a8a1e624dc718df8d39297c6f7a6c18e34df43c55f7f5efce"
     },
     {
       "id": "slack_bolt:public_channel_admin:sponsored_intelligence",
@@ -13475,16 +13445,16 @@
         "member_content_permissions",
         "nonstreaming_web_search"
       ],
-      "custom_tool_count": 12,
+      "custom_tool_count": 10,
       "maximum_provider_tool_count": 1,
       "maximum_provider_tool_names": [
         "web_search"
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10855,
-      "tool_reference_bytes": 5654,
-      "tool_reference_sha256": "2aa0a97b400436a12c08acdaf0e5cd601e28e6be8e31779e70f199631a0e4e4a",
+      "wire_schema_bytes": 8561,
+      "tool_reference_bytes": 5586,
+      "tool_reference_sha256": "5a0ed306ce9bc167e9c6a508a5f44d27565c925ab9849ae357ec8b57e2868b0e",
       "overridden_tool_count": 0,
       "conflicting_override_count": 0,
       "conflicting_override_names": [],
@@ -13498,12 +13468,10 @@
         "get_si_session_status",
         "escalate_to_admin",
         "get_escalation_status",
-        "capture_learning",
-        "list_escalations",
-        "resolve_escalation"
+        "capture_learning"
       ],
-      "ordered_tool_names_sha256": "8cc625ee7c4ef89b0c2008612b54f48aabc0a940ed714c43de3900a116292215",
-      "wire_schema_sha256": "ed551d8c06358804ff22c92a7218ade5d1f246d9c7a4b80059d652ca47d8aec0"
+      "ordered_tool_names_sha256": "a18a2fc490dbe8c3d7ead4915eac4cadca560a21db47ba18f394bedfbb14412f",
+      "wire_schema_sha256": "484b5f49287f3bf0d77931721ee808ed738d79d8d3bb2769d790966862acc033"
     },
     {
       "id": "slack_bolt:public_channel_member:adcp_operations",
@@ -13684,7 +13652,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 128301,
+      "wire_schema_bytes": 128296,
       "tool_reference_bytes": 30932,
       "tool_reference_sha256": "4a7ee9b4c10b4d565eeef851cb294ea5528500b6bb4c8560325442eb065834eb",
       "overridden_tool_count": 11,
@@ -13841,7 +13809,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "57f0ef7a602f90ab6060dc9e8d6315a975f1b693244e2beb790ee8f9666e1748",
-      "wire_schema_sha256": "61881c75ab90ab1154b7721e561ad9ee56efdb972b321aef7887c4f738040158"
+      "wire_schema_sha256": "9e90e097d7d9a933ab2374e66f4f14b6ec96ca03f162dd2b391066645ac56cc4"
     },
     {
       "id": "slack_bolt:public_channel_member:brand_registry",
@@ -14767,7 +14735,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16834,
+      "wire_schema_bytes": 16829,
       "tool_reference_bytes": 7311,
       "tool_reference_sha256": "21e09979964c84fda582577a89ae18eb1657c2f4bac3f25820bc76ab41a75ce3",
       "overridden_tool_count": 4,
@@ -14793,7 +14761,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
-      "wire_schema_sha256": "1b4a4a050058c4d9af4ef7b26f64793bccaa4e7d51aea3f3e4951fc4abc29cce"
+      "wire_schema_sha256": "8cf5bc03c91028ba2f5d916ef5526500728d05d0938216914b9b64fedd47eb7d"
     },
     {
       "id": "slack_bolt:public_channel_member:schema_reference",
@@ -14817,7 +14785,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9024,
+      "wire_schema_bytes": 9019,
       "tool_reference_bytes": 5268,
       "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
@@ -14834,7 +14802,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
-      "wire_schema_sha256": "aac6d356aba4f213f23acd38b8ffe7b130880de5588c51a602c11fc90961b6bf"
+      "wire_schema_sha256": "de935d7a3943637a8a1e624dc718df8d39297c6f7a6c18e34df43c55f7f5efce"
     },
     {
       "id": "slack_bolt:public_channel_member:sponsored_intelligence",
@@ -14936,7 +14904,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15164,7 +15132,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:system_channel_admin:billing:all_valid_sets_maximum",
@@ -15223,7 +15191,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15451,7 +15419,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:system_channel_admin:error:all_valid_sets_maximum",
@@ -15510,7 +15478,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15738,7 +15706,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:system_channel_admin:escalation:all_valid_sets_maximum",
@@ -15797,7 +15765,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -16025,7 +15993,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "slack_bolt:system_channel_admin:prospect:all_valid_sets_maximum",
@@ -16084,7 +16052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173152,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -16312,7 +16280,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "88547db5ffdaa56e12dfebbd9c4624aff88a293a20812e475bd06e3157198b43"
     },
     {
       "id": "tavus_voice:admin:maximum",
@@ -16327,7 +16295,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 163569,
+      "wire_schema_bytes": 163564,
       "tool_reference_bytes": 27489,
       "tool_reference_sha256": "53966de22812288edef87880ee78ec6a5ba985cf49615d3c2bbea38195e500c8",
       "overridden_tool_count": 0,
@@ -16553,7 +16521,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ee026b5c5493eecf66980d8bc45d13bca576838fd1e56d46a225d8c0a8fc735a",
-      "wire_schema_sha256": "23cbb026612362ba72d81d6473b35c39bdbca5634c04b37db99e2ad2d7c7a68e"
+      "wire_schema_sha256": "e0250902f2dfefc845775f38cce7e7c872ffb656af4413b662f4b15f871f4edb"
     },
     {
       "id": "tavus_voice:baseline:exact",
@@ -16610,7 +16578,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 105902,
+      "wire_schema_bytes": 105897,
       "tool_reference_bytes": 23922,
       "tool_reference_sha256": "3325db8b4c0e632e29f6310065b1d6ba66eba31d5292b7f3c4852e3e041c5a79",
       "overridden_tool_count": 0,
@@ -16751,7 +16719,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "1014ec0f38456600ea98be64558e693f91e59d9f0c9a9802743152bb36a42710",
-      "wire_schema_sha256": "999861a9182626c246dc4296060f3c0353db71f9f5cb499d2f4c62d88e9570ef"
+      "wire_schema_sha256": "647fd9dc64eb674d752d7658532f66b2ed2a6d676d1163c359448014cb66c686"
     },
     {
       "id": "tavus_voice:member:maximum",
@@ -16765,7 +16733,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 95785,
+      "wire_schema_bytes": 95780,
       "tool_reference_bytes": 22901,
       "tool_reference_sha256": "1626c891eac9cef4f152d07c383ff695b93150c9bf4d2206c6385e70aed48c0f",
       "overridden_tool_count": 0,
@@ -16895,7 +16863,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "777fd9afbfea06766211ff5d208c0e612bbfdc08756213f9ea1501efdf9dd33b",
-      "wire_schema_sha256": "e5b9169f6282de09fa80cc58f4a0bba46ad06069eb4e7c97e931f5fed30f8096"
+      "wire_schema_sha256": "79ab26d706e2f3e0781273da8a97e22e9c849150c65a5012c9b90f2e6cf405f8"
     },
     {
       "id": "web_chat:anonymous:maximum",
@@ -16957,7 +16925,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30506,
+      "wire_schema_bytes": 30501,
       "tool_reference_bytes": 10366,
       "tool_reference_sha256": "a219e487880587994b46462d6a15b21622541645a10de8900d137f9d0ab771b8",
       "overridden_tool_count": 0,
@@ -16994,7 +16962,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bd72ada800be89b75c9934f22d39da2716d408cfd7082d78250a5d8ba518170c",
-      "wire_schema_sha256": "cef030c8537758cb77ee289bfa123494a87af371eba2ac87e0610123ee042ebc"
+      "wire_schema_sha256": "c0d5089b506971f109afb97b5268d6220e1c5656d5148d7a622f5a2e9cc8afee"
     },
     {
       "id": "web_chat:authenticated_admin:active_certification_learning",
@@ -17018,7 +16986,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31409,
+      "wire_schema_bytes": 31404,
       "tool_reference_bytes": 11603,
       "tool_reference_sha256": "d76dcf7d3aa954a2b242983315175a0912bddfcb244c420a0db39009b9ea4596",
       "overridden_tool_count": 0,
@@ -17056,7 +17024,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "35d65076ecee4d988204088ee64422da183fe75da2c59e606217e62e228e1024",
-      "wire_schema_sha256": "4daeda93f7ddd5a50f8067da981a592e8efef04efac487c48c5c219338ffe4ea"
+      "wire_schema_sha256": "28a7df77c6e854525eb331383b62ef17b3fc50c9f608f37aab519b7309a44db5"
     },
     {
       "id": "web_chat:authenticated_admin:active_certification_mixed",
@@ -17081,7 +17049,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 33858,
+      "wire_schema_bytes": 33853,
       "tool_reference_bytes": 13758,
       "tool_reference_sha256": "8d038a023dcccc7137b07e92d399808cb6c4ee256aa089bc8fc26f60aae826eb",
       "overridden_tool_count": 0,
@@ -17122,7 +17090,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "6c5ec13ab1e04229284b2416d75b4b9ad7f06ff570821cea95cffa4c972ff8c6",
-      "wire_schema_sha256": "448607a32c2bb972a06460a4747338fb9fd532d3ddfa7819f8c152bfffb421ba"
+      "wire_schema_sha256": "e1ee2accd5aed081439952ca1f560ae81ad0f93a41eae3f402705bedf21bdee3"
     },
     {
       "id": "web_chat:authenticated_admin:routed_combination:agent_validation+adcp_operations:si_context",
@@ -18960,7 +18928,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15092,
+      "wire_schema_bytes": 15087,
       "tool_reference_bytes": 6861,
       "tool_reference_sha256": "c8be8f92486324ce39f9bed199d73802ee78c7347223e7c1fe7b51ab1a3d91db",
       "overridden_tool_count": 0,
@@ -18983,7 +18951,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b9a369aced7f69958d3abce09c0719fe1dbd4e36bd1ca5faced3cd0c0a929de9",
-      "wire_schema_sha256": "2f5e3103b00b4b0bde92cb877d83e29386cb1be3b3b8499b581708afb10d02a4"
+      "wire_schema_sha256": "0d96f0e213a44f4ceecb4ed1b87f8089a02bca4a5904ab3cbffd9e4822d6c633"
     },
     {
       "id": "web_chat:authenticated_admin:routed:sponsored_intelligence",
@@ -19051,7 +19019,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9894,
+      "wire_schema_bytes": 9889,
       "tool_reference_bytes": 7097,
       "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
       "overridden_tool_count": 0,
@@ -19071,7 +19039,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
-      "wire_schema_sha256": "c62875c292b24c0e30cb62209c1a9d5b3163fb492b4c4c76f79b146c7e79b883"
+      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_assessment",
@@ -19095,7 +19063,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28212,
+      "wire_schema_bytes": 28207,
       "tool_reference_bytes": 10298,
       "tool_reference_sha256": "a4cf746de6ff6b2d705c89744d5a0fe9e62e0d4aa907a2c69effe43b4dc3a600",
       "overridden_tool_count": 0,
@@ -19130,7 +19098,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "d5fede9abe22dc9e9881c02a0273f7c97d12f14b898f6a95124633edf174fb03",
-      "wire_schema_sha256": "84d0fef2f62ab92692b2462edb992cd0697fa9dc44958b458148bcbd55754984"
+      "wire_schema_sha256": "23c8e7ed45dd022edb1966609ef40428cf1e4c8630f76a03562b99d91061a7e6"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_learning",
@@ -19154,7 +19122,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29115,
+      "wire_schema_bytes": 29110,
       "tool_reference_bytes": 11535,
       "tool_reference_sha256": "3b6270c3d17733243ba13d975ed10e2f95f8dfa8584da7ca2618225210aeebca",
       "overridden_tool_count": 0,
@@ -19190,7 +19158,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bab8226b2b5de31430f15b50111a74fb4c48b6c740a6acb7cd827244d1f65c6e",
-      "wire_schema_sha256": "b88eb7d2218d905dfdae788ca6f865ad9144d4559617a31ccceaeed68a1a062f"
+      "wire_schema_sha256": "5e19bbfc48273bf70e749297fd3b9ab5c5aaf9b08bb8af8bd86325623c9f04e1"
     },
     {
       "id": "web_chat:authenticated_member:active_certification_mixed",
@@ -19215,7 +19183,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31564,
+      "wire_schema_bytes": 31559,
       "tool_reference_bytes": 13690,
       "tool_reference_sha256": "dda898eb7b32d395561f645aab4404c8a5b6ea14be882d5dd142c12b8ebee308",
       "overridden_tool_count": 0,
@@ -19254,7 +19222,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "409043ee299e0fb5f20b8a94de341fc6e92f1dc0c6f010a74777841984b8542b",
-      "wire_schema_sha256": "f74cf9697eefe8f7c6061fb6007e0a486dad4dae42a187b967b7dbb612b1c257"
+      "wire_schema_sha256": "6438078f7b960ea8c2ddd2acc89e7d8026cfdb675fd1c0956f6c746a9bbbb2a5"
     },
     {
       "id": "web_chat:authenticated_member:routed_combination:agent_validation+adcp_operations:si_context",
@@ -20522,7 +20490,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12798,
+      "wire_schema_bytes": 12793,
       "tool_reference_bytes": 6793,
       "tool_reference_sha256": "ca32a251214b1b83f7762242f92ee9bb0dfcb6bea0ec43d443aae7a1f801a3e1",
       "overridden_tool_count": 0,
@@ -20543,7 +20511,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "74740d71b620fb902938bec28560ab71f5233be2d9af7ba9b9ce495da18b2a12",
-      "wire_schema_sha256": "558680828d978fb6e8555c838e2252311c0ed7a53df9f0ed7db65e963d879e4d"
+      "wire_schema_sha256": "004461998e57fdaf62f2350527e49acafe5246048e1da2b7933753049a0d51a7"
     },
     {
       "id": "web_chat:authenticated_member:routed:sponsored_intelligence",
@@ -20609,7 +20577,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9894,
+      "wire_schema_bytes": 9889,
       "tool_reference_bytes": 7097,
       "tool_reference_sha256": "2a604c0a8a582e893fd20ed6be59e476aee1cfac4fe9472d6a01014bfd031352",
       "overridden_tool_count": 0,
@@ -20629,7 +20597,7 @@
         "get_channel_activity"
       ],
       "ordered_tool_names_sha256": "86d3918b1fad128dcfda701322b81e7c442bf56c46defc93280ddffd45509d13",
-      "wire_schema_sha256": "c62875c292b24c0e30cb62209c1a9d5b3163fb492b4c4c76f79b146c7e79b883"
+      "wire_schema_sha256": "9207bd4be8a56d98386b88bf9a35d6829f959fc8f72f905eaa33f8cbf4500cf1"
     }
   ],
   "baseline": {
@@ -20657,21 +20625,21 @@
     },
     "deltas": {
       "routed_unique_tools": 20,
-      "runtime_unique_tools": -3,
+      "runtime_unique_tools": -4,
       "runtime_tools_not_declared_to_router": -18,
       "routed_tools_missing_runtime_definition": -1,
       "maximum_conflicting_tool_overrides": 0,
       "runtime_tools_missing_prompt_catalog": -8,
       "prompt_catalog_tools_missing_runtime": -2,
       "always_available_tools": -13,
-      "tool_reference_bytes": -6776,
-      "system_prompt_bytes": -1898,
+      "tool_reference_bytes": -8152,
+      "system_prompt_bytes": -3274,
       "maximum_slack_member_tools": 6,
       "maximum_slack_admin_tools": 3,
-      "maximum_slack_public_tools": -4,
-      "maximum_slack_member_schema_bytes": 7412,
-      "maximum_slack_admin_schema_bytes": 7037,
-      "maximum_slack_public_schema_bytes": 2660,
+      "maximum_slack_public_tools": -6,
+      "maximum_slack_member_schema_bytes": 7407,
+      "maximum_slack_admin_schema_bytes": 7032,
+      "maximum_slack_public_schema_bytes": 361,
       "legacy_slack_member_tools": -83,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -196
@@ -20743,26 +20711,26 @@
         "maximum_provider_tool_wire_bytes": 2
       },
       "slack_bolt_reaction:admin": {
-        "custom_tool_count": 243,
-        "wire_schema_bytes": 191322,
+        "custom_tool_count": 36,
+        "wire_schema_bytes": 36467,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:member": {
-        "custom_tool_count": 163,
-        "wire_schema_bytes": 139685,
+        "custom_tool_count": 34,
+        "wire_schema_bytes": 34173,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:public_channel": {
-        "custom_tool_count": 162,
-        "wire_schema_bytes": 137874,
+        "custom_tool_count": 33,
+        "wire_schema_bytes": 33700,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:public_channel_admin": {
-        "custom_tool_count": 242,
-        "wire_schema_bytes": 189511,
+        "custom_tool_count": 33,
+        "wire_schema_bytes": 33700,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
@@ -20857,12 +20825,12 @@
         "maximum_provider_tool_wire_bytes": 52
       }
     },
-    "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
-    "profile_contract_sha256": "9805570b53d3f4a405a1c39d027733b11db5860fb947e29d6abdb1d4921ab992",
+    "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
+    "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce",
     "status": "within_budget"
   },
   "profile_contract": {
-    "profile_ids_sha256": "24b1ae25ef363383f47a58d0d87b5703669ca2bfeb6140ddc69058562ea0f3ef",
-    "profile_contract_sha256": "9805570b53d3f4a405a1c39d027733b11db5860fb947e29d6abdb1d4921ab992"
+    "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
+    "profile_contract_sha256": "864713aa3cab55f5991a26a7bd26c19d18ffe1af71b91602c035f7bc60605fce"
   }
 }

--- a/server/src/addie/slack-tool-selection.ts
+++ b/server/src/addie/slack-tool-selection.ts
@@ -1,4 +1,12 @@
-import { getValidToolSetNames, SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS } from './tool-sets.js';
+import type { ExecutionPlan } from './router.js';
+import {
+  buildUnavailableSetsHint,
+  getSafeReadOnlyFallbackTools,
+  getToolsForSets,
+  getValidToolSetNames,
+  MAX_DIRECT_ROUTED_TOOL_SET_COUNT,
+  SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS,
+} from './tool-sets.js';
 
 export type SlackToolSource = 'dm' | 'mention' | 'channel';
 export type SystemChannelRole = 'prospect' | 'escalation' | 'billing' | 'error' | 'admin';
@@ -104,6 +112,104 @@ export function selectSlackToolSets(input: SlackToolSetSelectionInput): string[]
  * Slack retains its established export while web chat shares the exact policy.
  */
 export const selectRoutedToolSets = selectSlackToolSets;
+
+export interface BoundedRoutedToolSetSelectionInput {
+  /** A plan is trusted only after it has passed the bounded-domain checks below. */
+  plan: ExecutionPlan | null;
+  routerAvailable: boolean;
+  source: SlackToolSource;
+  isAdmin: boolean;
+  isPublicChannel?: boolean;
+  workingGroupSlug?: string | null;
+  systemRole?: SystemChannelRole | null;
+  activeCertificationKind?: ActiveCertificationKind | null;
+  hasSponsoredIntelligenceContext?: boolean;
+  /** Exact definition-and-handler availability at the delivery boundary. */
+  isToolAvailable?: (toolName: string) => boolean;
+}
+
+export interface BoundedRoutedToolSetSelection {
+  selectedToolSets: string[];
+  allowedToolNames: string[];
+  unavailableHint: string;
+  useSafeFallback: boolean;
+}
+
+/**
+ * Validate a direct, user-visible routed response before tool or prompt
+ * assembly. Delivery layers retain ownership of how a response is triggered
+ * and delivered; this policy only determines the request-scoped capability
+ * surface. A router error, non-response action, empty/stale/unauthorized
+ * domain, or an over-broad plan receives the explicit read-only fallback.
+ */
+export function selectBoundedRoutedToolSets(
+  input: BoundedRoutedToolSetSelectionInput,
+): BoundedRoutedToolSetSelection {
+  const validToolSets = getValidToolSetNames(input.isAdmin);
+  const respondPlan = input.plan?.action === 'respond' ? input.plan : null;
+  const hasValidRespondPlan = input.routerAvailable
+    && respondPlan !== null
+    && Array.isArray(respondPlan.tool_sets)
+    && respondPlan.tool_sets.length > 0
+    && respondPlan.tool_sets.length <= MAX_DIRECT_ROUTED_TOOL_SET_COUNT
+    && respondPlan.tool_sets.every((name) => typeof name === 'string' && validToolSets.has(name));
+  let useSafeFallback = !hasValidRespondPlan;
+
+  // Never retain certification, Sponsored Intelligence, or server-configured
+  // channel overlays when routing is unavailable or untrusted. They may be
+  // added only to a valid, bounded response plan below.
+  let selectedToolSets = selectRoutedToolSets({
+    routerSelectedSets: hasValidRespondPlan
+      ? respondPlan.tool_sets
+      : [...SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS],
+    routerAvailable: hasValidRespondPlan,
+    source: input.source,
+    isAdmin: input.isAdmin,
+    workingGroupSlug: useSafeFallback ? undefined : input.workingGroupSlug,
+    systemRole: useSafeFallback ? undefined : input.systemRole,
+    activeCertificationKind: useSafeFallback ? null : input.activeCertificationKind,
+    hasSponsoredIntelligenceContext: useSafeFallback
+      ? false
+      : input.hasSponsoredIntelligenceContext,
+  });
+  let allowedToolNames = useSafeFallback
+    ? getSafeReadOnlyFallbackTools()
+    : getToolsForSets(selectedToolSets, input.isAdmin, input.isPublicChannel);
+  const isToolAvailable = input.isToolAvailable;
+  if (!useSafeFallback && isToolAvailable && allowedToolNames.some((name) =>
+    name !== 'web_search' && !isToolAvailable(name),
+  )) {
+    // A bounded domain with an incomplete registration is no safer than a
+    // stale router result. Do not hand a model a definition without its
+    // handler (or vice versa); recover to the read-only domain instead.
+    useSafeFallback = true;
+    selectedToolSets = selectRoutedToolSets({
+      routerSelectedSets: [...SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS],
+      routerAvailable: false,
+      source: input.source,
+      isAdmin: input.isAdmin,
+      activeCertificationKind: null,
+      hasSponsoredIntelligenceContext: false,
+    });
+    allowedToolNames = getSafeReadOnlyFallbackTools();
+  }
+
+  // The provider-managed web search tool has no custom handler. Every other
+  // name must remain in the exact definition/handler intersection, including
+  // in the read-only fallback when a deployment has a partial registration.
+  if (isToolAvailable) {
+    allowedToolNames = allowedToolNames.filter((name) =>
+      name === 'web_search' || isToolAvailable(name),
+    );
+  }
+
+  return {
+    selectedToolSets,
+    allowedToolNames,
+    unavailableHint: buildUnavailableSetsHint(selectedToolSets, input.isAdmin),
+    useSafeFallback,
+  };
+}
 
 /** Normalize Slack conversation privacy, including DM shapes that omit is_private. */
 export function resolveSlackChannelPrivacy(channel: {

--- a/server/src/addie/tool-sets.ts
+++ b/server/src/addie/tool-sets.ts
@@ -708,7 +708,10 @@ export function getToolsForSets(
     : ALWAYS_AVAILABLE_TOOLS;
   const tools = new Set<string>(alwaysAvailable);
 
-  if (isAAOAdmin) {
+  // Public-channel replies must not expose escalation records: even an admin
+  // can retrieve member identities and private request context from them.
+  // Keep those tools to direct/private surfaces only.
+  if (isAAOAdmin && !isPublicChannel) {
     for (const tool of ALWAYS_AVAILABLE_ADMIN_TOOLS) {
       tools.add(tool);
     }

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -24,16 +24,8 @@ import {
 } from "../addie/router.js";
 import { createProductionRouter } from "../addie/router-runtime.js";
 import {
-  buildUnavailableSetsHint,
-  getSafeReadOnlyFallbackTools,
-  getToolsForSets,
-  getValidToolSetNames,
-  MAX_DIRECT_ROUTED_TOOL_SET_COUNT,
-  SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS,
-} from "../addie/tool-sets.js";
-import {
   classifyActiveCertificationProgress,
-  selectRoutedToolSets,
+  selectBoundedRoutedToolSets,
   type ActiveCertificationKind,
 } from "../addie/slack-tool-selection.js";
 import { classifyLocalModelExecution } from "../addie/model-providers/model-provider.js";
@@ -363,48 +355,22 @@ export async function selectRoutedWebTools(input: {
     }
   }
 
-  const validToolSets = getValidToolSetNames(input.isAAOAdmin);
-  const respondPlan = plan?.action === 'respond' ? plan : null;
-  const hasValidRespondPlan = respondPlan !== null
-    && Array.isArray(respondPlan.tool_sets)
-    && respondPlan.tool_sets.length <= MAX_DIRECT_ROUTED_TOOL_SET_COUNT
-    && respondPlan.tool_sets.every((name) => typeof name === 'string' && validToolSets.has(name));
-  const useSafeFallback = !routerAvailable || !hasValidRespondPlan;
-
-  // Web chat is a direct interaction. An ignore/react, malformed, stale, or
-  // unauthorized plan cannot be delivered safely, so use the explicit
-  // read-only fallback rather than the normal always-available escape hatches.
-  const routerSelectedSets = hasValidRespondPlan
-    ? respondPlan.tool_sets
-    : [...SAFE_KNOWLEDGE_FALLBACK_TOOL_SETS];
-  const selectedToolSets = selectRoutedToolSets({
-    routerSelectedSets,
-    routerAvailable: !useSafeFallback,
-    source: 'dm',
-    isAdmin: input.isAAOAdmin,
-    activeCertificationKind: useSafeFallback ? null : input.activeCertificationKind,
-    hasSponsoredIntelligenceContext: useSafeFallback
-      ? false
-      : input.hasSponsoredIntelligenceContext,
-  });
-  const allowedToolNames = useSafeFallback
-    ? getSafeReadOnlyFallbackTools()
-    : getToolsForSets(selectedToolSets, input.isAAOAdmin);
   const definitions = new Map(input.requestTools.tools.map((tool) => [tool.name, tool]));
   const globalToolNames = new Set(input.globalToolNames ?? []);
-  const matchedToolNames = allowedToolNames.filter((name) =>
-    (definitions.has(name) || globalToolNames.has(name))
-    && (input.requestTools.handlers.has(name) || globalToolNames.has(name)),
-  );
-  const incompleteToolNames = allowedToolNames.filter((name) =>
-    name !== 'web_search' && !matchedToolNames.includes(name),
-  );
-  if (incompleteToolNames.length > 0) {
-    logger.warn(
-      { threadId: input.threadId, incompleteToolNames },
-      'Addie Chat: Excluded incomplete routed tool registrations',
-    );
-  }
+  const isToolAvailable = (name: string) => name === 'web_search'
+    || ((definitions.has(name) || globalToolNames.has(name))
+      && (input.requestTools.handlers.has(name) || globalToolNames.has(name)));
+  const selection = selectBoundedRoutedToolSets({
+    plan,
+    routerAvailable,
+    source: 'dm',
+    isAdmin: input.isAAOAdmin,
+    activeCertificationKind: input.activeCertificationKind,
+    hasSponsoredIntelligenceContext: input.hasSponsoredIntelligenceContext,
+    isToolAvailable,
+  });
+  const { selectedToolSets, allowedToolNames } = selection;
+  const matchedToolNames = allowedToolNames.filter(isToolAvailable);
   const matched = new Set(matchedToolNames);
 
   return {
@@ -418,7 +384,7 @@ export async function selectRoutedWebTools(input: {
     // Keep provider-managed web_search in the allowlist even though it has no
     // custom handler. The client applies this list to global definitions too.
     allowedToolNames,
-    unavailableHint: buildUnavailableSetsHint(selectedToolSets, input.isAAOAdmin),
+    unavailableHint: selection.unavailableHint,
   };
 }
 

--- a/server/tests/unit/addie-chat-org-selection.test.ts
+++ b/server/tests/unit/addie-chat-org-selection.test.ts
@@ -14,10 +14,27 @@ const siMocks = vi.hoisted(() => ({
 
 const siHostMocks = vi.hoisted(() => ({
   hasCachedSiSession: vi.fn(),
+  toolNames: [
+    'get_si_availability',
+    'list_si_agents',
+    'connect_to_si_agent',
+    'send_to_si_agent',
+    'end_si_session',
+    'get_si_session_status',
+  ],
 }));
 
 const directoryMocks = vi.hoisted(() => ({
   createHandlers: vi.fn(),
+  toolNames: [
+    'list_members',
+    'get_member',
+    'list_agents',
+    'get_agent',
+    'validate_agent',
+    'lookup_domain',
+    'list_publishers',
+  ],
 }));
 
 const threadMocks = vi.hoisted(() => ({
@@ -42,20 +59,29 @@ vi.mock('../../src/addie/services/si-retriever.js', () => ({
 }));
 
 vi.mock('../../src/addie/mcp/directory-tools.js', () => ({
-  DIRECTORY_TOOLS: [{
-    name: 'list_agents',
-    description: 'Test directory tool',
+  DIRECTORY_TOOLS: directoryMocks.toolNames.map((name) => ({
+    name,
+    description: `Test ${name}`,
     input_schema: { type: 'object', properties: {} },
-  }],
+  })),
   createDirectoryToolHandlers: (context: unknown) => {
     directoryMocks.createHandlers(context);
-    return new Map([['list_agents', async () => JSON.stringify({ scoped: true })]]);
+    return new Map(directoryMocks.toolNames.map((name) => [
+      name,
+      async () => JSON.stringify({ scoped: true }),
+    ]));
   },
 }));
 
 vi.mock('../../src/addie/mcp/si-host-tools.js', () => ({
-  SI_HOST_TOOLS: [],
-  createSiHostToolHandlers: () => new Map(),
+  SI_HOST_TOOLS: siHostMocks.toolNames.map((name) => ({
+    name,
+    description: `Test ${name}`,
+    input_schema: { type: 'object', properties: {} },
+  })),
+  createSiHostToolHandlers: () => new Map(
+    siHostMocks.toolNames.map((name) => [name, async () => '{}']),
+  ),
   hasCachedSiSession: siHostMocks.hasCachedSiSession,
 }));
 
@@ -91,6 +117,8 @@ import {
   prepareRequestWithMemberTools,
 } from '../../src/routes/addie-chat.js';
 import { MAX_INPUT_LENGTH } from '../../src/addie/security.js';
+import { DIRECTORY_TOOLS } from '../../src/addie/mcp/directory-tools.js';
+import { ANONYMOUS_SAFE_KNOWLEDGE_TOOLS } from '../../src/mcp/chat-tool.js';
 import { issueAnonymousSessionCapability } from '../../src/routes/helpers/anonymous-session-capability.js';
 
 describe('prepareRequestWithMemberTools organization selection', () => {
@@ -155,6 +183,14 @@ describe('prepareRequestWithMemberTools organization selection', () => {
 
 describe('mounted Addie web-thread ownership', () => {
   const chatClient = {
+    // Production globally registers public directory, search-member, and
+    // anonymous-safe knowledge tools. SI host tools remain request-scoped
+    // because their handlers bind the external conversation id.
+    getRegisteredTools: vi.fn(() => [
+      ...DIRECTORY_TOOLS.map((tool) => tool.name),
+      'search_members',
+      ...ANONYMOUS_SAFE_KNOWLEDGE_TOOLS,
+    ]),
     processMessage: vi.fn().mockResolvedValue({
       text: 'Hello',
       tools_used: [],

--- a/server/tests/unit/addie/slack-tool-selection.test.ts
+++ b/server/tests/unit/addie/slack-tool-selection.test.ts
@@ -5,6 +5,7 @@ import {
   hasActiveCertificationProgress,
   resolveRequiredSlackChannelContext,
   resolveSlackChannelPrivacy,
+  selectBoundedRoutedToolSets,
   selectSlackToolSets,
   SYSTEM_CHANNEL_TOOL_SETS,
   type SystemChannelRole,
@@ -189,6 +190,106 @@ describe('Slack tool-set selection policy', () => {
       source: 'channel',
       isAdmin: true,
     })).toEqual([]);
+  });
+
+  it('bounds reaction response plans by member/admin and public/private policy', () => {
+    const member = selectBoundedRoutedToolSets({
+      plan: { action: 'respond', tool_sets: ['member_billing'], confidence: 'high', reason: 'test', decision_method: 'quick_match' },
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: false,
+      isPublicChannel: false,
+    });
+    expect(member.useSafeFallback).toBe(false);
+    expect(member.selectedToolSets).toEqual(['member_billing']);
+    expect(member.allowedToolNames).toContain('create_payment_link');
+
+    const publicMember = selectBoundedRoutedToolSets({
+      plan: { action: 'respond', tool_sets: ['member_billing'], confidence: 'high', reason: 'test', decision_method: 'quick_match' },
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: false,
+      isPublicChannel: true,
+    });
+    expect(publicMember.allowedToolNames).not.toContain('create_payment_link');
+    expect(publicMember.allowedToolNames).not.toContain('get_account_link');
+
+    const admin = selectBoundedRoutedToolSets({
+      plan: { action: 'respond', tool_sets: ['admin_prospects'], confidence: 'high', reason: 'test', decision_method: 'quick_match' },
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: true,
+      isPublicChannel: false,
+    });
+    expect(admin.useSafeFallback).toBe(false);
+    expect(admin.allowedToolNames).toContain('add_prospect');
+  });
+
+  it.each([
+    ['non-response action', { action: 'react', emoji: 'wave', reason: 'test', decision_method: 'quick_match' }],
+    ['stale alias', { action: 'respond', tool_sets: ['admin'], confidence: 'high', reason: 'test', decision_method: 'quick_match' }],
+    ['unauthorized admin domain', { action: 'respond', tool_sets: ['admin_prospects'], confidence: 'high', reason: 'test', decision_method: 'quick_match' }],
+    ['over-broad domains', { action: 'respond', tool_sets: ['knowledge', 'directory', 'events'], confidence: 'high', reason: 'test', decision_method: 'quick_match' }],
+  ] as const)('uses the mutation-free fallback for reaction %s', (_label, plan) => {
+    const selection = selectBoundedRoutedToolSets({
+      plan,
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: false,
+      isPublicChannel: false,
+      activeCertificationKind: 'mixed',
+      hasSponsoredIntelligenceContext: true,
+      systemRole: 'billing',
+    });
+    expect(selection.useSafeFallback).toBe(true);
+    expect(selection.selectedToolSets).toEqual(safeKnowledgeFallback);
+    expect(selection.selectedToolSets).not.toContain('sponsored_intelligence');
+    expect(selection.allowedToolNames).not.toEqual(expect.arrayContaining([
+      'capture_learning', 'set_outreach_preference', 'create_payment_link',
+      'add_prospect', 'send_to_si_agent', 'start_certification_module',
+    ]));
+  });
+
+  it('uses the mutation-free fallback when the reaction router is unavailable', () => {
+    const selection = selectBoundedRoutedToolSets({
+      plan: null,
+      routerAvailable: false,
+      source: 'channel',
+      isAdmin: true,
+      isPublicChannel: false,
+      activeCertificationKind: 'learning',
+      hasSponsoredIntelligenceContext: true,
+    });
+    expect(selection.useSafeFallback).toBe(true);
+    expect(selection.selectedToolSets).toEqual(safeKnowledgeFallback);
+    expect(selection.allowedToolNames).not.toContain('resolve_escalation');
+    expect(selection.allowedToolNames).not.toContain('start_certification_module');
+    expect(selection.allowedToolNames).not.toContain('send_to_si_agent');
+  });
+
+  it('does not expose a routed domain when one of its tools lacks a paired handler', () => {
+    const selection = selectBoundedRoutedToolSets({
+      plan: { action: 'respond', tool_sets: ['member_billing'], confidence: 'high', reason: 'test', decision_method: 'quick_match' },
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: false,
+      isToolAvailable: (name) => name !== 'create_payment_link',
+    });
+    expect(selection.useSafeFallback).toBe(true);
+    expect(selection.selectedToolSets).toEqual(safeKnowledgeFallback);
+    expect(selection.allowedToolNames).not.toContain('create_payment_link');
+  });
+
+  it('withholds escalation records from public admin reactions', () => {
+    const selection = selectBoundedRoutedToolSets({
+      plan: { action: 'respond', tool_sets: ['knowledge'], confidence: 'high', reason: 'test', decision_method: 'quick_match' },
+      routerAvailable: true,
+      source: 'channel',
+      isAdmin: true,
+      isPublicChannel: true,
+    });
+    expect(selection.allowedToolNames).not.toContain('resolve_escalation');
+    expect(selection.allowedToolNames).not.toContain('list_escalations');
   });
 
   it('returns verified channel context from the required resolver', async () => {

--- a/server/tests/unit/addie/tool-sets.test.ts
+++ b/server/tests/unit/addie/tool-sets.test.ts
@@ -40,6 +40,12 @@ describe('getToolsForSets', () => {
         expect(tools).toContain(tool);
       }
     });
+
+    it('withholds admin escalation records from public channels', () => {
+      const tools = getToolsForSets(['knowledge'], true, true);
+      expect(tools).not.toContain('resolve_escalation');
+      expect(tools).not.toContain('list_escalations');
+    });
   });
 
   describe('bounded admin domains', () => {

--- a/server/tests/unit/addie/web-tool-selection.test.ts
+++ b/server/tests/unit/addie/web-tool-selection.test.ts
@@ -3,6 +3,7 @@ import type { AddieTool } from '../../../src/addie/types.js';
 import {
   selectRoutedWebTools,
 } from '../../../src/routes/addie-chat.js';
+import { getToolsForSets } from '../../../src/addie/tool-sets.js';
 
 const tools: AddieTool[] = [
   { name: 'search_docs', description: 'Search docs', input_schema: { type: 'object', properties: {} } },
@@ -14,6 +15,18 @@ const handlers = new Map(tools
   .filter((tool) => tool.name !== 'orphaned_definition')
   .map((tool) => [tool.name, async () => '{}']));
 handlers.set('orphaned_handler', async () => '{}');
+
+// The selector also receives baseline definitions registered by the client.
+// Keep this fixture narrow while modeling those paired globals, deliberately
+// excluding the request-local tool each routing assertion is about.
+const pairedGlobalToolNames = [...new Set([
+  ...getToolsForSets(['knowledge'], false, false)
+    .filter((name) => name !== 'search_docs'),
+  ...getToolsForSets(['member_billing'], false, false)
+    .filter((name) => name !== 'create_payment_link'),
+  ...getToolsForSets(['admin_prospects'], true, false)
+    .filter((name) => name !== 'add_prospect'),
+])];
 
 function routerFor(toolSets: string[]) {
   return {
@@ -32,7 +45,7 @@ async function select(
   router: Parameters<typeof selectRoutedWebTools>[0]['router'],
   isAAOAdmin = false,
   requestTools = { tools, handlers },
-  globalToolNames?: string[],
+  globalToolNames: string[] = pairedGlobalToolNames,
 ) {
   return selectRoutedWebTools({
     message: 'Test message',
@@ -97,6 +110,24 @@ describe('authenticated web Addie tool routing', () => {
     expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual(['search_docs']);
     expect(selected.allowedToolNames).not.toContain('create_payment_link');
     expect(selected.allowedToolNames).not.toContain('add_prospect');
+  });
+
+  it('uses the complete read-only fallback when a routed web domain has an incomplete registration', async () => {
+    const incompleteHandlers = new Map(handlers);
+    incompleteHandlers.delete('create_payment_link');
+    const selected = await select(
+      routerFor(['member_billing']),
+      false,
+      { tools, handlers: incompleteHandlers },
+    );
+
+    expect(selected.selectedToolSets).toEqual([
+      'knowledge',
+      'community_research',
+      'schema_reference',
+    ]);
+    expect(selected.allowedToolNames).not.toContain('create_payment_link');
+    expect(selected.requestTools.tools.map((tool) => tool.name)).toEqual(['search_docs']);
   });
 
   it('fails closed when a router plan exceeds the two-domain direct-chat bound', async () => {
@@ -201,7 +232,7 @@ describe('authenticated web Addie tool routing', () => {
       routerFor(['member_billing']),
       false,
       { tools: localTools, handlers: localHandlers },
-      ['search_docs'],
+      [...pairedGlobalToolNames, 'search_docs'],
     );
 
     // The definition is paired in the global registry; the request-local


### PR DESCRIPTION
## Summary
- Bound Slack Bolt reaction-triggered Addie replies to the existing provider-neutral two-domain routing policy, with request-scoped tool/prompt modules and paired definition/handler checks.
- Preserved reaction triggering, confirmation and feedback semantics, source-thread binding, authorization, persistence, audit/logging, billing, and same-thread delivery.
- Invalid, stale, unauthorized, non-response, over-broad, router-unavailable, or incomplete plans now receive a useful read-only fallback. Active certification and Sponsored Intelligence capability overlays are removed on fallback.
- Public admin surfaces suppress escalation-record tools. The shared authenticated web selector uses the same complete-domain registration fallback; JSON/stream parity is covered.

## Exact reaction inventory maxima

| Audience | Tools before → after | Wire-schema bytes before → after | Tool-reference bytes before → after |
| --- | ---: | ---: | ---: |
| Member | 163 → 34 | 139,564 → 26,780 | 33,830 → 8,439 |
| Admin | 243 → 36 | 191,201 → 29,074 | 37,017 → 8,507 |
| Public channel | 158 → 33 | 136,291 → 26,307 | 32,958 → 8,421 |
| Public-channel admin | 238 → 33 | 187,928 → 26,307 | 36,145 → 8,421 |

Generated inventory models normal routes, valid trusted active-SI overlays, and explicit safe fallbacks. No global ceilings were raised.

## Safety boundaries
- No legacy Slack, Tavus, provider activation, rollout/canary, daily-budget policy, secrets, or terminal-response behavior changes.
- Public/private restrictions, reaction-specific delivery, audit/persistence/billing, and confirmation/idempotency behavior are retained.
- No paid/live model or API calls were made.

## Verification
- Deterministic focused routing/eval tests: 125 passed.
- `npm run test:addie-tools`
- `npm run typecheck`
- `npm run build`
- `npm run precommit` (final normalized hook: 542 files, 7,808 passed; 30 skipped)
- `git diff --check`
- Independent Codex gpt-5.6-sol medium code + security review: clean.

Environment note: copied `.env.local` exports `DEV_USER_EMAIL=dev@example.com` and `DEV_USER_ID=dev-user-123`; the known four unrelated auth tests pass when both are explicitly exported empty. The final hook ran with both empty.

Related to #6845
