### PR TITLE
fix(mcp): include get_principal in media-buy profile

### DIFF
--- a/.changeset/include-get-principal-media-buy-profile.md
+++ b/.changeset/include-get-principal-media-buy-profile.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Include `get_principal` alongside `sync_principal` in the MCP media-buy role profile.

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -73,6 +73,7 @@ const MCP_ROLE_PROFILE_TOOLS = {
     'get_adcp_capabilities',
     'get_media_buy_delivery',
     'get_media_buys',
+    'get_principal',
     'get_reporting_status',
     'get_task_status',
     'list_accounts',

--- a/tests/mcp-schema-projection.test.cjs
+++ b/tests/mcp-schema-projection.test.cjs
@@ -1283,6 +1283,8 @@ test('generated role profiles are host-compatible discovery catalogs with bounde
     .map(([toolName]) => toolName)
     .filter(toolName => toolName !== 'build_creative');
   for (const toolName of activeMediaBuyTools) assert.ok(mediaBuyTools.has(toolName), toolName);
+  assert.ok(mediaBuyTools.has('get_principal'));
+  assert.ok(mediaBuyTools.has('sync_principal'));
   assert.ok(mediaBuyTools.has('sync_creatives'));
   assert.ok(mediaBuyTools.has('sync_governance'));
   assert.ok(mediaBuyTools.has('provide_performance_feedback'));


### PR DESCRIPTION
## Summary

- include `get_principal` alongside `sync_principal` in the MCP media-buy role profile
- add a regression assertion for the required principal tool pair
- add a patch changeset for the next 3.2 beta release

Closes #7148

## Testing

- `npm run test:mcp-schema-projection` (29 passing across the projection and analysis suites)
- `npm run build`
- `npm run test:immutable-release-artifacts`
- pre-commit unit suite (1,056 tests) and typecheck
- changeset protocol scope and status checks
- inspected the generated protocol bundle for media-buy request, response, and model-context files

## Expert review

- ad-tech protocol: approved
- Node.js testing: approved
- code review: approved
- security review: approved

## Risk

Low. This is an additive discovery-profile correction for an existing experimental task and does not change runtime task semantics or released artifacts.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/170eada3-e821-4073-9dd3-e42823f704b7)
