### PR TITLE
fix(registry): align capability-gated compliance scoring

### DIFF
--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -23,20 +23,20 @@ For the layered model behind this — what each layer contains and what an SDK a
 
 What "shipped" means at each layer is the [L0–L3 checklist](/docs/building/cross-cutting/sdk-stack#what-an-sdk-at-each-layer-should-provide).
 
-*Last updated: 2026-08-30.*
+*Last updated: 2026-09-02.*
 
 | SDK | Current package | 3.2 beta support | L0 | L1 | L2 | L3 |
 |---|---|---|:-:|:-:|:-:|:-:|
-| **`@adcp/sdk`** (TypeScript) | `14.0.0-beta.22` | Exact `3.2.0-beta.9` support | ✅ | ✅ | ✅ | ✅ |
+| **`@adcp/sdk`** (TypeScript) | `14.0.0-beta.27` | Exact `3.2.0-beta.10` support | ✅ | ✅ | ✅ | ✅ |
 | **`adcp`** (Python) | `8.0.0b10` | Exact `3.2.0-beta.9` schemas and types; higher-level helpers remain partial | ✅ | ⚠️ | ⚠️ | ⚠️ |
 | **`adcp/v3`** (Go) | `v3.0.0` | Pending exact 3.2 support | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
 
 Legend: ✅ shipped · ⚠️ partial / role-dependent · ❌ not yet covered. The L0–L3 columns describe the current package, not a 3.2 support claim.
 
 <Warning>
-**3.2 packages are prereleases.** The TypeScript and Python betas support the
-exact beta.9 protocol checkpoint; neither implies compatibility with a later
-checkpoint. Go has not published an exact
+**3.2 packages are prereleases.** TypeScript beta.27 supports the exact beta.10
+protocol checkpoint; Python beta.10 supports the exact beta.9 checkpoint.
+Neither implies compatibility with a later checkpoint. Go has not published an exact
 3.2 support statement yet. See the [3.2 beta program](/docs/reference/3-2-beta).
 </Warning>
 
@@ -59,7 +59,7 @@ and the [Slack community](/docs/community/joining-slack).
 [![npm version](https://img.shields.io/npm/v/@adcp/sdk)](https://www.npmjs.com/package/@adcp/sdk)
 
 ```bash
-npm install @adcp/sdk@14.0.0-beta.22
+npm install @adcp/sdk@14.0.0-beta.27
 ```
 
 ```javascript
@@ -73,7 +73,7 @@ const client = createSingleAgentClient({
 });
 
 const products = await client.listProducts({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   account: { account_id: 'account_123' },
   criteria: {
     offer_filters: { channels: ['ctv'] },
@@ -168,11 +168,11 @@ Both SDKs share the same positional shape: `adcp <agent> [tool] [payload]`. The 
 ### JavaScript CLI
 
 ```bash
-npx @adcp/sdk@14.0.0-beta.22 --help
-npx @adcp/sdk@14.0.0-beta.22 --save-auth my-agent https://sales.example.com/mcp
-npx @adcp/sdk@14.0.0-beta.22 my-agent list_products '{"adcp_version":"3.2-beta.9","account":{"account_id":"account_123"}}'
+npx @adcp/sdk@14.0.0-beta.27 --help
+npx @adcp/sdk@14.0.0-beta.27 --save-auth my-agent https://sales.example.com/mcp
+npx @adcp/sdk@14.0.0-beta.27 my-agent list_products '{"adcp_version":"3.2-beta.10","account":{"account_id":"account_123"}}'
 # or against the built-in public test agent:
-npx @adcp/sdk@14.0.0-beta.22 test-mcp list_products '{"adcp_version":"3.2-beta.9"}'
+npx @adcp/sdk@14.0.0-beta.27 test-mcp list_products '{"adcp_version":"3.2-beta.10"}'
 ```
 
 The CLI also drives storyboards (`adcp storyboard run`), conformance grading (`adcp grade`), and registry diagnostics. See `--help` for the full surface.

--- a/docs/learning/supplements/buyer-briefs-and-get-products.mdx
+++ b/docs/learning/supplements/buyer-briefs-and-get-products.mdx
@@ -13,8 +13,8 @@ The goal is not to make the brief verbose. The goal is to put intent in the brie
 
 <Note>
 This module teaches the AdCP 3.2 targeting-aware discovery contract. The public
-training seller supports the exact `3.2-beta.9` wire bundle with
-`@adcp/sdk@14.0.0-beta.22`. Verify those advertised capabilities before the lab;
+training seller supports the exact `3.2-beta.10` wire bundle with
+`@adcp/sdk@14.0.0-beta.27`. Verify those advertised capabilities before the lab;
 unknown-field acceptance by an older seller is not evidence of support.
 </Note>
 
@@ -45,7 +45,7 @@ Example:
 ```json
 {
   "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/request-proposals-request.json",
-  "adcp_version": "3.2-beta.9",
+  "adcp_version": "3.2-beta.10",
   "idempotency_key": "550e8400-e29b-41d4-a716-446655442008",
   "brief": "Launch Nova Running's spring trail shoe line with outdoor enthusiasts. Favor trusted adventure and fitness contexts, avoid discount-led positioning, and prioritize packages that can support a brand-lift readout.",
   "brand": {
@@ -77,7 +77,7 @@ Example:
 {
   "$schema": "https://adcontextprotocol.org/schemas/v3/media-buy/request-proposals-request.json",
   "idempotency_key": "550e8400-e29b-41d4-a716-446655442009",
-  "adcp_version": "3.2-beta.9",
+  "adcp_version": "3.2-beta.10",
   "brief": "Launch Nova Running's spring trail shoe line with outdoor enthusiasts. Favor trusted adventure and fitness contexts.",
   "brand": {
     "domain": "novarunning.example"
@@ -144,7 +144,7 @@ Do not send a totally new campaign through `refine_proposals`; start a new `requ
 
 ## Implementation checklist
 
-- Read `get_adcp_capabilities.adcp.supported_versions` and `media_buy.lifecycle_tools`, pin `adcp_version: "3.2-beta.9"` for this lab, and validate the echoed served release before using targeting-aware discovery.
+- Read `get_adcp_capabilities.adcp.supported_versions` and `media_buy.lifecycle_tools`, pin `adcp_version: "3.2-beta.10"` for this lab, and validate the echoed served release before using targeting-aware discovery.
 - If release precision is absent, major-only, or 3.1-or-earlier, omit the 3.2 fields and fall back to retained legacy targeting filters or explicit brief prose; unknown fields may otherwise be silently ignored.
 - Normalize the human request into intent, hard constraints, and follow-up changes before calling the seller.
 - Preserve the buyer's business language in `brief`; do not collapse it into only keywords.

--- a/docs/learning/tracks/buyer.mdx
+++ b/docs/learning/tracks/buyer.mdx
@@ -257,7 +257,7 @@ New to running tool calls and reading JSON in a terminal? Do [A2b: Testing your 
 
 <Note>
 The public training seller implements targeting-aware discovery on the exact
-AdCP `3.2-beta.9` wire bundle. Pin `@adcp/sdk@14.0.0-beta.22`, verify the
+AdCP `3.2-beta.10` wire bundle. Pin `@adcp/sdk@14.0.0-beta.27`, verify the
 seller's advertised version and lifecycle tools, and retain the request,
 response, and package readback as assessment evidence. Do not treat an
 uncapable seller silently ignoring unknown fields as validation.
@@ -281,7 +281,7 @@ To see the seller responses your agent must handle, you can inspect the test sel
 
 ```bash
 # Inspects the test SELLER's get_products response — the shape your buyer agent must parse.
-npx @adcp/sdk@14.0.0-beta.22 test-mcp get_products '{"adcp_version":"3.2-beta.9","idempotency_key":"550e8400-e29b-41d4-a716-446655442065","buying_mode":"brief","brief":"your campaign brief"}'
+npx @adcp/sdk@14.0.0-beta.27 test-mcp get_products '{"adcp_version":"3.2-beta.10","idempotency_key":"550e8400-e29b-41d4-a716-446655442065","buying_mode":"brief","brief":"your campaign brief"}'
 ```
 
 See [Build a caller](/docs/building/by-layer/L4/build-a-caller) for client setup and [Validate Your Agent](/docs/building/verification/validate-your-agent) for the storyboard workflow.

--- a/docs/media-buy/index.mdx
+++ b/docs/media-buy/index.mdx
@@ -46,7 +46,7 @@ delivery constraints use structured criteria:
 const proposals = await Promise.all(
   sellers.map((seller) =>
     seller.requestProposals({
-      adcp_version: '3.2-beta.9',
+      adcp_version: '3.2-beta.10',
       idempotency_key: 'acme-q2-proposals-001',
       account: { account_id: 'account_123' },
       brand: { domain: 'acme-outdoor.example' },
@@ -108,7 +108,7 @@ draft with typed constraints:
 
 ```javascript
 const refined = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-refine-001',
   refinements: [
     {
@@ -154,7 +154,7 @@ creates a committed successor and an inventory hold:
 
 ```javascript
 const finalized = await streamHaus.refineProposals({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-finalize-001',
   refinements: [
     {
@@ -170,7 +170,7 @@ accepts that exact snapshot:
 
 ```javascript
 const buy = await streamHaus.acceptProposal({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-accept-001',
   account: { account_id: 'account_123' },
   proposal_id: 'proposal_streamhaus_003',
@@ -200,7 +200,7 @@ required format has coverage, then moves to `pending_start` or `active`.
 
 ```javascript
 await streamHaus.syncCreatives({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-creatives-001',
   account: { account_id: 'account_123' },
   creatives: [
@@ -255,7 +255,7 @@ a package or adjust a budget inside the accepted commercial envelope, he uses
 
 ```javascript
 const controlled = await streamHaus.controlMediaBuy({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-control-001',
   account: { account_id: 'account_123' },
   media_buy_id: buy.media_buy_id,

--- a/docs/media-buy/product-discovery/index.mdx
+++ b/docs/media-buy/product-discovery/index.mdx
@@ -103,7 +103,7 @@ without asking the seller to author a media plan:
 
 ```javascript
 const result = await seller.listProducts({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   account: { account_id: 'account_123' },
   criteria: {
     offer_filters: {
@@ -155,7 +155,7 @@ structured criteria to StreamHaus while keeping strategy in prose:
 
 ```javascript
 const response = await seller.requestProposals({
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   idempotency_key: 'acme-q2-proposals-001',
   account: { account_id: 'account_123' },
   brand: { domain: 'acme-outdoor.example' },

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -534,7 +534,7 @@ Record the authenticated buyer, source IDs, successor IDs, idempotency fingerpri
 
 The canonical compliance scenario is `media_buy_seller/typed_proposal_negotiation`. It exercises capability gating, satisfied and unsatisfied constraints, alternatives, immutable lineage, finalize atomicity, exact replay, acceptance, amendment, cancellation, double-finalize rejection, and multi-source ordering.
 
-The deterministic training profiles expose the exact `3.2-beta.9` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
+The deterministic training profiles expose the exact `3.2-beta.10` proposal-negotiation wire contract. The ordinary `/sales/mcp` route remains the backward-compatible ask-only seller. Use the [public test token](/docs/quickstart#setup) with `https://test-agent.adcontextprotocol.org` and one of these capability-distinct routes:
 
 | Profile | Route | Deterministic behavior |
 | --- | --- | --- |
@@ -542,7 +542,7 @@ The deterministic training profiles expose the exact `3.2-beta.9` proposal-negot
 | Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
 | Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
 
-Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. SDK 14 beta.22 accepts `wireAdcpVersion: "3.2-beta.9"` on its single- and multi-agent client configuration; raw calls remain useful for inspecting the exact envelope as below.
+Pin the beta exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into beta behavior. SDK 14 beta.27 accepts `wireAdcpVersion: "3.2-beta.10"` on its single- and multi-agent client configuration; raw calls remain useful for inspecting the exact envelope as below.
 
 ### Try the lifecycle with Addie or Sage
 
@@ -556,7 +556,7 @@ conversation and paste:
 
 > Walk me through the AdCP 3.2 proposal lifecycle against
 > `https://test-agent.adcontextprotocol.org/sales/profiles/constrained-seller/mcp`.
-> Pin `adcp_version` to `3.2-beta.9` and send `adcp_major_version: 3`. First
+> Pin `adcp_version` to `3.2-beta.10` and send `adcp_major_version: 3`. First
 > inspect capabilities, then request a draft for `acmeoutdoor.example`, ask for
 > three alternatives under a USD 50,000 ceiling, and help me interpret the
 > structured counteroffer. Stop before finalizing the hold, and stop again
@@ -611,14 +611,14 @@ async function callTool(id, name, args) {
 }
 
 const version = {
-  adcp_version: '3.2-beta.9',
+  adcp_version: '3.2-beta.10',
   adcp_major_version: 3,
 };
 const nonce = crypto.randomUUID();
 
 const capabilities = await callTool(1, 'get_adcp_capabilities', version);
 if (
-  capabilities.adcp_version !== '3.2-beta.9'
+  capabilities.adcp_version !== '3.2-beta.10'
   || capabilities.media_buy?.supports_proposals !== true
   || !capabilities.media_buy?.lifecycle_tools?.includes('refine_proposals')
 ) {

--- a/docs/media-buy/task-reference/get_reporting_status.mdx
+++ b/docs/media-buy/task-reference/get_reporting_status.mdx
@@ -14,9 +14,9 @@ reporting delivery. It answers whether every report that should exist is present
 usable. It does not replace [`get_media_buy_delivery`](/docs/media-buy/task-reference/get_media_buy_delivery)
 as the reporting-data API.
 
-**Request schema:** [`get-reporting-status-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-reporting-status-request.json)
+**Request schema:** [`get-reporting-status-request.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/media-buy/get-reporting-status-request.json)
 
-**Response schema:** [`get-reporting-status-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/get-reporting-status-response.json)
+**Response schema:** [`get-reporting-status-response.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/media-buy/get-reporting-status-response.json)
 
 ## Views
 

--- a/docs/media-buy/task-reference/sync_reporting_receipts.mdx
+++ b/docs/media-buy/task-reference/sync_reporting_receipts.mdx
@@ -17,9 +17,9 @@ receipts. Sellers implementing it declare `media_buy.reporting_delivery` in
 report” and “this consumer independently observed matching data.” It is a batched,
 idempotent write. It does not acknowledge mere webhook delivery.
 
-**Request schema:** [`sync-reporting-receipts-request.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-reporting-receipts-request.json)
+**Request schema:** [`sync-reporting-receipts-request.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/media-buy/sync-reporting-receipts-request.json)
 
-**Response schema:** [`sync-reporting-receipts-response.json`](https://adcontextprotocol.org/schemas/latest/media-buy/sync-reporting-receipts-response.json)
+**Response schema:** [`sync-reporting-receipts-response.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/media-buy/sync-reporting-receipts-response.json)
 
 ```json
 {

--- a/docs/protocol/get_principal.mdx
+++ b/docs/protocol/get_principal.mdx
@@ -9,10 +9,10 @@ description: "Read the authenticated caller's seller-resolved identity, principa
 The read is side-effect free. It never creates a principal record, issues identifiers, sends endpoint proof challenges, mutates state, or advances `configuration_version`.
 
 {/* Using latest because this experimental schema is not yet released. Update after release. */}
-**Request schema:** [`/schemas/latest/protocol/get-principal-request.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-principal-request.json)
+**Request schema:** [`/schemas/3.2.0-beta.10/protocol/get-principal-request.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/protocol/get-principal-request.json)
 
 {/* Using latest because this experimental schema is not yet released. Update after release. */}
-**Response schema:** [`/schemas/latest/protocol/get-principal-response.json`](https://adcontextprotocol.org/schemas/latest/protocol/get-principal-response.json)
+**Response schema:** [`/schemas/3.2.0-beta.10/protocol/get-principal-response.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/protocol/get-principal-response.json)
 
 ## When to call
 

--- a/docs/protocol/sync_principal.mdx
+++ b/docs/protocol/sync_principal.mdx
@@ -17,10 +17,10 @@ A **principal** is the durable party behind an authenticated caller — a buyer 
 The task does not register a buyer agent and does not accept a buyer-agent URL or identity in its body. Who the principal is comes only from authenticated transport.
 
 {/* Using latest because this experimental schema is not yet released. Update after release. */}
-**Request schema:** [`/schemas/latest/protocol/sync-principal-request.json`](https://adcontextprotocol.org/schemas/latest/protocol/sync-principal-request.json)
+**Request schema:** [`/schemas/3.2.0-beta.10/protocol/sync-principal-request.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/protocol/sync-principal-request.json)
 
 {/* Using latest because this experimental schema is not yet released. Update after release. */}
-**Response schema:** [`/schemas/latest/protocol/sync-principal-response.json`](https://adcontextprotocol.org/schemas/latest/protocol/sync-principal-response.json)
+**Response schema:** [`/schemas/3.2.0-beta.10/protocol/sync-principal-response.json`](https://adcontextprotocol.org/schemas/3.2.0-beta.10/protocol/sync-principal-response.json)
 
 ## Identity and authority
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.2.0-beta.10",
       "dependencies": {
-        "@adcp/sdk": "14.0.0-beta.22",
+        "@adcp/sdk": "14.0.0-beta.27",
         "@anthropic-ai/sdk": "^0.121.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.9.1",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "14.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.22.tgz",
-      "integrity": "sha512-k95ME4sqogwrLuogo/HVF1QqLzvoD2JzMJT3p7lHnBAdfnXyPXjRt6YuKRYiE/8VrxdGXyq/ntZG6YAtE3+DRw==",
+      "version": "14.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-beta.27.tgz",
+      "integrity": "sha512-Mv1vp34kJSB2O834YWs5Is6kUGtxt6HZ3iT0eTqJj1YRIF8GpL12w0Y77AVN2bMjXwlnYV2L+iwlUK7OeTTT2Q==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -151,6 +151,7 @@
         "ajv-formats": "^3.0.1",
         "fast-check": "^4.9.0",
         "jose": "^6.2.10",
+        "pg": "^8.23.0",
         "secure-json-parse": "^4.1.0",
         "semver": "^7.8.5",
         "structured-headers": "2.0.3",
@@ -169,15 +170,11 @@
         "@a2a-js/sdk": "^1.0.1",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "@opentelemetry/api": "^1.0.0",
-        "pg": "^8.0.0",
         "redis": "^4.6.0 || ^5.0.0 || ^6.0.0",
         "zod": "^4.1.5"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
-          "optional": true
-        },
-        "pg": {
           "optional": true
         },
         "redis": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts"
   },
   "dependencies": {
-    "@adcp/sdk": "14.0.0-beta.22",
+    "@adcp/sdk": "14.0.0-beta.27",
     "@anthropic-ai/sdk": "^0.121.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.9.1",

--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-  "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af",
+  "profile_contract_sha256": "0268dbd6be7bc0dea55ed208b061744c50a29fcc65c304501bb6b3d6c6bbc50c",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {
@@ -55,10 +55,10 @@
     "legacy_slack:member_mention": { "custom_tool_count": 133, "wire_schema_bytes": 117335, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "mcp_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "official_docs_replay:evaluation_only": { "custom_tool_count": 2, "wire_schema_bytes": 1873, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
-    "slack_bolt_reaction:admin": { "custom_tool_count": 36, "wire_schema_bytes": 36467, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:member": { "custom_tool_count": 34, "wire_schema_bytes": 34173, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:public_channel": { "custom_tool_count": 33, "wire_schema_bytes": 33700, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "slack_bolt_reaction:public_channel_admin": { "custom_tool_count": 33, "wire_schema_bytes": 33700, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:admin": { "custom_tool_count": 36, "wire_schema_bytes": 36468, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:member": { "custom_tool_count": 34, "wire_schema_bytes": 34174, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:public_channel": { "custom_tool_count": 33, "wire_schema_bytes": 33701, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "slack_bolt_reaction:public_channel_admin": { "custom_tool_count": 33, "wire_schema_bytes": 33701, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:admin_dm": { "custom_tool_count": 219, "wire_schema_bytes": 173278, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:admin_working_group": { "custom_tool_count": 219, "wire_schema_bytes": 173278, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt:member_dm": { "custom_tool_count": 153, "wire_schema_bytes": 131695, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
@@ -72,7 +72,7 @@
     "tavus_voice:committee_leader": { "custom_tool_count": 132, "wire_schema_bytes": 106023, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "tavus_voice:member": { "custom_tool_count": 121, "wire_schema_bytes": 95906, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "web_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9322, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "web_chat:authenticated_admin": { "custom_tool_count": 39, "wire_schema_bytes": 39768, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
-    "web_chat:authenticated_member": { "custom_tool_count": 37, "wire_schema_bytes": 37474, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 }
+    "web_chat:authenticated_admin": { "custom_tool_count": 39, "wire_schema_bytes": 39769, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
+    "web_chat:authenticated_member": { "custom_tool_count": 37, "wire_schema_bytes": 37475, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 }
   }
 }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -110,7 +110,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 172332,
+      "wire_schema_bytes": 172333,
       "tool_reference_bytes": 29572,
       "tool_reference_sha256": "4d90d8576f2f543ed2646294b69a7e0e08201b8efd312b904ea43baa3a2a83b5",
       "overridden_tool_count": 7,
@@ -337,7 +337,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "cc78806188aa3b7be55bba733abc1ecbf7b2eea9f83ae6068e5b97ef694eb072",
-      "wire_schema_sha256": "72589df4027d4d1ad75354b46aead59c4691c088c4a791636355d68bf0caa74f"
+      "wire_schema_sha256": "f0ab40f88c3467a586fbb33feebca14c29ee692360dda6fcd408233492bb3f75"
     },
     {
       "id": "legacy_slack:admin_mention:maximum",
@@ -355,7 +355,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 168851,
+      "wire_schema_bytes": 168852,
       "tool_reference_bytes": 28616,
       "tool_reference_sha256": "41b9d3e6692a8601f73deca9d90a76fcc100e1cde724e3d99c185ad4903c4ad1",
       "overridden_tool_count": 7,
@@ -577,7 +577,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "1d769dca5f53c7baee0102ce9e49384e23c11d51e1e44d65913124563c08e97c",
-      "wire_schema_sha256": "377b10d7c32fbe77fd488626a84d3b608bc9c54d146ab551b2a80184c3ad8e13"
+      "wire_schema_sha256": "fd816bad6146309cc825c9f14dd769a1f469309ede2844ebc23c85f7461f82d6"
     },
     {
       "id": "legacy_slack:member_dm:maximum",
@@ -595,7 +595,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 120695,
+      "wire_schema_bytes": 120696,
       "tool_reference_bytes": 26385,
       "tool_reference_sha256": "993ca372acea9111b4ec3efc74d631c448e056613031d4fa975bc8c918763e68",
       "overridden_tool_count": 7,
@@ -742,7 +742,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "88484816c567cdded948a50c26649b061d39509263be69448049497bd93edc30",
-      "wire_schema_sha256": "427e3383c3b8a39456ce1d035b2c85f9d3e35ce3928477d1aff474df188468cf"
+      "wire_schema_sha256": "519e3bbe6ac1d597de9e5e731c45ab8ef48c15cd868ce381b7e787ea6b398602"
     },
     {
       "id": "legacy_slack:member_mention:maximum",
@@ -760,7 +760,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 117214,
+      "wire_schema_bytes": 117215,
       "tool_reference_bytes": 25429,
       "tool_reference_sha256": "4306e0bb518b18dd5527a459b510b17cad6e720c4ec3e3e65b971de4c3ddfff4",
       "overridden_tool_count": 7,
@@ -902,7 +902,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "93d3ff44c928cde4c4b5e99b42fc7711177e21c39c2f1ce6e4c49d966d7fa241",
-      "wire_schema_sha256": "f34d19b8858d5cea3e249f2739a79132704c1a702f188f4e564ba285d112bf4e"
+      "wire_schema_sha256": "35a2b3699e156bbcfd4b768b23b2cd33f7b20185ea975844cf07f64427e56e18"
     },
     {
       "id": "mcp_chat:anonymous:exact",
@@ -1127,7 +1127,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 36467,
+      "wire_schema_bytes": 36468,
       "tool_reference_bytes": 9143,
       "tool_reference_sha256": "7265966088c7621da96f67f87c11c31918a85b1c0600cce078a96ac9081007aa",
       "overridden_tool_count": 1,
@@ -1168,7 +1168,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "694b4ef9ca09500caa814228edba48db79937ad9c3a3dca6e24357e3f8732ba2",
-      "wire_schema_sha256": "77b176a4f175f09ac6ca5fa1fee886f4eae053aed0a4b576b29199da79a5a1ef"
+      "wire_schema_sha256": "303dd36a284051970632d9d61d256e585dea6db46c703af9d87ec78f9dc1fe0a"
     },
     {
       "id": "slack_bolt_reaction:admin:safe_fallback",
@@ -1368,7 +1368,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 34173,
+      "wire_schema_bytes": 34174,
       "tool_reference_bytes": 9075,
       "tool_reference_sha256": "fd2ce66763a76a42309a4b32e8570dd292d6082c74e935cfd07d9cb927648c03",
       "overridden_tool_count": 1,
@@ -1407,7 +1407,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "43fe6d50fa4886c69cf0289b2bc50f75646e4d86f9af7baa7168cc9fc24e195b",
-      "wire_schema_sha256": "f2ab6776eed292ccca57dba528e6319c519e40dd0418c9a3f12bbb5176eeb0bb"
+      "wire_schema_sha256": "573bd33ffb1b6f6d9df3d9510b3cc1bf21ad95cf3f57e4dad2950b97bd698b68"
     },
     {
       "id": "slack_bolt_reaction:member:safe_fallback",
@@ -1605,7 +1605,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 33700,
+      "wire_schema_bytes": 33701,
       "tool_reference_bytes": 9057,
       "tool_reference_sha256": "cc5f9a748614b60e5a126dc349b8ebe3b4b446ec3c05eb9c3ac2bd5c47452ebc",
       "overridden_tool_count": 1,
@@ -1643,7 +1643,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "58633158dd7801a0b0bfb7b66663e5901a35852f2379adaf65675268d5d6cb86",
-      "wire_schema_sha256": "fe78e547e7891e5a07fd21c93821d2102b1c2e9ba257dabf76b0193841646409"
+      "wire_schema_sha256": "0eb503f9ecc7ff0e0ec408accde99ef6aaec9267e65ce12bc405ec8fd38efd03"
     },
     {
       "id": "slack_bolt_reaction:public_channel_admin:safe_fallback",
@@ -1841,7 +1841,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 33700,
+      "wire_schema_bytes": 33701,
       "tool_reference_bytes": 9057,
       "tool_reference_sha256": "cc5f9a748614b60e5a126dc349b8ebe3b4b446ec3c05eb9c3ac2bd5c47452ebc",
       "overridden_tool_count": 1,
@@ -1879,7 +1879,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "58633158dd7801a0b0bfb7b66663e5901a35852f2379adaf65675268d5d6cb86",
-      "wire_schema_sha256": "fe78e547e7891e5a07fd21c93821d2102b1c2e9ba257dabf76b0193841646409"
+      "wire_schema_sha256": "0eb503f9ecc7ff0e0ec408accde99ef6aaec9267e65ce12bc405ec8fd38efd03"
     },
     {
       "id": "slack_bolt_reaction:public_channel:safe_fallback",
@@ -1949,7 +1949,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24094,
+      "wire_schema_bytes": 24095,
       "tool_reference_bytes": 7532,
       "tool_reference_sha256": "03fea349a1ff2eb8a964b256e72ba4bf10504c7bbef3f6e0813a9fafabdc0f33",
       "overridden_tool_count": 0,
@@ -1975,7 +1975,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "06a9e67f9a420498206344ffef3754a0730e41c6d280b898d180b3e41f4b402b",
-      "wire_schema_sha256": "1a1af30abd33e6ffb29963d00268902d55f3e677e8aa619c4d61d60f1836ab48"
+      "wire_schema_sha256": "abc9ab6f802a5bd83ea3c27618ea1a184a2148978be4d948500a6418875cf8fe"
     },
     {
       "id": "slack_bolt:admin_dm:admin_brands",
@@ -2591,7 +2591,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -2819,7 +2819,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:admin_dm:billing",
@@ -4351,7 +4351,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20793,
+      "wire_schema_bytes": 20794,
       "tool_reference_bytes": 6966,
       "tool_reference_sha256": "5c86c764953c613a8b75864dc2b50198095551b80f349b98d29ec0136b20a56c",
       "overridden_tool_count": 0,
@@ -4374,7 +4374,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "d4f06578fcfb85bd236f009cf958f3659d1a63af8684c4e0f53a0b780a658006",
-      "wire_schema_sha256": "32f08a6e99bd1338380d4407e8c34152bc0601d6b34e708dff9ca353a576b9eb"
+      "wire_schema_sha256": "5d0ab4b87a29c11d0866b89b9b6b69e2deee8862202e196db6834194e175ab2b"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_brands",
@@ -4946,7 +4946,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -5174,7 +5174,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:admin_working_group:billing",
@@ -6410,7 +6410,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 21800,
+      "wire_schema_bytes": 21801,
       "tool_reference_bytes": 7464,
       "tool_reference_sha256": "3385748df4d82728ff435822b89289e6a79cc3808a0cbaafa04d580d5bf4b21e",
       "overridden_tool_count": 0,
@@ -6434,7 +6434,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "4e47024f93ff366df0df56712a9867d564351a62e2012e1416a2c63f34388a18",
-      "wire_schema_sha256": "13fe8fdb72b08b99732d89790b338511fae95710ca0ce702e9f3d43a880d30df"
+      "wire_schema_sha256": "f7b2ffa25afc7f1e66bc7c7c7bf9a6d18ae3c5c061176b082a803f25709de3f8"
     },
     {
       "id": "slack_bolt:member_dm:agent_conformance",
@@ -6581,7 +6581,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131574,
+      "wire_schema_bytes": 131575,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -6743,7 +6743,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
+      "wire_schema_sha256": "e6b74e39be6af4f25bbe8ed98c3d9b2edb31195b2ebff0052fb569f8c7eef4a2"
     },
     {
       "id": "slack_bolt:member_dm:brand_registry",
@@ -8115,7 +8115,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20793,
+      "wire_schema_bytes": 20794,
       "tool_reference_bytes": 6966,
       "tool_reference_sha256": "5c86c764953c613a8b75864dc2b50198095551b80f349b98d29ec0136b20a56c",
       "overridden_tool_count": 0,
@@ -8138,7 +8138,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "d4f06578fcfb85bd236f009cf958f3659d1a63af8684c4e0f53a0b780a658006",
-      "wire_schema_sha256": "32f08a6e99bd1338380d4407e8c34152bc0601d6b34e708dff9ca353a576b9eb"
+      "wire_schema_sha256": "5d0ab4b87a29c11d0866b89b9b6b69e2deee8862202e196db6834194e175ab2b"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_brands",
@@ -8710,7 +8710,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -8938,7 +8938,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:private_channel_admin:billing",
@@ -10173,7 +10173,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18499,
+      "wire_schema_bytes": 18500,
       "tool_reference_bytes": 6898,
       "tool_reference_sha256": "50321b0764bf8eac5e43a2e87007766721d3695cfe9c8c65c243c026aece86d8",
       "overridden_tool_count": 0,
@@ -10194,7 +10194,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "8433bbec2668360620293546d761ca7438baae0890c83b6cfad3086629a7d315",
-      "wire_schema_sha256": "b767afd5c03bf53bc6a8934ea37d0ab1e57ee1f2f5ece30020f402507e759af8"
+      "wire_schema_sha256": "e96b55dd018f1577bf39795d77c8b516c8bbe8787975dce6a343096b92fd1c5a"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_conformance",
@@ -10333,7 +10333,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 131574,
+      "wire_schema_bytes": 131575,
       "tool_reference_bytes": 31804,
       "tool_reference_sha256": "be00f77c0ca1122039249683fea97ae18fd0037f015f3481d2107854af6581fe",
       "overridden_tool_count": 11,
@@ -10495,7 +10495,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "35bc37d9deefc093c2736a2f4e519058fad2dc3255ef1a7de65d2fd8114e90d8",
-      "wire_schema_sha256": "6bf4d4462b2d710ce35e13162b0acd3f6f670bdf7a943a71c9ea33fe12d39c31"
+      "wire_schema_sha256": "e6b74e39be6af4f25bbe8ed98c3d9b2edb31195b2ebff0052fb569f8c7eef4a2"
     },
     {
       "id": "slack_bolt:private_channel_member:brand_registry",
@@ -11584,7 +11584,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18026,
+      "wire_schema_bytes": 18027,
       "tool_reference_bytes": 6880,
       "tool_reference_sha256": "411901d7b513077b4eee7ba245a032ccf4add4fc2a505af0c0a4d2f2f8809dc1",
       "overridden_tool_count": 0,
@@ -11604,7 +11604,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "15d16ceb1a9bc6265391d8fbe0006361afbb71c7acd797ca1ce5784454e31754",
-      "wire_schema_sha256": "aa05316da667aab159257729fb6f7e1c67e8a76dffc3bd478311f9f2dcf657cd"
+      "wire_schema_sha256": "0750243b87cc49eeff5b215719bab14fdd3dc25b48eec5517efce0eefe3cf2d7"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_brands",
@@ -12143,7 +12143,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 160483,
+      "wire_schema_bytes": 160484,
       "tool_reference_bytes": 34474,
       "tool_reference_sha256": "082f5b11955ea3225ca39699e70870cc46423164601c030617038945c8d3852c",
       "overridden_tool_count": 11,
@@ -12354,7 +12354,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "93f092a464d52d315e0f74c3e6290de1078619517d88839984c9b6aa584c5e44",
-      "wire_schema_sha256": "b41017eb96d2ecca23c6cb16eca9cd7bbd3784d8d851547ded26796772856d3d"
+      "wire_schema_sha256": "9a88d7a85dd2f4e16333ba349578ccc60584c0a8e7081aae5d320d5786b3e563"
     },
     {
       "id": "slack_bolt:public_channel_admin:billing",
@@ -13495,7 +13495,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18026,
+      "wire_schema_bytes": 18027,
       "tool_reference_bytes": 6880,
       "tool_reference_sha256": "411901d7b513077b4eee7ba245a032ccf4add4fc2a505af0c0a4d2f2f8809dc1",
       "overridden_tool_count": 0,
@@ -13515,7 +13515,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "15d16ceb1a9bc6265391d8fbe0006361afbb71c7acd797ca1ce5784454e31754",
-      "wire_schema_sha256": "aa05316da667aab159257729fb6f7e1c67e8a76dffc3bd478311f9f2dcf657cd"
+      "wire_schema_sha256": "0750243b87cc49eeff5b215719bab14fdd3dc25b48eec5517efce0eefe3cf2d7"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_conformance",
@@ -13652,7 +13652,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 128301,
+      "wire_schema_bytes": 128302,
       "tool_reference_bytes": 30932,
       "tool_reference_sha256": "4a7ee9b4c10b4d565eeef851cb294ea5528500b6bb4c8560325442eb065834eb",
       "overridden_tool_count": 11,
@@ -13809,7 +13809,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "57f0ef7a602f90ab6060dc9e8d6315a975f1b693244e2beb790ee8f9666e1748",
-      "wire_schema_sha256": "61881c75ab90ab1154b7721e561ad9ee56efdb972b321aef7887c4f738040158"
+      "wire_schema_sha256": "a1c97406dc6e17016d66a9aef6d858f92eca2dc9ac764ee52435d509b334a6e6"
     },
     {
       "id": "slack_bolt:public_channel_member:brand_registry",
@@ -14904,7 +14904,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15132,7 +15132,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:system_channel_admin:billing:all_valid_sets_maximum",
@@ -15191,7 +15191,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15419,7 +15419,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:system_channel_admin:error:all_valid_sets_maximum",
@@ -15478,7 +15478,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15706,7 +15706,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:system_channel_admin:escalation:all_valid_sets_maximum",
@@ -15765,7 +15765,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -15993,7 +15993,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "slack_bolt:system_channel_admin:prospect:all_valid_sets_maximum",
@@ -16052,7 +16052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 173157,
+      "wire_schema_bytes": 173158,
       "tool_reference_bytes": 35641,
       "tool_reference_sha256": "2d5af5307047cfc4398caf8ef0bf76145323594edc3e7299dc14f13f885aa4c2",
       "overridden_tool_count": 11,
@@ -16280,7 +16280,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "27a7d7e5296f9045a67135f020b62b19f7347667f26cb67889a2f4cfb5c6cbca",
-      "wire_schema_sha256": "801b29e0420b0d18fe36d97625de4979b603a303f17cf936c21532237ba27b6b"
+      "wire_schema_sha256": "cf49a55b9b07fdbf8bc41d6ee68d8f73f0fcec61d8945f98ca6b83af4c6dfef9"
     },
     {
       "id": "tavus_voice:admin:maximum",
@@ -16295,7 +16295,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 163569,
+      "wire_schema_bytes": 163570,
       "tool_reference_bytes": 27489,
       "tool_reference_sha256": "53966de22812288edef87880ee78ec6a5ba985cf49615d3c2bbea38195e500c8",
       "overridden_tool_count": 0,
@@ -16521,7 +16521,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "ee026b5c5493eecf66980d8bc45d13bca576838fd1e56d46a225d8c0a8fc735a",
-      "wire_schema_sha256": "23cbb026612362ba72d81d6473b35c39bdbca5634c04b37db99e2ad2d7c7a68e"
+      "wire_schema_sha256": "ca83d595f8a387cebc803fd817a9738ad219a37a3de1dd596a45561b43a9ec2b"
     },
     {
       "id": "tavus_voice:baseline:exact",
@@ -16578,7 +16578,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 105902,
+      "wire_schema_bytes": 105903,
       "tool_reference_bytes": 23922,
       "tool_reference_sha256": "3325db8b4c0e632e29f6310065b1d6ba66eba31d5292b7f3c4852e3e041c5a79",
       "overridden_tool_count": 0,
@@ -16719,7 +16719,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "1014ec0f38456600ea98be64558e693f91e59d9f0c9a9802743152bb36a42710",
-      "wire_schema_sha256": "999861a9182626c246dc4296060f3c0353db71f9f5cb499d2f4c62d88e9570ef"
+      "wire_schema_sha256": "f53b90020103837afc2c41a9962d5fde7e07f8a226b5a49f92d41c007b394f44"
     },
     {
       "id": "tavus_voice:member:maximum",
@@ -16733,7 +16733,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 95785,
+      "wire_schema_bytes": 95786,
       "tool_reference_bytes": 22901,
       "tool_reference_sha256": "1626c891eac9cef4f152d07c383ff695b93150c9bf4d2206c6385e70aed48c0f",
       "overridden_tool_count": 0,
@@ -16863,7 +16863,7 @@
         "get_moltbook_feed"
       ],
       "ordered_tool_names_sha256": "777fd9afbfea06766211ff5d208c0e612bbfdc08756213f9ea1501efdf9dd33b",
-      "wire_schema_sha256": "e5b9169f6282de09fa80cc58f4a0bba46ad06069eb4e7c97e931f5fed30f8096"
+      "wire_schema_sha256": "5e09fab0501bbf8ed83db6d24364c2eda891e972cb8fc773f55266062a85dc44"
     },
     {
       "id": "web_chat:anonymous:maximum",
@@ -17114,7 +17114,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 39768,
+      "wire_schema_bytes": 39769,
       "tool_reference_bytes": 9709,
       "tool_reference_sha256": "a8bcfc2eb50c8c0103a385d315f2b4e6aa539c3725323b0aec76561819034e10",
       "overridden_tool_count": 1,
@@ -17158,7 +17158,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1eacb60df1ca04a1a0d245ba05db752c5d077e1c6df298e782bba19099b503df",
-      "wire_schema_sha256": "c73356386d20044f41dbe2e50db9b5c1386a13c71e7a4d87fbf166a27edcac09"
+      "wire_schema_sha256": "853e10ec7f8a4b3a55658a77908ebdb72f85c768428308de409ed813d012583c"
     },
     {
       "id": "web_chat:authenticated_admin:routed_combination:community_groups+agent_validation:si_context",
@@ -17317,7 +17317,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24094,
+      "wire_schema_bytes": 24095,
       "tool_reference_bytes": 7532,
       "tool_reference_sha256": "03fea349a1ff2eb8a964b256e72ba4bf10504c7bbef3f6e0813a9fafabdc0f33",
       "overridden_tool_count": 0,
@@ -17343,7 +17343,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "9f28a693476baff5aefec20b2db206b558bbcb79597c3bc265e241d7ed2751d2",
-      "wire_schema_sha256": "6b7a2e58fbe2f0cbfffe87a60affec9e06b0206a5b800add73ae66e79176fafc"
+      "wire_schema_sha256": "994c4a64f41725a9f074d1ec65c68fbc0b3b8a25628fd91d57ac8b3fd4f09827"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_brands",
@@ -19246,7 +19246,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 37474,
+      "wire_schema_bytes": 37475,
       "tool_reference_bytes": 9641,
       "tool_reference_sha256": "c93e3fc58d318e0db3f177206d84185942338f619843e3627a359e6321f57211",
       "overridden_tool_count": 1,
@@ -19288,7 +19288,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "c96c5ea6aba257c440dc2ff7a9acf2817a02307703702c81a2288f7430b5b45c",
-      "wire_schema_sha256": "26a6321f24c94f3e90a93b8fabeb1b89cfb69a0eb026f90d391621587e858e82"
+      "wire_schema_sha256": "a96745c1ce9004801fa7f79d033c5f1687831bb597a24e2e4eaf383730549f50"
     },
     {
       "id": "web_chat:authenticated_member:routed_combination:community_groups+agent_validation:si_context",
@@ -19443,7 +19443,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 21800,
+      "wire_schema_bytes": 21801,
       "tool_reference_bytes": 7464,
       "tool_reference_sha256": "3385748df4d82728ff435822b89289e6a79cc3808a0cbaafa04d580d5bf4b21e",
       "overridden_tool_count": 0,
@@ -19467,7 +19467,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bfc83c6d48f46068f0f72a53bde488954ce10b62a5413a4161001c1c00f91ae2",
-      "wire_schema_sha256": "ff1ef77cb525e20d05d42c8b1f1f1aea2958e036bd9ad9abfda770666b40a5a9"
+      "wire_schema_sha256": "f24096e7c65fb93267695e5aa97a08a979853c7912b7a78668c3cbe048595df7"
     },
     {
       "id": "web_chat:authenticated_member:routed:agent_conformance",
@@ -20637,9 +20637,9 @@
       "maximum_slack_member_tools": 6,
       "maximum_slack_admin_tools": 3,
       "maximum_slack_public_tools": -6,
-      "maximum_slack_member_schema_bytes": 7412,
-      "maximum_slack_admin_schema_bytes": 7037,
-      "maximum_slack_public_schema_bytes": 366,
+      "maximum_slack_member_schema_bytes": 7413,
+      "maximum_slack_admin_schema_bytes": 7038,
+      "maximum_slack_public_schema_bytes": 367,
       "legacy_slack_member_tools": -83,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -196
@@ -20712,25 +20712,25 @@
       },
       "slack_bolt_reaction:admin": {
         "custom_tool_count": 36,
-        "wire_schema_bytes": 36467,
+        "wire_schema_bytes": 36468,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:member": {
         "custom_tool_count": 34,
-        "wire_schema_bytes": 34173,
+        "wire_schema_bytes": 34174,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:public_channel": {
         "custom_tool_count": 33,
-        "wire_schema_bytes": 33700,
+        "wire_schema_bytes": 33701,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "slack_bolt_reaction:public_channel_admin": {
         "custom_tool_count": 33,
-        "wire_schema_bytes": 33700,
+        "wire_schema_bytes": 33701,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
@@ -20814,23 +20814,23 @@
       },
       "web_chat:authenticated_admin": {
         "custom_tool_count": 39,
-        "wire_schema_bytes": 39768,
+        "wire_schema_bytes": 39769,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       },
       "web_chat:authenticated_member": {
         "custom_tool_count": 37,
-        "wire_schema_bytes": 37474,
+        "wire_schema_bytes": 37475,
         "maximum_provider_tool_count": 1,
         "maximum_provider_tool_wire_bytes": 52
       }
     },
     "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-    "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af",
+    "profile_contract_sha256": "0268dbd6be7bc0dea55ed208b061744c50a29fcc65c304501bb6b3d6c6bbc50c",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "44f7619cdb90fa75646034b2e9c750684af254be19a0b6ebb2ee0db9353e3c2d",
-    "profile_contract_sha256": "1cbb817e9b63a57628ae6af792bce034fd9d03069e0fb6c812aa8574824b78af"
+    "profile_contract_sha256": "0268dbd6be7bc0dea55ed208b061744c50a29fcc65c304501bb6b3d6c6bbc50c"
   }
 }

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -799,7 +799,7 @@ const getAdcpCapabilitiesTool: AddieTool = {
       debug: { type: 'boolean' },
       adcp_version: {
         type: 'string',
-        description: 'Optional exact release pin, for example "3.2-beta.9" during prerelease testing',
+        description: 'Optional exact release pin, for example "3.2-beta.10" during prerelease testing',
       },
       adcp_major_version: {
         type: 'integer',

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -3024,7 +3024,7 @@ Tell ${codingTool}: "Build a buyer agent using @adcp/sdk that connects to the pu
 
 The SDK handles protocol details — the learner focuses on orchestration logic.
 
-Use the current 3.2 beta.9 wire pin with @adcp/sdk@14.0.0-beta.22 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
+Use the current 3.2 beta.10 wire pin with @adcp/sdk@14.0.0-beta.27 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
 
 Reference: ${SDKS_URL}
 
@@ -3039,12 +3039,12 @@ Validate in two parts.
 
 1. Run the compatibility buying workflow against the public test agent and share the output. Use the \`adcp\` CLI:
 \`\`\`
-npx @adcp/sdk@14.0.0-beta.22 test-mcp get_products '{"adcp_version":"3.2-beta.9","buying_mode":"brief","brief":"<your campaign brief>"}'
+npx @adcp/sdk@14.0.0-beta.27 test-mcp get_products '{"adcp_version":"3.2-beta.10","buying_mode":"brief","brief":"<your campaign brief>"}'
 \`\`\`
 
 Replace \`<your campaign brief>\` with your actual brief. Then run the full buying flow: get_products (select a canonical \`format_options[]\` entry) → create_media_buy → get_adcp_capabilities on the chosen creative endpoint → sync_creatives with \`format_kind\` and optional \`format_option_ref\`.
 
-2. Validate the 3.2 targeting-aware objectives live with \`list_products\` and \`request_proposals\`: request decomposition, required future targeting support, disclosed modification acceptance/rejection, and effective package readback. First retain a capability response advertising the exact served version and relevant lifecycle tools. Then retain one supported and one unsupported requirement result, the beta.9 request/response envelopes, and the post-purchase package readback. An empty result for the unsupported requirement is evidence only when the same seller returns an eligible product for the supported control request.
+2. Validate the 3.2 targeting-aware objectives live with \`list_products\` and \`request_proposals\`: request decomposition, required future targeting support, disclosed modification acceptance/rejection, and effective package readback. First retain a capability response advertising the exact served version and relevant lifecycle tools. Then retain one supported and one unsupported requirement result, the beta.10 request/response envelopes, and the post-purchase package readback. An empty result for the unsupported requirement is evidence only when the same seller returns an eligible product for the supported control request.
 
 Paste the live output and validation results. We'll verify both the compatibility workflow and the native 3.2 behavior.
 

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -710,6 +710,7 @@ function isRunnerApplicabilitySkip(step: {
 }, scenario?: unknown): boolean {
   switch (step.skip_reason) {
     case 'capability_unsupported':
+    case 'capability_prerequisite_unavailable':
       return true;
     case 'missing_test_kit_contract':
       return scenario === 'idempotency/rate_limit_replay_invariant' &&

--- a/server/src/training-agent/FRAMEWORK_MIGRATION.md
+++ b/server/src/training-agent/FRAMEWORK_MIGRATION.md
@@ -60,7 +60,7 @@ working during the 3.x compatibility window.
   proposal negotiation is a 3.2 feature.
 - Capability projection removes lifecycle and proposal-refinement metadata for
   pre-3.2 callers.
-- The current wire bundle is `3.2-beta.9`; `3.2-beta.0` remains only as the
+- The current wire bundle is `3.2-beta.10`; `3.2-beta.0` remains only as the
   historical feature-introduction boundary for rejected discovery responses.
 
 ## Invariants for future changes

--- a/server/src/training-agent/agent-notification-configs.ts
+++ b/server/src/training-agent/agent-notification-configs.ts
@@ -80,10 +80,14 @@ function normalizedConfig(config: InputNotificationConfig): AgentNotificationCon
   if (url.protocol !== 'https:' || !hostname || isPrivateHostname(hostname)) {
     throw new Error('notification URL must be a public HTTPS endpoint');
   }
+  const [firstEventType, ...remainingEventTypes] = [...new Set(config.event_types)].sort();
+  if (!firstEventType) {
+    throw new Error('notification config must include at least one event type');
+  }
   return {
     ...structuredClone(config),
     url: normalizedUrl,
-    event_types: [...new Set(config.event_types)].sort() as ['capabilities.changed'],
+    event_types: [firstEventType, ...remainingEventTypes],
     active: config.active ?? true,
   };
 }

--- a/server/src/training-agent/product-factory.ts
+++ b/server/src/training-agent/product-factory.ts
@@ -923,7 +923,7 @@ export function buildShowsForProducts(products: Product[]): ShowResponse[] {
     const collections = (p as Product & { collections?: CollectionSelector[] }).collections;
     if (collections) {
       for (const selector of collections) {
-        selector.collection_ids.forEach((id: string) => referencedIds.add(id));
+        selector.collection_ids?.forEach((id: string) => referencedIds.add(id));
       }
     }
   }

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -741,7 +741,7 @@ describe('tenant routing smoke', () => {
       );
 
       const capabilitiesResponse = await callTenantTool(url, 3, 'get_adcp_capabilities', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
       }) as {
         result?: { structuredContent?: {
@@ -759,7 +759,7 @@ describe('tenant routing smoke', () => {
           };
         } };
       };
-      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.9');
+      expect(capabilitiesResponse.result?.structuredContent?.adcp_version).toBe('3.2-beta.10');
       expect(capabilitiesResponse.result?.structuredContent?.adcp?.supported_versions).toContain('3.2-beta.6');
       const mediaBuy = capabilitiesResponse.result?.structuredContent?.media_buy;
       expect(mediaBuy?.supports_proposals).toBe(true);
@@ -815,7 +815,7 @@ describe('tenant routing smoke', () => {
       }
 
       const requested = await callTenantTool(url, 4, 'request_proposals', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-request-0001',
         account: {
@@ -829,12 +829,12 @@ describe('tenant routing smoke', () => {
           proposals?: Array<{ proposal_id?: string }>;
         } };
       };
-      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.9');
+      expect(requested.result?.structuredContent?.adcp_version).toBe('3.2-beta.10');
       const sourceProposalId = requested.result?.structuredContent?.proposals?.[0]?.proposal_id;
       expect(sourceProposalId, JSON.stringify(requested)).toBeTruthy();
 
       const partial = await callTenantTool(url, 5, 'refine_proposals', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-three-0001',
         account: {
@@ -855,14 +855,14 @@ describe('tenant routing smoke', () => {
         } };
       };
       const counteroffer = partial.result?.structuredContent;
-      expect(counteroffer?.adcp_version).toBe('3.2-beta.9');
+      expect(counteroffer?.adcp_version).toBe('3.2-beta.10');
       expect(counteroffer?.adcp_error).toBeUndefined();
       expect(counteroffer?.results?.[0]?.outcome, JSON.stringify(counteroffer)).toBe('partial');
       expect(counteroffer?.results?.[0]?.reason_code).toBe('alternatives_unavailable');
       expect(counteroffer?.results?.[0]?.proposals).toHaveLength(2);
 
       const refined = await callTenantTool(url, 6, 'refine_proposals', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-refine-two-0001',
         account: {
@@ -883,7 +883,7 @@ describe('tenant routing smoke', () => {
         } };
       };
       const refinement = refined.result?.structuredContent;
-      expect(refinement?.adcp_version).toBe('3.2-beta.9');
+      expect(refinement?.adcp_version).toBe('3.2-beta.10');
       expect(refinement?.adcp_error).toBeUndefined();
       expect(refinement?.results?.[0]?.outcome).toBe('revised');
       expect(refinement?.results?.[0]?.proposals).toHaveLength(2);
@@ -891,7 +891,7 @@ describe('tenant routing smoke', () => {
       const revisedProposalId = refinement?.results?.[0]?.proposals?.[0]?.proposal_id;
       expect(revisedProposalId).toEqual(expect.any(String));
       const finalized = await callTenantTool(url, 7, 'refine_proposals', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         idempotency_key: 'tenant-profile-finalize-0001',
         refinements: [{ proposal_id: revisedProposalId, action: 'finalize' }],
@@ -2055,9 +2055,9 @@ describe('tenant routing smoke', () => {
         ?.filter(format => format.operations?.includes('preview'))
         .map(format => format.capability_id) ?? [];
       const previewRouteIds = creative?.preview?.routes?.map(route => route.capability_id) ?? [];
-      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.9');
+      expect(body.result?.structuredContent?.adcp_version).toBe('3.2-beta.10');
       expect(body.result?.structuredContent?.adcp?.major_versions).toContain(3);
-      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.9']);
+      expect(body.result?.structuredContent?.adcp?.supported_versions).toEqual(['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.10']);
       expect(mediaBuy?.features?.inline_creative_management).toBe(true);
       expect(mediaBuy?.supported_optimization_metrics).toContain('clicks');
       expect(mediaBuy?.vendor_metric_optimization?.supported_targets).toContain('threshold_rate');
@@ -3450,7 +3450,7 @@ describe('tenant routing smoke', () => {
         field: 'adcp_version',
         details: {
           adcp_version: '4.0',
-          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.9'],
+          supported_versions: ['3.0', '3.1-beta.5', '3.1-beta.7', '3.1-rc.4', '3.1-rc.6', '3.1-rc.7', '3.1-rc.8', '3.1-rc.9', '3.1-rc.10', '3.1-rc.14', '3.1-rc.15', '3.1', '3.2-beta.6', '3.2-beta.10'],
         },
       });
       expect(unsupportedBody.result?.structuredContent?.context?.correlation_id).toBe('tenant-local-version-unsupported');
@@ -3872,7 +3872,7 @@ describe('tenant routing smoke', () => {
       };
       const payload = {
         idempotency_key: 'tenant-products-idempotency-0001',
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         buying_mode: 'wholesale',
         account,
       };
@@ -3990,7 +3990,7 @@ describe('tenant routing smoke', () => {
         brand: account.brand,
       }) as { result?: { structuredContent?: { adcp_version?: string; products?: Array<{ product_id?: string }>; replayed?: boolean } } };
       expect(aliasReplay.result?.structuredContent).not.toHaveProperty('adcp_error');
-      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.9');
+      expect(aliasReplay.result?.structuredContent?.adcp_version).toBe('3.2-beta.10');
       expect(aliasReplay.result?.structuredContent?.products?.map(product => product.product_id))
         .toEqual(first.result?.structuredContent?.products?.map(product => product.product_id));
       expect(aliasReplay.result?.structuredContent?.replayed).toBeUndefined();
@@ -4222,7 +4222,7 @@ describe('tenant routing smoke', () => {
         sandbox: true,
       };
       const directive = await callTenantTool(url, 91, 'comply_test_controller', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account,
         scenario: 'force_get_products_arm',
         params: {
@@ -4234,7 +4234,7 @@ describe('tenant routing smoke', () => {
       expect(directive.result?.structuredContent?.success).toBe(true);
 
       const rejected = await callTenantTool(url, 92, 'get_products', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         idempotency_key: 'tenant-products-rejected-0001',
         buying_mode: 'brief',

--- a/server/src/training-agent/types.ts
+++ b/server/src/training-agent/types.ts
@@ -29,7 +29,7 @@ export const GET_PRODUCTS_REJECTED_ADCP_VERSION = '3.2-beta.2' as const;
 export const SELLER_GOVERNANCE_DISCOVERY_ADCP_VERSION = '3.2-beta.6' as const;
 
 /** Current prerelease schema bundle shipped by the server SDK. */
-export const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.9' as const;
+export const TRAINING_AGENT_CURRENT_ADCP_VERSION = '3.2-beta.10' as const;
 
 /** Release checkpoints the reference training agent can serve. */
 export const TRAINING_AGENT_SUPPORTED_RELEASE_VERSIONS = [

--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -21,7 +21,7 @@ const { stopSessionCleanup } = await import('../../src/training-agent/state.js')
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.2-beta.9';
+const CURRENT_ADCP_VERSION = '3.2-beta.10';
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/unit/addie/adcp-tools.test.ts
+++ b/server/tests/unit/addie/adcp-tools.test.ts
@@ -415,7 +415,7 @@ describe('call_adcp_task training module isolation', () => {
     } as any, { moduleId: 'S1' });
     const callAdcpTask = handlers.get('call_adcp_task');
     const params = {
-      adcp_version: '3.2-beta.9',
+      adcp_version: '3.2-beta.10',
       adcp_major_version: 3,
       idempotency_key: 'proposal-refinement-key',
       refinements: [{ proposal_id: 'proposal_123', action: 'finalize' }],

--- a/server/tests/unit/certification-module-methodology.test.ts
+++ b/server/tests/unit/certification-module-methodology.test.ts
@@ -80,8 +80,8 @@ describe('selectModuleMethodology', () => {
     for (const phase of ['build', 'validate']) {
       const instructions = await getInstructions({ module_id: 'C4', phase });
 
-      expect(instructions).toContain('@adcp/sdk@14.0.0-beta.22');
-      expect(instructions).toContain('beta.9');
+      expect(instructions).toContain('@adcp/sdk@14.0.0-beta.27');
+      expect(instructions).toContain('beta.10');
       expect(instructions).not.toContain('beta.5');
       expect(instructions).not.toContain('@adcp/sdk@14.0.0-beta.7');
     }

--- a/server/tests/unit/comply-test-controller.test.ts
+++ b/server/tests/unit/comply-test-controller.test.ts
@@ -253,7 +253,7 @@ describe('comply_test_controller', () => {
 
     it('advertises force_get_products_arm for the 3.2 beta release', async () => {
       const { result } = await simulateCallTool(server, 'comply_test_controller', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         adcp_major_version: 3,
         scenario: 'list_scenarios',
         account: ACCOUNT,
@@ -1009,7 +1009,7 @@ describe('comply_test_controller', () => {
       expect(seeded.success).toBe(true);
 
       const { result: active32 } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         brand: BRAND,
         media_buy_ids: ['proposal_bound_change_rights'],
@@ -1073,7 +1073,7 @@ describe('comply_test_controller', () => {
       expect(released31Errors, released31Errors.join('; ')).toEqual([]);
 
       const sellerManaged = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1089,7 +1089,7 @@ describe('comply_test_controller', () => {
       });
 
       const unevaluatedCondition = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1105,7 +1105,7 @@ describe('comply_test_controller', () => {
       });
 
       const packageCeiling = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1125,7 +1125,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: paused } = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'proposal_bound_change_rights',
         revision: activeBuy32.revision,
@@ -1144,7 +1144,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: pausedRead } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_ids: ['proposal_bound_change_rights'],
       });
@@ -1225,7 +1225,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result: before } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_ids: ['bounded_self_serve_budget'],
       });
@@ -1238,7 +1238,7 @@ describe('comply_test_controller', () => {
       }]);
 
       const { result: increased, isError: increaseError } = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'bounded_self_serve_budget',
         revision: buy.revision,
@@ -1251,7 +1251,7 @@ describe('comply_test_controller', () => {
       });
 
       const requote = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'bounded_self_serve_budget',
         revision: increased.revision,
@@ -1276,7 +1276,7 @@ describe('comply_test_controller', () => {
       ];
       for (const { field, value } of untypedCommercialUpdates) {
         const rejected = await simulateCallTool(server, 'update_media_buy', {
-          adcp_version: '3.2-beta.9',
+          adcp_version: '3.2-beta.10',
           account: ACCOUNT,
           brand: BRAND,
           media_buy_id: 'bounded_self_serve_budget',
@@ -1349,7 +1349,7 @@ describe('comply_test_controller', () => {
       });
 
       const { result } = await simulateCallTool(server, 'get_media_buys', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_ids: ['paused_without_resume_term'],
       });
@@ -1444,7 +1444,7 @@ describe('comply_test_controller', () => {
         });
 
         const attempt = await simulateCallTool(server, testCase.tool, {
-          adcp_version: testCase.tool === 'control_media_buy' ? '3.2-beta.9' : '3.1',
+          adcp_version: testCase.tool === 'control_media_buy' ? '3.2-beta.10' : '3.1',
           account: ACCOUNT,
           media_buy_id: testCase.id,
           revision: 1,
@@ -1768,7 +1768,7 @@ describe('comply_test_controller', () => {
       });
 
       const rejectedCompactControl = await simulateCallTool(server, 'control_media_buy', {
-        adcp_version: '3.2-beta.9',
+        adcp_version: '3.2-beta.10',
         account: ACCOUNT,
         media_buy_id: 'created_from_allowed_actions',
         revision: updated.revision,

--- a/tests/addie/compliance-testing.test.ts
+++ b/tests/addie/compliance-testing.test.ts
@@ -179,6 +179,74 @@ describe('compliance result adapter', () => {
     });
   });
 
+  it('does not degrade capability-gated dependent phases from the SDK runner', () => {
+    const result = baseResult({
+      tracks: [
+        {
+          track: 'core',
+          label: 'Core',
+          status: 'pass',
+          duration_ms: 1,
+          scenarios: [
+            {
+              scenario: 'media_buy_state_machine/setup',
+              overall_passed: true,
+              steps: [
+                {
+                  step: 'Create media buy',
+                  step_id: 'create_buy',
+                  task: 'create_media_buy',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'not_applicable',
+                  skip: {
+                    reason: 'not_applicable',
+                    detail: 'Capability predicate `creative.has_creative_library === true` not satisfied: agent declared false.',
+                  },
+                },
+              ],
+            },
+            {
+              scenario: 'media_buy_state_machine/state_transitions',
+              overall_passed: true,
+              steps: [
+                {
+                  step: 'Pause media buy',
+                  step_id: 'pause_buy',
+                  task: 'update_media_buy',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'capability_prerequisite_unavailable',
+                  skip: {
+                    reason: 'not_applicable',
+                    detail: 'Skipped: prior stateful step "create_buy" skipped (not_applicable); state never materialized.',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(deriveStoryboardStatuses(result)).toEqual([
+      {
+        storyboard_id: 'media_buy_state_machine',
+        status: 'untested',
+        steps_passed: 0,
+        steps_total: 0,
+      },
+    ]);
+
+    const dbInput = complianceResultToDbInput(result, 'https://agent.example/mcp', 'production');
+    expect(dbInput.overall_status).toBe('passing');
+    expect(dbInput.tracks_partial).toBe(0);
+    expect(dbInput.tracks_json[0]).toMatchObject({
+      track: 'core',
+      has_coverage_gap_skip: false,
+    });
+  });
+
   it('keeps non-idempotency missing runner contracts visible as coverage gaps', () => {
     const result = baseResult({
       tracks: [

--- a/tests/sdk-runner-capability-gates.test.cjs
+++ b/tests/sdk-runner-capability-gates.test.cjs
@@ -40,6 +40,83 @@ function loadMediaBuyStoryboard(name) {
   return YAML.parse(fs.readFileSync(storyboardPath, 'utf8'));
 }
 
+test('phase capability gates do not dispatch dependents with unresolved context', async () => {
+  const storyboard = {
+    id: 'phase_capability_cascade_regression',
+    version: '1.0',
+    title: 'Phase capability cascade regression',
+    category: 'media_buy',
+    summary: 'Regression',
+    narrative: 'Regression',
+    agent: { interaction_model: 'single_agent', capabilities: [] },
+    caller: { role: 'buyer' },
+    phases: [
+      {
+        id: 'setup',
+        title: 'Setup',
+        requires_capability: {
+          path: 'creative.has_creative_library',
+          equals: true,
+        },
+        steps: [
+          {
+            id: 'create_buy',
+            title: 'Create media buy',
+            task: 'create_media_buy',
+            stateful: true,
+            sample_request: { brand_id: 'test' },
+            context_outputs: [{ key: 'media_buy_id', path: 'media_buy_id' }],
+          },
+        ],
+      },
+      {
+        id: 'state_transitions',
+        title: 'State transitions',
+        steps: [
+          {
+            id: 'pause_buy',
+            title: 'Pause media buy',
+            task: 'update_media_buy',
+            stateful: true,
+            sample_request: {
+              media_buy_id: '$context.media_buy_id',
+              paused: true,
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const dispatchedRequests = [];
+
+  const result = await runStoryboard('https://agent.example/mcp', storyboard, {
+    _profile: {
+      tools: ['get_adcp_capabilities', 'create_media_buy', 'update_media_buy'],
+      raw_capabilities: { creative: { has_creative_library: false } },
+    },
+    agentTools: ['get_adcp_capabilities', 'create_media_buy', 'update_media_buy'],
+    _client: {
+      resetContext() {},
+      async createMediaBuy(request) {
+        dispatchedRequests.push(request);
+        throw new Error('capability-gated setup must not execute');
+      },
+      async updateMediaBuy(request) {
+        dispatchedRequests.push(request);
+        throw new Error('dependent phase must not execute');
+      },
+    },
+  });
+
+  assert.deepEqual(dispatchedRequests, []);
+  assert.equal(result.failed_count, 0);
+  assert.equal(result.phases[0].steps[0].skip_reason, 'not_applicable');
+  const dependent = result.phases[1].steps[0];
+  assert.equal(dependent.skip_reason, 'capability_prerequisite_unavailable');
+  assert.equal(dependent.skip.reason, 'not_applicable');
+  assert.match(dependent.skip.detail, /create_buy.*not_applicable/);
+});
+
 test('runStoryboard skips an equals-gated storyboard when the capability path is absent', async () => {
   const storyboard = {
     id: 'equals_absent_regression',

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -1269,7 +1269,7 @@ test("buyer teaching surfaces explain structured-first targeting", () => {
   }
   assert.match(skill, /fewer tokens/);
   assert.match(addieKnowledge, /No targeting-resolution echo confirms only/);
-  assert.match(certificationTools, /current 3\.2 beta\.9 wire pin with @adcp\/sdk@14\.0\.0-beta\.22/);
+  assert.match(certificationTools, /current 3\.2 beta\.10 wire pin with @adcp\/sdk@14\.0\.0-beta\.27/);
   assert.match(certificationTools, /3\.2 targeting-aware objectives live/);
   assert.doesNotMatch(certificationTools, /issues\/6199/);
   assert.match(


### PR DESCRIPTION
## Summary

- update `@adcp/sdk` to `14.0.0-beta.27`, which includes the fix that stops dependent phases after a capability-gated prerequisite is inapplicable
- treat `capability_prerequisite_unavailable` as a neutral applicability skip in registry scoring
- add runner-level no-dispatch and registry scoring regression coverage
- adapt training-agent types to the widened beta.27 schemas
- align the training agent's current wire checkpoint with the beta.10 schema bundle shipped by beta.27
- update active 3.2 SDK and live-lab guidance to the beta.10/beta.27 pairing while retaining historical beta.9 records

## Validation

- `npm run build`
- `node --test tests/sdk-runner-capability-gates.test.cjs`
- `npx vitest run tests/addie/compliance-testing.test.ts tests/addie/compliance-sdk-rc-transport.test.ts`
- `npx vitest run server/tests/unit/training-agent-agent-notification-configs.test.ts server/tests/unit/training-agent.test.ts`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- docs navigation, owned-link, and release-navigation tests
- code, protocol, testing, and security expert reviews

No changeset: this is internal registry-runner parity and does not change the protocol schema.

Closes #7115
