### PR TITLE
fix(storyboards): stabilize mainline candidate validation

### DIFF
--- a/.changeset/bright-lobsters-agree.md
+++ b/.changeset/bright-lobsters-agree.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Validate and materialize training-agent collection selections consistently across create and update flows, and grade current mainline storyboard runs against candidate schemas.
+Validate and materialize training-agent collection selections consistently across create and update flows, grade current mainline storyboard runs against candidate schemas, stabilize sandbox account scope propagation, and make isolated storyboard RSS monitoring resilient to normal procfs process-exit races. Clarify current sales storyboards' account, budget, and ungoverned DOOH baselines.

--- a/.changeset/bright-lobsters-agree.md
+++ b/.changeset/bright-lobsters-agree.md
@@ -2,4 +2,4 @@
 "adcontextprotocol": patch
 ---
 
-Validate and materialize training-agent collection selections consistently across create and update flows, grade current mainline storyboard runs against candidate schemas, stabilize sandbox account scope propagation, and make isolated storyboard RSS monitoring resilient to normal procfs process-exit races. Clarify current sales storyboards' account, budget, and ungoverned DOOH baselines.
+Validate and materialize training-agent collection selections consistently across create and update flows, grade current mainline storyboard runs against candidate schemas, stabilize sandbox account scope propagation, and make isolated storyboard RSS monitoring resilient to normal procfs process-exit races. Clarify current sales storyboards' account, budget, and ungoverned DOOH baselines, including a context-free core media-buy lifecycle while dedicated capability-gated scenarios cover governance bindings and approvals.

--- a/.changeset/bright-lobsters-agree.md
+++ b/.changeset/bright-lobsters-agree.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Validate and materialize training-agent collection selections consistently across create and update flows, and grade current mainline storyboard runs against candidate schemas.

--- a/.github/workflows/training-agent-storyboards.yml
+++ b/.github/workflows/training-agent-storyboards.yml
@@ -237,7 +237,7 @@ jobs:
           PUBLIC_TEST_AGENT_TOKEN: storyboard-ci-token
           ADCP_COMPLIANCE_DIR: ${{ matrix.surface == 'current' && 'dist/compliance/latest' || steps.compat-bundle.outputs.dir }}
           ADCP_SCHEMA_ROOT: ${{ matrix.surface == 'current' && 'dist/schemas/latest' || steps.compat-bundle.outputs.schema_dir }}
-          ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ matrix.surface == 'current' && github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main' && '1' || '0' }}
+          ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ matrix.surface == 'current' && ((github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && '1' || '0' }}
         run: |
           set -uo pipefail
           # Creative-builder retains a large generated-schema graph after its
@@ -473,7 +473,7 @@ jobs:
       SALES_ORCHESTRATOR_COUNT: 8
       ADCP_COMPLIANCE_DIR: dist/compliance/latest
       ADCP_SCHEMA_ROOT: dist/schemas/latest
-      ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main' && '1' || '0' }}
+      ADCP_STORYBOARD_CANDIDATE_VERSION_MODE: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && '1' || '0' }}
       # SDK beta.11 keeps each storyboard inside the 4 GiB RSS envelope, but
       # the heaviest lifecycle flows can approach two minutes on a loaded
       # runner. Preserve the hard memory bound and allow teardown headroom.

--- a/scripts/run-storyboards-3-0-compat.sh
+++ b/scripts/run-storyboards-3-0-compat.sh
@@ -7,4 +7,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec bash "${SCRIPT_DIR}/run-storyboards-matrix.sh" --latest-3.0
+# Immutable 3.0 bundles must never use current-candidate schema resolution,
+# even when this wrapper is called from a main-line candidate validation.
+ADCP_STORYBOARD_CANDIDATE_VERSION_MODE=0 exec bash "${SCRIPT_DIR}/run-storyboards-matrix.sh" --latest-3.0

--- a/scripts/run-storyboards-isolated.mjs
+++ b/scripts/run-storyboards-isolated.mjs
@@ -158,13 +158,17 @@ function killProcessGroup(pid) {
 
 function linuxProcessGroupRssBytes(processGroupId) {
   let totalKb = 0;
-  for (const entry of readdirSync('/proc', { withFileTypes: true })) {
-    if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) continue;
+  // Reading Dirent metadata can race a process exiting: Node's procfs
+  // implementation may lstat the entry before our ENOENT-safe reads below.
+  // Numeric proc entries are process directories by definition, so enumerate
+  // names only and keep every per-process read within the existing race guard.
+  for (const pid of readdirSync('/proc')) {
+    if (!/^\d+$/.test(pid)) continue;
     try {
-      const stat = readFileSync(join('/proc', entry.name, 'stat'), 'utf8');
+      const stat = readFileSync(join('/proc', pid, 'stat'), 'utf8');
       const afterCommand = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/);
       if (Number(afterCommand[2]) !== processGroupId) continue;
-      const status = readFileSync(join('/proc', entry.name, 'status'), 'utf8');
+      const status = readFileSync(join('/proc', pid, 'status'), 'utf8');
       const match = status.match(/^VmRSS:\s+(\d+)\s+kB$/m);
       if (match) totalKb += Number(match[1]);
     } catch (error) {

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -1983,6 +1983,33 @@ function validateTargeting(t: unknown, pathLabel: string): { targeting?: Package
   const ple = validateListRef(src.property_list_exclude, `${pathLabel}.property_list_exclude`);
   const cl = validateListRef(src.collection_list, `${pathLabel}.collection_list`);
   const cle = validateListRef(src.collection_list_exclude, `${pathLabel}.collection_list_exclude`);
+  const collectionSelection = src.collection_selection;
+  if (isRecord(collectionSelection) && collectionSelection.mode === 'selected') {
+    const selectors = collectionSelection.collections;
+    if (!Array.isArray(selectors) || selectors.length === 0) {
+      errors.push({
+        code: 'INVALID_REQUEST',
+        message: `${pathLabel}.collection_selection.collections: selected mode requires at least one collection selector`,
+        field: `${pathLabel}.collection_selection.collections`,
+      });
+    } else {
+      selectors.forEach((selector, index) => {
+        if (
+          !isRecord(selector)
+          || typeof selector.publisher_domain !== 'string'
+          || selector.publisher_domain.length === 0
+          || !Array.isArray(selector.collection_ids)
+          || selector.collection_ids.length === 0
+        ) {
+          errors.push({
+            code: 'INVALID_REQUEST',
+            message: `${pathLabel}.collection_selection.collections[${index}]: selected mode requires a publisher domain and explicit collection IDs`,
+            field: `${pathLabel}.collection_selection.collections[${index}]`,
+          });
+        }
+      });
+    }
+  }
   const validateAudienceIds = (value: unknown, field: string): string[] | undefined => {
     if (value === undefined) return undefined;
     if (!Array.isArray(value)) {
@@ -6372,6 +6399,10 @@ const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
   'radio': 'radio',
 };
 
+const BRIEF_STOP_WORDS = new Set([
+  'across', 'and', 'app', 'for', 'from', 'into', 'on', 'the', 'with',
+]);
+
 // Vendor-metric briefs often ask for a measurement outcome (emissions,
 // brand lift, attention) rather than the literal field name. Score against
 // each product's declared vendor metrics so the named vendor/metric pair wins
@@ -7743,6 +7774,120 @@ function packageTargetingResolution(
         : { type: 'continuous_bounds' },
     },
   };
+}
+
+/** Persist a product's concrete collection bundle when the buyer chose its
+ * default. Package readback must expose the committed selection. */
+function materializeDefaultCollectionSelection(
+  product: Product,
+  targeting: PackageTargeting | undefined,
+): PackageTargeting | undefined {
+  if (!targeting) return undefined;
+  const committed = structuredClone(targeting) as unknown as Record<string, unknown>;
+  const selection = isRecord(committed.collection_selection)
+    ? committed.collection_selection
+    : undefined;
+  const collections = (product as unknown as Record<string, unknown>).collections;
+  if (selection?.mode !== 'default' || !Array.isArray(collections) || collections.length === 0) {
+    return targeting;
+  }
+  committed.collection_selection = {
+    mode: 'selected',
+    collections: structuredClone(collections),
+    ...(Object.hasOwn(selection, 'ext') && { ext: structuredClone(selection.ext) }),
+  };
+  return committed as unknown as PackageTargeting;
+}
+
+/** Validate a concrete buyer collection selection against the product's
+ * advertised inventory. Fixed bundles accept only their exact full selector
+ * set; selectable bundles may be narrowed to a subset. */
+function validateCollectionSelectionForProduct(
+  product: Product,
+  targeting: PackageTargeting | undefined,
+  targetingPath: string,
+): TaskError | undefined {
+  const selection = targeting && isRecord((targeting as unknown as Record<string, unknown>).collection_selection)
+    ? (targeting as unknown as Record<string, unknown>).collection_selection as Record<string, unknown>
+    : undefined;
+  const advertised = (product as unknown as Record<string, unknown>).collections;
+  if (selection?.mode === 'default') {
+    return !Array.isArray(advertised) || advertised.length === 0
+      ? {
+        code: 'UNSUPPORTED_FEATURE',
+        message: 'The selected product does not advertise a collection bundle to use as its default selection.',
+        field: `${targetingPath}.collection_selection`,
+        recovery: 'correctable',
+      }
+      : undefined;
+  }
+  if (selection?.mode !== 'selected' || !Array.isArray(selection.collections)) return undefined;
+  if (!Array.isArray(advertised) || advertised.length === 0) {
+    return {
+      code: 'UNSUPPORTED_FEATURE',
+      message: 'The selected product does not advertise collection selectors.',
+      field: `${targetingPath}.collection_selection`,
+      recovery: 'correctable',
+    };
+  }
+  const advertisedIdsByDomain = new Map<string, Set<string>>();
+  for (const selector of advertised) {
+    if (!isRecord(selector) || typeof selector.publisher_domain !== 'string' || !Array.isArray(selector.collection_ids)) continue;
+    const collectionIds = advertisedIdsByDomain.get(selector.publisher_domain) ?? new Set<string>();
+    for (const collectionId of selector.collection_ids) {
+      if (typeof collectionId === 'string') collectionIds.add(collectionId);
+    }
+    advertisedIdsByDomain.set(selector.publisher_domain, collectionIds);
+  }
+  const requestedIds = new Set<string>();
+  for (const [selectorIndex, selector] of selection.collections.entries()) {
+    if (!isRecord(selector) || typeof selector.publisher_domain !== 'string' || !Array.isArray(selector.collection_ids)) continue;
+    const advertisedIds = advertisedIdsByDomain.get(selector.publisher_domain);
+    if (!advertisedIds) {
+      return {
+        code: 'REFERENCE_NOT_FOUND',
+        message: `Collection publisher domain "${selector.publisher_domain}" is not declared by the selected product.`,
+        field: `${targetingPath}.collection_selection.collections[${selectorIndex}].publisher_domain`,
+        recovery: 'correctable',
+      };
+    }
+    for (const [collectionIndex, collectionId] of selector.collection_ids.entries()) {
+      if (typeof collectionId !== 'string' || !advertisedIds.has(collectionId)) {
+        return {
+          code: 'REFERENCE_NOT_FOUND',
+          message: `Collection ID "${String(collectionId)}" is not declared by the selected product.`,
+          field: `${targetingPath}.collection_selection.collections[${selectorIndex}].collection_ids[${collectionIndex}]`,
+          recovery: 'correctable',
+        };
+      }
+      const requestedId = `${selector.publisher_domain}\u0000${collectionId}`;
+      if (requestedIds.has(requestedId)) {
+        return {
+          code: 'INVALID_REQUEST',
+          message: `Collection ID "${collectionId}" is selected more than once for publisher domain "${selector.publisher_domain}".`,
+          field: `${targetingPath}.collection_selection.collections[${selectorIndex}].collection_ids[${collectionIndex}]`,
+          recovery: 'correctable',
+        };
+      }
+      requestedIds.add(requestedId);
+    }
+  }
+  if ((product as unknown as Record<string, unknown>).collection_targeting_allowed === true) return undefined;
+  const advertisedIds = new Set(
+    Array.from(advertisedIdsByDomain.entries()).flatMap(([domain, ids]) => (
+      Array.from(ids, id => `${domain}\u0000${id}`)
+    )),
+  );
+  const isExactRestatement = requestedIds.size === advertisedIds.size
+    && Array.from(requestedIds).every(id => advertisedIds.has(id));
+  return isExactRestatement
+    ? undefined
+    : {
+      code: 'UNSUPPORTED_FEATURE',
+      message: 'The selected product is a fixed collection bundle and does not allow partial collection selection.',
+      field: `${targetingPath}.collection_selection`,
+      recovery: 'correctable',
+    };
 }
 
 /** Execute the 3.2 discovery targeting contract for the deterministic training
@@ -9575,7 +9720,10 @@ async function handleGetProductsUnlocked(
   // Brief mode: channel-aware keyword matching
   if (buyingMode === 'brief' && brief) {
     const briefLower = brief.toLowerCase();
-    const terms = briefLower.split(/\s+/);
+    const terms = briefLower
+      .replace(/[_-]+/g, ' ')
+      .split(/[^a-z0-9]+/)
+      .filter(term => term.length >= 3 && !BRIEF_STOP_WORDS.has(term));
 
     // Extract channel names mentioned in the brief — these get heavy weight
     const briefChannels = new Set<string>();
@@ -9585,15 +9733,44 @@ async function handleGetProductsUnlocked(
 
     const scored = products
       .map(p => {
-        const text = `${p.name} ${p.description} ${p.channels?.join(' ')}`.toLowerCase();
+        // Product identifiers and inventory selectors are buyer-visible
+        // metadata. A brief naming a collection (for example `retro_news`)
+        // should discover the product that advertises that collection.
+        const collectionTerms = (p.collections ?? []).flatMap(collection => [
+          collection.publisher_domain,
+          ...(collection.collection_ids ?? []),
+        ]);
+        const publisherPropertyTerms = (p.publisher_properties ?? []).flatMap(property => [
+          property.publisher_domain,
+          ...('publisher_domains' in property ? property.publisher_domains ?? [] : []),
+          ...('property_ids' in property ? property.property_ids ?? [] : []),
+        ]);
+        const collectionText = collectionTerms.join(' ').replace(/[_-]+/g, ' ').toLowerCase();
+        const publisherPropertyText = publisherPropertyTerms.join(' ').replace(/[_-]+/g, ' ').toLowerCase();
+        const text = [
+          p.name,
+          p.description,
+          p.product_id,
+          ...(p.channels ?? []),
+          ...collectionTerms,
+          ...publisherPropertyTerms,
+        ].join(' ').replace(/[_-]+/g, ' ').toLowerCase();
         const keywordScore = terms.filter(t => text.includes(t)).length;
+        const collectionScore = terms.filter(t => collectionText.includes(t)).length * 3;
+        const publisherPropertyScore = terms.filter(t => publisherPropertyText.includes(t)).length * 2;
+        const collectionSelectionScore = collectionScore > 0
+          && (p as unknown as Record<string, unknown>).collection_targeting_allowed === true
+          ? 1
+          : 0;
         // Channel match: +10 per matching channel (dominates keyword scoring)
         const channelScore = briefChannels.size > 0
           ? (p.channels?.filter(c => briefChannels.has(c)).length ?? 0) * 10
           : 0;
         const vendorMetricScore = vendorMetricBriefScore(p, briefLower);
-        const totalScore = channelScore + keywordScore + vendorMetricScore;
-        return totalScore > 0 ? { product: p, totalScore, channelScore, keywordScore, vendorMetricScore } : null;
+        const totalScore = channelScore + keywordScore + collectionScore + publisherPropertyScore + collectionSelectionScore + vendorMetricScore;
+        return totalScore > 0
+          ? { product: p, totalScore, channelScore, keywordScore, collectionScore, publisherPropertyScore, collectionSelectionScore, vendorMetricScore }
+          : null;
       })
       .filter((s): s is NonNullable<typeof s> => s !== null)
       .sort((a, b) => b.totalScore - a.totalScore);
@@ -9604,6 +9781,9 @@ async function handleGetProductsUnlocked(
       const matchParts = [
         ...(s.channelScore > 0 ? [`${s.channelScore / 10} channel(s)`] : []),
         ...(s.keywordScore > 0 ? ['keywords'] : []),
+        ...(s.collectionScore > 0 ? ['collection selectors'] : []),
+        ...(s.collectionSelectionScore > 0 ? ['selectable collection bundle'] : []),
+        ...(s.publisherPropertyScore > 0 ? ['publisher-property selectors'] : []),
         ...(s.vendorMetricScore > 0 ? ['vendor-metric optimization'] : []),
       ];
       return {
@@ -13844,6 +14024,13 @@ async function handleCreateMediaBuyUnlocked(
     const targetingResult = validateTargeting(incomingTargeting, targetingPath);
     if (targetingResult.errors.length) {
       errors.push(...targetingResult.errors);
+    } else {
+      const collectionSelectionError = validateCollectionSelectionForProduct(
+        product,
+        targetingResult.targeting,
+        targetingPath,
+      );
+      if (collectionSelectionError) errors.push(collectionSelectionError);
     }
     const requestedAssignmentRows = [
       ...(Array.isArray(pkg.creative_assignments) ? pkg.creative_assignments : []),
@@ -13923,7 +14110,8 @@ async function handleCreateMediaBuyUnlocked(
       formatSnapshot.legacyFormatIds,
       formatSnapshot.selectedLegacyFormatIds,
     );
-    const targetingResolution = packageTargetingResolution(product, targetingResult.targeting);
+    const committedTargeting = materializeDefaultCollectionSelection(product, targetingResult.targeting);
+    const targetingResolution = packageTargetingResolution(product, committedTargeting);
 
     const candidatePackage: PackageState = {
       packageId: `pkg-${i}`,
@@ -13947,7 +14135,7 @@ async function handleCreateMediaBuyUnlocked(
       }),
       creativeAssignments,
       creativeAssignmentDetails: requestedAssignmentRows.map(assignment => structuredClone(assignment)),
-      targeting: targetingResult.targeting,
+      targeting: committedTargeting,
       ...(targetingResolution && { targetingResolution }),
       ...(isRecord(pkg.context) && { context: pkg.context }),
       ...(isRecord(pkg.measurement_terms) && { measurementTerms: structuredClone(pkg.measurement_terms) }),
@@ -16236,7 +16424,7 @@ async function handleUpdateMediaBuyUnlocked(
         || update.targeting !== undefined;
       if (!traffickingChanged) continue;
       const enforceLifecycleSplit = supportsLifecycleSplitCompatibility(lifecycleSplitVersionForContext(ctx));
-      const product = enforceLifecycleSplit ? productMap.get(pkg.productId) : undefined;
+      const product = productMap.get(pkg.productId);
       if (enforceLifecycleSplit && !product) {
         return { errors: [{ code: 'PRODUCT_NOT_FOUND', message: `Product not found for package ${pkgId}: ${pkg.productId}` }] };
       }
@@ -16314,6 +16502,14 @@ async function handleUpdateMediaBuyUnlocked(
         ?? pkg.targeting;
       const targetingResult = validateTargeting(incomingTargeting, `packages[${pkgId}].targeting_overlay`);
       if (targetingResult.errors.length) return { errors: targetingResult.errors };
+      if (product) {
+        const collectionSelectionError = validateCollectionSelectionForProduct(
+          product,
+          targetingResult.targeting,
+          `packages[${pkgId}].targeting_overlay`,
+        );
+        if (collectionSelectionError) return { errors: [collectionSelectionError] };
+      }
       if (enforceLifecycleSplit) {
         const assignmentErrors = validateCreateAssignmentSemantics(
           candidateRows,
@@ -16545,8 +16741,20 @@ async function handleUpdateMediaBuyUnlocked(
         if (targetingResult.errors.length) {
           return { errors: targetingResult.errors };
         }
+        const product = productMap.get(pkg.productId);
+        if (product) {
+          const collectionSelectionError = validateCollectionSelectionForProduct(
+            product,
+            targetingResult.targeting,
+            `packages[${pkgId}].targeting_overlay`,
+          );
+          if (collectionSelectionError) return { errors: [collectionSelectionError] };
+        }
+        const committedTargeting = product
+          ? materializeDefaultCollectionSelection(product, targetingResult.targeting)
+          : targetingResult.targeting;
         const before = pkg.targeting;
-        pkg.targeting = targetingResult.targeting;
+        pkg.targeting = committedTargeting;
         const changed = JSON.stringify(before ?? null) !== JSON.stringify(pkg.targeting ?? null);
         // A valid exact restatement is still an accepted package operation and
         // belongs in affected_packages even when it is state-idempotent.
@@ -16642,6 +16850,13 @@ async function handleUpdateMediaBuyUnlocked(
       if (targetingResult.errors.length) {
         return { errors: targetingResult.errors };
       }
+      const collectionSelectionError = validateCollectionSelectionForProduct(
+        product,
+        targetingResult.targeting,
+        `new_packages[${i}].targeting_overlay`,
+      );
+      if (collectionSelectionError) return { errors: [collectionSelectionError] };
+      const committedTargeting = materializeDefaultCollectionSelection(product, targetingResult.targeting);
       const inlineCreatives = collectInlineCreativeIds(npkg.creatives, `new_packages[${i}].creatives`);
       if (inlineCreatives.errors.length) return { errors: inlineCreatives.errors };
       for (const inline of inlineCreatives.validatedCreatives) {
@@ -16727,7 +16942,7 @@ async function handleUpdateMediaBuyUnlocked(
         }),
         creativeAssignments: assignmentRows.flatMap(row => typeof row.creative_id === 'string' ? [row.creative_id] : []),
         creativeAssignmentDetails: assignmentRows.map(row => structuredClone(row)),
-        targeting: targetingResult.targeting,
+        targeting: committedTargeting,
         context: npkg.context ? structuredClone(npkg.context) : undefined,
       };
       stagedInlineCreatives.push(...inlineCreatives.validatedCreatives);

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -55,6 +55,7 @@ import {
   AccountRefValidationError,
   accountScopeFromRef,
   canonicalizeAccountRef,
+  syntheticAccountIdFromRef,
 } from './account-scope.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import {
@@ -2894,7 +2895,7 @@ import { buildFormats, FORMAT_CHANNEL_MAP } from './formats.js';
 import { getAllSignals, SIGNAL_PROVIDERS } from './signal-providers.js';
 import {
   controllerFixturePrincipal, getSession, getProductsSessionKeyFromArgs, sessionKeyFromArgs,
-  findSessionMatching,
+  findSessionMatching, findMediaBuyAcrossSessions,
   runWithSessionContext, flushDirtySessions, evictSessionFromRequestCache,
   getComplianceCreatives, getComplianceCreative,
   getComplianceMediaBuys, getComplianceMediaBuy,
@@ -6399,10 +6400,6 @@ const BRIEF_CHANNEL_ALIASES: Record<string, string> = {
   'radio': 'radio',
 };
 
-const BRIEF_STOP_WORDS = new Set([
-  'across', 'and', 'app', 'for', 'from', 'into', 'on', 'the', 'with',
-]);
-
 // Vendor-metric briefs often ask for a measurement outcome (emissions,
 // brand lift, attention) rather than the literal field name. Score against
 // each product's declared vendor metrics so the named vendor/metric pair wins
@@ -9720,10 +9717,21 @@ async function handleGetProductsUnlocked(
   // Brief mode: channel-aware keyword matching
   if (buyingMode === 'brief' && brief) {
     const briefLower = brief.toLowerCase();
-    const terms = briefLower
+    // Keep ordinary natural-language relevance ordering byte-for-byte aligned
+    // with the established corpus. Selector metadata receives a narrow,
+    // full-phrase boost below, so `retro_news` and `vintage-static` remain
+    // discoverable without treating generic words as selector hints.
+    const terms = briefLower.split(/\s+/);
+    const normalizedBrief = ` ${briefLower
       .replace(/[_-]+/g, ' ')
       .split(/[^a-z0-9]+/)
-      .filter(term => term.length >= 3 && !BRIEF_STOP_WORDS.has(term));
+      .filter(Boolean)
+      .join(' ')} `;
+    const namesSelector = (value: string | undefined) => {
+      if (!value) return false;
+      const phrase = value.replace(/[_-]+/g, ' ').split(/[^a-z0-9]+/).filter(Boolean).join(' ');
+      return phrase.length > 0 && normalizedBrief.includes(` ${phrase} `);
+    };
 
     // Extract channel names mentioned in the brief — these get heavy weight
     const briefChannels = new Set<string>();
@@ -9745,19 +9753,14 @@ async function handleGetProductsUnlocked(
           ...('publisher_domains' in property ? property.publisher_domains ?? [] : []),
           ...('property_ids' in property ? property.property_ids ?? [] : []),
         ]);
-        const collectionText = collectionTerms.join(' ').replace(/[_-]+/g, ' ').toLowerCase();
-        const publisherPropertyText = publisherPropertyTerms.join(' ').replace(/[_-]+/g, ' ').toLowerCase();
-        const text = [
-          p.name,
-          p.description,
-          p.product_id,
-          ...(p.channels ?? []),
-          ...collectionTerms,
-          ...publisherPropertyTerms,
-        ].join(' ').replace(/[_-]+/g, ' ').toLowerCase();
+        const text = `${p.name} ${p.description} ${p.channels?.join(' ')}`.toLowerCase();
         const keywordScore = terms.filter(t => text.includes(t)).length;
-        const collectionScore = terms.filter(t => collectionText.includes(t)).length * 3;
-        const publisherPropertyScore = terms.filter(t => publisherPropertyText.includes(t)).length * 2;
+        const selectorKeywordScore = namesSelector(p.product_id) ? 1 : 0;
+        // An exact advertised collection selector is materially more specific
+        // than generic brief words. This keeps a buyer-selectable bundle ahead
+        // of a broadly matching static offer without changing normal briefs.
+        const collectionScore = collectionTerms.filter(namesSelector).length * 12;
+        const publisherPropertyScore = publisherPropertyTerms.filter(namesSelector).length * 2;
         const collectionSelectionScore = collectionScore > 0
           && (p as unknown as Record<string, unknown>).collection_targeting_allowed === true
           ? 1
@@ -9767,9 +9770,9 @@ async function handleGetProductsUnlocked(
           ? (p.channels?.filter(c => briefChannels.has(c)).length ?? 0) * 10
           : 0;
         const vendorMetricScore = vendorMetricBriefScore(p, briefLower);
-        const totalScore = channelScore + keywordScore + collectionScore + publisherPropertyScore + collectionSelectionScore + vendorMetricScore;
+        const totalScore = channelScore + keywordScore + selectorKeywordScore + collectionScore + publisherPropertyScore + collectionSelectionScore + vendorMetricScore;
         return totalScore > 0
-          ? { product: p, totalScore, channelScore, keywordScore, collectionScore, publisherPropertyScore, collectionSelectionScore, vendorMetricScore }
+          ? { product: p, totalScore, channelScore, keywordScore, selectorKeywordScore, collectionScore, publisherPropertyScore, collectionSelectionScore, vendorMetricScore }
           : null;
       })
       .filter((s): s is NonNullable<typeof s> => s !== null)
@@ -9780,7 +9783,7 @@ async function handleGetProductsUnlocked(
     products = scored.slice(0, MAX_BRIEF_RESULTS).map(s => {
       const matchParts = [
         ...(s.channelScore > 0 ? [`${s.channelScore / 10} channel(s)`] : []),
-        ...(s.keywordScore > 0 ? ['keywords'] : []),
+        ...(s.keywordScore > 0 || s.selectorKeywordScore > 0 ? ['keywords'] : []),
         ...(s.collectionScore > 0 ? ['collection selectors'] : []),
         ...(s.collectionSelectionScore > 0 ? ['selectable collection bundle'] : []),
         ...(s.publisherPropertyScore > 0 ? ['publisher-property selectors'] : []),
@@ -19673,6 +19676,52 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
       sessionKeyFromArgs(mediaBuyArgs, ctx.mode, ctx.userId, ctx.moduleId),
       controllerFixtureSessionKey(mediaBuyArgs, ctx),
     );
+    // Public typed-refinement requests deliberately omit account selectors.
+    // When that omission derives a different legacy session shape, follow only
+    // the trusted accepted-proposal link—not a caller-supplied media-buy ID—
+    // and require that its stored media buy resolves to the same owner account.
+    const currentMediaBuys = new Map(mediaBuySession.mediaBuys);
+    const typedArgs = args as unknown as Record<string, unknown>;
+    const refinements = typedArgs.refinements;
+    const referencedProposalIds = Array.isArray(refinements)
+      ? refinements
+        .filter(isRecord)
+        .map(refinement => refinement.proposal_id)
+        .filter((proposalId): proposalId is string => typeof proposalId === 'string')
+      : [];
+    for (const proposalId of referencedProposalIds) {
+      const sourceRecord = session.proposalRefinementRecords.get(proposalId);
+      const linkedMediaBuyId = sourceRecord?.accepted?.media_buy_id;
+      const ownerAccountId = sourceRecord?.ownerAccountId;
+      if (
+        !linkedMediaBuyId
+        || !ownerAccountId
+        || currentMediaBuys.has(linkedMediaBuyId)
+      ) continue;
+      const linkedSession = await findMediaBuyAcrossSessions(linkedMediaBuyId);
+      const linkedMediaBuy = linkedSession?.mediaBuys.get(linkedMediaBuyId);
+      if (!linkedMediaBuy) continue;
+      const linkedOwnerAccountId = resolveAccountIdForRef(
+        sessionKeyFromArgs(
+          { account: linkedMediaBuy.accountRef },
+          ctx.mode,
+          ctx.userId,
+          ctx.moduleId,
+        ),
+        ctx.principal,
+        linkedMediaBuy.accountRef,
+      );
+      // Framework-resolved natural accounts are synthetic and are not
+      // necessarily persisted through sync_accounts. Reconstruct that stable
+      // framework identity only for this already-linked natural account; an
+      // opaque account must have a same-principal registry resolution.
+      const resolvedLinkedOwnerAccountId = linkedOwnerAccountId
+        ?? (canonicalizeAccountRef(linkedMediaBuy.accountRef).kind === 'natural'
+          ? syntheticAccountIdFromRef(linkedMediaBuy.accountRef)
+          : undefined);
+      if (resolvedLinkedOwnerAccountId !== ownerAccountId) continue;
+      currentMediaBuys.set(linkedMediaBuyId, linkedMediaBuy);
+    }
     const now = new Date();
     const activeHoldCount = Array.from(session.proposalRefinementRecords.values())
       .filter(record => record.activeHold && Date.parse(record.activeHold.expires_at) > now.getTime())
@@ -19689,7 +19738,7 @@ async function handleTypedProposalRefinement(args: ToolArgs, ctx: TrainingContex
       TrainingProposalPolicyContext
     >({
       capabilities: proposalCapabilitiesForProfile(profile),
-      store: proposalStoreForSession(session, now, mediaBuySession.mediaBuys),
+      store: proposalStoreForSession(session, now, currentMediaBuys),
       scope: (): ProposalRefinementScope => ctx.proposalRefinementScope ?? ({
         tenant_id: ctx.tenantId ?? 'sales',
         principal_id: ctx.principal ?? 'anonymous',
@@ -19774,6 +19823,14 @@ export async function executeProductDiscoveryPlatformTool(
     };
   }
   const typedRefinement = toolName === 'refine_proposals' && usesTypedProposalNegotiation(ctx);
+  // `refine_proposals` deliberately has no account field in its public wire
+  // schema. The platform restored this source-validated account before this
+  // adapter, but normalizing it out here used to make amendment reconstruction
+  // read a brand-only session instead of the live sandbox media-buy session.
+  // Keep it internal to the handler context; it is never exposed on the wire.
+  const restoredRefinementAccount = typedRefinement && isRecord(args.account)
+    ? args.account as ToolArgs['account']
+    : undefined;
   const handler = typedRefinement
     ? handleTypedProposalRefinement
     : handleGetProducts;
@@ -19790,6 +19847,9 @@ export async function executeProductDiscoveryPlatformTool(
     : normalizeProductDiscoveryArgs(toolName, args);
   const result = await Promise.resolve(handler(normalized as ToolArgs, {
     ...ctx,
+    ...(ctx.resolvedAccount === undefined && restoredRefinementAccount !== undefined && {
+      resolvedAccount: restoredRefinementAccount,
+    }),
     servedAdcpVersion: ctx.servedAdcpVersion ?? CURRENT_ADCP_VERSION,
   }));
   await flushDirtySessions();

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -536,7 +536,7 @@ describe('tenant routing smoke', () => {
       });
 
       const brand = { domain: 'tenant-seller-delegation.example' };
-      const account = { brand, operator: 'pinnacle-agency.example' };
+      const account = { brand, operator: 'pinnacle-agency.example', sandbox: true };
       const structured = (response: Record<string, unknown>) => (
         response as { result?: { structuredContent?: Record<string, unknown> } }
       ).result?.structuredContent;
@@ -567,22 +567,28 @@ describe('tenant routing smoke', () => {
       })) as {
         products?: Array<{
           product_id?: string;
-          pricing_options?: Array<{ pricing_option_id?: string; floor_price?: number; fixed_price?: number }>;
+          pricing_options?: Array<{
+            pricing_option_id?: string;
+            floor_price?: number;
+            fixed_price?: number;
+            min_spend_per_package?: number;
+          }>;
         }>;
       };
       const product = productResponse.products?.find(candidate => candidate.pricing_options?.[0]?.pricing_option_id);
       expect(product?.product_id).toEqual(expect.any(String));
       const pricing = product!.pricing_options![0]!;
+      const budget = pricing.min_spend_per_package ?? 500;
       const createPayload = {
         account,
         brand,
-        total_budget: { amount: 500, currency: 'USD' },
+        total_budget: { amount: budget, currency: 'USD' },
         start_time: '2027-06-01T00:00:00Z',
         end_time: '2027-06-30T23:59:59Z',
         packages: [{
           product_id: product!.product_id,
           pricing_option_id: pricing.pricing_option_id,
-          budget: 500,
+          budget,
           bid_price: Math.max(pricing.floor_price ?? pricing.fixed_price ?? 1, 1),
         }],
         idempotency_key: 'tenant-seller-delegation-create',
@@ -599,7 +605,7 @@ describe('tenant routing smoke', () => {
         caller,
         task: 'create_media_buy',
         payload: createPayload,
-        commitment: { amount: 500, currency: 'USD' },
+        commitment: { amount: budget, currency: 'USD' },
         phase: 'intent',
       });
 
@@ -616,7 +622,7 @@ describe('tenant routing smoke', () => {
         phase: 'purchase',
         planned_delivery: expect.objectContaining({
           media_buy_id: expect.any(String),
-          total_budget: 500,
+          total_budget: budget,
           currency: 'USD',
           channels: expect.any(Array),
         }),
@@ -1367,7 +1373,7 @@ describe('tenant routing smoke', () => {
       await initializeTenant(salesUrl);
       await initializeTenant(governanceUrl);
       const brand = { domain: 'tenant-governed-native.example' };
-      const account = { brand, operator: brand.domain };
+      const account = { brand, operator: brand.domain, sandbox: true };
       const planId = 'plan-tenant-governed-native';
       const caller = `https://training-agent.adcontextprotocol.org/authenticated/${createHash('sha256')
         .update('test-token')

--- a/server/src/training-agent/v6-sales-platform.ts
+++ b/server/src/training-agent/v6-sales-platform.ts
@@ -601,7 +601,7 @@ function brandDomainFromCtx(account: unknown): string | undefined {
   return (account as { ctx_metadata?: TrainingSalesMeta } | undefined)?.ctx_metadata?.brand_domain;
 }
 
-function accountRefFromCtx(
+export function accountRefFromCtx(
   account: unknown,
   storyboardCompat?: TrainingContext['storyboardCompat'],
 ): ToolArgs['account'] | undefined {
@@ -616,7 +616,15 @@ function accountRefFromCtx(
     ctx_metadata?: TrainingSalesMeta;
   } | undefined;
   const originalRef = acct?.ctx_metadata?.account_ref;
-  if (storyboardCompat?.version !== '3.0' && originalRef) return originalRef;
+  if (storyboardCompat?.version !== '3.0' && originalRef) {
+    // The framework's original natural ref predates its resolved sandbox
+    // disposition. Preserve its identity fields, but retain the trusted
+    // framework mode so all current handlers derive the same account scope.
+    return {
+      ...originalRef,
+      ...(acct?.mode === 'sandbox' && !('account_id' in originalRef) && { sandbox: true }),
+    };
+  }
   const brandDomain = acct?.ctx_metadata?.brand_domain;
   const accountId = typeof acct?.id === 'string' && !acct.id.startsWith('synthetic_') && acct.id !== 'public_sandbox'
     ? acct.id

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1883,6 +1883,220 @@ describe('get_products handler', () => {
     expect((result.products as unknown[]).length).toBeGreaterThan(0);
   });
 
+  it('preserves collection targeting capability on controller-seeded products', async () => {
+    const server = createTrainingAgentServer(DEFAULT_CTX);
+    const account = {
+      brand: { domain: 'collection-targeting.example' },
+      operator: 'pinnacle-agency.example',
+      sandbox: true,
+    };
+    const productId = 'retro_bundle_ctv';
+    const fixture = {
+      channels: ['ctv'],
+      delivery_type: 'non_guaranteed',
+      format_options: [{
+        format_option_id: 'video_30s',
+        format_kind: 'video',
+        params: { duration_ms: 15000 },
+      }],
+      collections: [{
+        publisher_domain: 'channel-owner.example',
+        collection_ids: ['retro_news', 'vintage_static'],
+      }],
+    };
+    for (const [seededProductId, seededFixture] of [
+      ['retro_bundle_ctv_fixed', fixture],
+      [productId, { ...fixture, collection_targeting_allowed: true }],
+      ['no_collection_ctv', {
+        channels: ['ctv'],
+        delivery_type: 'non_guaranteed',
+        format_options: fixture.format_options,
+      }],
+    ] as const) {
+      const { result: seeded } = await simulateCallTool(server, 'comply_test_controller', {
+        account,
+        brand: account.brand,
+        scenario: 'seed_product',
+        params: { product_id: seededProductId, fixture: seededFixture },
+      });
+      expect(seeded.success).toBe(true);
+    }
+
+    const { result: discovered } = await simulateCallTool(server, 'get_products', {
+      buying_mode: 'brief',
+      brief: 'Pre-roll across the HostStream channel bundle: Acme Retro News and Vintage Static',
+      account,
+      filters: { channels: ['ctv'] },
+    });
+    const product = (discovered.products as Array<Record<string, unknown>>)[0];
+    expect(product?.product_id).toBe(productId);
+    expect(product?.collection_targeting_allowed).toBe(true);
+
+    const defaultSelection = { mode: 'default', ext: { example: { source: 'test' } } };
+    const expectedSelection = {
+      mode: 'selected',
+      collections: [{
+        publisher_domain: 'channel-owner.example',
+        collection_ids: ['retro_news', 'vintage_static'],
+      }],
+      ext: { example: { source: 'test' } },
+    };
+    const { result: created } = await simulateCallTool(server, 'create_media_buy', {
+      account,
+      idempotency_key: 'collection-targeting-default-bundle',
+      start_time: 'asap',
+      end_time: '2099-09-30T23:59:59Z',
+      packages: [{
+        product_id: productId,
+        pricing_option_id: 'fixture_default_cpm',
+        bid_price: 5,
+        budget: 5_000,
+        targeting_overlay: { collection_selection: defaultSelection },
+      }],
+    });
+    const mediaBuyId = created.media_buy_id as string;
+    const packageId = (created.packages as Array<{ package_id: string }>)[0]!.package_id;
+    expect((created.packages as Array<{ targeting_overlay?: { collection_selection?: unknown } }>)[0]
+      ?.targeting_overlay?.collection_selection).toEqual(expectedSelection);
+
+    const create = (idempotencyKey: string, targetProductId: string, collectionSelection: unknown) => (
+      simulateCallTool(server, 'create_media_buy', {
+        account,
+        idempotency_key: idempotencyKey,
+        start_time: 'asap',
+        end_time: '2099-09-30T23:59:59Z',
+        packages: [{
+          product_id: targetProductId,
+          pricing_option_id: 'fixture_default_cpm',
+          bid_price: 5,
+          budget: 5_000,
+          targeting_overlay: { collection_selection: collectionSelection },
+        }],
+      })
+    );
+    const { result: defaultWithoutCollections } = await create(
+      'collection-targeting-default-without-collections',
+      'no_collection_ctv',
+      { mode: 'default' },
+    );
+    expect(defaultWithoutCollections).toMatchObject({ code: 'UNSUPPORTED_FEATURE' });
+
+    const { result: updatedDefault } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{ package_id: packageId, targeting_overlay: { collection_selection: defaultSelection } }],
+    });
+    expect((updatedDefault.packages as Array<{ package_id: string; targeting_overlay?: { collection_selection?: unknown } }>)
+      .find(pkg => pkg.package_id === packageId)?.targeting_overlay?.collection_selection).toEqual(expectedSelection);
+    const { result: addedDefault } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      new_packages: [{
+        product_id: productId,
+        pricing_option_id: 'fixture_default_cpm',
+        bid_price: 5,
+        budget: 5_000,
+        targeting_overlay: { collection_selection: defaultSelection },
+      }],
+    });
+    expect((addedDefault.packages as Array<{ package_id: string; targeting_overlay?: { collection_selection?: unknown } }>)
+      .find(pkg => pkg.package_id === 'pkg-1')?.targeting_overlay?.collection_selection).toEqual(expectedSelection);
+    const { result: addedWithoutCollections } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      new_packages: [{
+        product_id: 'no_collection_ctv',
+        pricing_option_id: 'fixture_default_cpm',
+        bid_price: 5,
+        budget: 5_000,
+      }],
+    });
+    const noCollectionPackageId = (addedWithoutCollections.packages as Array<{ package_id: string; product_id: string }>)
+      .find(pkg => pkg.product_id === 'no_collection_ctv')!.package_id;
+    const { result: defaultUpdateWithoutCollections } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{
+        package_id: noCollectionPackageId,
+        targeting_overlay: { collection_selection: { mode: 'default' } },
+      }],
+    });
+    expect(defaultUpdateWithoutCollections).toMatchObject({ code: 'UNSUPPORTED_FEATURE' });
+
+    const selected = (collections: unknown[]) => ({ mode: 'selected', collections });
+    const { result: unknownDomain } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      packages: [{
+        package_id: packageId,
+        targeting_overlay: { collection_selection: selected([
+          { publisher_domain: 'other-owner.example', collection_ids: ['retro_news'] },
+        ]) },
+      }],
+    });
+    expect(unknownDomain).toMatchObject({ code: 'REFERENCE_NOT_FOUND' });
+    const { result: partialFixedAdded } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      new_packages: [{
+        product_id: 'retro_bundle_ctv_fixed',
+        pricing_option_id: 'fixture_default_cpm',
+        bid_price: 5,
+        budget: 5_000,
+        targeting_overlay: { collection_selection: selected([
+          { publisher_domain: 'channel-owner.example', collection_ids: ['retro_news'] },
+        ]) },
+      }],
+    });
+    expect(partialFixedAdded).toMatchObject({ code: 'UNSUPPORTED_FEATURE' });
+    const { result: defaultAddedWithoutCollections } = await simulateCallTool(server, 'update_media_buy', {
+      account,
+      media_buy_id: mediaBuyId,
+      new_packages: [{
+        product_id: 'no_collection_ctv',
+        pricing_option_id: 'fixture_default_cpm',
+        bid_price: 5,
+        budget: 5_000,
+        targeting_overlay: { collection_selection: { mode: 'default' } },
+      }],
+    });
+    expect(defaultAddedWithoutCollections).toMatchObject({ code: 'UNSUPPORTED_FEATURE' });
+    const { result: readback } = await simulateCallTool(server, 'get_media_buys', {
+      account,
+      media_buy_ids: [mediaBuyId],
+    });
+    const readbackPackages = (readback.media_buys as Array<{
+      packages: Array<{ package_id: string; targeting_overlay?: { collection_selection?: unknown } }>;
+    }>)[0]!.packages;
+    expect(readbackPackages).toHaveLength(3);
+    expect(readbackPackages.find(pkg => pkg.package_id === packageId)?.targeting_overlay?.collection_selection)
+      .toEqual(expectedSelection);
+
+    const invalidSelection = (idempotencyKey: string, collections: unknown[]) => create(
+      idempotencyKey,
+      productId,
+      selected(collections),
+    );
+    const { result: malformed } = await invalidSelection(
+      'collection-targeting-domain-only', [{ publisher_domain: 'channel-owner.example' }],
+    );
+    expect(malformed).toMatchObject({ code: 'INVALID_REQUEST' });
+    const { result: unknownCollection } = await invalidSelection(
+      'collection-targeting-unknown-id', [{ publisher_domain: 'channel-owner.example', collection_ids: ['unknown'] }],
+    );
+    expect(unknownCollection).toMatchObject({ code: 'REFERENCE_NOT_FOUND' });
+    const { result: duplicate } = await invalidSelection(
+      'collection-targeting-duplicate-id', [{ publisher_domain: 'channel-owner.example', collection_ids: ['retro_news', 'retro_news'] }],
+    );
+    expect(duplicate).toMatchObject({ code: 'INVALID_REQUEST' });
+    const { result: fullFixedBundle } = await create(
+      'collection-targeting-fixed-full',
+      'retro_bundle_ctv_fixed',
+      selected([{ publisher_domain: 'channel-owner.example', collection_ids: ['retro_news', 'vintage_static'] }]),
+    );
+    expect(fullFixedBundle).toMatchObject({ packages: [{ product_id: 'retro_bundle_ctv_fixed' }] });
+  });
+
   it('warns when a custom format shape has been promoted in 3.2', async () => {
     const server = createTrainingAgentServer(DEFAULT_CTX);
     const account = {

--- a/server/tests/unit/v6-sales-platform-owner-scope.test.ts
+++ b/server/tests/unit/v6-sales-platform-owner-scope.test.ts
@@ -1,8 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import {
+  accountRefFromCtx,
   taskOwnerScopeForPlatformContext,
   webhookTenantScopeForPlatformContext,
 } from '../../src/training-agent/v6-sales-platform.js';
+import { sessionKeyFromArgs } from '../../src/training-agent/state.js';
+
+describe('framework account scope', () => {
+  const naturalAccount = {
+    brand: { domain: 'acmeoutdoor.example' },
+    operator: 'pinnacle-agency.example',
+  };
+
+  it('preserves framework sandbox mode on an original natural account ref', () => {
+    const account = accountRefFromCtx({
+      mode: 'sandbox',
+      ctx_metadata: { account_ref: naturalAccount },
+    });
+
+    expect(account).toEqual({ ...naturalAccount, sandbox: true });
+    expect(sessionKeyFromArgs({ account }, 'open')).toBe(
+      sessionKeyFromArgs({ account: { ...naturalAccount, sandbox: true } }, 'open'),
+    );
+  });
+
+  it('does not add sandbox mode outside a trusted sandbox context', () => {
+    const account = accountRefFromCtx({
+      mode: 'production',
+      ctx_metadata: { account_ref: naturalAccount },
+    });
+
+    expect(account).toEqual(naturalAccount);
+    expect(sessionKeyFromArgs({ account }, 'open')).toBe(
+      sessionKeyFromArgs({ account: naturalAccount }, 'open'),
+    );
+  });
+});
 
 describe('seller-managed task owner scope', () => {
   it('preserves captured session scope when an agent is also resolved', () => {

--- a/static/compliance/source/protocols/media-buy/index.yaml
+++ b/static/compliance/source/protocols/media-buy/index.yaml
@@ -1,5 +1,5 @@
 id: media_buy_seller
-version: "1.0.1"
+version: "1.0.2"
 title: "Media buy seller agent"
 category: media_buy_seller
 summary: "Seller agent that receives briefs, returns products, accepts media buys, and reports delivery."
@@ -69,12 +69,10 @@ narrative: |
   This storyboard walks through the core media buy flow: account setup, product discovery,
   buy creation, and delivery monitoring.
 
-  Creative sync, governance integration, product refinement, and proposal finalization
-  are tested by capability-gated required scenarios that run alongside this storyboard.
+  Creative sync, governance binding and approval, product refinement, and proposal
+  finalization are tested by capability-gated required scenarios that run alongside
+  this storyboard.
   See requires_scenarios for the full set of seller behaviors validated.
-
-context:
-  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 agent:
   interaction_model: media_buy_seller
@@ -313,64 +311,6 @@ phases:
             context_key: "account_timezone"
             description: "Seller echoes the chosen immutable timezone"
 
-  - id: governance_setup
-    title: "Governance agent registration"
-    depends_on: [account_setup]
-    requires_capability:
-      path: account.timezone.supported_timezones
-      present: false
-    narrative: |
-      The buyer registers their governance agent with your platform. This tells your
-      platform where to call check_governance before confirming media buys.
-
-    steps:
-      - id: sync_governance
-        title: "Register governance agents"
-        narrative: |
-          The buyer tells your platform: "Before you confirm any media buy for this
-          account, call this governance agent to validate it."
-        task: sync_governance
-        schema_ref: "account/sync-governance-request.json"
-        response_schema_ref: "account/sync-governance-response.json"
-        doc_ref: "/accounts/tasks/sync_governance"
-        requires_tool: sync_governance
-        stateful: true
-        expected: |
-          Acknowledge the governance agents. Your platform should:
-          - Store the governance agent URLs for the specified accounts
-          - Return confirmation that agents were registered
-
-        sample_request:
-          accounts:
-            - account:
-                &media_buy_lifecycle_account
-                brand:
-                  domain: "acmeoutdoor.example"
-                operator: "pinnacle-agency.example"
-                sandbox: true
-              governance_agents:
-                - url: "$context.governance_agent_url"
-                  authentication:
-                    schemes: ["Bearer"]
-                    credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_governance_setup_sync_governance"
-          context:
-            correlation_id: "media_buy_seller--sync_governance"
-          ext:
-            test_platform:
-              governance_tier: "standard"
-
-        validations:
-          - check: response_schema
-            description: "Response matches sync-governance-response.json schema"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "media_buy_seller--sync_governance"
-            description: "Context correlation_id returned unchanged"
-
   - id: product_discovery
     title: "Product discovery"
     depends_on: [account_setup]
@@ -426,7 +366,11 @@ phases:
           brief: "Premium video inventory on sports and outdoor lifestyle publishers. Q2 flight, $50K budget. Adults 25-54, US and Canada."
           pagination:
             max_results: 5
-          account: *media_buy_lifecycle_account
+          account: &media_buy_lifecycle_account
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+            sandbox: true
           context:
             correlation_id: "media_buy_seller--get_products_brief"
 
@@ -483,18 +427,17 @@ phases:
       is no "pending_approval" media buy status — IO review is modelled at the task
       layer, not as a MediaBuy.status value.
 
-      If the buyer registered governance agents in Phase 2, your platform calls
-      check_governance before confirming the buy. The governance agent validates budget
-      authority, brand safety, and compliance. If governance denies the buy, return the
-      denial — don't override it.
+      This core flow intentionally creates the buy without a governance-agent binding.
+      Governance registration, approval, and rejection are exercised by the dedicated
+      capability-gated required scenarios.
 
     steps:
       - id: create_media_buy
         title: "Create a media buy"
         narrative: |
           The buyer commits to specific products with budgets and flight dates. Your
-          platform validates the request, optionally calls governance, and either confirms
-          the buy or sends it through an approval workflow.
+          platform validates the request and either confirms the buy or sends it through
+          an approval workflow.
 
           Two creation modes:
           - Manual: buyer specifies packages array with explicit product selections
@@ -524,7 +467,7 @@ phases:
 
           Asynchronous (working):
           - percentage: 0-100 completion
-          - current_step: what's happening ("Validating inventory", "Checking governance")
+          - current_step: what's happening ("Validating inventory")
 
           Async with human approval (submitted):
           - task_id: AdCP handle the buyer passes to get_task_status or receives webhooks on; it is not the A2A Task id
@@ -697,51 +640,6 @@ phases:
   # The buyer-selected branch repeats the lifecycle with the complete
   # timezone-bearing natural AccountRef. The request bodies are explicit so
   # authored-storyboard consumers do not need YAML merge-key support.
-  - id: buyer_selected_governance_setup
-    title: "Buyer-selected timezone governance registration"
-    depends_on: [buyer_selected_account_setup]
-    requires_capability:
-      path: account.timezone.account_selection
-      equals: buyer_selected
-    steps:
-      - id: sync_governance_buyer_selected_timezone
-        title: "Register governance agents for the timezone-bound account"
-        task: sync_governance
-        schema_ref: "account/sync-governance-request.json"
-        response_schema_ref: "account/sync-governance-response.json"
-        doc_ref: "/accounts/tasks/sync_governance"
-        requires_tool: sync_governance
-        stateful: true
-        sample_request:
-          accounts:
-            - account:
-                brand:
-                  domain: "acmeoutdoor.example"
-                operator: "pinnacle-agency.example"
-                timezone: "$context.account_timezone"
-                sandbox: true
-              governance_agents:
-                - url: "$context.governance_agent_url"
-                  authentication:
-                    schemes: ["Bearer"]
-                    credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-          idempotency_key: "$generate:uuid_v4#media_buy_seller_buyer_timezone_sync_governance"
-          context:
-            correlation_id: "media_buy_seller--sync_governance"
-          ext:
-            test_platform:
-              governance_tier: "standard"
-        validations:
-          - check: response_schema
-            description: "Response matches sync-governance-response.json schema"
-          - check: field_present
-            path: "context"
-            description: "Response echoes back the context object"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "media_buy_seller--sync_governance"
-            description: "Context correlation_id returned unchanged"
-
   - id: buyer_selected_product_discovery
     title: "Buyer-selected timezone product discovery"
     depends_on: [buyer_selected_account_setup]

--- a/static/compliance/source/specialisms/sales-dooh/index.yaml
+++ b/static/compliance/source/specialisms/sales-dooh/index.yaml
@@ -1,12 +1,12 @@
 id: sales_dooh
-version: "1.0.0"
+version: "1.0.1"
 title: "Digital out-of-home — non-guaranteed"
 protocol: media-buy
 category: sales_dooh
 summary: "DOOH seller for non-guaranteed venue and screen inventory with canonical screen formats and substantive play reporting."
 track: media_buy
 required_tools:
-  - sync_governance
+  - sync_accounts
   - sync_creatives
   - list_products
   - create_media_buy
@@ -19,9 +19,6 @@ requires_scenarios:
 
 invariants:
   - status.monotonic
-
-context:
-  governance_agent_url: "https://test-agent.adcontextprotocol.org"
 
 narrative: |
   You run a digital out-of-home seller that offers venue and screen inventory
@@ -40,6 +37,13 @@ narrative: |
 
   This storyboard intentionally does not require click, conversion, browser-pixel,
   or persistent-person identifiers. Those are not inherent to DOOH delivery.
+
+  This is deliberately the ungoverned DOOH baseline. Registering a governance
+  agent changes the account contract: every later commitment needs an approved
+  `governance_context`, so registration followed by this context-free create
+  would correctly be rejected. The linked single-agent scenario covers
+  registration validation; governance-aware-seller owns the complete
+  multi-agent signed-context flow.
 
 agent:
   interaction_model: media_buy_seller
@@ -166,6 +170,42 @@ phases:
           - check: field_value
             path: "context.correlation_id"
             value: "sales_dooh--get_capabilities"
+            description: "Context correlation_id returned unchanged"
+
+  - id: account_setup
+    title: "Establish the sandbox account"
+    steps:
+      - id: sync_accounts
+        title: "Establish the sandbox account"
+        task: sync_accounts
+        schema_ref: "account/sync-accounts-request.json"
+        response_schema_ref: "account/sync-accounts-response.json"
+        doc_ref: "/accounts/tasks/sync_accounts"
+        stateful: true
+        expected: "Provision the sandbox account before discovery and creative sync."
+        sample_request:
+          accounts:
+            - brand:
+                domain: "acmeoutdoor.example"
+              operator: "pinnacle-agency.example"
+              billing: "operator"
+              sandbox: true
+          idempotency_key: "$generate:uuid_v4#sales_dooh_account_setup_sync_accounts"
+          context:
+            correlation_id: "sales_dooh--sync_accounts"
+        validations:
+          - check: response_schema
+            description: "Response matches sync-accounts-response.json schema"
+          - check: field_present
+            path: "accounts[0].account_id"
+            description: "Sandbox account has a platform-assigned ID"
+          - check: field_value
+            path: "accounts[0].action"
+            allowed_values: ["created", "updated"]
+            description: "Sandbox account establishment succeeds"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "sales_dooh--sync_accounts"
             description: "Context correlation_id returned unchanged"
 
   - id: product_discovery
@@ -390,44 +430,9 @@ phases:
   - id: create_buy
     title: "Create the non-guaranteed DOOH buy"
     narrative: |
-      The buyer registers governance and creates a non-guaranteed buy against
-      the exact product and pricing option returned by discovery.
+      The buyer creates a non-guaranteed buy against the exact product and
+      pricing option returned by discovery.
     steps:
-      - id: sync_governance
-        title: "Register governance agent"
-        task: sync_governance
-        schema_ref: "account/sync-governance-request.json"
-        response_schema_ref: "account/sync-governance-response.json"
-        doc_ref: "/accounts/tasks/sync_governance"
-        stateful: true
-        expected: "Acknowledge governance registration for the sandbox account."
-        sample_request:
-          accounts:
-            - account:
-                brand:
-                  domain: "acmeoutdoor.example"
-                operator: "pinnacle-agency.example"
-                sandbox: true
-              governance_agents:
-                - url: "$context.governance_agent_url"
-                  authentication:
-                    schemes: ["Bearer"]
-                    credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-          idempotency_key: "$generate:uuid_v4#sales_dooh_create_buy_sync_governance"
-          context:
-            correlation_id: "sales_dooh--sync_governance"
-        validations:
-          - check: response_schema
-            description: "Response matches sync-governance-response.json schema"
-          - check: field_value
-            path: "accounts[0].status"
-            value: "synced"
-            description: "Governance agent is registered"
-          - check: field_value
-            path: "context.correlation_id"
-            value: "sales_dooh--sync_governance"
-            description: "Context correlation_id returned unchanged"
-
       - id: create_media_buy
         title: "Buy the DOOH product"
         task: create_media_buy

--- a/static/compliance/source/specialisms/sales-guaranteed/index.yaml
+++ b/static/compliance/source/specialisms/sales-guaranteed/index.yaml
@@ -393,7 +393,7 @@ phases:
               budget: 30000
               pricing_option_id: "$context.pricing_option_1_id"
             - product_id: "$context.product_2_id"
-              budget: 20000
+              budget: 25000
               pricing_option_id: "$context.pricing_option_2_id"
           push_notification_config:
             url: "https://buyer.example/webhooks/adcp"

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -124,8 +124,24 @@ const storyboardCandidateMode = trainingAgentWorkflowConfig.jobs.storyboards.ste
 ).env.ADCP_STORYBOARD_CANDIDATE_VERSION_MODE;
 assert(
   storyboardCandidateMode.includes("matrix.surface == 'current'") &&
-    storyboardCandidateMode.includes("github.head_ref == 'changeset-release/main'"),
-  'Only current-surface Version Packages PR jobs may enable candidate-version resolution.'
+    storyboardCandidateMode.includes("github.base_ref == 'main'") &&
+    storyboardCandidateMode.includes("github.ref == 'refs/heads/main'"),
+  'Only current-surface main-line PRs and pushes may enable candidate-version resolution.'
+);
+assert(
+  !storyboardCandidateMode.includes('github.head_ref'),
+  'Matrix candidate-version resolution must not depend on a release-branch head ref.'
+);
+const salesStoryboardCandidateMode = trainingAgentWorkflowConfig.jobs.sales_storyboard_orchestrators.env
+  .ADCP_STORYBOARD_CANDIDATE_VERSION_MODE;
+assert(
+  salesStoryboardCandidateMode.includes("github.base_ref == 'main'") &&
+    salesStoryboardCandidateMode.includes("github.ref == 'refs/heads/main'"),
+  'All isolated current /sales jobs must enable candidate-version resolution for main-line PRs and pushes.'
+);
+assert(
+  !salesStoryboardCandidateMode.includes('github.head_ref'),
+  'Isolated current /sales candidate-version resolution must not depend on a release-branch head ref.'
 );
 
 assert.strictEqual(

--- a/tests/run-storyboards-isolation.test.cjs
+++ b/tests/run-storyboards-isolation.test.cjs
@@ -83,6 +83,15 @@ test('orchestrator does not load the training agent or SDK', () => {
   assert.match(source, /process\.platform === 'win32' \? pid : -pid/);
 });
 
+test('Linux RSS monitoring enumerates proc process names without Dirent lstat races', () => {
+  const source = fs.readFileSync(ORCHESTRATOR, 'utf8');
+  assert.match(source, /for \(const pid of readdirSync\('\/proc'\)\)/);
+  assert.match(source, /if \(!\/\^\\d\+\$\/\.test\(pid\)\) continue/);
+  assert.doesNotMatch(source, /readdirSync\('\/proc', \{ withFileTypes: true \}\)/);
+  assert.match(source, /readFileSync\(join\('\/proc', pid, 'stat'\)/);
+  assert.match(source, /error\?\.code !== 'ENOENT' && error\?\.code !== 'ESRCH'/);
+});
+
 test('child V8 heap is bounded without discarding caller Node options', (t) => {
   const { result } = runFixture(t, ['node_options'], [], { NODE_OPTIONS: '--trace-warnings' });
 

--- a/tests/run-storyboards-schema-root-options.test.cjs
+++ b/tests/run-storyboards-schema-root-options.test.cjs
@@ -12,6 +12,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const RUNNER_FILE = path.join(__dirname, '..', 'server', 'tests', 'manual', 'run-storyboards.ts');
+const THREE_ZERO_COMPAT_WRAPPER = path.join(__dirname, '..', 'scripts', 'run-storyboards-3-0-compat.sh');
 
 function findMatchingBrace(source, openIndex) {
   let depth = 0;
@@ -101,6 +102,15 @@ test('candidate-version compatibility is explicit and resolver-scoped', () => {
     source,
     /supported_versions:\s*\[[^\]]*releasedComplianceVersion/,
     'candidate mode must not rewrite the seller capability declaration',
+  );
+});
+
+test('3.0 compatibility wrapper overrides inherited candidate mode', () => {
+  const source = fs.readFileSync(THREE_ZERO_COMPAT_WRAPPER, 'utf8');
+  assert.match(
+    source,
+    /ADCP_STORYBOARD_CANDIDATE_VERSION_MODE=0\s+exec bash .*run-storyboards-matrix\.sh" --latest-3\.0/,
+    'immutable 3.0 runs must override a candidate-mode environment inherited from current validation',
   );
 });
 

--- a/tests/timezone-resolution-storyboards.test.cjs
+++ b/tests/timezone-resolution-storyboards.test.cjs
@@ -187,7 +187,7 @@ test('parent flow carries the correct complete natural AccountRef through each t
   assert.equal(buyerSync.sample_request.accounts[0].sandbox, true);
 
   const defaultLifecycle = doc.phases.filter(phase =>
-    ['governance_setup', 'product_discovery', 'create_buy', 'delivery_monitoring'].includes(phase.id)
+    ['product_discovery', 'create_buy', 'delivery_monitoring'].includes(phase.id)
   );
   const buyerLifecycle = doc.phases.filter(phase => phase.id.startsWith('buyer_selected_') && phase.id !== 'buyer_selected_account_setup');
   const defaultAccount = {
@@ -197,8 +197,8 @@ test('parent flow carries the correct complete natural AccountRef through each t
   };
   const buyerAccount = { ...defaultAccount, timezone: '$context.account_timezone' };
 
-  assert.deepEqual(accountRefsIn(defaultLifecycle), Array(5).fill(defaultAccount));
-  assert.deepEqual(accountRefsIn(buyerLifecycle), Array(5).fill(buyerAccount));
+  assert.deepEqual(accountRefsIn(defaultLifecycle), Array(4).fill(defaultAccount));
+  assert.deepEqual(accountRefsIn(buyerLifecycle), Array(4).fill(buyerAccount));
   assert.doesNotMatch(JSON.stringify(doc), /\$context\.account_id/);
   assert.equal(doc.phases.flatMap(phase => phase.steps).some(candidate => candidate.task === 'list_accounts'), false);
 });


### PR DESCRIPTION
## Summary

- enable candidate-schema resolution only for current-surface PRs targeting `main` and pushes to `main`, while the training agent continues to advertise and speak its real `3.2-beta.9` wire version
- enforce and materialize collection-selection semantics consistently across create/update flows
- stabilize sandbox account scoping, proposal reconstruction, and isolated storyboard process monitoring
- correct current sales storyboard baselines for account setup, budgets, and ungoverned core/DOOH flows
- force candidate mode off inside the immutable 3.0 compatibility wrapper

This validates compatibility with the beta.10 candidate source bundle. It does **not** claim that the reference training agent is beta.10-conformant; the SDK and advertised training-agent version remain beta.9.

## Validation

- full normal pre-push matrix passed
  - all current candidate tenants
  - all 8 isolated `/sales` shards
  - all 8 isolated `/creative-builder` shards
  - immutable `--latest-3.0` compatibility matrix
- training-agent unit suite: 766/766
- tenant smoke: 45/45
- isolation tests: 15/15
- owner-scope tests: 7/7
- candidate `collection_selection`: 11P / 0F
- candidate `owner_sold_channel_carriage`: 7P / 0F
- candidate `sales_dooh`: 10P / 0F
- candidate `sales_guaranteed`: 14P / 0F / 1 expected capability skip
- proposal negotiation profiles: 11/11
- timezone storyboard tests: 9/9
- typecheck, build, compliance build, workflow immutability, schema/path lints, and changeset checks passed

## Review

Independent protocol and security reviews found no blocking issues. Candidate-mode scope is fail-closed and restricted to current mainline validation; released 3.0 artifacts remain immutable and explicitly run with candidate mode disabled.
