### PR TITLE
fix(registry): authenticate admin refresh probes

### DIFF
--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7835,7 +7835,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
       try {
         lease.assertValid();
         probeResult = safeProbeResult(await crawler.refreshSingleAgent(agentUrl, {
-          auth: resolvedAuth,
+          auth: complianceAuth,
           ...(request.owner_org_id ? { ownerOrgId: request.owner_org_id } : {}),
         }));
         lease.assertValid();

--- a/server/tests/integration/registry-api-agent-refresh.test.ts
+++ b/server/tests/integration/registry-api-agent-refresh.test.ts
@@ -1011,11 +1011,11 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
     ]));
   });
 
-  // Regression for #7070: admin-refresh must not run comply() anonymously
+  // Regression for #7070: admin-refresh must not probe or run comply() anonymously
   // when the agent owner has stored credentials. The route now falls back
   // to complianceDb.resolveOwnerAuth (the heartbeat pattern) so the
-  // compliance run uses the owner's saved token.
-  it('admin refresh falls back to stored owner auth for compliance (#7070)', async () => {
+  // capability probe and compliance run use the owner's saved token.
+  it('admin refresh falls back to stored owner auth for probe and compliance (#7070)', async () => {
     currentUserId = STATIC_ADMIN_USER_ID;
     const agentUrl = ownedAgentUrl('admin-auth-fallback');
 
@@ -1039,6 +1039,12 @@ describe('POST /api/registry/agents/:encodedUrl/refresh (integration)', () => {
         ran: true,
         auth_available: true,
       });
+      expect(refreshSingleAgentMock).toHaveBeenCalledWith(
+        agentUrl,
+        expect.objectContaining({
+          auth: expect.objectContaining({ type: 'bearer', token: STORED_BEARER }),
+        }),
+      );
       expect(complyMock).toHaveBeenCalledWith(
         agentUrl,
         expect.objectContaining({


### PR DESCRIPTION
## Summary

- use the owner credential resolved for an admin-triggered compliance refresh during the registry capability probe
- keep the probe and full `comply()` run on the same authentication context
- extend the existing admin-refresh regression to assert the saved bearer reaches both calls

## Production failure

After deploying the #7115 runner/scoring fix, the BidMachine rerun stopped before `comply()`: static-admin refresh resolved the saved owner credential into `complianceAuth`, but passed the owner-request-only `resolvedAuth` variable to `refreshSingleAgent`. That made the pre-probe anonymous and triggered the seller's authentication wall.

Owner-triggered refresh semantics are unchanged because `resolvedAuth` and `complianceAuth` are identical on that path.

## Verification

- `server/tests/integration/registry-api-agent-refresh.test.ts`: 23 passed
- `server/tests/unit/admin-refresh-auth-safety.test.ts`: 5 passed
- `npm run typecheck`
- `git diff --check`

The full precommit server-unit sweep was stopped after unrelated main-branch failures appeared in billing/session authorization suites; focused coverage and typecheck are green.

## Changeset

None. This is an internal registry runner parity fix with no protocol, schema, or package surface change.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/462d769f-c5c4-448a-b5b8-13cdd04f57ce)
