### PR TITLE
fix(compliance): use test-kit auth for controller mode gate

### DIFF
--- a/server/src/compliance/storyboard-runner-options.ts
+++ b/server/src/compliance/storyboard-runner-options.ts
@@ -71,7 +71,12 @@ export function authForStoryboard(
     );
   }
 
-  if ((storyboardId === 'billing_gate_dispatch' || storyboardId === 'security_baseline') && kit?.auth?.api_key) {
+  if (
+    (storyboardId === 'billing_gate_dispatch' ||
+      storyboardId === 'comply_controller_mode_gate' ||
+      storyboardId === 'security_baseline') &&
+    kit?.auth?.api_key
+  ) {
     return { type: 'bearer', token: kit.auth.api_key };
   }
 

--- a/server/tests/unit/storyboard-runner-options.test.ts
+++ b/server/tests/unit/storyboard-runner-options.test.ts
@@ -101,12 +101,16 @@ describe('storyboard runner option helpers', () => {
     expect(() => authForStoryboard('security_baseline', kit, 'default-token')).toThrow(/both auth\.api_key and auth\.basic/);
   });
 
-  it('keeps billing_gate_dispatch on the kit API key and other storyboards on the default token', () => {
+  it('keeps credential-gated storyboards on the kit API key and other storyboards on the default token', () => {
     const kit: LoadedTestKit = {
       auth: { api_key: 'kit-api-key', probe_task: 'list_creatives' },
     };
 
     expect(authForStoryboard('billing_gate_dispatch', kit, 'default-token')).toEqual({
+      type: 'bearer',
+      token: 'kit-api-key',
+    });
+    expect(authForStoryboard('comply_controller_mode_gate', kit, 'default-token')).toEqual({
       type: 'bearer',
       token: 'kit-api-key',
     });


### PR DESCRIPTION
## Summary

- allow comply_controller_mode_gate to receive the compliance test-kit API key
- cover the controller-mode gate alongside the other credential-gated storyboards

Fixes #7151.

## Validation

- npx vitest run server/tests/unit/storyboard-runner-options.test.ts (11 passed)
- npx tsc --project server/tsconfig.json --noEmit
- root unit suite in the pre-commit hook: 1,057 passed

## Known unrelated test failures

The repository-wide server-unit hook also reported existing failures in billing-admin-tenant-boundary.test.ts and authorization-epoch-session.test.ts. Neither file nor its implementation path is touched by this two-file allowlist change; the focused suite and server typecheck are green.