### PR TITLE
fix(training): reject invalid collection selectors

### DIFF
--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -12881,11 +12881,50 @@ interface MediaBuyExecutionOptions {
   governance?: TrustedGovernedExecution;
 }
 
+function invalidSelectedCollectionSelector(
+  args: ToolArgs,
+  packageFields: readonly string[],
+): TaskError[] | undefined {
+  const input = args as unknown as Record<string, unknown>;
+  for (const packageField of packageFields) {
+    const packages = input[packageField];
+    if (!Array.isArray(packages)) continue;
+    for (let packageIndex = 0; packageIndex < packages.length; packageIndex++) {
+      const pkg = packages[packageIndex];
+      if (!isRecord(pkg)) continue;
+      const overlay = isRecord(pkg.targeting_overlay)
+        ? pkg.targeting_overlay
+        : isRecord(pkg.targeting)
+          ? pkg.targeting
+          : undefined;
+      if (!overlay || !isRecord(overlay.collection_selection)) continue;
+      const selection = overlay.collection_selection;
+      if (selection.mode !== 'selected' || !Array.isArray(selection.collections)) continue;
+      for (let collectionIndex = 0; collectionIndex < selection.collections.length; collectionIndex++) {
+        const selector = selection.collections[collectionIndex];
+        const collectionIds = isRecord(selector) ? selector.collection_ids : undefined;
+        if (Array.isArray(collectionIds) && collectionIds.length > 0) continue;
+        const field = `${packageField}[${packageIndex}].targeting_overlay.collection_selection.collections[${collectionIndex}].collection_ids`;
+        return [{
+          code: 'INVALID_REQUEST',
+          message: 'Selected collection selectors must include at least one collection_id.',
+          field,
+          recovery: 'correctable',
+        }];
+      }
+    }
+  }
+  return undefined;
+}
+
 export async function handleCreateMediaBuy(
   args: ToolArgs,
   ctx: TrainingContext,
   options: MediaBuyExecutionOptions = {},
 ) {
+  const invalidCollectionSelector = invalidSelectedCollectionSelector(args, ['packages']);
+  if (invalidCollectionSelector) return { errors: invalidCollectionSelector };
+
   const proposalId = (args as unknown as Record<string, unknown>).proposal_id;
   if (typeof proposalId !== 'string') return handleCreateMediaBuyUnlocked(args, ctx, options);
 
@@ -15939,6 +15978,9 @@ export async function handleUpdateMediaBuy(
   ctx: TrainingContext,
   options: { acceptedProposalExecution?: boolean; operationalControlExecution?: boolean; governance?: TrustedGovernedExecution } = {},
 ): Promise<Record<string, unknown>> {
+  const invalidCollectionSelector = invalidSelectedCollectionSelector(args, ['packages', 'new_packages']);
+  if (invalidCollectionSelector) return { errors: invalidCollectionSelector };
+
   const mutex = await acquireMediaBuyMutationMutex(args, ctx);
   if (!mutex) return mediaBuyMutationConflict();
   try {

--- a/server/src/training-agent/tenants/tenant-smoke.test.ts
+++ b/server/src/training-agent/tenants/tenant-smoke.test.ts
@@ -14,6 +14,7 @@ import { clearIdempotencyCache } from '../idempotency.js';
 import {
   clearSessions,
   flushDirtySessions,
+  findSessionsMatching,
   getSession,
   registerSharedPublicBrandPartition,
   runWithSessionContext,
@@ -3227,6 +3228,57 @@ describe('tenant routing smoke', () => {
       expect(packages?.every(pkg => JSON.stringify(pkg.format_ids) === JSON.stringify([legacyFormat]))).toBe(true);
       expect(packages?.every(pkg => !Object.hasOwn(pkg, 'format_option_refs'))).toBe(true);
       expect(JSON.stringify(read.result?.structuredContent)).not.toContain('__selected_legacy_format_ids');
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('rejects selected collection selectors without collection_ids before creating a media buy', async () => {
+    const { baseUrl, close } = await bootServer();
+    try {
+      const url = `${baseUrl}/sales/mcp`;
+      await initializeTenant(url);
+      const account = {
+        brand: { domain: 'invalid-collection-selector.example' },
+        operator: 'pinnacle-agency.example',
+        sandbox: true,
+      };
+      const response = await callTenantTool(url, 75, 'create_media_buy', {
+        adcp_version: '3.2-beta.10',
+        idempotency_key: 'invalid-collection-selector-create-0001',
+        account,
+        brand: account.brand,
+        start_time: '2027-06-01T00:00:00Z',
+        end_time: '2027-07-01T00:00:00Z',
+        packages: [{
+          product_id: 'retro_news_owner_sold',
+          pricing_option_id: 'retro_news_cpm',
+          budget: 5_000,
+          bid_price: 20,
+          targeting_overlay: {
+            collection_selection: {
+              mode: 'selected',
+              collections: [{ publisher_domain: 'channel-owner.example' }],
+            },
+          },
+        }],
+      }) as {
+        result?: {
+          structuredContent?: {
+            adcp_error?: { code?: string; field?: string };
+            media_buy_id?: string;
+          };
+        };
+      };
+
+      expect(response.result?.structuredContent).toMatchObject({
+        adcp_error: {
+          code: 'INVALID_REQUEST',
+          field: 'packages[0].targeting_overlay.collection_selection.collections[0].collection_ids',
+        },
+      });
+      expect(response.result?.structuredContent?.media_buy_id).toBeUndefined();
+      expect(await findSessionsMatching(session => session.mediaBuys.size > 0)).toEqual([]);
     } finally {
       await close();
     }

--- a/server/tests/manual/run-storyboards.ts
+++ b/server/tests/manual/run-storyboards.ts
@@ -279,10 +279,6 @@ const KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
     'media_buy_seller/canonical_formats/reject_unprojectable_legacy_dual_emission',
     'The SDK drops an unprojectable deprecated format_ids route before the platform can return UNSUPPORTED_FEATURE. Raw receiver behavior is covered by training-agent unit tests. Remove when the SDK exposes unresolved legacy routes to the receiver.',
   ],
-  [
-    'media_buy_seller/owner_sold_channel_carriage/reject_bulk_grant_form_selection',
-    'The SDK rejects this intentionally schema-invalid request before dispatch but does not normalize the local validation failure to the authored INVALID_REQUEST error code (adcontextprotocol/adcp-client#2813). The schema-valid unknown-ID and mismatched-domain rejection legs remain graded. Remove when the storyboard runner recognizes local request-schema rejection for negative_path: schema_invalid.',
-  ],
 ]);
 
 const THREE_ZERO_COMPAT_KNOWN_FAILING_STEPS: ReadonlyMap<string, string> = new Map([
@@ -439,19 +435,6 @@ function patchStoryboardForLocalRunner(sb: Storyboard): Storyboard {
         // local semantic assertion is suppressed until the SDK is directional.
         step.validations = (step.validations ?? [])
           .filter(validation => validation.check !== 'canonical_format_satisfaction');
-      }
-    }
-  }
-
-  if (sb.id === 'media_buy_seller/owner_sold_channel_carriage') {
-    patched = structuredClone(patched) as Storyboard;
-    for (const phase of patched.phases ?? []) {
-      for (const step of phase.steps ?? []) {
-        if (step.id !== 'reject_bulk_grant_form_selection') continue;
-        // The SDK-local schema rejection is recorded as a compatibility skip
-        // after the run. Keep the independent, schema-valid rejection probes
-        // executable instead of letting this pre-dispatch failure cascade.
-        step.stateful = false;
       }
     }
   }


### PR DESCRIPTION
## Summary

- reject `selected` collection selectors that omit `collection_ids` before media-buy mutation
- return a structured `INVALID_REQUEST` at the precise selector field
- restore full grading of the owner-sold channel-carriage storyboard

## Why

The beta.28 SDK candidate correctly exposed that the training seller accepted a schema-invalid selector, created a media buy, and only failed later while validating the malformed echoed response. Broadening SDK error normalization would have hidden that seller-side mutation. This change fixes the receiver boundary instead.

## Validation

- owner-sold channel-carriage storyboard with published `@adcp/sdk@14.0.0-beta.27`: 7/7 passed, 0 skipped
- same storyboard with exact packed beta.28 release candidate: 7/7 passed, 0 skipped
- tenant smoke plus certification methodology tests: 69 passed with beta.27
- same focused suite: 69 passed with the beta.28 candidate
- regression verifies structured error, no `media_buy_id`, and no persisted media-buy session

## Baseline note

The repository-wide pre-commit server suite currently reports four unrelated auth failures (`authorization-epoch-session` and `billing-admin-tenant-boundary`). They reproduce identically in a clean sparse worktree at the unchanged `origin/main` commit. The changed-file focused suites above are green.
