### PR TITLE
fix(compliance): use media-buy schema for creative format pagination

### DIFF
--- a/.changeset/fix-creative-formats-schema-ref.md
+++ b/.changeset/fix-creative-formats-schema-ref.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Use the media-buy request schema when validating the universal creative-format pagination storyboard, avoiding spurious `input_schema_field_stripped` notices when the target is a media-buy agent.

--- a/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
+++ b/static/compliance/source/universal/pagination-integrity-creative-formats.yaml
@@ -174,7 +174,7 @@ phases:
           non-terminal. The runner captures `pagination.cursor` for the
           follow-up step.
         task: list_creative_formats
-        schema_ref: "creative/list-creative-formats-request.json"
+        schema_ref: "media-buy/list-creative-formats-request.json"
         response_schema_ref: "creative/list-creative-formats-response.json"
         doc_ref: "/creative/task-reference/list_creative_formats"
         comply_scenario: pagination_integrity
@@ -225,7 +225,7 @@ phases:
           `cursor` field. A cursor on `has_more=false` is a stale token
           that invites callers to follow it past the end of results.
         task: list_creative_formats
-        schema_ref: "creative/list-creative-formats-request.json"
+        schema_ref: "media-buy/list-creative-formats-request.json"
         response_schema_ref: "creative/list-creative-formats-response.json"
         doc_ref: "/creative/task-reference/list_creative_formats"
         comply_scenario: pagination_integrity


### PR DESCRIPTION
## Summary

- anchor both universal creative-format pagination requests to the media-buy request schema
- preserve the existing response schema, sample payloads, and pagination assertions
- avoid spurious input_schema_field_stripped notices for media-buy agents

Closes #7143

## Verification

- npm run build:compliance
- npm run test:storyboard-sample-request-schema
- npm run test:compliance-source-authority
- npm run test:pagination-invariant
- npm run test:storyboard-doc-parity
- node scripts/check-changeset-protocol-scope.cjs origin/3.1.x
- npx --yes @changesets/cli@^3.0.0 status --since=origin/3.1.x