### PR TITLE
feat(web): close dark-mode token gaps and add chat drop overlay

### DIFF
--- a/server/public/about.html
+++ b/server/public/about.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="The member organization pioneering a human-centric advertising future through Agentic AI. Open standards, education, and governance for the agentic era.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agenticadvertising.org/about">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/adagents-builder.html
+++ b/server/public/adagents-builder.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AdAgents.json Manager - AdCP Testing Framework</title>
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
     <link rel="stylesheet" href="/layout.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -629,23 +629,8 @@
         border: var(--border-1) solid var(--color-border);
       }
 
-      .result-success {
-        background: var(--color-success-50);
-        border-color: var(--color-success-200);
-        color: var(--color-success-700);
-      }
 
-      .result-warning {
-        background: var(--color-warning-50);
-        border-color: var(--color-warning-300);
-        color: var(--color-warning-800);
-      }
 
-      .result-error {
-        background: var(--color-error-50);
-        border-color: var(--color-error-300);
-        color: var(--color-error-600);
-      }
 
       /* JSON Output */
       .json-output-container {
@@ -1909,7 +1894,7 @@
         } catch (error) {
           console.error(`Domain validation failed: ${error.message}`);
           resultsDiv.innerHTML = `
-                    <div class="validation-result result-error">
+                    <div class="validation-result result-error ds-alert ds-alert-error ds-alert-ring">
                         <strong>❌ Validation Error</strong><br>
                         ${error.message}
                     </div>
@@ -1930,21 +1915,21 @@
         // Overall status
         if (found && validation.valid) {
           html += `
-                    <div class="validation-result result-success">
+                    <div class="validation-result result-success ds-alert ds-alert-success ds-alert-ring">
                         <strong>✅ Valid AdAgents.json Found</strong><br>
                         Found at: <code>${escapeHtml(validation.url)}</code>
                     </div>
                 `;
         } else if (found && !validation.valid) {
           html += `
-                    <div class="validation-result result-warning">
+                    <div class="validation-result result-warning ds-alert ds-alert-warning ds-alert-ring">
                         <strong>⚠️ AdAgents.json Found but Invalid</strong><br>
                         Found at: <code>${escapeHtml(validation.url)}</code>
                     </div>
                 `;
         } else {
           html += `
-                    <div class="validation-result result-error">
+                    <div class="validation-result result-error ds-alert ds-alert-error ds-alert-ring">
                         <strong>❌ No AdAgents.json Found</strong><br>
                         Expected at: <code>https://${escapeHtml(domain)}/.well-known/adagents.json</code>
                     </div>

--- a/server/public/adagents-landing.html
+++ b/server/public/adagents-landing.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>adagents.json - Declare Your Advertising Inventory for AI Sales Agents</title>
   <meta name="description" content="adagents.json is a standard file that tells AI advertising agents what you publish, what inventory is available, and which agents are authorized to sell it.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================

--- a/server/public/addie-mark-on-brand.svg
+++ b/server/public/addie-mark-on-brand.svg
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Addie mark for saturated brand fills (buttons, CTAs): white body,
+     original dark eyes. Pairs with color: white, so it stays legible on
+     whatever value color-brand resolves to in either theme. -->
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="65.00 10.00 200.00 175.00">
-<path fill="#2b3796" d="
+<path fill="#ffffff" d="
   M 245.14 140.82
   Q 240.72 149.79 230.17 148.82
   Q 226.96 148.53 220.79 149.07
@@ -57,7 +60,7 @@
   Q 144.59 45.53 137.44 56.81
   Z"
 />
-<path fill="#688ae8" d="
+<path fill="#ffffff" d="
   M 192.19 55.43
   Q 164.92 59.79 137.44 56.81
   Q 144.59 45.53 151.76 34.03
@@ -66,7 +69,7 @@
   Q 184.22 42.58 192.19 55.43
   Z"
 />
-<path fill="#576fdd" d="
+<path fill="#ffffff" d="
   M 211.80 86.43
   Q 200.33 90.13 188.62 92.20
   Q 191.25 85.45 187.90 79.64
@@ -98,7 +101,7 @@
   Q 191.25 85.45 188.62 92.20
   Z"
 />
-<path fill="#4859d0" d="
+<path fill="#ffffff" d="
   M 225.74 108.39
   C 209.19 113.34 193.11 113.45 176.09 111.92
   Q 178.93 110.40 178.56 108.31
@@ -116,7 +119,7 @@
   L 225.74 108.39
   Z"
 />
-<path fill="#3b4ac2" d="
+<path fill="#ffffff" d="
   M 153.14 110.70
   Q 164.30 119.14 176.09 111.92
   C 193.11 113.45 209.19 113.34 225.74 108.39
@@ -149,7 +152,7 @@
   Q 178.93 110.40 176.09 111.92
   Z"
 />
-<path fill="#3b4ac2" d="
+<path fill="#ffffff" d="
   M 85.68 140.49
   Q 89.87 149.53 99.75 148.73
   Q 105.41 148.28 110.71 149.04
@@ -160,7 +163,7 @@
   C 76.49 148.40 81.24 144.75 85.68 140.49
   Z"
 />
-<path fill="#3b4ac2" d="
+<path fill="#ffffff" d="
   M 245.14 140.82
   C 249.53 144.14 254.45 148.58 257.18 153.49
   C 260.72 159.88 258.26 164.97 250.75 165.10
@@ -169,7 +172,7 @@
   Q 240.72 149.79 245.14 140.82
   Z"
 />
-<path fill="#3b4ac2" d="
+<path fill="#ffffff" d="
   M 145.00 154.82
   Q 142.37 164.02 137.95 170.95
   C 134.61 176.18 127.06 181.26 121.54 176.71
@@ -178,7 +181,7 @@
   Q 134.60 154.60 145.00 154.82
   Z"
 />
-<path fill="#3b4ac2" d="
+<path fill="#ffffff" d="
   M 213.16 155.24
   C 213.69 161.96 214.21 167.76 211.48 173.97
   C 209.75 177.90 205.20 179.36 201.10 177.72

--- a/server/public/admin-account-detail.html
+++ b/server/public/admin-account-detail.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Account - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/js/company-types.js"></script>
@@ -284,7 +284,7 @@
     /* Pending invoice highlight */
     .invoice-highlight {
       background: var(--color-warning-bg);
-      border-left: 3px solid var(--color-warning-500);
+      border-left: 3px solid var(--color-warning-fg);
       padding: var(--space-3);
       border-radius: var(--radius-sm);
       margin-bottom: var(--space-4);
@@ -299,13 +299,13 @@
     .next-step-item {
       padding: var(--space-3);
       background: var(--color-warning-bg);
-      border-left: 3px solid var(--color-warning-500);
+      border-left: 3px solid var(--color-warning-fg);
       border-radius: var(--radius-sm);
       margin-bottom: var(--space-3);
     }
     .next-step-item.overdue {
       background: var(--color-error-bg);
-      border-left-color: var(--color-error-500);
+      border-left-color: var(--color-error-fg);
     }
     .next-step-due {
       font-size: var(--text-xs);
@@ -313,7 +313,7 @@
       margin-bottom: var(--space-1);
     }
     .next-step-item.overdue .next-step-due {
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
     }
     .next-step-description {
       font-size: var(--text-sm);
@@ -1770,7 +1770,7 @@
 
         // Show warning if no owner
         if (!hasOwner) {
-          membersHtml += `<li class="no-owner-warning" role="alert" style="background: var(--color-warning-bg); border: 1px solid var(--color-warning-200); border-radius: var(--radius-md); padding: var(--space-3); margin-bottom: var(--space-3);">
+          membersHtml += `<li class="no-owner-warning" role="alert" style="background: var(--color-warning-bg); border: 1px solid var(--color-warning-border, var(--color-border)); border-radius: var(--radius-md); padding: var(--space-3); margin-bottom: var(--space-3);">
             <div style="display: flex; align-items: center; gap: var(--space-2); color: var(--color-warning-fg);">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>

--- a/server/public/admin-accounts.html
+++ b/server/public/admin-accounts.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Accounts - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/js/company-types.js"></script>

--- a/server/public/admin-addie-costs.html
+++ b/server/public/admin-addie-costs.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Addie Cost Cap — AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -105,10 +105,10 @@
       letter-spacing: 0.3px;
     }
     .tier-anonymous { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
-    .tier-member_free { background: var(--color-info-50); color: var(--color-info-700); }
-    .tier-member_paid { background: var(--color-success-50); color: var(--color-success-700); }
+    .tier-member_free { background: var(--color-info-bg); color: var(--color-info-fg); }
+    .tier-member_paid { background: var(--color-success-bg); color: var(--color-success-fg); }
     .tier-public_community { background: var(--color-brand-bg); color: var(--color-brand-hover); }
-    .tier-aao_team { background: var(--color-warning-50); color: var(--color-warning-700); }
+    .tier-aao_team { background: var(--color-warning-bg); color: var(--color-warning-fg); }
 
     .ns-badge {
       display: inline-block;
@@ -191,10 +191,10 @@
       margin-bottom: 16px;
     }
     .danger-btn {
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
       border-radius: 6px;
-      color: var(--color-error-700);
+      color: var(--color-error-fg);
       cursor: pointer;
       font-size: 14px;
       padding: 6px 12px;

--- a/server/public/admin-addie.html
+++ b/server/public/admin-addie.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Addie - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -146,7 +146,7 @@
       padding: var(--space-4);
     }
     .interaction-item.flagged {
-      border-color: var(--color-warning-400);
+      border-color: var(--color-warning-border, var(--color-border));
       background: var(--color-warning-bg);
     }
     .interaction-header {
@@ -565,8 +565,8 @@
     .badge-experiment { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-publish_content { background: var(--color-primary-100); color: var(--color-primary-700); }
     /* Content type badges */
-    .badge-docs { background: var(--color-info-50); color: var(--color-info-600); }
-    .badge-perspectives { background: var(--color-success-50); color: var(--color-success-600); }
+    .badge-docs { background: var(--color-info-bg); color: var(--color-info-fg); }
+    .badge-perspectives { background: var(--color-success-bg); color: var(--color-success-fg); }
     .badge-external_link { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
 
     /* Suggestion detail */
@@ -1177,7 +1177,7 @@
     .low-rated-item {
       padding: var(--space-3);
       background: var(--color-error-bg);
-      border: 1px solid var(--color-error-200);
+      border: 1px solid var(--color-error-border, var(--color-border));
       border-radius: var(--radius-md);
       cursor: pointer;
     }

--- a/server/public/admin-agreements.html
+++ b/server/public/admin-agreements.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Agreements - AdCP Registry</title>
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="/nav.js"></script>

--- a/server/public/admin-analytics.html
+++ b/server/public/admin-analytics.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Analytics - AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -139,8 +139,8 @@
     }
 
     .error {
-      background-color: var(--color-error-50);
-      color: var(--color-error-800);
+      background-color: var(--color-error-bg);
+      color: var(--color-error-fg);
       padding: 16px;
       border-radius: 8px;
       margin-bottom: 20px;

--- a/server/public/admin-announcements.html
+++ b/server/public/admin-announcements.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin — Announcements — AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>

--- a/server/public/admin-api-keys.html
+++ b/server/public/admin-api-keys.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - API Keys - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-audit.html
+++ b/server/public/admin-audit.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Audit Log - AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -126,23 +126,23 @@
     }
 
     .action-created {
-      background-color: var(--color-success-50);
-      color: var(--color-success-700);
+      background-color: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
 
     .action-updated {
-      background-color: var(--color-info-50);
-      color: var(--color-info-700);
+      background-color: var(--color-info-bg);
+      color: var(--color-info-fg);
     }
 
     .action-deleted, .action-rejected, .action-cancelled {
-      background-color: var(--color-error-50);
-      color: var(--color-error-700);
+      background-color: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
 
     .action-approved {
-      background-color: var(--color-success-50);
-      color: var(--color-success-700);
+      background-color: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
 
     .details-cell {

--- a/server/public/admin-bans.html
+++ b/server/public/admin-bans.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Bans - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -99,7 +99,7 @@
       color: var(--color-text);
       font-size: var(--text-sm);
     }
-    tbody tr:hover { background: var(--color-primary-50); }
+    tbody tr:hover { background: var(--color-brand-bg); }
     tr.clickable { cursor: pointer; }
 
     /* Badges */
@@ -110,7 +110,7 @@
       font-size: var(--text-xs);
       font-weight: var(--font-medium);
     }
-    .badge-platform { background: var(--color-error-50); color: var(--color-error-700); }
+    .badge-platform { background: var(--color-error-bg); color: var(--color-error-fg); }
     .badge-registry { background: var(--color-warning-100); color: var(--color-warning-700); }
     .badge-user { background: var(--color-primary-50); color: var(--color-primary-700); }
     .badge-organization { background: var(--color-bg-subtle); color: var(--color-text); }

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -133,7 +133,7 @@
     .link-form input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 2px var(--color-primary-100);
+      box-shadow: 0 0 0 2px var(--color-focus-ring);
     }
 
     .btn {

--- a/server/public/admin-billing.html
+++ b/server/public/admin-billing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Billing - Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -277,7 +277,7 @@
 
     /* Conflicts section */
     .conflicts-card {
-      border: var(--border-1) solid var(--color-error-200);
+      border: var(--border-1) solid var(--color-error-border, var(--color-border));
       background: var(--color-error-bg);
     }
     .conflicts-card .card-title {

--- a/server/public/admin-brand-logos.html
+++ b/server/public/admin-brand-logos.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Brand Logo Review - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-brands.html
+++ b/server/public/admin-brands.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Brands - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -294,7 +294,7 @@
     }
     .error-message {
       background: var(--color-error-bg);
-      border: 1px solid var(--color-error-200);
+      border: 1px solid var(--color-error-border, var(--color-border));
       color: var(--color-error-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);
@@ -302,7 +302,7 @@
     }
     .success-message {
       background: var(--color-success-bg);
-      border: 1px solid var(--color-success-200);
+      border: 1px solid var(--color-success-border, var(--color-border));
       color: var(--color-success-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);

--- a/server/public/admin-certification.html
+++ b/server/public/admin-certification.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Certification - AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -109,8 +109,6 @@
       100% { transform: rotate(360deg); }
     }
     .error {
-      background-color: var(--color-error-50);
-      color: var(--color-error-800);
       padding: 16px;
       border-radius: 8px;
       margin-bottom: 20px;
@@ -340,7 +338,7 @@
       <p>Loading certification data...</p>
     </div>
 
-    <div id="error" class="error" style="display: none;"></div>
+    <div id="error" class="error ds-alert ds-alert-error" style="display: none;"></div>
 
     <div id="content" style="display: none;">
       <!-- Overview metrics -->
@@ -957,7 +955,7 @@
         `;
       } catch (err) {
         console.error('Error loading detail:', err);
-        panel.innerHTML = '<button class="close-btn" onclick="closeDetail()">&times;</button><p class="error">Error loading learner detail.</p>';
+        panel.innerHTML = '<button class="close-btn" onclick="closeDetail()">&times;</button><p class="error ds-alert ds-alert-error">Error loading learner detail.</p>';
       }
     }
 

--- a/server/public/admin-community-mirrors.html
+++ b/server/public/admin-community-mirrors.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Community mirror review - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-content.html
+++ b/server/public/admin-content.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Content — AgenticAdvertising.org</title>
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -44,9 +44,9 @@
     .tab .count.alert { background: var(--color-warning-100); color: var(--color-warning-700); }
 
     /* Alert banner */
-    .alert-banner { background: var(--color-warning-50); border: var(--border-1) solid var(--color-warning-200); border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-5); display: flex; align-items: center; gap: var(--space-3); }
-    .alert-banner-content h3 { color: var(--color-warning-800); font-size: var(--text-sm); margin-bottom: var(--space-1); }
-    .alert-banner-content p { color: var(--color-warning-700); font-size: var(--text-sm); }
+    .alert-banner { border-radius: var(--radius-md); padding: var(--space-4); margin-bottom: var(--space-5); display: flex; align-items: center; gap: var(--space-3); }
+    .alert-banner-content h3 { color: var(--color-text-heading); font-size: var(--text-sm); margin-bottom: var(--space-1); }
+    .alert-banner-content p { color: var(--color-text); font-size: var(--text-sm); }
 
     /* Filter bar */
     .filter-bar { display: flex; gap: var(--space-2_5); margin-bottom: var(--space-5); flex-wrap: wrap; align-items: center; }
@@ -83,15 +83,15 @@
     .badge-article { background: var(--color-info-100); color: var(--color-info-700); }
     .badge-link { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-committee { background: var(--color-primary-50); color: var(--color-primary-700); }
-    .badge-author { background: var(--color-info-50); color: var(--color-info-700); }
+    .badge-author { background: var(--color-info-bg); color: var(--color-info-fg); }
     .badge-hero-ready { background: var(--color-success-100); color: var(--color-success-700); }
     .badge-hero-manual { background: var(--color-primary-100); color: var(--color-primary-700); }
-    .badge-proposer { background: var(--color-warning-50); color: var(--color-warning-700); }
-    .badge-owner { background: var(--color-success-50); color: var(--color-success-700); }
+    .badge-proposer { background: var(--color-warning-bg); color: var(--color-warning-fg); }
+    .badge-owner { background: var(--color-success-bg); color: var(--color-success-fg); }
     .authors-list { display: flex; gap: var(--space-1); flex-wrap: wrap; margin-top: var(--space-1); }
     .author-tag { background: var(--color-bg-subtle); padding: 2px var(--space-2); border-radius: var(--radius-sm); font-size: var(--text-xs); color: var(--color-text-secondary); }
     .proposer-info { font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-2); }
-    .rejection-reason { background: var(--color-error-50); border: var(--border-1) solid var(--color-error-200); border-radius: var(--radius-md); padding: var(--space-3); margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-error-700); }
+    .rejection-reason { border-radius: var(--radius-md); padding: var(--space-3); margin-top: var(--space-2); font-size: var(--text-sm); }
 
     /* Buttons */
     .btn { padding: var(--space-2) var(--space-4); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; transition: var(--transition-all); text-decoration: none; display: inline-flex; align-items: center; gap: var(--space-1_5); }
@@ -218,7 +218,7 @@
     .empty-state p { max-width: 36ch; margin: 0 auto; line-height: var(--leading-relaxed); }
 
     /* Confirm dialog inline */
-    .confirm-inline { background: var(--color-warning-50); border: var(--border-1) solid var(--color-warning-200); border-radius: var(--radius-md); padding: var(--space-3); margin-top: var(--space-2); display: flex; align-items: center; gap: var(--space-3); font-size: var(--text-sm); }
+    .confirm-inline { background: var(--color-warning-bg); border: var(--border-1) solid var(--color-warning-border, var(--color-border)); border-radius: var(--radius-md); padding: var(--space-3); margin-top: var(--space-2); display: flex; align-items: center; gap: var(--space-3); font-size: var(--text-sm); }
 
     /* Participation summary */
     .participation-summary { display: flex; gap: var(--space-5); align-items: center; padding: var(--space-4) var(--space-5); margin-bottom: var(--space-4); background: var(--color-bg-subtle); border-radius: var(--radius-md); border: var(--border-1) solid var(--color-gray-200); }
@@ -291,7 +291,7 @@
       </div>
 
       <!-- Alert banner for pending reviews -->
-      <div id="pendingAlert" class="alert-banner hidden">
+      <div id="pendingAlert" class="alert-banner hidden ds-alert ds-alert-warning ds-alert-ring">
         <div class="alert-banner-content">
           <h3>Content awaiting review</h3>
           <p id="pendingAlertText"></p>
@@ -522,7 +522,7 @@
           </div>
         </div>
 
-        <div id="publishedEditWarning" class="alert-banner hidden">
+        <div id="publishedEditWarning" class="alert-banner hidden ds-alert ds-alert-warning ds-alert-ring">
           <div class="alert-banner-content">
             <h3>Published edits require review</h3>
             <p>Your changes will be removed from the live site and submitted for review before they are published again.</p>
@@ -1037,9 +1037,9 @@
       const authors = (item.authors || []).map(a => `<span class="author-tag">${esc(a.display_name)}</span>`).join('');
       const proposerInfo = item.proposer ? `<div class="proposer-info">Proposed by ${esc(item.proposer.name)} on ${formatDate(item.proposed_at)}</div>` : '';
       const rejectionInfo = item.status === 'rejected' && item.rejection_reason
-        ? `<div class="rejection-reason"><strong>Rejection reason:</strong> ${esc(item.rejection_reason)}</div>`
+        ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring"><strong>Rejection reason:</strong> ${esc(item.rejection_reason)}</div>`
         : item.status === 'needs_revisions' && item.revision_notes
-          ? `<div class="rejection-reason" style="border-color: var(--color-warning-300);"><strong>Revision notes:</strong> ${esc(item.revision_notes)}</div>`
+          ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring" style="border-color: var(--color-warning-300);"><strong>Revision notes:</strong> ${esc(item.revision_notes)}</div>`
           : '';
 
       const pageviews30d = Number(item.performance?.pageviews_last_30d || 0);
@@ -1263,10 +1263,10 @@
 
       const reviewNotes = document.getElementById('articleReviewNotes');
       const rejectionInfo = item.rejection_reason
-        ? `<div class="rejection-reason"><strong>Rejection reason:</strong> ${esc(item.rejection_reason)}</div>`
+        ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring"><strong>Rejection reason:</strong> ${esc(item.rejection_reason)}</div>`
         : '';
       const revisionInfo = item.revision_notes
-        ? `<div class="rejection-reason" style="border-color: var(--color-warning-300); color: var(--color-warning-700); background: var(--color-warning-50);"><strong>Revision notes:</strong> ${esc(item.revision_notes)}</div>`
+        ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring" style="border-color: var(--color-warning-300); color: var(--color-warning-700); background: var(--color-warning-50);"><strong>Revision notes:</strong> ${esc(item.revision_notes)}</div>`
         : '';
       reviewNotes.innerHTML = `${rejectionInfo}${revisionInfo}`;
 

--- a/server/public/admin-data-cleanup.html
+++ b/server/public/admin-data-cleanup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Data Cleanup - Admin Tools - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
@@ -235,25 +235,13 @@
       padding: var(--space-3);
       border-radius: var(--radius-md);
     }
-    .action-panel-warning {
-      background: var(--color-warning-50);
-      border: 1px solid var(--color-warning-200);
-    }
-    .action-panel-info {
-      background: var(--color-info-50);
-      border: 1px solid var(--color-info-200);
-    }
-    .action-panel-success {
-      background: var(--color-success-50);
-      border: 1px solid var(--color-success-200);
-    }
     .action-panel-title {
       font-weight: var(--font-semibold);
       margin-bottom: var(--space-2);
     }
-    .action-panel-warning .action-panel-title { color: var(--color-warning-700); }
-    .action-panel-info .action-panel-title { color: var(--color-info-700); }
-    .action-panel-success .action-panel-title { color: var(--color-success-700); }
+    .action-panel-warning .action-panel-title { color: var(--color-text-heading); }
+    .action-panel-info .action-panel-title { color: var(--color-text-heading); }
+    .action-panel-success .action-panel-title { color: var(--color-text-heading); }
   </style>
 </head>
 <body>
@@ -569,7 +557,7 @@
 
         if (mergeActions.length > 0) {
           actionsHtml += `
-            <div class="action-panel action-panel-warning">
+            <div class="action-panel action-panel-warning ds-alert ds-alert-warning ds-alert-ring">
               <div class="action-panel-title">Duplicate Organizations Found</div>
               ${mergeActions.map(a => `
                 <div style="margin-top: var(--space-3); padding: var(--space-3); background: var(--color-bg-card); border-radius: var(--radius-sm);">
@@ -593,7 +581,7 @@
 
         if (updateActions.length > 0) {
           actionsHtml += `
-            <div class="action-panel action-panel-info">
+            <div class="action-panel action-panel-info ds-alert ds-alert-info ds-alert-ring">
               <div class="action-panel-title">Recommended Updates</div>
               <ul style="margin: var(--space-2) 0 0 var(--space-4); list-style: none; padding: 0;">
                 ${updateActions.map(a => {
@@ -617,7 +605,7 @@
 
         if (enrichActions.length > 0) {
           actionsHtml += `
-            <div class="action-panel action-panel-success">
+            <div class="action-panel action-panel-success ds-alert ds-alert-success ds-alert-ring">
               <div class="action-panel-title">Enrichment Available</div>
               <div style="margin-top: var(--space-2);">
                 <button class="btn btn-primary btn-sm" onclick="enrichAccount('${orgId}')">Enrich with Lusha</button>
@@ -690,7 +678,7 @@
         const preview = await response.json();
 
         const warningsHtml = preview.warnings.length > 0 ? `
-          <div class="action-panel action-panel-warning" style="margin-bottom: var(--space-4);">
+          <div class="action-panel action-panel-warning ds-alert ds-alert-warning ds-alert-ring" style="margin-bottom: var(--space-4);">
             <strong>Warnings:</strong>
             <ul style="margin: var(--space-2) 0 0 var(--space-4);">
               ${preview.warnings.map(w => `<li>${escapeHtml(w)}</li>`).join('')}
@@ -841,7 +829,7 @@
                 <h3 style="color: var(--color-success-600); margin-bottom: var(--space-4);">Merge Complete</h3>
                 <p>Successfully merged organizations. ${totalMoved} records were moved.</p>
                 ${result.warnings.length > 0 ? `
-                  <div class="action-panel action-panel-warning" style="margin-top: var(--space-3);">
+                  <div class="action-panel action-panel-warning ds-alert ds-alert-warning ds-alert-ring" style="margin-top: var(--space-3);">
                     <strong>Notes:</strong>
                     <ul style="margin: var(--space-1) 0 0 var(--space-4);">
                       ${result.warnings.map(w => `<li>${escapeHtml(w)}</li>`).join('')}

--- a/server/public/admin-domain-discovery.html
+++ b/server/public/admin-domain-discovery.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Domain Discovery - Admin Tools - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/js/company-types.js"></script>

--- a/server/public/admin-domain-health.html
+++ b/server/public/admin-domain-health.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Domain Health - Admin - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -139,14 +139,14 @@
       display: inline-block;
       margin-left: var(--space-1);
       padding: var(--space-0_5) var(--space-1);
-      background: var(--color-warning-100);
-      color: var(--color-warning-700);
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
       border-radius: var(--radius-sm);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
     }
     .claimed-tag:hover {
-      background: var(--color-warning-50);
+      background: var(--color-warning-border, var(--color-warning-bg));
     }
     .personal-tag {
       display: inline-block;

--- a/server/public/admin-email.html
+++ b/server/public/admin-email.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Email Management - AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -153,8 +153,8 @@
     }
 
     .status-sent {
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
 
     .status-draft {
@@ -163,8 +163,8 @@
     }
 
     .status-scheduled {
-      background: var(--color-info-50);
-      color: var(--color-info-700);
+      background: var(--color-info-bg);
+      color: var(--color-info-fg);
     }
 
     .btn {

--- a/server/public/admin-escalation-triage.html
+++ b/server/public/admin-escalation-triage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Escalation Triage - AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>

--- a/server/public/admin-escalations.html
+++ b/server/public/admin-escalations.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Escalations - AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>
@@ -176,16 +176,13 @@
       white-space: pre-wrap;
     }
     .info-banner {
-      background: var(--color-warning-50);
-      border: var(--border-1) solid var(--color-warning-200);
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-5);
       font-size: var(--text-sm);
-      color: var(--color-warning-800);
     }
     .info-banner a {
-      color: var(--color-warning-700);
+      color: var(--color-brand);
       font-weight: var(--font-medium);
     }
   </style>
@@ -207,7 +204,7 @@
           </div>
         </div>
 
-        <div id="notConfiguredBanner" class="info-banner" style="display: none;">
+        <div id="notConfiguredBanner" class="info-banner ds-alert ds-alert-warning ds-alert-ring" style="display: none;">
           <strong>Notifications not configured.</strong>
           Escalation notifications are disabled. <a href="/admin/settings">Configure a Slack channel</a> to receive alerts when users need help.
         </div>

--- a/server/public/admin-events.html
+++ b/server/public/admin-events.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Events - AAO</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>

--- a/server/public/admin-feeds.html
+++ b/server/public/admin-feeds.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Industry Feeds - AdCP Registry</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>
@@ -428,8 +428,6 @@
       font-size: var(--text-xs);
     }
     .email-info-box {
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
       border-radius: var(--radius-md);
       padding: var(--space-4);
     }
@@ -440,7 +438,7 @@
     .email-info-box ol {
       margin: 0;
       padding-left: var(--space-5);
-      color: var(--color-text-secondary);
+      color: var(--color-text);
       font-size: var(--text-sm);
     }
     .email-info-box li {
@@ -449,9 +447,9 @@
     .email-section {
       margin-top: var(--space-3);
       padding: var(--space-3);
-      background: var(--color-info-50);
+      background: var(--color-info-bg);
       border-radius: var(--radius-md);
-      border: var(--border-1) solid var(--color-info-200);
+      border: var(--border-1) solid var(--color-info-border, var(--color-border));
     }
     .email-address {
       font-family: var(--font-mono);
@@ -608,7 +606,7 @@
         <!-- Email-specific info -->
         <div id="emailFields" style="display: none;">
           <div class="form-group">
-            <div class="email-info-box">
+            <div class="email-info-box ds-alert ds-alert-info ds-alert-ring">
               <p><strong>How it works:</strong></p>
               <ol>
                 <li>Enter a name for the newsletter source below</li>

--- a/server/public/admin-geo.html
+++ b/server/public/admin-geo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>GEO visibility - Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -193,8 +193,6 @@
     }
 
     .error {
-      background-color: var(--color-error-50);
-      color: var(--color-error-700);
       padding: 16px;
       border-radius: 8px;
       margin-bottom: 20px;
@@ -434,7 +432,7 @@
       <p>Loading GEO visibility data...</p>
     </div>
 
-    <div id="error" class="error" role="alert" style="display: none;"></div>
+    <div id="error" class="error ds-alert ds-alert-error" role="alert" style="display: none;"></div>
     <div id="stale-banner" class="status-banner warning" role="status" aria-live="polite"></div>
 
     <div id="unconfigured" class="unconfigured" style="display: none;">

--- a/server/public/admin-jobs.html
+++ b/server/public/admin-jobs.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Jobs - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-manifest-refs.html
+++ b/server/public/admin-manifest-refs.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Manifest Registry - Admin</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/server/public/admin-meetings.html
+++ b/server/public/admin-meetings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Meetings - AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>

--- a/server/public/admin-moltbook.html
+++ b/server/public/admin-moltbook.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Moltbook - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -177,7 +177,8 @@
       font-size: var(--text-sm);
       margin-top: var(--space-2);
       padding: var(--space-3);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
+      color: var(--color-text);
       border-radius: var(--radius-sm);
       font-style: italic;
     }
@@ -322,12 +323,12 @@
       font-size: var(--text-sm);
     }
     .result-box.success {
-      background: var(--color-success-50);
-      border: 1px solid var(--color-success-200);
+      background: var(--color-success-bg);
+      border: 1px solid var(--color-success-border, var(--color-border));
     }
     .result-box.error {
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
     }
 
     /* Loading */

--- a/server/public/admin-network-health.html
+++ b/server/public/admin-network-health.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Network Health - Admin - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-newsletter.html
+++ b/server/public/admin-newsletter.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/sage-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Newsletter</title>
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -81,7 +81,7 @@
 
     .paste-area { width: 100%; min-height: 200px; font-family: monospace; font-size: 13px; padding: 12px; border: 1px solid var(--color-border-strong); border-radius: 6px; resize: vertical; box-sizing: border-box; }
     .paste-area:focus { border-color: var(--nl-primary); outline: none; }
-    .paste-warning { background: var(--color-warning-50); border: 1px solid var(--color-warning-200); border-left: 4px solid var(--color-warning-500); border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; color: var(--color-warning-800); font-size: 13px; line-height: 1.45; }
+    .paste-warning { border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; font-size: 13px; line-height: 1.45; }
 
     .mode-tabs { display: flex; gap: 0; margin-bottom: 16px; border-bottom: 2px solid var(--color-border); }
     .mode-tab { padding: 8px 16px; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); cursor: pointer; border: none; border-bottom: 2px solid transparent; margin-bottom: -2px; background: none; }
@@ -125,7 +125,7 @@
       <div id="pasteMode" style="display:none;">
         <div class="section">
           <h2>Paste your newsletter</h2>
-          <div class="paste-warning">
+          <div class="paste-warning ds-alert ds-alert-warning ds-alert-ring">
             Replace content hides the auto-generated body sections and sends this pasted body instead. Custom sections still send unless you remove them separately.
           </div>
           <p class="section-hint">Replaces all auto-generated sections. Use **bold**, [links](url), and `code` markdown.</p>

--- a/server/public/admin-notification-channels.html
+++ b/server/public/admin-notification-channels.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Notification Channels - AdCP Registry</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>
@@ -253,7 +253,7 @@
     }
     .info-box {
       background: var(--color-info-bg);
-      border: var(--border-1) solid var(--color-info-200);
+      border: var(--border-1) solid var(--color-info-border, var(--color-border));
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-5);

--- a/server/public/admin-outreach.html
+++ b/server/public/admin-outreach.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Outreach - AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>

--- a/server/public/admin-people.html
+++ b/server/public/admin-people.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - People - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-policies.html
+++ b/server/public/admin-policies.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Policies - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-products.html
+++ b/server/public/admin-products.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Products - AdCP Registry</title>
   <script src="/admin-nav.js"></script>
   <link rel="stylesheet" href="/design-system.css">
@@ -277,12 +277,9 @@
       border-color: var(--color-error-700);
     }
     .form-error {
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
       border-radius: var(--radius-md);
       padding: var(--space-3);
       margin-bottom: var(--space-4);
-      color: var(--color-error-700);
       font-size: var(--text-sm);
     }
     .invoiceable-yes {
@@ -386,7 +383,7 @@
         <button class="modal-close" onclick="closeProductModal()">&times;</button>
       </div>
 
-      <div id="formError" class="form-error" style="display: none;"></div>
+      <div id="formError" class="form-error ds-alert ds-alert-error ds-alert-ring" style="display: none;"></div>
 
       <form id="productForm" onsubmit="saveProduct(event)">
         <input type="hidden" id="editProductId" value="">

--- a/server/public/admin-products.html
+++ b/server/public/admin-products.html
@@ -231,7 +231,7 @@
     .form-group textarea:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .form-group .help-text {
       font-size: var(--text-xs);

--- a/server/public/admin-prompt-metrics.html
+++ b/server/public/admin-prompt-metrics.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Suggested-prompt metrics — AdCP Admin</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-properties.html
+++ b/server/public/admin-properties.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Properties - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -242,17 +242,17 @@
       border-top: var(--border-1) solid var(--color-gray-200);
     }
     .error-message {
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
-      color: var(--color-error-700);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
+      color: var(--color-error-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
     }
     .success-message {
-      background: var(--color-success-50);
-      border: 1px solid var(--color-success-200);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      border: 1px solid var(--color-success-border, var(--color-border));
+      color: var(--color-success-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);

--- a/server/public/admin-referrals.html
+++ b/server/public/admin-referrals.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Referrals - Admin - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-referrals.html
+++ b/server/public/admin-referrals.html
@@ -93,7 +93,7 @@
     .form-group input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .form-actions {

--- a/server/public/admin-relationship-detail.html
+++ b/server/public/admin-relationship-detail.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Person memory · AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-settings.html
+++ b/server/public/admin-settings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - System Settings - AgenticAdvertising.org</title>
   <script src="/nav.js"></script>
   <script src="/admin-sidebar.js"></script>
@@ -104,11 +104,11 @@
       align-items: center;
       gap: var(--space-2);
       padding: var(--space-2) var(--space-3);
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
+      background: var(--color-info-bg);
+      border: var(--border-1) solid var(--color-info-border, var(--color-border));
       border-radius: var(--radius-sm);
       font-size: var(--text-sm);
-      color: var(--color-info-700);
+      color: var(--color-info-fg);
       margin-bottom: var(--space-4);
     }
     .current-value.not-set {
@@ -131,13 +131,10 @@
       color: var(--color-error-700);
     }
     .info-box {
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-5);
       font-size: var(--text-sm);
-      color: var(--color-info-700);
     }
     .loading-channels {
       padding: var(--space-4);
@@ -162,7 +159,7 @@
 
         <div id="statusMessage" class="status-message" style="display: none;"></div>
 
-        <div class="info-box">
+        <div class="info-box ds-alert ds-alert-info ds-alert-ring">
           These settings control how the system behaves. Changes take effect immediately.
         </div>
 

--- a/server/public/admin-sidebar.js
+++ b/server/public/admin-sidebar.js
@@ -184,8 +184,8 @@
     }
 
     .admin-nav-item.active {
-      background: var(--color-primary-50);
-      color: var(--color-brand);
+      background: var(--color-brand-bg);
+      color: var(--color-brand-fg, var(--color-brand));
       border-left-color: var(--color-brand);
       font-weight: 500;
     }

--- a/server/public/admin-simulations.html
+++ b/server/public/admin-simulations.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Outreach simulator - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/admin-users.html
+++ b/server/public/admin-users.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Users & Actions - AgenticAdvertising.org</title>
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/css/thread-widget.css">
@@ -535,7 +535,7 @@
     /* Sync banner */
     .sync-banner {
       background: var(--color-info-bg);
-      border: 1px solid var(--color-info-200);
+      border: 1px solid var(--color-info-border, var(--color-border));
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-5);

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Committees - AdCP Registry</title>
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="/nav.js"></script>

--- a/server/public/admin.html
+++ b/server/public/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>

--- a/server/public/agent-viewer.html
+++ b/server/public/agent-viewer.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agent registry profile</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/design-system.css" />
     <style>
       body {
@@ -98,26 +99,26 @@
         font-weight: var(--font-semibold);
         background: var(--color-info-bg);
         color: var(--color-info-fg);
-        border: 1px solid var(--color-info-200);
+        border: 1px solid var(--color-info-border, var(--color-border));
         white-space: nowrap;
       }
 
       .pill.success {
         background: var(--color-success-bg);
         color: var(--color-success-fg);
-        border-color: var(--color-success-200);
+        border-color: var(--color-success-border, var(--color-border));
       }
 
       .pill.warning {
         background: var(--color-warning-bg);
         color: var(--color-warning-fg);
-        border-color: var(--color-warning-200);
+        border-color: var(--color-warning-border, var(--color-border));
       }
 
       .pill.error {
         background: var(--color-error-bg);
         color: var(--color-error-fg);
-        border-color: var(--color-error-200);
+        border-color: var(--color-error-border, var(--color-border));
       }
 
       .badge-list {

--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Agents | AgenticAdvertising.org</title>
     <meta name="description" content="Sales, creative, and signals agents implementing AdCP.">
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
     <link rel="stylesheet" href="/layout.css">
     <style>
@@ -40,7 +40,7 @@
         .search-box input:focus {
             outline: none;
             border-color: var(--color-brand);
-            box-shadow: 0 0 0 3px var(--color-primary-100);
+            box-shadow: 0 0 0 3px var(--color-focus-ring);
         }
         .filter-row {
             display: flex;
@@ -196,8 +196,8 @@
         }
         .streak-badge {
             padding: var(--space-1) var(--space-2);
-            background: var(--color-success-50);
-            color: var(--color-success-700);
+            background: var(--color-success-bg);
+            color: var(--color-success-fg);
             border-radius: var(--radius-full);
             font-size: var(--text-xs);
             font-weight: var(--font-semibold);
@@ -301,19 +301,14 @@
         .status-banner > div:first-child { display: flex; flex-direction: column; align-items: flex-start; }
 
         /* Compliance badge */
+        /* Layout only — colour, padding and the left accent come from .ds-alert */
         .compliance-badge {
-            border-left: 4px solid;
-            padding: var(--space-4);
-            border-radius: var(--radius-md);
             margin-bottom: var(--space-8);
             display: flex;
             align-items: center;
             gap: var(--space-3);
         }
-        .compliance-badge--compliant { background: var(--color-success-50); border-color: var(--color-success-500); }
-        .compliance-badge--incomplete { background: var(--color-warning-50); border-color: var(--color-warning-500); }
-        .compliance-badge__title { font-size: var(--text-lg); font-weight: var(--font-semibold); }
-        .compliance-badge__subtitle { font-size: var(--text-sm); color: var(--color-text-muted); margin-top: var(--space-1); }
+        .compliance-badge__title { font-size: var(--text-lg); }
 
         /* Collapsible detail sections */
         .detail-section__summary {
@@ -332,15 +327,7 @@
         details summary::-webkit-details-marker { display: none; }
 
         /* Tools list */
-        .tools-summary {
-            background: var(--color-info-50);
-            padding: var(--space-4);
-            border-radius: var(--radius-md);
-            border-left: 3px solid var(--color-info-500);
-            margin-bottom: var(--space-6);
-        }
-        .tools-summary__count { font-weight: var(--font-semibold); }
-        .tools-summary__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
+        .tools-summary { margin-bottom: var(--space-6); }
         .tools-list { display: grid; gap: var(--space-4); }
         .tool-item {
             background: var(--color-bg-subtle);
@@ -367,7 +354,7 @@
             border-radius: var(--radius-md);
         }
         .publisher-item--verified { border-left: 3px solid var(--color-success-500); }
-        .publisher-item--unverified { border-left: 3px solid var(--color-error-500); background: var(--color-error-bg); }
+        .publisher-item--unverified { border-left: 3px solid var(--color-error-fg); background: var(--color-error-bg); }
         .publisher-item--unchecked { border-left: 3px solid var(--color-warning-500); }
         .publisher-domain { font-weight: var(--font-semibold); margin-bottom: var(--space-1); }
         .publisher-verify-link { color: var(--color-brand); text-decoration: none; font-size: var(--text-xs); white-space: nowrap; }
@@ -387,14 +374,6 @@
         .product-card__name { font-weight: var(--font-semibold); margin-bottom: var(--space-2); }
         .product-card__desc { font-size: var(--text-sm); color: var(--color-text-muted); margin-bottom: var(--space-2); }
         .product-card__meta { font-size: var(--text-xs); color: var(--color-text-muted); }
-        .agent-params-required {
-            background: var(--color-warning-50);
-            padding: var(--space-4);
-            border-radius: var(--radius-md);
-            border-left: 3px solid var(--color-warning-500);
-        }
-        .agent-params-required__title { font-weight: var(--font-semibold); }
-        .agent-params-required__desc { margin-top: var(--space-2); font-size: var(--text-sm); color: var(--color-text-muted); }
 
         /* Format cards */
         .format-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-4); }
@@ -450,15 +429,15 @@
         .format-modal__cta:hover { background: var(--color-brand-hover); }
 
         /* Info box */
-        .info-box { background: var(--color-bg-subtle); padding: var(--space-4); border-radius: var(--radius-md); }
+        .info-box { background: var(--color-bg-subtle); border: 1px solid var(--color-border); padding: var(--space-4); border-radius: var(--radius-md); }
         .info-box__desc { margin-bottom: var(--space-4); font-size: var(--text-base); }
         .info-box__grid { display: grid; gap: var(--space-3); }
-        .info-box__code { background: var(--color-primary-100); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-size: var(--text-sm); word-break: break-all; }
+        .info-box__code { background: var(--color-code-bg); color: var(--color-code-text); border: 1px solid var(--color-code-border); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--text-sm); word-break: break-all; -webkit-box-decoration-break: clone; box-decoration-break: clone; }
         .info-box__contact { margin-top: var(--space-6); padding-top: var(--space-6); border-top: 1px solid var(--color-border); }
         .info-box__contact-link { color: var(--color-brand); }
 
         /* Error states */
-        .tool-error-box { font-size: var(--text-xs); color: var(--color-error-fg); padding: var(--space-2); background: var(--color-error-bg); border-radius: var(--radius-sm); border-left: 3px solid var(--color-error-500); }
+        .tool-error-box { font-size: var(--text-xs); color: var(--color-error-fg); padding: var(--space-2); background: var(--color-error-bg); border-radius: var(--radius-sm); border-left: 3px solid var(--color-error-fg); }
         .tool-error-box__title { font-weight: var(--font-semibold); }
         .tool-error-box__msg { font-size: var(--text-xs); color: var(--color-error-fg); font-family: monospace; word-break: break-word; }
 
@@ -975,10 +954,10 @@
                     if (toolNames.has('get_media_buy_delivery')) capLabels.push('Reporting');
 
                     html += `
-                        <div class="compliance-badge ${hasCoreTools ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
+                        <div class="compliance-badge ds-alert ${hasCoreTools ? 'ds-alert-success' : 'ds-alert-warning'}">
                             <div>
-                                <div class="compliance-badge__title">${hasCoreTools ? 'AdCP sales agent' : 'Incomplete implementation'}</div>
-                                <div class="compliance-badge__subtitle">
+                                <div class="ds-alert__title compliance-badge__title">${hasCoreTools ? 'AdCP sales agent' : 'Incomplete implementation'}</div>
+                                <div class="ds-alert__desc">
                                     ${capLabels.length > 0 ? capLabels.join(' &middot; ') : 'Implements ' + coreImplemented.length + ' tools'}
                                     &middot; ${agentToolCount(agentWithCaps)} tools
                                 </div>
@@ -997,10 +976,10 @@
                     if (hasOptionalPreview) capabilities.push('Preview');
 
                     html += `
-                        <div class="compliance-badge ${isCompliant ? 'compliance-badge--compliant' : 'compliance-badge--incomplete'}">
+                        <div class="compliance-badge ds-alert ${isCompliant ? 'ds-alert-success' : 'ds-alert-warning'}">
                             <div>
-                                <div class="compliance-badge__title">${isCompliant ? 'AdCP creative agent' : 'Incomplete implementation'}</div>
-                                <div class="compliance-badge__subtitle">
+                                <div class="ds-alert__title compliance-badge__title">${isCompliant ? 'AdCP creative agent' : 'Incomplete implementation'}</div>
+                                <div class="ds-alert__desc">
                                     ${isCompliant ?
                                         `${supportedFormats.length} canonical capability(s)${capabilities.length > 0 ? ' &middot; ' + capabilities.join(' &middot; ') : ''}` :
                                         'Missing creative.supported_formats declaration'}
@@ -1015,11 +994,11 @@
             if (agent.compliance && agent.compliance.status !== 'unknown') {
                 const cs = agent.compliance;
                 const statusColors = {
-                    passing: { bg: 'var(--color-success-50)', border: 'var(--color-success-500)', label: 'Passing' },
-                    degraded: { bg: 'var(--color-warning-50)', border: 'var(--color-warning-500)', label: 'Degraded' },
-                    failing: { bg: 'var(--color-error-50)', border: 'var(--color-error-500)', label: 'Failing' },
+                    passing: { variant: 'ds-alert-success', label: 'Passing' },
+                    degraded: { variant: 'ds-alert-warning', label: 'Degraded' },
+                    failing: { variant: 'ds-alert-error', label: 'Failing' },
                 };
-                const sc = statusColors[cs.status] || { bg: 'var(--color-gray-100)', border: 'var(--color-gray-400)', label: 'Unknown' };
+                const sc = statusColors[cs.status] || { variant: 'ds-alert-info', label: 'Unknown' };
 
                 let trackPillsHtml = '';
                 const tracks = cs.tracks || {};
@@ -1032,13 +1011,13 @@
                 }
 
                 html += `
-                    <div class="compliance-badge" style="background: ${sc.bg}; border-color: ${sc.border};">
+                    <div class="compliance-badge ds-alert ${sc.variant}">
                         <div>
-                            <div class="compliance-badge__title">
+                            <div class="ds-alert__title compliance-badge__title">
                                 Compliance: ${sc.label}
                                 ${cs.streak_days > 0 ? `<span class="streak-badge">${parseInt(cs.streak_days, 10)}d streak</span>` : ''}
                             </div>
-                            <div class="compliance-badge__subtitle">
+                            <div class="ds-alert__desc">
                                 ${cs.headline ? escapeHtml(cs.headline) : ''}
                                 ${cs.last_checked_at ? ` &middot; Last checked: ${new Date(cs.last_checked_at).toLocaleString()}` : ''}
                             </div>
@@ -1172,18 +1151,18 @@
 
             if (tools.length === 0) {
                 section.innerHTML = `
-                    <div class="tools-summary">
-                        <span class="tools-summary__count">Total tools: ${toolCount}</span>
-                        <p class="tools-summary__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                    <div class="tools-summary ds-alert ds-alert-info">
+                        <span class="ds-alert__title">Total tools: ${toolCount}</span>
+                        <p class="ds-alert__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
                     </div>
                 `;
                 return;
             }
 
             let html = `
-                <div class="tools-summary">
-                    <span class="tools-summary__count">Total tools: ${toolCount}</span>
-                    <p class="tools-summary__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
+                <div class="tools-summary ds-alert ds-alert-info">
+                    <span class="ds-alert__title">Total tools: ${toolCount}</span>
+                    <p class="ds-alert__desc">This agent exposes ${toolCount} tools via ${agent.protocol || 'mcp'} protocol.</p>
                 </div>
                 <div class="tools-list">
             `;
@@ -1372,9 +1351,9 @@
                 const message = data.error?.message || data.message || data.error || 'Unknown error';
                 const isValidationError = message.includes('does not match') || message.includes('Input should be');
                 section.innerHTML = `
-                    <div class="agent-params-required">
-                        <div class="agent-params-required__title">${isValidationError ? 'Agent requires parameters' : 'Agent error'}</div>
-                        <div class="agent-params-required__desc">
+                    <div class="ds-alert ds-alert-warning">
+                        <div class="ds-alert__title">${isValidationError ? 'Agent requires parameters' : 'Agent error'}</div>
+                        <div class="ds-alert__desc">
                             ${isValidationError ? 'This agent requires specific targeting criteria (brief, brand_manifest, etc.) and does not support browsing public products.' : escapeHtml(message)}
                         </div>
                     </div>

--- a/server/public/agreement.html
+++ b/server/public/agreement.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agreement - AgenticAdvertising.org</title>
   <meta name="description" content="Read the current AgenticAdvertising.org membership agreement.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/ai-disclosure.html
+++ b/server/public/ai-disclosure.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="How AgenticAdvertising.org uses AI — what's AI-authored, what's AI-assisted, model and provider disclosure, and how to request human review.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agenticadvertising.org/ai-disclosure">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>brand.json Builder - AdCP Brand Protocol</title>
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
     <link rel="stylesheet" href="/layout.css">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -331,16 +331,11 @@
         color: var(--color-primary-800);
       }
 
-      .result-warning {
-        background: var(--color-warning-50);
-        border: 1px solid var(--color-warning-200);
-        color: var(--color-warning-800);
-      }
 
       .result-error {
-        background: var(--color-error-50);
-        border: 1px solid var(--color-error-200);
-        color: var(--color-error-800);
+        background: var(--color-error-bg);
+        border: 1px solid var(--color-error-border, var(--color-border));
+        color: var(--color-error-fg);
       }
 
       .result-info {
@@ -553,8 +548,6 @@
 
       /* Next Steps Styles */
       .next-steps {
-        background: var(--color-success-50);
-        border: 1px solid var(--color-success-100);
         border-radius: var(--radius-lg);
         padding: var(--space-5);
         margin-top: var(--space-6);
@@ -562,7 +555,7 @@
 
       .next-steps h4 {
         margin: 0 0 var(--space-4) 0;
-        color: var(--color-success-700);
+        color: var(--color-text-heading);
         display: flex;
         align-items: center;
         gap: var(--space-2);
@@ -608,13 +601,13 @@
       .step-content strong {
         display: block;
         margin-bottom: var(--space-1);
-        color: var(--color-success-700);
+        color: var(--color-text-heading);
       }
 
       .step-content p {
         margin: 0 0 var(--space-2) 0;
         font-size: var(--text-sm);
-        color: var(--text-secondary);
+        color: var(--color-text);
       }
 
       .step-content code {
@@ -622,7 +615,7 @@
         padding: var(--space-1) var(--space-2);
         border-radius: var(--radius-sm);
         font-size: var(--text-sm);
-        border: 1px solid var(--color-success-100);
+        border: 1px solid var(--color-success-border, var(--color-border));
       }
 
       .registry-setup-panel {
@@ -667,21 +660,21 @@
       }
 
       .verify-result.success {
-        background: var(--color-success-50);
-        border: 1px solid var(--color-success-100);
-        color: var(--color-success-700);
+        background: var(--color-success-bg);
+        border: 1px solid var(--color-success-border, var(--color-border));
+        color: var(--color-success-fg);
       }
 
       .verify-result.error {
-        background: var(--color-error-50);
-        border: 1px solid var(--color-error-100);
-        color: var(--color-error-700);
+        background: var(--color-error-bg);
+        border: 1px solid var(--color-error-border, var(--color-border));
+        color: var(--color-error-fg);
       }
 
       .verify-result.pending {
-        background: var(--color-warning-50);
-        border: 1px solid var(--color-warning-100);
-        color: var(--color-warning-700);
+        background: var(--color-warning-bg);
+        border: 1px solid var(--color-warning-border, var(--color-border));
+        color: var(--color-warning-fg);
       }
 
       /* Portfolio Two-Panel Layout */
@@ -1632,7 +1625,7 @@
           </details>
 
           <!-- Next Steps / Success State -->
-          <div class="next-steps" id="next-steps">
+          <div class="next-steps ds-alert ds-alert-success ds-alert-ring" id="next-steps">
             <h4>Next steps</h4>
             <div class="registry-setup-panel hidden" id="registry-setup-panel">
               <p id="registry-setup-message">
@@ -2066,7 +2059,7 @@
           try {
             const savedDate = new Date(savedDraft.savedAt).toLocaleString();
             validationResults.innerHTML = `
-              <div class="validation-result result-warning">
+              <div class="validation-result result-warning ds-alert ds-alert-warning ds-alert-ring">
                 <strong>No brand.json found</strong><br>
                 Restored your previous draft for ${escapeHtml(domain)} (saved ${escapeHtml(savedDate)})
               </div>

--- a/server/public/brand-builder.html
+++ b/server/public/brand-builder.html
@@ -966,7 +966,7 @@
 
       .chip-container:focus-within {
         border-color: var(--color-brand);
-        box-shadow: 0 0 0 3px var(--color-primary-100);
+        box-shadow: 0 0 0 3px var(--color-focus-ring);
       }
 
       .chip {

--- a/server/public/brand-landing.html
+++ b/server/public/brand-landing.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>brand.json - Machine-Readable Brand Identity | AdCP</title>
   <meta name="description" content="brand.json is a standard file at /.well-known/brand.json that tells AI agents who your brand is, what it looks like, and how it wants to be represented in advertising.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================
@@ -181,8 +181,8 @@
       color: var(--color-text-secondary);
     }
     .quick-start-note code {
-      background: var(--color-primary-50);
-      color: var(--color-brand);
+      background: var(--color-brand-bg);
+      color: var(--color-brand-fg, var(--color-brand));
       padding: var(--space-0_5) var(--space-1_5);
       border-radius: var(--radius-sm);
       font-family: var(--font-mono);

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -728,11 +728,11 @@
       .edit-form-input:focus {
         outline: none;
         border-color: var(--color-brand);
-        box-shadow: 0 0 0 3px var(--color-primary-100);
+        box-shadow: 0 0 0 3px var(--color-focus-ring);
       }
 
       .edit-form-input::placeholder {
-        color: var(--color-text-muted);
+        color: var(--color-text-placeholder);
       }
 
       select.edit-form-input {
@@ -773,7 +773,7 @@
       .edit-colors-row input[type="text"]:focus {
         outline: none;
         border-color: var(--color-brand);
-        box-shadow: 0 0 0 3px var(--color-primary-100);
+        box-shadow: 0 0 0 3px var(--color-focus-ring);
       }
 
       .edit-colors-row input[type="color"] {

--- a/server/public/brand-viewer.html
+++ b/server/public/brand-viewer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Brand Viewer - AgenticAdvertising.org</title>
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
     <style>
       body {
@@ -79,16 +79,16 @@
         line-height: 1;
       }
       .ownership-badge[data-status="verified"] {
-        background: var(--color-success-100, #d1fae5);
-        color: var(--color-success-700, #047857);
+        background: var(--color-success-100);
+        color: var(--color-success-700);
       }
       .ownership-badge[data-status="community"] {
-        background: var(--color-purple-100);
-        color: var(--color-purple-700);
+        background: var(--color-pill-neutral-bg);
+        color: var(--color-text-on-light);
       }
       .ownership-badge[data-status="orphaned"] {
-        background: var(--color-warning-100, #fef3c7);
-        color: var(--color-warning-700, #b45309);
+        background: var(--color-warning-100);
+        color: var(--color-warning-700);
       }
       .ownership-badge[data-status=""] {
         display: none;
@@ -364,11 +364,11 @@
       }
 
       .voice-dos .voice-guidelines-list li {
-        color: var(--color-success-700);
+        color: var(--color-text);
       }
 
       .voice-donts .voice-guidelines-list li {
-        color: var(--color-error-700);
+        color: var(--color-text);
       }
 
       /* Brand info */
@@ -677,8 +677,8 @@
         gap: var(--space-1);
         margin-bottom: var(--space-5);
         padding: var(--space-4);
-        border: var(--border-2) solid var(--color-warning-500);
-        border-left: var(--border-4) solid var(--color-warning-500);
+        border: var(--border-2) solid var(--color-warning-border, var(--color-border));
+        border-left: var(--border-4) solid var(--color-warning-fg);
         border-radius: var(--radius-md);
         background: var(--color-warning-bg);
         color: var(--color-warning-fg);
@@ -800,8 +800,8 @@
       }
 
       .edit-color-remove:hover {
-        color: var(--color-error-500);
-        background-color: var(--color-error-50);
+        color: var(--color-error-fg);
+        background-color: var(--color-error-bg);
       }
 
       /* Collapsible edit sections */
@@ -944,8 +944,8 @@
       }
 
       .edit-list-remove:hover {
-        color: var(--color-error-500);
-        background-color: var(--color-error-50);
+        color: var(--color-error-fg);
+        background-color: var(--color-error-bg);
       }
 
       .edit-list-remove:focus-visible,
@@ -1244,11 +1244,11 @@
         <p class="hero-subtitle" id="hero-subtitle">Loading brand data...</p>
         <div id="ownership-row" class="hidden" style="margin-top: var(--space-3); display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2);">
           <span id="ownership-badge" class="ownership-badge" data-status=""></span>
-          <a id="claim-brand-btn" class="hidden btn btn-primary" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Claim this brand</a>
-          <a id="manage-brand-btn" class="hidden btn btn-primary" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Manage brand</a>
-          <a id="claim-signin-btn" class="hidden" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); text-decoration: none;">Sign in to claim</a>
+          <a id="claim-brand-btn" class="hidden btn btn-on-dark" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Claim this brand</a>
+          <a id="manage-brand-btn" class="hidden btn btn-on-dark" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Manage brand</a>
+          <a id="claim-signin-btn" class="hidden btn btn-on-dark" href="#" style="padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Sign in to claim</a>
         </div>
-        <button id="refresh-brand-btn" class="hidden" onclick="refreshBrand()" style="margin-top: var(--space-3); padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); cursor: pointer; transition: var(--transition-all);">Refresh from brand.json</button>
+        <button id="refresh-brand-btn" class="hidden btn btn-secondary-on-dark" onclick="refreshBrand()" style="margin-top: var(--space-3); padding: 4px 12px; font-size: var(--text-xs); font-weight: var(--font-semibold); border-radius: var(--radius-md);">Refresh from brand.json</button>
       </div>
     </section>
 

--- a/server/public/brands.html
+++ b/server/public/brands.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Brands | AgenticAdvertising.org</title>
   <meta name="description" content="Brand identities and brand.json manifests in the AdCP ecosystem.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -65,7 +65,7 @@
     .search-box input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .filter-row {
       display: flex;

--- a/server/public/certification.html
+++ b/server/public/certification.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AdCP Certification - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ask Addie - AgenticAdvertising.org</title>
-  <link rel="icon" type="image/svg+xml" href="/addie-icon.svg">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <!-- Runs before CSS to apply stored theme and avoid flash of wrong theme -->
   <script>
     (function () {
@@ -156,11 +156,11 @@
     }
 
     .message--assistant .message-avatar {
-      background: none;
+      background: var(--color-avatar-disc, var(--color-brand-bg));
     }
 
     .message--assistant .message-avatar img {
-      width: 100%;
+      width: 82%;
       height: auto;
     }
 
@@ -490,6 +490,12 @@
       max-width: 680px;
     }
 
+    /* Welcome state — the header's only content was the theme toggle, which now
+       lives in .chat-header-actions, so the bar itself has nothing to show. */
+    .chat-container:not(.has-messages) .chat-header {
+      display: none;
+    }
+
     .chat-container:not(.has-messages) .messages-container {
       flex: none;
       padding: 0;
@@ -645,9 +651,117 @@
       min-width: 0;
     }
 
-    .chat-container.drag-over .chat-input-container {
-      box-shadow: inset 0 0 0 2px var(--color-brand);
-      border-radius: 12px;
+    /* Drag-and-drop attachment overlay ----------------------------------------
+       A pointer-only affordance covering the whole viewport, because the drag
+       listeners sit on `document` — a file dropped anywhere on the page
+       attaches. `pointer-events: none` is load-bearing: an overlay that
+       hit-tests fires `dragleave` the instant it appears, collapsing the drag
+       state on the very frame it becomes visible. */
+    .drop-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: var(--z-overlay, 40);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      pointer-events: none;
+      background: var(--color-drop-scrim, var(--color-surface-overlay));
+      animation: drop-overlay-in 120ms ease-out;
+    }
+
+    @supports (backdrop-filter: blur(2px)) {
+      .drop-overlay {
+        backdrop-filter: blur(2px);
+      }
+    }
+
+    .drop-overlay.visible {
+      display: flex;
+    }
+
+    .drop-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      max-width: 340px;
+      padding: 32px 36px;
+      text-align: center;
+      border-radius: 16px;
+      border: 2px dashed var(--color-brand);
+      background: var(--color-bg-card);
+      box-shadow: var(--shadow-2xl);
+      animation: drop-card-in 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+
+    .drop-card-icon {
+      width: 36px;
+      height: 36px;
+      color: var(--color-brand);
+    }
+
+    .drop-card-title {
+      margin: 0;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--color-text-heading);
+    }
+
+    .drop-card-hint {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: var(--color-text-secondary);
+      /* Progressive enhancement: evens out the two wrapped lines where
+         supported, ignored everywhere else. */
+      text-wrap: balance;
+    }
+
+    /* Refusal state — the dragged items carry no supported MIME type, the
+       per-message cap is already reached, or the conversation is read-only.
+       Only the MIME type is legible mid-drag, never the filename or size, so
+       size errors still surface after release via showError(). */
+    .drop-overlay.reject .drop-card {
+      border-color: var(--color-error-fg);
+    }
+
+    .drop-overlay.reject .drop-card-icon {
+      color: var(--color-error-fg);
+    }
+
+    /* One glyph per state — an upload arrow beside "Can't attach this" reads
+       as a contradiction. */
+    .drop-card-icon-reject,
+    .drop-overlay.reject .drop-card-icon-accept {
+      display: none;
+    }
+
+    .drop-overlay.reject .drop-card-icon-reject {
+      display: block;
+    }
+
+    @keyframes drop-overlay-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+
+    @keyframes drop-card-in {
+      from { opacity: 0; transform: scale(0.96) translateY(6px); }
+      to   { opacity: 1; transform: none; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .drop-overlay,
+      .drop-card {
+        animation: none;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .drop-card {
+        padding: 24px 22px;
+      }
     }
 
     .chat-input {
@@ -790,7 +904,7 @@
     .addie-home-error {
       text-align: center;
       padding: 16px;
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
       background: var(--color-error-bg);
       border-radius: var(--radius-lg);
       margin-bottom: 16px;
@@ -1308,6 +1422,15 @@
       .chat-header h1 {
         font-size: 20px;
       }
+
+      /* The larger title reaches further, so the actions collapse to icons */
+      .video-call-btn {
+        padding: var(--space-2);
+      }
+
+      .video-call-btn span {
+        display: none;
+      }
     }
 
     /* Chat Sidebar - Vertical Tab Layout */
@@ -1795,10 +1918,6 @@
       color: var(--color-text-secondary);
       cursor: pointer;
       transition: all 0.15s;
-      position: absolute;
-      top: 12px;
-      right: 16px;
-      z-index: 10;
     }
     .video-call-btn:hover {
       border-color: var(--color-brand);
@@ -1979,6 +2098,7 @@
     /* Native app mode - hide site nav, chat header, and status indicator (app provides its own) */
     body.native-app #adcp-nav,
     body.native-app .chat-header,
+    body.native-app .dark-mode-toggle,
     body.native-app .status-indicator {
       display: none !important;
     }
@@ -2682,16 +2802,25 @@
       flex-shrink: 0;
     }
 
+    /* Matches .video-call-btn — the two sit together in .chat-header-actions and
+       read as one control group, so they must give the same hover feedback. */
     .dark-mode-toggle:hover {
-      background: var(--color-bg-subtle);
-      border-color: var(--color-border-strong);
-      color: var(--color-text);
+      background: var(--color-brand-bg);
+      border-color: var(--color-brand);
+      color: var(--color-brand);
     }
 
-    /* In conversation state the toggle sits at the right edge of the header */
-    .chat-container.has-messages .dark-mode-toggle {
+    /* Header actions — video call + theme toggle share one containing block so they
+       can never overlap. The 8px offset centres the 34px controls in the 50px
+       conversation-state header; in the welcome state it floats at the top right. */
+    .chat-header-actions {
       position: absolute;
-      right: 32px;
+      top: var(--space-2);
+      right: 16px;
+      z-index: 10;
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
     }
 
     /* Icon visibility — sun shows in dark mode, moon in light mode */
@@ -2762,6 +2891,25 @@
   <!-- Mobile overlay -->
   <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
+  <!-- Drag-and-drop attachment overlay. aria-hidden because dragging is a
+       pointer-only interaction — the paperclip button is the keyboard path,
+       and #attachmentTray already announces the result via aria-live. -->
+  <div class="drop-overlay" id="dropOverlay" aria-hidden="true">
+    <div class="drop-card">
+      <svg class="drop-card-icon drop-card-icon-accept" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+        <path d="M17 8l-5-5-5 5"></path>
+        <path d="M12 3v12"></path>
+      </svg>
+      <svg class="drop-card-icon drop-card-icon-reject" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="9"></circle>
+        <path d="M5.6 5.6l12.8 12.8"></path>
+      </svg>
+      <p class="drop-card-title" id="dropCardTitle">Drop to attach</p>
+      <p class="drop-card-hint" id="dropCardHint"></p>
+    </div>
+  </div>
+
   <div class="page-layout">
     <!-- Chat Sidebar -->
     <div class="chat-sidebar" id="chatSidebar">
@@ -2825,6 +2973,16 @@
           Ask Addie
         </h1>
         <p>Your AI guide to agentic advertising</p>
+      </div>
+
+      <div class="chat-header-actions">
+        <button class="video-call-btn" id="videoCallBtn" title="Video chat with Addie">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="23 7 16 12 23 17 23 7"></polygon>
+            <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
+          </svg>
+          <span>Video chat</span>
+        </button>
         <button type="button" class="dark-mode-toggle" id="darkModeToggle">
           <!-- moon icon — shown in light mode -->
           <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -2844,14 +3002,6 @@
           </svg>
         </button>
       </div>
-
-      <button class="video-call-btn" id="videoCallBtn" title="Video chat with Addie">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polygon points="23 7 16 12 23 17 23 7"></polygon>
-          <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
-        </svg>
-        <span>Video chat</span>
-      </button>
 
       <div class="video-panel" id="videoPanel">
         <div class="video-panel-loading" id="videoPanelLoading">
@@ -5322,24 +5472,129 @@
         }
       });
 
-      ['dragenter', 'dragover'].forEach(eventName => {
-        document.addEventListener(eventName, (e) => {
-          if (Array.from(e.dataTransfer?.items || []).some(item => item.kind === 'file')) {
-            e.preventDefault();
-            document.getElementById('chatContainer')?.classList.add('drag-over');
-          }
-        });
+      // --- Drag-and-drop attachments -----------------------------------------
+      // Listened for on `document`, so a file dropped anywhere on the page
+      // attaches. Two traps shape this code:
+      //
+      //  1. `dragleave` bubbles up from every element the pointer crosses, so
+      //     naively hiding on it strobes the overlay as the cursor moves. Depth
+      //     counting tracks entries against exits; the short debounce absorbs
+      //     browsers that fire dragleave-before-dragenter when crossing a
+      //     boundary, which momentarily zeroes the count.
+      //  2. A drag that leaves the window or ends outside the page fires no
+      //     balancing dragleave, which would strand the overlay on screen.
+      //     A null relatedTarget, dragend, and window blur all force a reset.
+      const dropOverlay = document.getElementById('dropOverlay');
+      const dropCardTitle = document.getElementById('dropCardTitle');
+      const dropCardHint = document.getElementById('dropCardHint');
+      const ACCEPTED_ATTACHMENT_LABEL = 'PNG, JPEG, GIF, WebP or PDF';
+      let dragDepth = 0;
+      let dragHideTimer = null;
+
+      function dragCarriesFiles(e) {
+        if (Array.from(e.dataTransfer?.types || []).includes('Files')) return true;
+        return Array.from(e.dataTransfer?.items || []).some(item => item.kind === 'file');
+      }
+
+      // Only the MIME type is legible while a drag is in flight — never the
+      // filename or the byte size. So type and count can be refused before the
+      // user lets go; size is still reported by addAttachmentFiles afterwards.
+      function assessDrag(e) {
+        if (isReadOnly) {
+          return { ok: false, title: 'Can\u2019t attach here', hint: 'This conversation is read-only.' };
+        }
+        if (pendingAttachments.length >= ATTACHMENT_MAX_COUNT) {
+          return {
+            ok: false,
+            title: 'Attachment limit reached',
+            hint: `You can attach up to ${ATTACHMENT_MAX_COUNT} files per message.`,
+          };
+        }
+        // An empty type means the source told us nothing (a folder, for
+        // instance). Stay optimistic rather than refusing a valid file.
+        const draggedTypes = Array.from(e.dataTransfer?.items || [])
+          .filter(item => item.kind === 'file')
+          .map(item => (item.type || '').toLowerCase())
+          .filter(Boolean);
+        if (draggedTypes.length > 0 && !draggedTypes.some(type => ALLOWED_ATTACHMENT_TYPES.has(type))) {
+          return {
+            ok: false,
+            title: 'Can\u2019t attach this',
+            hint: 'Addie accepts images (PNG, JPEG, GIF, WebP) and PDFs.',
+          };
+        }
+        return {
+          ok: true,
+          title: 'Drop to attach',
+          hint: `${ACCEPTED_ATTACHMENT_LABEL} \u00b7 up to ${ATTACHMENT_MAX_COUNT} files, ${formatBytes(ATTACHMENT_MAX_BYTES)} each`,
+        };
+      }
+
+      function showDropOverlay(e) {
+        const verdict = assessDrag(e);
+        dropCardTitle.textContent = verdict.title;
+        dropCardHint.textContent = verdict.hint;
+        dropOverlay.classList.toggle('reject', !verdict.ok);
+        dropOverlay.classList.add('visible');
+      }
+
+      function hideDropOverlay() {
+        clearTimeout(dragHideTimer);
+        dragHideTimer = null;
+        dragDepth = 0;
+        dropOverlay.classList.remove('visible', 'reject');
+      }
+
+      function cancelPendingDropHide() {
+        clearTimeout(dragHideTimer);
+        dragHideTimer = null;
+      }
+
+      document.addEventListener('dragenter', (e) => {
+        if (!dragCarriesFiles(e)) return;
+        e.preventDefault();
+        cancelPendingDropHide();
+        dragDepth++;
+        if (!dropOverlay.classList.contains('visible')) showDropOverlay(e);
       });
 
-      ['dragleave', 'drop'].forEach(eventName => {
-        document.addEventListener(eventName, (e) => {
-          document.getElementById('chatContainer')?.classList.remove('drag-over');
-          if (eventName === 'drop' && e.dataTransfer?.files?.length) {
-            e.preventDefault();
-            addAttachmentFiles(e.dataTransfer.files);
-          }
-        });
+      document.addEventListener('dragover', (e) => {
+        if (!dragCarriesFiles(e)) return;
+        // Required even when the drop will be refused: without it the browser
+        // takes over and navigates the tab to the dropped file.
+        e.preventDefault();
+        cancelPendingDropHide();
+        if (!dropOverlay.classList.contains('visible')) {
+          dragDepth = Math.max(dragDepth, 1);
+          showDropOverlay(e);
+        }
       });
+
+      document.addEventListener('dragleave', (e) => {
+        if (!dropOverlay.classList.contains('visible')) return;
+        // A null relatedTarget means the pointer left the window outright.
+        if (!e.relatedTarget) {
+          hideDropOverlay();
+          return;
+        }
+        dragDepth = Math.max(0, dragDepth - 1);
+        if (dragDepth > 0 || dragHideTimer) return;
+        dragHideTimer = setTimeout(() => {
+          dragHideTimer = null;
+          if (dragDepth <= 0) hideDropOverlay();
+        }, 120);
+      });
+
+      document.addEventListener('drop', (e) => {
+        if (!dragCarriesFiles(e)) return;
+        e.preventDefault();
+        hideDropOverlay();
+        if (isReadOnly) return;
+        if (e.dataTransfer?.files?.length) addAttachmentFiles(e.dataTransfer.files);
+      });
+
+      document.addEventListener('dragend', hideDropOverlay);
+      window.addEventListener('blur', hideDropOverlay);
 
       chatInput.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -83,8 +83,12 @@
     }
 
     .chat-header h1 .addie-avatar {
-      width: 28px;
-      height: auto;
+      width: 32px;
+      height: 32px;
+      padding: 3px;
+      border-radius: 50%;
+      background: var(--color-avatar-disc);
+      object-fit: contain;
     }
 
     .chat-header p {
@@ -102,7 +106,11 @@
 
     .welcome-identity .addie-avatar {
       width: 64px;
-      height: auto;
+      height: 64px;
+      padding: 6px;
+      border-radius: 50%;
+      background: var(--color-avatar-disc);
+      object-fit: contain;
       margin-bottom: 4px;
     }
 
@@ -783,11 +791,11 @@
     .chat-input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .chat-input::placeholder {
-      color: var(--color-text-muted);
+      color: var(--color-text-placeholder);
     }
 
     .send-button {
@@ -2343,7 +2351,7 @@
     }
 
     .si-modal-input::placeholder {
-      color: var(--color-text-muted);
+      color: var(--color-text-placeholder);
     }
 
     .si-modal-send {
@@ -5503,7 +5511,14 @@
         if (isReadOnly) {
           return { ok: false, title: 'Can\u2019t attach here', hint: 'This conversation is read-only.' };
         }
-        if (pendingAttachments.length >= ATTACHMENT_MAX_COUNT) {
+        const draggedItems = Array.from(e.dataTransfer?.items || [])
+          .filter(item => item.kind === 'file');
+        const droppedFiles = Array.from(e.dataTransfer?.files || []);
+        const draggedCount = Math.max(draggedItems.length, droppedFiles.length);
+        if (
+          pendingAttachments.length >= ATTACHMENT_MAX_COUNT
+          || pendingAttachments.length + draggedCount > ATTACHMENT_MAX_COUNT
+        ) {
           return {
             ok: false,
             title: 'Attachment limit reached',
@@ -5512,11 +5527,10 @@
         }
         // An empty type means the source told us nothing (a folder, for
         // instance). Stay optimistic rather than refusing a valid file.
-        const draggedTypes = Array.from(e.dataTransfer?.items || [])
-          .filter(item => item.kind === 'file')
+        const draggedTypes = [...draggedItems, ...droppedFiles]
           .map(item => (item.type || '').toLowerCase())
           .filter(Boolean);
-        if (draggedTypes.length > 0 && !draggedTypes.some(type => ALLOWED_ATTACHMENT_TYPES.has(type))) {
+        if (draggedTypes.some(type => !ALLOWED_ATTACHMENT_TYPES.has(type))) {
           return {
             ok: false,
             title: 'Can\u2019t attach this',
@@ -5588,8 +5602,13 @@
       document.addEventListener('drop', (e) => {
         if (!dragCarriesFiles(e)) return;
         e.preventDefault();
+        const verdict = assessDrag(e);
         hideDropOverlay();
         if (isReadOnly) return;
+        if (!verdict.ok) {
+          showError(verdict.hint);
+          return;
+        }
         if (e.dataTransfer?.files?.length) addAttachmentFiles(e.dataTransfer.files);
       });
 

--- a/server/public/committees.html
+++ b/server/public/committees.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title id="pageTitle">Committees | AgenticAdvertising.org</title>
   <meta name="description" id="pageDescription" content="Collaborative committees driving the future of agentic advertising standards.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" id="canonicalUrl" href="https://agenticadvertising.org/committees">
 
   <!-- Open Graph / Facebook -->

--- a/server/public/community/connections.html
+++ b/server/public/community/connections.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My connections - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/community/hub.html
+++ b/server/public/community/hub.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Community - AgenticAdvertising.org</title>
   <meta name="description" content="The people and agents building the future of agentic advertising. Members, AI assistants, and the characters who tell our stories.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -222,15 +222,13 @@
       align-items: center;
       justify-content: space-between;
       padding: var(--space-4) var(--space-6);
-      background: var(--color-warning-50);
-      border: var(--border-1) solid var(--color-warning-500);
       border-radius: var(--card-radius);
     }
 
     .pending-banner-text {
       font-size: var(--text-sm);
       font-weight: var(--font-medium);
-      color: var(--color-warning-700);
+      color: var(--color-text);
     }
 
     /* Section card base */
@@ -433,7 +431,7 @@
     .event-date-box {
       width: 48px;
       height: 48px;
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
       border-radius: var(--radius-lg);
       display: flex;
       flex-direction: column;
@@ -445,7 +443,7 @@
     .event-date-month {
       font-size: var(--text-xs);
       font-weight: var(--font-bold);
-      color: var(--color-brand);
+      color: var(--color-brand-fg, var(--color-brand));
       text-transform: uppercase;
     }
 
@@ -543,7 +541,7 @@
     .journey-card-title { font-size: var(--text-lg); font-weight: var(--font-bold); color: var(--color-text-heading); }
 
     /* Level stepper */
-    .level-stepper { display: flex; align-items: flex-start; margin-bottom: var(--space-6); overflow-x: auto; padding-bottom: var(--space-2); }
+    .level-stepper { display: flex; align-items: flex-start; margin-bottom: var(--space-6); overflow-x: auto; padding-top: var(--space-1); padding-bottom: var(--space-2); }
     .level-step { display: flex; flex-direction: column; align-items: center; flex: 1; min-width: 72px; position: relative; }
     .level-step-dot {
       width: 32px; height: 32px; border-radius: var(--radius-full);
@@ -552,7 +550,7 @@
       position: relative; z-index: 1; font-size: var(--text-xs); font-weight: var(--font-bold); color: var(--color-text-muted);
     }
     .level-step--completed .level-step-dot { background: var(--color-brand); border-color: var(--color-brand); color: white; }
-    .level-step--current .level-step-dot { background: var(--color-brand); border-color: var(--color-brand); color: white; box-shadow: 0 0 0 4px var(--color-primary-100); }
+    .level-step--current .level-step-dot { background: var(--color-brand); border-color: var(--color-brand); color: white; box-shadow: 0 0 0 4px var(--color-focus-ring, var(--color-brand-bg)); }
     .level-step-label { font-size: var(--text-xs); color: var(--color-text-muted); margin-top: var(--space-2); text-align: center; }
     .level-step--completed .level-step-label, .level-step--current .level-step-label { color: var(--color-text-heading); font-weight: var(--font-medium); }
     .level-step:not(:last-child)::after { content: ''; position: absolute; top: 16px; left: calc(50% + 16px); right: calc(-50% + 16px); height: 2px; background: var(--color-bg-button-secondary); z-index: 0; }
@@ -561,7 +559,7 @@
     /* Achievements grid */
     .achievements-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
     .achievement { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-radius: var(--radius-lg); }
-    .achievement--earned { background: var(--color-success-bg); border: var(--border-1) solid var(--color-success-200); }
+    .achievement--earned { background: var(--color-success-bg); border: var(--border-1) solid var(--color-success-border, var(--color-border)); }
     .achievement--locked { background: var(--color-bg-subtle); border: var(--border-1) dashed var(--color-border); }
     .achievement-icon { width: 36px; height: 36px; border-radius: var(--radius-lg); display: flex; align-items: center; justify-content: center; font-size: var(--text-lg); flex-shrink: 0; }
     .achievement--earned .achievement-icon { background: var(--color-success-bg); }
@@ -1059,7 +1057,7 @@
 
       // Pending banner
       const pendingHtml = pending_request_count > 0 ? `
-        <div class="pending-banner">
+        <div class="pending-banner ds-alert ds-alert-warning ds-alert-ring">
           <span class="pending-banner-text">You have ${pending_request_count} pending connection request${pending_request_count > 1 ? 's' : ''}</span>
           <a href="/community/connections#pending" class="btn btn-primary btn-sm">View requests</a>
         </div>

--- a/server/public/community/hub.html
+++ b/server/public/community/hub.html
@@ -1351,15 +1351,14 @@
         grid.appendChild(link);
       });
 
-      // Ghost placeholder slots
-      for (var i = 0; i < 2; i++) {
-        var ghost = document.createElement('div');
-        ghost.className = 'face-ghost';
-        ghost.innerHTML =
-          '<div class="face-ghost-ring">+</div>' +
-          '<span class="face-ghost-label">You?</span>';
-        grid.appendChild(ghost);
-      }
+      // A single ghost placeholder closes out the grid: one open seat reads as
+      // an invitation, where a run of identical ones reads as a rendering bug.
+      var ghost = document.createElement('div');
+      ghost.className = 'face-ghost';
+      ghost.innerHTML =
+        '<div class="face-ghost-ring">+</div>' +
+        '<span class="face-ghost-label">You?</span>';
+      grid.appendChild(ghost);
     })();
   </script>
 </body>

--- a/server/public/community/notifications.html
+++ b/server/public/community/notifications.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Notifications - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -70,9 +70,12 @@
       border-color: var(--color-brand);
     }
 
+    /* Tint layered over the card colour, so the unread surface follows the
+       theme instead of pinning itself to a fixed light-mode blue. */
     .notif-item.unread {
-      background: var(--color-primary-50);
-      border-color: var(--color-primary-200, var(--color-brand));
+      background-color: var(--color-bg-card);
+      background-image: linear-gradient(var(--color-brand-bg), var(--color-brand-bg));
+      border-color: var(--color-brand);
     }
 
     .notif-avatar {

--- a/server/public/community/people.html
+++ b/server/public/community/people.html
@@ -47,7 +47,7 @@
     .search-bar input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .filters-row {

--- a/server/public/community/people.html
+++ b/server/public/community/people.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>People - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profile - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -188,8 +188,8 @@
       align-items: center;
       gap: var(--space-1_5);
       padding: var(--space-1_5) var(--space-3);
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
       border-radius: var(--radius-full);
       font-size: var(--text-xs);
       font-weight: var(--font-semibold);
@@ -266,7 +266,7 @@
 
     .wg-item:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .wg-item-icon {
@@ -455,9 +455,9 @@
     }
 
     .connect-btn-success {
-      background: var(--color-success-50);
-      color: var(--color-success-700);
-      border: var(--border-1) solid var(--color-success-500);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
+      border: var(--border-1) solid var(--color-success-border, var(--color-border));
       cursor: default;
     }
 
@@ -473,12 +473,12 @@
 
     .connect-btn-decline {
       background: var(--color-bg-card);
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
       border: var(--border-1) solid var(--color-error-500);
     }
 
     .connect-btn-decline:hover {
-      background: var(--color-error-50);
+      background: var(--color-error-bg);
     }
 
     .connection-actions {

--- a/server/public/community/person-profile.html
+++ b/server/public/community/person-profile.html
@@ -515,7 +515,7 @@
     .connect-message-input textarea:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .connect-message-actions {

--- a/server/public/community/profile-edit.html
+++ b/server/public/community/profile-edit.html
@@ -132,7 +132,7 @@
     .form-input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .form-input:disabled {
@@ -298,7 +298,7 @@
 
     .tag-input-container:focus-within {
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .tag {
@@ -359,7 +359,7 @@
     }
 
     .tag-text-input::placeholder {
-      color: var(--color-text-muted);
+      color: var(--color-text-placeholder);
     }
 
     /* Social links prefix */
@@ -375,7 +375,7 @@
 
     .input-with-prefix:focus-within {
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .input-prefix {

--- a/server/public/community/profile-edit.html
+++ b/server/public/community/profile-edit.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Edit profile - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -476,20 +476,8 @@
       gap: var(--space-4);
     }
 
-    .addie-cta-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--space-2);
-      padding: var(--space-3) var(--space-5);
-      background: var(--color-brand);
-      color: white;
-      border: none;
-      border-radius: var(--radius-md);
-      font-size: var(--text-sm);
-      font-weight: var(--font-medium);
-      cursor: pointer;
-      text-decoration: none;
-      white-space: nowrap;
+    /* Layout only - appearance comes from .btn .btn-primary */
+    .addie-cta-row .btn {
       flex-shrink: 0;
     }
 
@@ -513,11 +501,6 @@
       .addie-cta-row {
         flex-direction: column;
         align-items: stretch;
-      }
-
-      .addie-cta-btn {
-        text-align: center;
-        justify-content: center;
       }
     }
   </style>
@@ -597,7 +580,7 @@
                 </div>
 
                 <div style="margin-top: var(--space-3); display: flex; align-items: center; gap: var(--space-3);">
-                  <button type="button" id="portrait-generate-btn" style="padding: var(--space-2) var(--space-4); background: var(--color-brand); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: var(--font-medium); cursor: pointer;">Generate portrait</button>
+                  <button type="button" id="portrait-generate-btn" class="btn btn-primary btn-sm">Generate portrait</button>
                   <span id="portrait-gen-count" style="font-size: var(--text-xs); color: var(--color-text-muted);"></span>
                 </div>
               </div>
@@ -630,13 +613,13 @@
         </div>
 
         <!-- Addie setup CTA (new members only) -->
-        <div class="edit-section" id="addie-setup-section" style="background: var(--color-primary-50); border-color: var(--color-primary-200);">
+        <div class="edit-section" id="addie-setup-section" style="background: var(--color-brand-bg); border-color: var(--color-brand-border, var(--color-border));">
           <div class="addie-cta-row">
             <div style="flex: 1;">
               <div style="font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-1);">Let Addie fill this in for you</div>
-              <p style="font-size: var(--text-xs); color: var(--color-text-muted); line-height: var(--leading-relaxed); margin: 0;">Addie can set up your headline, bio, expertise, and everything else from a quick conversation.</p>
+              <p style="font-size: var(--text-xs); color: var(--color-text); line-height: var(--leading-relaxed); margin: 0;">Addie can set up your headline, bio, expertise, and everything else from a quick conversation.</p>
             </div>
-            <a id="addie-setup-link" href="/chat?prompt=I%27d%20like%20to%20set%20up%20my%20community%20profile.%20Can%20you%20help%3F" class="addie-cta-btn">Ask Addie</a>
+            <a id="addie-setup-link" href="/chat?prompt=I%27d%20like%20to%20set%20up%20my%20community%20profile.%20Can%20you%20help%3F" class="btn btn-primary">Ask Addie</a>
           </div>
         </div>
 

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agents - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
@@ -108,8 +108,8 @@
 
     .agent-streak {
       padding: 1px var(--space-2);
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
       border-radius: var(--radius-full);
       font-size: 10px;
       font-weight: var(--font-semibold);
@@ -3712,7 +3712,7 @@
           : '<div style="margin-bottom:var(--space-3);font-size:var(--text-sm);color:var(--color-text-secondary);">This agent requires OAuth authorization before storyboards can run.</div>';
         const ctxAttr = agentContextId ? ' data-agent-context-id="' + escapeHtml(agentContextId) + '"' : '';
         return (
-          '<div style="padding:var(--space-3);background:var(--color-warning-50);border:1px solid var(--color-warning-200);border-radius:var(--radius-md);">'
+          '<div style="padding:var(--space-3);background:var(--color-warning-bg);border:1px solid var(--color-warning-border, var(--color-border));border-radius:var(--radius-md);">'
           + '<div style="font-weight:var(--font-semibold);margin-bottom:var(--space-2);">Connect via OAuth</div>'
           + safeReason
           + '<button class="agent-oauth-challenge-btn" data-agent-url="' + escapeHtml(agentUrl) + '"' + ctxAttr + '>Authorize with agent</button>'
@@ -3737,7 +3737,7 @@
         const retryText = retryMinutes
           ? ' Try again in ' + retryMinutes + ' minute' + (retryMinutes === 1 ? '.' : 's.')
           : ' Try again later.';
-        let html = '<div class="capability-probe-rate-limit" style="padding:var(--space-3);background:var(--color-warning-50);border:1px solid var(--color-warning-200);border-radius:var(--radius-md);color:var(--color-warning-800);font-size:var(--text-sm);margin-bottom:var(--space-2);">';
+        let html = '<div class="capability-probe-rate-limit" style="padding:var(--space-3);background:var(--color-warning-bg);border:1px solid var(--color-warning-border, var(--color-border));border-radius:var(--radius-md);color:var(--color-warning-fg);font-size:var(--text-sm);margin-bottom:var(--space-2);">';
         html += '<strong>Capability check paused.</strong> AgenticAdvertising.org has temporarily limited capability checks. Your agent was not contacted.' + retryText;
         html += '</div>';
         html += savedStatusSummary || '';
@@ -3764,7 +3764,7 @@
             let html = '';
 
             if (data.capabilities_probe_error) {
-              html += '<div style="padding:var(--space-2) var(--space-3);margin-bottom:var(--space-2);background:var(--color-warning-50);border:1px solid var(--color-warning-200);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-warning-800);">';
+              html += '<div style="padding:var(--space-2) var(--space-3);margin-bottom:var(--space-2);background:var(--color-warning-bg);border:1px solid var(--color-warning-border, var(--color-border));border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-warning-fg);">';
               html += 'Capabilities probe warning: ' + escapeHtml(String(data.capabilities_probe_error));
               html += '</div>';
             }
@@ -3913,10 +3913,10 @@
           if (errBody.error_kind === 'unsupported_adcp_version') {
             const complianceVersion = errBody.compliance_version || 'the selected cache';
             const supportedVersions = errBody.supported_versions || '(none advertised)';
-            let html = '<div style="padding:var(--space-3);background:var(--color-error-50);border:1px solid var(--color-error-200);border-radius:var(--radius-md);color:var(--color-error-700);font-size:var(--text-sm);">';
+            let html = '<div style="padding:var(--space-3);background:var(--color-error-bg);border:1px solid var(--color-error-border, var(--color-border));border-radius:var(--radius-md);color:var(--color-error-fg);font-size:var(--text-sm);">';
             html += '<strong>Unsupported compliance target.</strong> This check selected <code>' + escapeHtml(String(complianceVersion)) + '</code>, but the agent advertises <code>adcp.supported_versions</code>:';
             html += '<div style="margin-top:var(--space-2);font-family:var(--font-mono);font-size:var(--text-xs);">' + escapeHtml(String(supportedVersions)) + '</div>';
-            html += '<div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--color-error-600);">Targets are selected automatically. Use Recheck &amp; retest to re-detect the advertised versions and run the matching suite. If the versions shown above are not what the agent intends to support, update <code>get_adcp_capabilities</code> first.</div>';
+            html += '<div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--color-error-fg);">Targets are selected automatically. Use Recheck &amp; retest to re-detect the advertised versions and run the matching suite. If the versions shown above are not what the agent intends to support, update <code>get_adcp_capabilities</code> first.</div>';
             html += '</div>';
             panel.innerHTML = html;
             return;

--- a/server/public/dashboard-api-keys.html
+++ b/server/public/dashboard-api-keys.html
@@ -213,7 +213,7 @@
     .form-group input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     /* Created key display */

--- a/server/public/dashboard-api-keys.html
+++ b/server/public/dashboard-api-keys.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>API keys - Dashboard</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
@@ -253,11 +253,8 @@
     .created-key-warning {
       margin-top: 12px;
       padding: 12px;
-      background: var(--color-warning-50);
-      border-left: 4px solid var(--color-warning-500);
       border-radius: 4px;
       font-size: 13px;
-      color: var(--color-warning-700);
     }
 
     /* Usage hint */
@@ -318,7 +315,7 @@
             <code id="createdKeyValue"></code>
             <button class="btn btn-secondary btn-sm" onclick="copyKey()">Copy</button>
           </div>
-          <div class="created-key-warning">
+          <div class="created-key-warning ds-alert ds-alert-warning">
             Copy this key now. You won't be able to see it again.
           </div>
         </div>

--- a/server/public/dashboard-emails.html
+++ b/server/public/dashboard-emails.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Email Preferences - Dashboard</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
@@ -155,8 +155,6 @@
     }
 
     .unsubscribed-banner {
-      background: var(--color-warning-50);
-      border: 1px solid var(--color-warning-300);
       border-radius: 8px;
       padding: 16px;
       margin-bottom: 24px;
@@ -173,13 +171,13 @@
     .unsubscribed-banner h3 {
       margin: 0 0 4px 0;
       font-size: 14px;
-      color: var(--color-warning-800);
+      color: var(--color-text-heading);
     }
 
     .unsubscribed-banner p {
       margin: 0;
       font-size: 13px;
-      color: var(--color-warning-700);
+      color: var(--color-text);
     }
 
     .loading {
@@ -229,7 +227,7 @@
 
     <div id="content" style="display: none;">
       <!-- Global unsubscribe banner -->
-      <div id="unsubscribedBanner" class="unsubscribed-banner" style="display: none;">
+      <div id="unsubscribedBanner" class="unsubscribed-banner ds-alert ds-alert-warning ds-alert-ring" style="display: none;">
         <div class="unsubscribed-banner-text">
           <h3>You're unsubscribed from all emails</h3>
           <p>You won't receive any marketing or community emails. Transactional emails (password resets, billing) will still be sent.</p>

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Membership - Dashboard</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
@@ -262,7 +262,7 @@
 
     .subscription-status.active {
       background: var(--color-success-bg);
-      border: 1px solid var(--color-success-200);
+      border: 1px solid var(--color-success-border, var(--color-border));
     }
 
     .subscription-status.inactive {
@@ -272,7 +272,7 @@
 
     .subscription-status.past_due {
       background: var(--color-warning-bg);
-      border: 1px solid var(--color-warning-200);
+      border: 1px solid var(--color-warning-border, var(--color-border));
     }
 
     .subscription-icon {
@@ -559,7 +559,7 @@
       font-size: 14px;
       padding: 12px;
       background: var(--color-warning-bg);
-      border: 1px solid var(--color-warning-300);
+      border: 1px solid var(--color-warning-border, var(--color-border));
       border-radius: 6px;
       margin-top: 16px;
     }

--- a/server/public/dashboard-membership.html
+++ b/server/public/dashboard-membership.html
@@ -95,7 +95,7 @@
     .profile-form-group select:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .profile-modal-footer {

--- a/server/public/dashboard-organization.html
+++ b/server/public/dashboard-organization.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Member settings - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
   <script src="/dashboard-nav.js"></script>
@@ -172,8 +172,8 @@
       align-items: center;
       gap: var(--space-3);
       padding: var(--space-3);
-      background: var(--color-success-50);
-      border: 1px solid var(--color-success-200);
+      background: var(--color-success-bg);
+      border: 1px solid var(--color-success-border, var(--color-border));
       border-radius: var(--radius-lg);
     }
     .champion-name {
@@ -221,6 +221,9 @@
       gap: 0;
       margin-bottom: var(--space-6);
       overflow-x: auto;
+      /* overflow-x forces overflow-y to auto, so the 4px focus ring on the
+         current dot needs room or it clips against the top edge. */
+      padding-top: var(--space-1);
       padding-bottom: var(--space-2);
       -webkit-overflow-scrolling: touch;
     }
@@ -261,7 +264,7 @@
       background: var(--color-brand);
       border-color: var(--color-brand);
       color: white;
-      box-shadow: 0 0 0 4px var(--color-primary-100);
+      box-shadow: 0 0 0 4px var(--color-focus-ring, var(--color-brand-bg));
     }
 
     .level-step-label {
@@ -308,8 +311,8 @@
     }
 
     .achievement--earned {
-      background: var(--color-success-50);
-      border: var(--border-1) solid var(--color-success-200);
+      background: var(--color-success-bg);
+      border: var(--border-1) solid var(--color-success-border, var(--color-border));
     }
 
     .achievement--locked {
@@ -581,9 +584,9 @@
     }
 
     .activity-metric:nth-child(1) { background: var(--color-brand-bg); }
-    .activity-metric:nth-child(2) { background: var(--color-success-50); }
-    .activity-metric:nth-child(3) { background: var(--color-warning-50); }
-    .activity-metric:nth-child(4) { background: var(--color-info-50); }
+    .activity-metric:nth-child(2) { background: var(--color-success-bg); }
+    .activity-metric:nth-child(3) { background: var(--color-warning-bg); }
+    .activity-metric:nth-child(4) { background: var(--color-info-bg); }
 
     .activity-value { font-size: var(--text-2xl); font-weight: var(--font-bold); color: var(--color-text-heading); line-height: var(--leading-tight); margin-bottom: var(--space-1); }
     .activity-label { font-size: var(--text-xs); color: var(--color-text-secondary); }

--- a/server/public/dashboard-settings.html
+++ b/server/public/dashboard-settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Your profile - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -462,20 +462,8 @@
       gap: var(--space-4);
     }
 
-    .addie-cta-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--space-2);
-      padding: var(--space-3) var(--space-5);
-      background: var(--color-brand);
-      color: white;
-      border: none;
-      border-radius: var(--radius-md);
-      font-size: var(--text-sm);
-      font-weight: var(--font-medium);
-      cursor: pointer;
-      text-decoration: none;
-      white-space: nowrap;
+    /* Layout only - appearance comes from .btn .btn-primary */
+    .addie-cta-row .btn {
       flex-shrink: 0;
     }
 
@@ -569,8 +557,6 @@
     }
 
     .unsubscribed-banner {
-      background: var(--color-warning-50);
-      border: 1px solid var(--color-warning-300);
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-4);
@@ -583,13 +569,13 @@
     .unsubscribed-banner h3 {
       margin: 0 0 var(--space-1) 0;
       font-size: var(--text-sm);
-      color: var(--color-warning-800);
+      color: var(--color-text-heading);
     }
 
     .unsubscribed-banner p {
       margin: 0;
       font-size: var(--text-xs);
-      color: var(--color-warning-700);
+      color: var(--color-text);
     }
 
     /* Modal */
@@ -678,11 +664,6 @@
       .addie-cta-row {
         flex-direction: column;
         align-items: stretch;
-      }
-
-      .addie-cta-btn {
-        text-align: center;
-        justify-content: center;
       }
     }
   </style>
@@ -778,7 +759,7 @@
                 </div>
 
                 <div style="margin-top: var(--space-3); display: flex; align-items: center; gap: var(--space-3);">
-                  <button type="button" id="portrait-generate-btn" style="padding: var(--space-2) var(--space-4); background: var(--color-brand); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: var(--font-medium); cursor: pointer;">Generate portrait</button>
+                  <button type="button" id="portrait-generate-btn" class="btn btn-primary btn-sm">Generate portrait</button>
                   <span id="portrait-gen-count" style="font-size: var(--text-xs); color: var(--color-text-muted);"></span>
                 </div>
               </div>
@@ -811,13 +792,13 @@
         </div>
 
         <!-- Addie setup CTA (new members only) -->
-        <div class="edit-section" id="addie-setup-section" style="background: var(--color-primary-50); border-color: var(--color-primary-200);">
+        <div class="edit-section" id="addie-setup-section" style="background: var(--color-brand-bg); border-color: var(--color-brand-border, var(--color-border));">
           <div class="addie-cta-row">
             <div style="flex: 1;">
               <div style="font-size: var(--text-sm); font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-1);">Let Addie fill this in for you</div>
-              <p style="font-size: var(--text-xs); color: var(--color-text-muted); line-height: var(--leading-relaxed); margin: 0;">Addie can set up your headline, bio, expertise, and everything else from a quick conversation.</p>
+              <p style="font-size: var(--text-xs); color: var(--color-text); line-height: var(--leading-relaxed); margin: 0;">Addie can set up your headline, bio, expertise, and everything else from a quick conversation.</p>
             </div>
-            <a id="addie-setup-link" href="/chat?prompt=I%27d%20like%20to%20set%20up%20my%20community%20profile.%20Can%20you%20help%3F" class="addie-cta-btn">Ask Addie</a>
+            <a id="addie-setup-link" href="/chat?prompt=I%27d%20like%20to%20set%20up%20my%20community%20profile.%20Can%20you%20help%3F" class="btn btn-primary">Ask Addie</a>
           </div>
         </div>
 
@@ -1022,7 +1003,7 @@
           <svg class="chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>
         </summary>
         <p class="edit-section-description">Choose which emails you receive from AgenticAdvertising.org.</p>
-        <div id="unsubscribedBanner" class="unsubscribed-banner" style="display: none;">
+        <div id="unsubscribedBanner" class="unsubscribed-banner ds-alert ds-alert-warning ds-alert-ring" style="display: none;">
           <div>
             <h3>You're unsubscribed from all emails</h3>
             <p>You won't receive any marketing or community emails. Transactional emails (password resets, billing) will still be sent.</p>
@@ -1082,7 +1063,7 @@
         for (var i = 0; i < data.aliases.length; i++) {
           html += '<div style="display: flex; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--color-border);">' +
             '<span style="font-size: var(--text-sm);">' + accountEscapeHtml(data.aliases[i].email) + '</span>' +
-            '<span style="margin-left: 8px; font-size: var(--text-xs); background: var(--color-success-50); color: var(--color-success-600); padding: 2px 8px; border-radius: 4px;">Linked</span>' +
+            '<span style="margin-left: 8px; font-size: var(--text-xs); background: var(--color-success-bg); color: var(--color-success-fg); padding: 2px 8px; border-radius: 4px;">Linked</span>' +
             '<button class="btn btn-ghost make-primary-btn" data-email="' + accountEscapeHtml(data.aliases[i].email) + '" style="margin-left: auto; font-size: var(--text-xs); padding: 2px 8px;">Make primary</button>' +
             '</div>';
         }
@@ -1090,7 +1071,7 @@
         for (var j = 0; j < data.pending.length; j++) {
           html += '<div style="display: flex; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--color-border);">' +
             '<span style="font-size: var(--text-sm); color: var(--color-text-muted);">' + accountEscapeHtml(data.pending[j].target_email) + '</span>' +
-            '<span style="margin-left: 8px; font-size: var(--text-xs); background: var(--color-warning-50); color: var(--color-warning-600); padding: 2px 8px; border-radius: 4px;">Pending</span>' +
+            '<span style="margin-left: 8px; font-size: var(--text-xs); background: var(--color-warning-bg); color: var(--color-warning-fg); padding: 2px 8px; border-radius: 4px;">Pending</span>' +
             '</div>';
         }
 

--- a/server/public/dashboard-settings.html
+++ b/server/public/dashboard-settings.html
@@ -118,7 +118,7 @@
     .form-input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .form-input:disabled {
@@ -284,7 +284,7 @@
 
     .tag-input-container:focus-within {
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .tag {
@@ -345,7 +345,7 @@
     }
 
     .tag-text-input::placeholder {
-      color: var(--color-text-muted);
+      color: var(--color-text-placeholder);
     }
 
     /* Social links prefix */
@@ -361,7 +361,7 @@
 
     .input-with-prefix:focus-within {
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .input-prefix {
@@ -641,7 +641,7 @@
     .modal .modal-form-group input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     @media (max-width: 640px) {

--- a/server/public/dashboard.html
+++ b/server/public/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -63,8 +63,8 @@
     }
 
     .info-box {
-      background: var(--color-info-50);
-      border-left: var(--border-4) solid var(--color-info-500);
+      background: var(--color-info-bg);
+      border-left: var(--border-4) solid var(--color-info-fg);
       padding: var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
@@ -1019,9 +1019,6 @@
 
         /* Setup alerts banner styles */
         .setup-alert {
-          background: var(--color-warning-50);
-          border: 1px solid var(--color-warning-200);
-          border-left: 4px solid var(--color-warning-500);
           border-radius: var(--radius-md);
           padding: var(--space-4);
           margin-bottom: var(--space-4);
@@ -1040,12 +1037,12 @@
         }
         .setup-alert-title {
           font-weight: 600;
-          color: var(--color-warning-800);
+          color: var(--color-text-heading);
           margin: 0 0 2px 0;
           font-size: 14px;
         }
         .setup-alert-message {
-          color: var(--color-warning-700);
+          color: var(--color-text);
           margin: 0;
           font-size: 13px;
         }
@@ -1059,7 +1056,7 @@
         .setup-alert-dismiss {
           background: none;
           border: none;
-          color: var(--color-warning-500);
+          color: var(--color-text-secondary);
           cursor: pointer;
           padding: 4px;
           font-size: 16px;
@@ -1071,9 +1068,9 @@
         }
 
         .support-alert {
-          background: var(--color-warning-50);
-          border: 1px solid var(--color-warning-200);
-          border-left: 4px solid var(--color-warning-500);
+          background: var(--color-warning-bg);
+          border: 1px solid var(--color-warning-border, var(--color-border));
+          border-left: 4px solid var(--color-warning-fg);
           border-radius: var(--radius-md);
           padding: var(--space-4);
           margin-bottom: var(--space-4);
@@ -1082,9 +1079,9 @@
           gap: var(--space-3);
         }
         .support-alert--urgent {
-          background: var(--color-error-50);
-          border-color: var(--color-error-200);
-          border-left-color: var(--color-error-500);
+          background: var(--color-error-bg);
+          border-color: var(--color-error-border, var(--color-border));
+          border-left-color: var(--color-error-fg);
         }
         .support-alert-content {
           flex: 1;
@@ -1161,8 +1158,8 @@
           white-space: nowrap;
         }
         .escalation-badge--follow-up {
-          background: var(--color-warning-50);
-          color: var(--color-warning-700);
+          background: var(--color-warning-bg);
+          color: var(--color-warning-fg);
         }
         .escalation-actions {
           flex-shrink: 0;
@@ -2354,7 +2351,7 @@
 
         // Render alerts
         setupAlerts.innerHTML = alerts.map(alert => `
-          <div class="setup-alert" data-alert-id="${escapeHtml(alert.id)}">
+          <div class="setup-alert ds-alert ds-alert-warning ds-alert-ring" data-alert-id="${escapeHtml(alert.id)}">
             <div class="setup-alert-icon">${alert.icon}</div>
             <div class="setup-alert-content">
               <h4 class="setup-alert-title">${escapeHtml(alert.title)}</h4>
@@ -2565,8 +2562,8 @@
       } catch (error) {
         console.error('Error loading products:', error);
         container.innerHTML = `
-          <div style="text-align: center; padding: 40px; background: var(--color-error-50); border-radius: 8px;">
-            <p style="color: var(--color-error-600); margin-bottom: 16px;">Unable to load membership options.</p>
+          <div style="text-align: center; padding: 40px; background: var(--color-error-bg); border-radius: 8px;">
+            <p style="color: var(--color-error-fg); margin-bottom: 16px;">Unable to load membership options.</p>
             <button onclick="updatePricingTable(currentOrg)" class="btn btn-secondary">Try Again</button>
           </div>
         `;

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -829,7 +829,7 @@ textarea::placeholder {
 }
 
 .ds-input::placeholder {
-  color: var(--color-text-muted);
+  color: var(--color-text-placeholder);
 }
 
 .ds-input:disabled {

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -2364,7 +2364,7 @@ body {
     --color-brand-fg: #8aa3f4;
     --color-brand-solid: #4169e1;
     --color-brand-solid-hover: #2d4fd6;
-    --color-focus-ring: rgba(107, 140, 239, 0.4);
+    --color-focus-ring: #6b8cef;
     --color-success-bg: rgba(16, 185, 129, 0.18);
     --color-success-fg: #6ee7b7;
     --color-warning-bg: rgba(245, 158, 11, 0.18);
@@ -2413,7 +2413,7 @@ html[data-theme="dark"] {
   --color-brand-fg: #8aa3f4;
   --color-brand-solid: #4169e1;
   --color-brand-solid-hover: #2d4fd6;
-  --color-focus-ring: rgba(107, 140, 239, 0.4);
+  --color-focus-ring: #6b8cef;
   --color-success-bg: rgba(16, 185, 129, 0.18);
   --color-success-fg: #6ee7b7;
   --color-warning-bg: rgba(245, 158, 11, 0.18);

--- a/server/public/design-system.css
+++ b/server/public/design-system.css
@@ -35,6 +35,17 @@
   --color-brand-hover: var(--color-primary-600);
   --color-brand-light: var(--color-primary-300);
   --color-brand-bg: var(--color-primary-50);
+  --color-brand-border: var(--color-primary-200);
+  /* Brand-hued ink for text on --color-brand-bg. The brand hue itself is
+     too dark-on-dark there (4.00:1); this is the missing sibling of
+     --color-{success,error,warning,info}-fg. */
+  --color-brand-fg: var(--color-primary-700);
+  --color-brand-solid: var(--color-primary-700);
+  --color-brand-solid-hover: var(--color-primary-600);
+  /* Focus halo painted behind the brand border on a focused control. It has
+     to be semantic: --color-primary-100 is a fixed palette step, so it drew
+     a near-white ring on the dark page background. */
+  --color-focus-ring: var(--color-primary-100);
 
   /* Semantic tag/badge color pairs (adapt in dark mode) */
   --color-success-bg: var(--color-success-100);
@@ -45,6 +56,11 @@
   --color-error-fg: var(--color-error-700);
   --color-info-bg: var(--color-info-100);
   --color-info-fg: var(--color-info-700);
+  /* Tinted 1px ring for a status surface; -fg stays the strong accent/ink */
+  --color-success-border: var(--color-success-200);
+  --color-warning-border: var(--color-warning-200);
+  --color-error-border: var(--color-error-200);
+  --color-info-border: var(--color-info-200);
 
   /* -----------------------------------------------------------------------------
      1.2 Neutral Colors (Gray Scale)
@@ -65,12 +81,22 @@
   --color-text: var(--color-gray-900);
   --color-text-secondary: var(--color-gray-500);
   --color-text-muted: var(--color-gray-400);
+  --color-text-placeholder: var(--color-gray-500);
   --color-text-heading: var(--color-gray-800);
   --color-border: var(--color-gray-200);
   --color-border-strong: var(--color-gray-300);
   --color-bg-page: var(--color-gray-100);
   --color-bg-subtle: var(--color-gray-50);
   --color-bg-card: #ffffff;
+  /* Avatar disc: the plate behind Addie's mark in chat. Deliberately
+     FIXED across all four theme blocks — the mark artwork is dark navy,
+     so a swapping surface would hide it in dark. Fixed plate + fixed
+     ink is legible in both themes by construction. */
+  --color-avatar-disc: #dfe7fb;
+  /* Inline code: a recessed field holding a literal value (URL, ID, snippet). */
+  --color-code-bg: #e9effb;
+  --color-code-text: #1f2937;
+  --color-code-border: #bacff2;
 
   /* -----------------------------------------------------------------------------
      1.3 Status Colors (Semantic)
@@ -135,6 +161,24 @@
   --color-text-on-dark: #ffffff;
   --color-text-on-dark-secondary: rgba(255, 255, 255, 0.8);
 
+  /* Mirror of --color-text-on-dark: always-dark brand ink for use on the
+     always-light surfaces that sit on saturated colored backgrounds (the
+     white .btn-on-dark pill in a hero). Does not swap — the surface it
+     sits on doesn't either, so a swapping brand blue would drop to
+     3.17:1 there in dark mode. */
+  --color-brand-on-light: var(--color-primary-700);
+
+  /* Mirror of --color-text-on-dark for neutral copy: fixed dark ink for the
+     fixed light surfaces that sit on saturated backgrounds. One step down
+     from --color-brand-on-light, which reads as the primary action. */
+  --color-text-on-light: var(--color-gray-700);
+
+  /* Neutral counterpart to the fixed --color-{success,warning}-100 pill
+     backgrounds, for a status that carries no judgement ("community
+     contributed", "unverified"). Fixed for the same reason its siblings
+     are: these pills sit on non-swapping surfaces. */
+  --color-pill-neutral-bg: var(--color-gray-100);
+
   /* Secondary button surfaces — swap in dark mode so the button stays
      distinguishable from the page background under both themes. */
   --color-bg-button-secondary: var(--color-gray-200);
@@ -149,6 +193,7 @@
      Swaps from black-tint in light mode to white-tint in dark mode so the
      hover affordance stays visible against either page background. */
   --color-hover-overlay: rgba(0, 0, 0, 0.05);
+  --color-drop-scrim: rgba(23, 37, 84, 0.35);
 
   /* -----------------------------------------------------------------------------
      1.5 Legacy Compatibility (map old vars to new)
@@ -502,6 +547,43 @@ textarea {
   color: inherit;
 }
 
+/* The same gap applies to the background: an input with no background of its
+   own paints the browser's default (a neutral #3b3b3b in dark Chrome), which
+   clashes with the blue-tinted --color-bg-* scale. Give text-entry controls
+   the card background, matching .ds-input, so an unclassed input is theme-
+   correct by default. Scoped to text-entry types by an explicit list —
+   checkbox, radio, file, color, range and button-like inputs are left to
+   their native rendering. background-color, not the shorthand, so a control
+   carrying a background-image (.ds-select's chevron) keeps it. */
+input:not([type]),
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="search"],
+input[type="tel"],
+input[type="url"],
+input[type="number"],
+input[type="date"],
+input[type="datetime-local"],
+input[type="month"],
+input[type="time"],
+input[type="week"],
+select,
+textarea {
+  background-color: var(--color-bg-card);
+}
+
+/* Placeholders leak the same UA default (~3.2:1 in dark Chrome, and Chrome's
+   light default is only ~4.6:1). --color-text-muted is not usable here: it is
+   gray-400 in BOTH themes, so it measures 2.54:1 on a white card. Hence a
+   dedicated token, tuned per theme — 4.83:1 light, 5.78:1 dark: clearly
+   secondary to entered text, but still AA. ::placeholder is inert on
+   checkbox/radio, so the broad selector needs no type list. */
+input::placeholder,
+textarea::placeholder {
+  color: var(--color-text-placeholder);
+}
+
 /* =============================================================================
    10. BASE COMPONENT CLASSES
 
@@ -535,12 +617,13 @@ textarea {
 
 /* Primary Button - Solid brand color */
 .ds-btn-primary {
-  background: var(--color-brand);
-  color: white;
+  background: var(--color-brand-solid, var(--color-brand));
+  color: var(--color-text-on-dark);
+  box-shadow: inset 0 0 0 var(--border-1) var(--color-brand);
 }
 
 .ds-btn-primary:hover:not(:disabled) {
-  background: var(--color-brand-hover);
+  background: var(--color-brand-solid-hover, var(--color-brand-hover));
   transform: translateY(-1px);
 }
 
@@ -636,7 +719,7 @@ textarea {
 .ds-pill.active {
   color: var(--color-warning-fg);
   background: var(--color-warning-bg);
-  border-color: var(--color-warning-500);
+  border-color: var(--color-warning-fg);
 }
 
 /* -----------------------------------------------------------------------------
@@ -742,7 +825,7 @@ textarea {
 .ds-input:focus {
   outline: none;
   border: var(--input-border-focus);
-  box-shadow: 0 0 0 3px var(--color-primary-100);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 .ds-input::placeholder {
@@ -802,30 +885,48 @@ textarea {
   padding: var(--space-4);
   border-radius: var(--radius-lg);
   border-left: var(--border-4) solid;
+  /* Explicit ink: the tints below swap for dark, so inheriting the page's
+     body color would put light text on a light panel. */
+  color: var(--color-text);
 }
 
 .ds-alert-info {
-  background: var(--color-info-50);
-  border-left-color: var(--color-info-500);
-  color: var(--color-info-700);
+  background: var(--color-info-bg);
+  border-left-color: var(--color-info-fg);
 }
 
 .ds-alert-success {
-  background: var(--color-success-50);
-  border-left-color: var(--color-success-500);
-  color: var(--color-success-700);
+  background: var(--color-success-bg);
+  border-left-color: var(--color-success-fg);
 }
 
 .ds-alert-warning {
-  background: var(--color-warning-50);
-  border-left-color: var(--color-warning-500);
-  color: var(--color-warning-700);
+  background: var(--color-warning-bg);
+  border-left-color: var(--color-warning-fg);
 }
 
 .ds-alert-error {
-  background: var(--color-error-50);
-  border-left-color: var(--color-error-500);
-  color: var(--color-error-700);
+  background: var(--color-error-bg);
+  border-left-color: var(--color-error-fg);
+}
+
+/* Optional ring, for panels that read as a bordered card rather than a
+   left-accented banner. The `border` shorthand resets border-left-color,
+   so the accent has to be restated after it. */
+.ds-alert-info.ds-alert-ring { border: var(--border-1) solid var(--color-info-border); border-left-width: var(--border-4); border-left-color: var(--color-info-fg); }
+.ds-alert-success.ds-alert-ring { border: var(--border-1) solid var(--color-success-border); border-left-width: var(--border-4); border-left-color: var(--color-success-fg); }
+.ds-alert-warning.ds-alert-ring { border: var(--border-1) solid var(--color-warning-border); border-left-width: var(--border-4); border-left-color: var(--color-warning-fg); }
+.ds-alert-error.ds-alert-ring { border: var(--border-1) solid var(--color-error-border); border-left-width: var(--border-4); border-left-color: var(--color-error-fg); }
+
+.ds-alert__title {
+  font-weight: var(--font-semibold);
+  color: var(--color-text-heading);
+}
+
+.ds-alert__desc {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text);
 }
 
 /* -----------------------------------------------------------------------------
@@ -1100,7 +1201,12 @@ textarea {
 
    Context modifiers (for dark backgrounds like hero/CTA):
    - .btn-on-dark = white background (use instead of btn-primary on dark bg)
-   - .btn-outline-on-dark = white outline (use instead of btn-secondary on dark bg)
+   - .btn-secondary-on-dark = light background, neutral ink (use instead of
+     btn-secondary on dark bg)
+   - .btn-outline-on-dark = white outline. Note: .hero and .cta are both the
+     brand gradient, not a true dark surface, so this variant's white label
+     only clears AA at large sizes there. Prefer .btn-secondary-on-dark for
+     anything at body size.
    ----------------------------------------------------------------------------- */
 
 /* Base button - all buttons need this */
@@ -1113,6 +1219,9 @@ textarea {
   border-radius: var(--radius-md);
   font-weight: var(--font-medium);
   font-size: var(--text-sm);
+  /* Match .ds-btn: without this a button inherits surrounding prose leading,
+     so the same class renders a different height depending on its context. */
+  line-height: var(--leading-tight);
   text-decoration: none;
   border: none;
   cursor: pointer;
@@ -1124,14 +1233,15 @@ textarea {
 .btn-primary,
 a.btn-primary,
 a.btn-primary:visited {
-  background: var(--color-brand);
-  color: white;
+  background: var(--color-brand-solid, var(--color-brand));
+  color: var(--color-text-on-dark);
+  box-shadow: inset 0 0 0 var(--border-1) var(--color-brand);
 }
 
 .btn-primary:hover,
 a.btn-primary:hover {
-  background: var(--color-brand-hover);
-  color: white;
+  background: var(--color-brand-solid-hover, var(--color-brand-hover));
+  color: var(--color-text-on-dark);
 }
 
 /* Secondary button - Surface background (secondary actions) */
@@ -1224,11 +1334,26 @@ a.btn-success:hover {
 /* White button on dark backgrounds */
 .btn-on-dark {
   background: white;
-  color: var(--color-brand);
+  color: var(--color-brand-on-light);
 }
 
 .btn-on-dark:hover {
   background: var(--color-off-white);
+}
+
+/* Muted button on dark backgrounds — a light pill with neutral ink, one step
+   down from .btn-on-dark's brand-blue ink. White text is not an option for a
+   secondary action here: both .hero and .cta are the brand gradient, whose
+   light end is #6b8cef in dark mode, where white at body size measures
+   3.17:1. Hierarchy therefore comes from the ink, not the fill. */
+.btn-secondary-on-dark {
+  background: white;
+  color: var(--color-text-on-light);
+}
+
+.btn-secondary-on-dark:hover {
+  background: var(--color-off-white);
+  color: var(--color-brand-on-light);
 }
 
 /* Outline button on dark backgrounds */
@@ -1403,7 +1528,7 @@ a.btn-success:hover {
 .card a.btn-primary,
 .card a.btn-primary:visited,
 .card a.btn-primary:hover {
-  color: white;
+  color: var(--color-text-on-dark);
 }
 
 .card a.btn-danger,
@@ -2213,12 +2338,17 @@ body {
     --color-text: #f9fafb;
     --color-text-secondary: #d1d5db;
     --color-text-muted: #9ca3af;
+    --color-text-placeholder: #9ca3af;
     --color-text-heading: #f9fafb;
     --color-border: #374151;
     --color-border-strong: #4b5563;
     --color-bg-page: #111827;
     --color-bg-subtle: #1f2937;
     --color-bg-card: #1f2937;
+    --color-avatar-disc: #dfe7fb;
+    --color-code-bg: #111827;
+    --color-code-text: #c7d7fb;
+    --color-code-border: #374151;
     --color-surface: #1f2937;
     --color-surface-raised: #374151;
     --color-bg-button-secondary: #4b5563;
@@ -2226,9 +2356,15 @@ body {
     --color-bg-table-header: #1f2937;
     --color-bg-row-hover: #374151;
     --color-hover-overlay: rgba(255, 255, 255, 0.06);
+    --color-drop-scrim: rgba(3, 7, 18, 0.62);
     --color-brand: #6b8cef;
     --color-brand-hover: #8aa3f4;
     --color-brand-bg: rgba(107, 140, 239, 0.1);
+    --color-brand-border: rgba(107, 140, 239, 0.35);
+    --color-brand-fg: #8aa3f4;
+    --color-brand-solid: #4169e1;
+    --color-brand-solid-hover: #2d4fd6;
+    --color-focus-ring: rgba(107, 140, 239, 0.4);
     --color-success-bg: rgba(16, 185, 129, 0.18);
     --color-success-fg: #6ee7b7;
     --color-warning-bg: rgba(245, 158, 11, 0.18);
@@ -2237,6 +2373,10 @@ body {
     --color-error-fg: #fca5a5;
     --color-info-bg: rgba(107, 140, 239, 0.18);
     --color-info-fg: #a4c2f4;
+    --color-success-border: rgba(16, 185, 129, 0.35);
+    --color-warning-border: rgba(245, 158, 11, 0.35);
+    --color-error-border: rgba(239, 68, 68, 0.35);
+    --color-info-border: rgba(107, 140, 239, 0.35);
   }
 }
 
@@ -2247,12 +2387,17 @@ html[data-theme="dark"] {
   --color-text: #f9fafb;
   --color-text-secondary: #d1d5db;
   --color-text-muted: #9ca3af;
+  --color-text-placeholder: #9ca3af;
   --color-text-heading: #f9fafb;
   --color-border: #374151;
   --color-border-strong: #4b5563;
   --color-bg-page: #111827;
   --color-bg-subtle: #1f2937;
   --color-bg-card: #1f2937;
+  --color-avatar-disc: #dfe7fb;
+  --color-code-bg: #111827;
+  --color-code-text: #c7d7fb;
+  --color-code-border: #374151;
   --color-surface: #1f2937;
   --color-surface-raised: #374151;
   --color-bg-button-secondary: #4b5563;
@@ -2260,9 +2405,15 @@ html[data-theme="dark"] {
   --color-bg-table-header: #1f2937;
   --color-bg-row-hover: #374151;
   --color-hover-overlay: rgba(255, 255, 255, 0.06);
+  --color-drop-scrim: rgba(3, 7, 18, 0.62);
   --color-brand: #6b8cef;
   --color-brand-hover: #8aa3f4;
   --color-brand-bg: rgba(107, 140, 239, 0.1);
+  --color-brand-border: rgba(107, 140, 239, 0.35);
+  --color-brand-fg: #8aa3f4;
+  --color-brand-solid: #4169e1;
+  --color-brand-solid-hover: #2d4fd6;
+  --color-focus-ring: rgba(107, 140, 239, 0.4);
   --color-success-bg: rgba(16, 185, 129, 0.18);
   --color-success-fg: #6ee7b7;
   --color-warning-bg: rgba(245, 158, 11, 0.18);
@@ -2271,6 +2422,10 @@ html[data-theme="dark"] {
   --color-error-fg: #fca5a5;
   --color-info-bg: rgba(107, 140, 239, 0.18);
   --color-info-fg: #a4c2f4;
+  --color-success-border: rgba(16, 185, 129, 0.35);
+  --color-warning-border: rgba(245, 158, 11, 0.35);
+  --color-error-border: rgba(239, 68, 68, 0.35);
+  --color-info-border: rgba(107, 140, 239, 0.35);
 }
 
 html[data-theme="light"] {
@@ -2278,12 +2433,17 @@ html[data-theme="light"] {
   --color-text: #1d1d1d;
   --color-text-secondary: #6b7280;
   --color-text-muted: #9ca3af;
+  --color-text-placeholder: #6b7280;
   --color-text-heading: #2d3748;
   --color-border: #e5e7eb;
   --color-border-strong: #d1d5db;
   --color-bg-page: #f3f4f6;
   --color-bg-subtle: #f9fafb;
   --color-bg-card: #ffffff;
+  --color-avatar-disc: #dfe7fb;
+  --color-code-bg: #e9effb;
+  --color-code-text: #1f2937;
+  --color-code-border: #bacff2;
   --color-surface: #ffffff;
   --color-surface-raised: #ffffff;
   --color-bg-button-secondary: #e5e7eb;
@@ -2291,9 +2451,15 @@ html[data-theme="light"] {
   --color-bg-table-header: #f9fafb;
   --color-bg-row-hover: #f9fafb;
   --color-hover-overlay: rgba(0, 0, 0, 0.05);
+  --color-drop-scrim: rgba(23, 37, 84, 0.35);
   --color-brand: #1a36b4;
   --color-brand-hover: #2d4fd6;
   --color-brand-bg: #eef4fc;
+  --color-brand-border: #c5d9f7;
+  --color-brand-fg: #1a36b4;
+  --color-brand-solid: #1a36b4;
+  --color-brand-solid-hover: #2d4fd6;
+  --color-focus-ring: #dbe8fc;
   --color-success-bg: #d1fae5;
   --color-success-fg: #047857;
   --color-warning-bg: #fef3c7;
@@ -2302,4 +2468,8 @@ html[data-theme="light"] {
   --color-error-fg: #b91c1c;
   --color-info-bg: #dbe8fc;
   --color-info-fg: #1a36b4;
+  --color-success-border: #a7f3d0;
+  --color-warning-border: #fde68a;
+  --color-error-border: #fecaca;
+  --color-info-border: #c5d9f7;
 }

--- a/server/public/dev-login.html
+++ b/server/public/dev-login.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dev Login - Select User</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="/csrf.js"></script>
   <style>
@@ -86,7 +87,7 @@
 
     .user-card:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .user-card:last-child {

--- a/server/public/event-detail.html
+++ b/server/public/event-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Event | AgenticAdvertising.org</title>
   <meta name="description" content="Event details from the Agentic Advertising Organization.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js" integrity="sha384-b5hg04N6F0rvyz1a/GVoPPY0JcqGTARCmEuFCqwQKX3zq7LsxhV+n+6Ykh2pQOCH" crossorigin="anonymous"></script>

--- a/server/public/events.html
+++ b/server/public/events.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Events | AgenticAdvertising.org</title>
   <meta name="description" content="Upcoming summits, meetups, webinars, and events from the Agentic Advertising Organization. Join us to learn about the future of AI-powered advertising.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://agenticadvertising.org/events">
 
   <!-- Open Graph / Facebook -->

--- a/server/public/favicon.svg
+++ b/server/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!--
+    AgenticAdvertising.org favicon. Derived from the AAo wordmark (/AAo.svg),
+    redrawn with solid glyphs because the wordmark's hairline strokes fall
+    below one pixel at 16px. The plate is what lets a single file stay legible
+    on both a light and a dark browser tab strip.
+
+    Colours are literals because an SVG asset cannot read page custom
+    properties. The plate mirrors the token "color-primary-700" and the mark
+    "color-text-on-dark", both defined in design-system.css. Keep them in
+    step with those tokens.
+  -->
+  <rect width="32" height="32" rx="7" fill="#1a36b4"/>
+  <g transform="translate(3 11.616) scale(1.0277)" fill="#ffffff">
+    <polygon points="3.936,0 7.872,8.532 0,8.532"/>
+    <polygon points="12.819,0 16.755,8.532 8.883,8.532"/>
+    <circle cx="21.7" cy="4.6" r="3.6"/>
+  </g>
+</svg>

--- a/server/public/governance.html
+++ b/server/public/governance.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Governance - AgenticAdvertising.org</title>
   <meta name="description" content="Learn about the Agentic Advertising Network's governance structure, board composition, and how decisions are made.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================
@@ -54,13 +54,15 @@
       border-bottom: var(--border-3) solid transparent;
       transition: var(--transition-all);
     }
-    .sub-nav-links a:hover {
-      color: var(--aao-primary);
+    .sub-nav-links a:hover,
+    .sub-nav-links a:focus-visible {
+      color: var(--color-brand-hover);
       background: var(--color-brand-bg);
+      border-bottom-color: var(--color-border-strong);
     }
     .sub-nav-links a.active {
-      color: var(--aao-primary);
-      border-bottom-color: var(--aao-primary);
+      color: var(--color-brand);
+      border-bottom-color: var(--color-brand);
     }
 
     /* Main Content */

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -11,7 +11,7 @@
 <meta property="og:url" content="https://agenticadvertising.org">
 <meta property="og:image" content="https://agenticadvertising.org/img/aao-social-card.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/design-system.css">
 <link rel="stylesheet" href="/layout.css">
 <script type="application/ld+json">

--- a/server/public/industry-gatherings.html
+++ b/server/public/industry-gatherings.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Industry Gatherings | AgenticAdvertising.org</title>
   <meta name="description" content="Connect with AgenticAdvertising.org members at industry conferences and events. Join attendee groups to network before, during, and after major advertising events.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://agenticadvertising.org/industry-gatherings">
 
   <!-- Open Graph / Facebook -->
@@ -244,7 +244,8 @@
     }
 
     .btn-outline:hover {
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
+      color: var(--color-brand-fg, var(--color-brand));
     }
 
     .btn-slack {

--- a/server/public/invite.html
+++ b/server/public/invite.html
@@ -6,7 +6,7 @@
   <meta name="referrer" content="same-origin">
   <title>Membership Invitation - AgenticAdvertising.org</title>
   <meta name="description" content="Accept your AgenticAdvertising.org membership invitation.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * { box-sizing: border-box; }
@@ -52,8 +52,6 @@
       margin: var(--space-4) 0;
     }
     .error {
-      color: var(--color-error-600);
-      background: var(--color-error-50);
       padding: var(--space-3);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
@@ -166,7 +164,7 @@
               </label>
             </div>
 
-            <div id="acceptError" class="error hidden"></div>
+            <div id="acceptError" class="error hidden ds-alert ds-alert-error"></div>
 
             <div style="display: flex; gap: var(--space-3); justify-content: flex-end;">
               <a href="/" class="btn-secondary">Cancel</a>

--- a/server/public/join.html
+++ b/server/public/join.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>You're invited - AgenticAdvertising.org</title>
   <meta name="description" content="You've been personally invited to join AgenticAdvertising.org.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * { box-sizing: border-box; }
@@ -140,9 +140,9 @@
       display: inline-flex;
       align-items: center;
       gap: var(--space-2);
-      background: var(--color-success-50);
-      border: var(--border-1) solid var(--color-success-500);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      border: var(--border-1) solid var(--color-success-border, var(--color-border));
+      color: var(--color-success-fg);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
       padding: var(--space-2) var(--space-4);
@@ -199,19 +199,17 @@
 
     /* Auth notice */
     .auth-notice {
-      background: var(--color-primary-50);
-      border: var(--border-1) solid var(--color-primary-200);
+      background: var(--color-brand-bg);
+      border: var(--border-1) solid var(--color-brand-border, var(--color-border));
       border-radius: var(--radius-lg);
       padding: var(--space-3) var(--space-4);
       font-size: var(--text-sm);
-      color: var(--color-text-secondary);
+      color: var(--color-text);
       margin-bottom: var(--space-5);
     }
 
     /* Already-accepted state */
     .already-accepted {
-      background: var(--color-success-50);
-      border: var(--border-1) solid var(--color-success-500);
       border-radius: var(--radius-lg);
       padding: var(--space-4) var(--space-5);
       margin-bottom: var(--space-6);
@@ -225,7 +223,7 @@
 
     .already-accepted-text {
       font-size: var(--text-sm);
-      color: var(--color-success-700);
+      color: var(--color-text);
       font-weight: var(--font-medium);
     }
 
@@ -355,7 +353,7 @@
         </div>
 
         <!-- Already-accepted notice (shown when user already has an active referral) -->
-        <div id="alreadyAccepted" class="already-accepted" style="display:none;">
+        <div id="alreadyAccepted" class="already-accepted ds-alert ds-alert-success ds-alert-ring" style="display:none;">
           <div class="already-accepted-icon">&#x2713;</div>
           <div class="already-accepted-text" id="alreadyAcceptedText">
             You've already accepted a referral invitation. Visit your dashboard to subscribe.

--- a/server/public/latest/index.html
+++ b/server/public/latest/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Latest | AgenticAdvertising.org</title>
   <meta name="description" content="Curated content about agentic AI in advertising. Industry news, research, tutorials, and announcements from the Agentic Advertising Organization.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://agenticadvertising.org/latest">
 
   <!-- Open Graph / Facebook -->

--- a/server/public/latest/section.html
+++ b/server/public/latest/section.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Latest | AgenticAdvertising.org</title>
   <meta name="description" content="Curated content about agentic AI in advertising.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -118,8 +118,6 @@
 
     .article-notes {
       font-size: 0.85rem;
-      color: var(--color-info-700);
-      background: var(--color-info-50);
       border-radius: 6px;
       padding: 0.75rem;
       margin-bottom: 0.75rem;
@@ -286,7 +284,7 @@
                 ${titleHtml}
               </h2>
               ${article.summary ? `<p class="article-summary">${escapeHtml(article.summary)}</p>` : ''}
-              ${article.addie_notes ? `<div class="article-notes"><strong>Why it matters:</strong> ${escapeHtml(article.addie_notes)}</div>` : ''}
+              ${article.addie_notes ? `<div class="article-notes ds-alert ds-alert-info"><strong>Why it matters:</strong> ${escapeHtml(article.addie_notes)}</div>` : ''}
               ${tags.length > 0 ? `<div class="article-tags">${tagsHtml}</div>` : ''}
             </div>
           `;

--- a/server/public/layout.css
+++ b/server/public/layout.css
@@ -164,12 +164,17 @@ body {
   font-size: var(--text-sm);
   white-space: nowrap;
   border-bottom: 3px solid transparent;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.sub-nav-links a:hover {
-  color: var(--color-brand);
-  background: var(--color-primary-50);
+/* Hover previews the active state: a brand tint plus a muted underline.
+   --color-brand-bg is semantic and swaps for dark; --color-primary-50 does
+   not, and rendered as a near-white slab on the dark sub-nav. */
+.sub-nav-links a:hover,
+.sub-nav-links a:focus-visible {
+  color: var(--color-brand-hover);
+  background: var(--color-brand-bg);
+  border-bottom-color: var(--color-border-strong);
 }
 
 .sub-nav-links a.active {
@@ -281,7 +286,7 @@ body {
 }
 
 .hero-cta-secondary:hover {
-  background: var(--color-primary-50);
+  background: var(--color-brand-bg);
 }
 
 /* -- Dark hero variant (must come after base styles to win cascade) -- */
@@ -542,6 +547,8 @@ body {
 }
 
 .cta-card {
+  display: flex;
+  flex-direction: column;
   padding: var(--space-6);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
@@ -568,6 +575,8 @@ body {
 }
 
 .cta-card a {
+  align-self: flex-start;
+  margin-top: auto;
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--color-brand);

--- a/server/public/legal/privacy.html
+++ b/server/public/legal/privacy.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy - AdCP Registry</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/server/public/legal/terms.html
+++ b/server/public/legal/terms.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Use - AdCP Registry</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/server/public/logo-preview.html
+++ b/server/public/logo-preview.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Member logo preview - AgenticAdvertising.org</title>
-<link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/design-system.css">
 <link rel="stylesheet" href="/layout.css">
 <style>

--- a/server/public/meetings.html
+++ b/server/public/meetings.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Meetings | AgenticAdvertising.org</title>
   <meta name="description" content="Upcoming working group meetings and calls from AgenticAdvertising.org. Join our committees to shape the future of AI-powered advertising.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://agenticadvertising.org/meetings">
 
   <!-- Open Graph / Facebook -->
@@ -295,7 +295,8 @@
     }
 
     .my-meetings-section {
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
+      border: var(--border-1) solid var(--color-brand-border, var(--color-border));
       border-radius: 16px;
       padding: 2rem;
       margin-bottom: 2rem;

--- a/server/public/member-card.js
+++ b/server/public/member-card.js
@@ -1076,16 +1076,16 @@ function getPublisherCardStyles() {
       margin-bottom: 8px;
     }
     .publisher-card.success {
-      background: var(--color-success-50);
-      border-color: var(--color-success-500);
+      background: var(--color-success-bg);
+      border-color: var(--color-success-border, var(--color-border));
     }
     .publisher-card.error {
-      background: var(--color-error-50);
-      border-color: var(--color-error-100);
+      background: var(--color-error-bg);
+      border-color: var(--color-error-border, var(--color-border));
     }
     .publisher-card.loading {
-      background: var(--color-warning-50);
-      border-color: var(--color-warning-100);
+      background: var(--color-warning-bg);
+      border-color: var(--color-warning-border, var(--color-border));
     }
     .publisher-card-main {
       display: flex;
@@ -1119,7 +1119,7 @@ function getPublisherCardStyles() {
     }
     .publisher-card-error {
       font-size: 13px;
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
     }
     .publisher-type-badge {
       display: inline-block;
@@ -1166,13 +1166,13 @@ function getPublisherCardStyles() {
     }
     .publisher-card-status.valid {
       background: var(--color-success-100);
-      color: var(--color-success-700);
+      color: var(--color-success-fg);
     }
     .publisher-card-status.error {
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
     }
     .publisher-card-status.loading {
-      color: var(--color-warning-600);
+      color: var(--color-warning-fg);
     }
     .publisher-card-status .status-dot {
       width: 6px;
@@ -1204,7 +1204,7 @@ function getPublisherCardStyles() {
     .publisher-card-remove {
       padding: 6px 12px;
       background: var(--color-error-100);
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
       border: none;
       border-radius: 6px;
       font-size: 12px;
@@ -1242,8 +1242,8 @@ function getPublisherCardStyles() {
       border: 1px solid var(--color-border);
     }
     a.publisher-card-compact.publisher-card-link:hover {
-      background: var(--color-success-50);
-      border-color: var(--color-success-500);
+      background: var(--color-success-bg);
+      border-color: var(--color-success-border, var(--color-border));
     }
   `;
 }

--- a/server/public/member-card.js
+++ b/server/public/member-card.js
@@ -1105,7 +1105,7 @@ function getPublisherCardStyles() {
     }
     .publisher-card-domain {
       font-size: 13px;
-      color: var(--color-text-secondary);
+      color: var(--color-text);
       word-break: break-all;
       margin-bottom: 6px;
     }
@@ -1140,7 +1140,7 @@ function getPublisherCardStyles() {
       color: var(--color-gray-700);
     }
     .publisher-stat {
-      color: var(--color-gray-700);
+      color: var(--color-text);
     }
     .publisher-visibility-badge {
       font-size: 11px;

--- a/server/public/member-card.js
+++ b/server/public/member-card.js
@@ -1148,8 +1148,8 @@ function getPublisherCardStyles() {
       border-radius: 4px;
     }
     .publisher-visibility-badge.public {
-      background: var(--color-success-100);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
     .publisher-visibility-badge.private {
       background: var(--color-gray-100);
@@ -1165,7 +1165,7 @@ function getPublisherCardStyles() {
       border-radius: 12px;
     }
     .publisher-card-status.valid {
-      background: var(--color-success-100);
+      background: var(--color-success-bg);
       color: var(--color-success-fg);
     }
     .publisher-card-status.error {
@@ -1203,7 +1203,7 @@ function getPublisherCardStyles() {
     }
     .publisher-card-remove {
       padding: 6px 12px;
-      background: var(--color-error-100);
+      background: var(--color-error-bg);
       color: var(--color-error-fg);
       border: none;
       border-radius: 6px;
@@ -1212,7 +1212,7 @@ function getPublisherCardStyles() {
       margin-top: 8px;
     }
     .publisher-card-remove:hover {
-      background: var(--color-error-100);
+      background: var(--color-error-bg);
       filter: brightness(0.95);
     }
     /* Compact layout for member cards */

--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Member Profile - AdCP</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================
@@ -178,8 +179,8 @@
       border-color: var(--color-success-500);
     }
     .checkbox-item.selected {
-      background: var(--color-success-50);
-      border-color: var(--color-success-500);
+      background: var(--color-success-bg);
+      border-color: var(--color-success-border, var(--color-border));
     }
     .checkbox-item input[type="checkbox"] {
       width: 18px;
@@ -340,9 +341,9 @@
       color: var(--color-text-muted);
     }
     .logo-input-group .upload-filename.has-file {
-      background: var(--color-success-50);
-      border-color: var(--color-success-500);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      border-color: var(--color-success-border, var(--color-border));
+      color: var(--color-success-fg);
     }
     .logo-input-group .btn-upload {
       padding: var(--space-2_5) var(--space-4);
@@ -361,12 +362,12 @@
     }
     .logo-input-group .btn-clear {
       padding: var(--space-2_5) var(--space-3);
-      background: var(--color-error-50);
-      border: var(--border-2) solid var(--color-error-200);
+      background: var(--color-error-bg);
+      border: var(--border-2) solid var(--color-error-border, var(--color-border));
       border-radius: var(--radius-md);
       cursor: pointer;
       font-size: var(--text-sm);
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
       white-space: nowrap;
       transition: var(--transition-all);
     }
@@ -410,8 +411,8 @@
       background: var(--color-bg-button-secondary);
     }
     .btn-danger {
-      background: var(--color-error-50);
-      color: var(--color-error-600);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
     .btn-danger:hover {
       background: var(--color-error-200);
@@ -421,20 +422,15 @@
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
     }
-    .alert-success {
-      background: var(--color-success-50);
-      color: var(--color-success-700);
-      border-left: 4px solid var(--color-success-500);
-    }
     .alert-error {
-      background: var(--color-error-50);
-      color: var(--color-error-700);
-      border-left: 4px solid var(--color-error-600);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
+      border-left: 4px solid var(--color-error-fg);
     }
     .alert-info {
-      background: var(--color-info-50);
-      color: var(--color-info-700);
-      border-left: 4px solid var(--color-info-500);
+      background: var(--color-info-bg);
+      color: var(--color-info-fg);
+      border-left: 4px solid var(--color-info-fg);
     }
     .loading {
       text-align: center;
@@ -550,16 +546,16 @@
       border-radius: var(--radius-md);
     }
     .agent-url-item.checking {
-      border-color: var(--color-warning-400);
-      background: var(--color-warning-50);
+      border-color: var(--color-warning-border, var(--color-border));
+      background: var(--color-warning-bg);
     }
     .agent-url-item.success {
-      border-color: var(--color-success-500);
-      background: var(--color-success-50);
+      border-color: var(--color-success-border, var(--color-border));
+      background: var(--color-success-bg);
     }
     .agent-url-item.error {
-      border-color: var(--color-error-600);
-      background: var(--color-error-50);
+      border-color: var(--color-error-border, var(--color-border));
+      background: var(--color-error-bg);
     }
     .agent-url-info {
       flex: 1;
@@ -648,8 +644,8 @@
       cursor: pointer;
     }
     .agent-url-actions .btn-remove {
-      background: var(--color-error-50);
-      color: var(--color-error-600);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
     .agent-url-actions .btn-remove:hover {
       background: var(--color-error-200);
@@ -704,8 +700,8 @@
       font-weight: var(--font-medium);
     }
     .visibility-badge-small.public {
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
     .visibility-badge-small.private {
       background: var(--color-bg-subtle);
@@ -767,7 +763,7 @@
           </div>
         </div>
 
-        <div id="success-message" class="alert alert-success" style="display: none;"></div>
+        <div id="success-message" class="alert alert-success ds-alert ds-alert-success" style="display: none;"></div>
         <div id="error-message" class="alert alert-error" style="display: none;"></div>
 
         <!-- Account type notice -->

--- a/server/public/members.html
+++ b/server/public/members.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Partner Directory - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -51,7 +51,7 @@
     .search-bar input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
 
     .search-bar button {
@@ -475,7 +475,7 @@
     }
     .agent-item:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
     .agent-icon {
       width: 48px;
@@ -1137,7 +1137,7 @@
       <div class="join-cta">
         <h3>Looking for implementation help?</h3>
         <p>Browse partners below, or ask Addie to help you find the right match and make an introduction.</p>
-        <a href="/chat?prompt=Help%20me%20find%20a%20partner%20who%20can%20help%20me%20implement%20AdCP" class="join-cta-btn" style="display: inline-flex; align-items: center; gap: 6px;"><img src="/addie-avatar.svg" alt="" style="width: 20px; height: auto;"> Ask Addie to help</a>
+        <a href="/chat?prompt=Help%20me%20find%20a%20partner%20who%20can%20help%20me%20implement%20AdCP" class="join-cta-btn" style="display: inline-flex; align-items: center; gap: 6px;"><img src="/addie-mark-on-brand.svg" alt="" style="width: 20px; height: auto;"> Ask Addie to help</a>
       </div>
 
       <div class="search-section">
@@ -1173,7 +1173,7 @@
       <div class="join-cta" id="general-inquiry" style="display: none;">
         <h3>Not finding the right fit?</h3>
         <p>Tell Addie what you're looking for and get matched with the right partner.</p>
-        <a href="/chat?prompt=I%27m%20looking%20for%20a%20partner%20who%20can%20help%20me%20with%20AdCP%20implementation" class="join-cta-btn" style="display: inline-flex; align-items: center; gap: 6px;"><img src="/addie-avatar.svg" alt="" style="width: 20px; height: auto;"> Ask Addie</a>
+        <a href="/chat?prompt=I%27m%20looking%20for%20a%20partner%20who%20can%20help%20me%20with%20AdCP%20implementation" class="join-cta-btn" style="display: inline-flex; align-items: center; gap: 6px;"><img src="/addie-mark-on-brand.svg" alt="" style="width: 20px; height: auto;"> Ask Addie</a>
       </div>
     </div>
   </div>

--- a/server/public/membership.html
+++ b/server/public/membership.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="Five membership tiers for practitioners, startups, and organizations. Slack, Addie AI access, certification, governance, and more.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agenticadvertising.org/membership">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/membership/assessment.html
+++ b/server/public/membership/assessment.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Organization type assessment - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {

--- a/server/public/membership/hub.html
+++ b/server/public/membership/hub.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Your hub - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {
@@ -312,6 +312,9 @@
       gap: 0;
       margin-bottom: var(--space-6);
       overflow-x: auto;
+      /* overflow-x forces overflow-y to auto, so the 4px focus ring on the
+         current dot needs room or it clips against the top edge. */
+      padding-top: var(--space-1);
       padding-bottom: var(--space-2);
       -webkit-overflow-scrolling: touch;
     }
@@ -352,7 +355,7 @@
       background: var(--color-brand);
       border-color: var(--color-brand);
       color: white;
-      box-shadow: 0 0 0 4px var(--color-primary-100);
+      box-shadow: 0 0 0 4px var(--color-focus-ring, var(--color-brand-bg));
     }
 
     .level-step-label {
@@ -554,7 +557,7 @@
 
     .achievement--earned {
       background: var(--color-success-bg);
-      border: var(--border-1) solid var(--color-success-200);
+      border: var(--border-1) solid var(--color-success-border, var(--color-border));
     }
 
     .achievement--locked {
@@ -745,8 +748,8 @@
     }
 
     .academy-stat:nth-child(1) { background: var(--color-brand-bg); }
-    .academy-stat:nth-child(2) { background: var(--color-warning-50); }
-    .academy-stat:nth-child(3) { background: var(--color-success-50); }
+    .academy-stat:nth-child(2) { background: var(--color-warning-bg); }
+    .academy-stat:nth-child(3) { background: var(--color-success-bg); }
 
     .academy-stat-value {
       font-size: var(--text-2xl);
@@ -1024,8 +1027,8 @@
     }
 
     .content-studio-stat:nth-child(1) { background: var(--color-bg-subtle); }
-    .content-studio-stat:nth-child(2) { background: var(--color-warning-50); }
-    .content-studio-stat:nth-child(3) { background: var(--color-success-50); }
+    .content-studio-stat:nth-child(2) { background: var(--color-warning-bg); }
+    .content-studio-stat:nth-child(3) { background: var(--color-success-bg); }
 
     .content-studio-stat-value {
       font-size: var(--text-2xl);

--- a/server/public/my-content.html
+++ b/server/public/my-content.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>My Content - AgenticAdvertising.org</title>
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="/nav.js"></script>
@@ -224,9 +224,9 @@
     .badge-link { background: var(--color-primary-100); color: var(--color-primary-700); }
     .badge-personal { background: var(--color-bg-subtle); color: var(--color-text-secondary); }
     .badge-committee { background: var(--color-primary-50); color: var(--color-primary-700); }
-    .badge-author { background: var(--color-info-50); color: var(--color-info-700); }
-    .badge-proposer { background: var(--color-warning-50); color: var(--color-warning-700); }
-    .badge-owner { background: var(--color-success-50); color: var(--color-success-700); }
+    .badge-author { background: var(--color-info-bg); color: var(--color-info-fg); }
+    .badge-proposer { background: var(--color-warning-bg); color: var(--color-warning-fg); }
+    .badge-owner { background: var(--color-success-bg); color: var(--color-success-fg); }
     .btn {
       padding: var(--space-2) var(--space-4);
       border: none;
@@ -401,8 +401,8 @@
     }
     .type-toggle button.active {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
-      color: var(--color-brand);
+      background: var(--color-brand-bg);
+      color: var(--color-brand-fg, var(--color-brand));
     }
     .url-input-group {
       display: flex;
@@ -489,13 +489,10 @@
 
     /* Rejection reason display */
     .rejection-reason {
-      background: var(--color-error-50);
-      border: var(--border-1) solid var(--color-error-200);
       border-radius: var(--radius-md);
       padding: var(--space-3);
       margin-top: var(--space-2);
       font-size: var(--text-sm);
-      color: var(--color-error-700);
     }
 
     /* Authors display */
@@ -518,8 +515,6 @@
 
     /* Alert banner */
     .alert-banner {
-      background: var(--color-warning-50);
-      border: var(--border-1) solid var(--color-warning-200);
       border-radius: var(--radius-md);
       padding: var(--space-4);
       margin-bottom: var(--space-5);
@@ -528,16 +523,16 @@
       gap: var(--space-3);
     }
     .alert-banner-icon {
-      color: var(--color-warning-600);
+      color: var(--color-warning-fg);
       font-size: var(--text-xl);
     }
     .alert-banner-content h3 {
-      color: var(--color-warning-800);
+      color: var(--color-text-heading);
       font-size: var(--text-sm);
       margin-bottom: var(--space-1);
     }
     .alert-banner-content p {
-      color: var(--color-warning-700);
+      color: var(--color-text);
       font-size: var(--text-sm);
     }
   </style>
@@ -584,7 +579,7 @@
       </div>
 
       <!-- Alert banner for pending reviews -->
-      <div id="pendingAlert" class="alert-banner hidden">
+      <div id="pendingAlert" class="alert-banner hidden ds-alert ds-alert-warning ds-alert-ring">
         <span class="alert-banner-icon">!</span>
         <div class="alert-banner-content">
           <h3>Content Awaiting Review</h3>
@@ -1067,9 +1062,9 @@
         : '';
 
       const rejectionInfo = item.status === 'rejected' && item.rejection_reason
-        ? `<div class="rejection-reason"><strong>Rejection reason:</strong> ${escapeHtml(item.rejection_reason)}</div>`
+        ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring"><strong>Rejection reason:</strong> ${escapeHtml(item.rejection_reason)}</div>`
         : item.status === 'needs_revisions' && item.revision_notes
-          ? `<div class="rejection-reason" style="border-color: var(--color-warning-300);"><strong>Revision notes:</strong> ${escapeHtml(item.revision_notes)}</div>`
+          ? `<div class="rejection-reason ds-alert ds-alert-error ds-alert-ring" style="border-color: var(--color-warning-300);"><strong>Revision notes:</strong> ${escapeHtml(item.revision_notes)}</div>`
           : '';
       const pageviews30dValue = Number(item.performance?.pageviews_last_30d || 0);
       const pageviews30d = pageviews30dValue > 0 ? formatMetricCount(pageviews30dValue) : null;

--- a/server/public/nav.js
+++ b/server/public/nav.js
@@ -90,19 +90,21 @@
         const avatarInitial = ((user.firstName || '')[0] || safeEmail[0] || displayName[0] || 'M').toUpperCase();
         const adminLink = user.isAdmin ? `<a href="${authBaseUrl}/admin" class="navbar__dropdown-item">Admin</a>` : '';
         authSection = `
-          <button class="navbar__notif-btn" id="notifBell" aria-label="Notifications">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
-              <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
-            </svg>
-            <span class="navbar__notif-badge" id="notifBadge" style="display:none;"></span>
-          </button>
-          <div class="navbar__notif-dropdown" id="notifDropdown">
-            <div class="navbar__notif-header">
-              <span>Notifications</span>
-              <a href="${authBaseUrl}/community/notifications" class="navbar__notif-view-all">View all</a>
+          <div class="navbar__notif">
+            <button class="navbar__notif-btn" id="notifBell" aria-label="Notifications">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+              </svg>
+              <span class="navbar__notif-badge" id="notifBadge" style="display:none;"></span>
+            </button>
+            <div class="navbar__notif-dropdown" id="notifDropdown">
+              <div class="navbar__notif-header">
+                <span>Notifications</span>
+                <a href="${authBaseUrl}/community/notifications" class="navbar__notif-view-all">View all</a>
+              </div>
+              <div class="navbar__notif-list" id="notifList"></div>
             </div>
-            <div class="navbar__notif-list" id="notifList"></div>
           </div>
           <div class="navbar__account">
             <button class="navbar__account-btn" id="accountMenuBtn">
@@ -328,6 +330,11 @@
       }
 
       /* Notification bell */
+      .navbar__notif {
+        position: relative;
+        display: flex;
+        align-items: center;
+      }
       .navbar__notif-btn {
         position: relative;
         background: none;
@@ -794,6 +801,16 @@
         .navbar__items--right {
           gap: 0.75rem;
         }
+
+        /* Too narrow to hang a 360px panel off the bell without clipping the
+           left edge — pin it across the viewport under the navbar instead. */
+        .navbar__notif-dropdown {
+          position: fixed;
+          top: calc(60px + 0.5rem);
+          left: 1rem;
+          right: 1rem;
+          width: auto;
+        }
       }
 
       /* Dark mode for hamburger and mobile menu */
@@ -954,11 +971,26 @@
   // Footer CSS
   const footerCSS = `
     <style>
+      /* Sticky footer. The footer is the last child of a plain block-level
+         body on most pages, so margin-top: auto alone is inert -- it only
+         does anything on the handful of pages whose own CSS makes body a
+         flex column. Reserving a viewport-tall body and offsetting the
+         footer with sticky pushes it to the bottom of a short page without
+         changing body's formatting context, which margin collapsing and
+         floats on 100+ pages depend on. */
+      body {
+        min-height: 100vh;
+        min-height: 100dvh;
+      }
+
       .aao-footer {
         background: #1b1b1d;
         color: #9ca3af;
         padding: 2.5rem 1rem 1.5rem;
         margin-top: auto;
+        position: sticky;
+        top: 100vh;
+        top: 100dvh;
       }
 
       .aao-footer__inner {

--- a/server/public/oauth-complete.html
+++ b/server/public/oauth-complete.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Authorization Complete - Agentic Advertising</title>
-  <link rel="icon" type="image/svg+xml" href="/addie-icon.svg">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     body {
@@ -90,7 +90,6 @@
     .oauth-complete__error-details {
       margin-top: var(--space-4);
       padding: var(--space-3);
-      background: var(--color-error-50);
       border-radius: var(--radius-md);
       text-align: left;
     }
@@ -188,7 +187,7 @@
             Something went wrong during authorization.
           </p>
           ${error ? `
-            <div class="oauth-complete__error-details">
+            <div class="oauth-complete__error-details ds-alert ds-alert-error">
               <div class="oauth-complete__error-label">Error</div>
               <div class="oauth-complete__error-text">${escapeHtml(error)}</div>
             </div>

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Get Started - AgenticAdvertising.org</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================
@@ -102,14 +103,12 @@
 
     /* Invitations section */
     .invitations-section {
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
       border-radius: var(--radius-md);
       padding: var(--space-5);
       margin-bottom: var(--space-6);
     }
     .invitations-section h3 {
-      color: var(--color-info-700);
+      color: var(--color-text-heading);
       font-size: var(--text-base);
       margin-bottom: var(--space-4);
     }
@@ -216,17 +215,17 @@
       background: var(--color-bg-button-secondary);
     }
     .error {
-      background: var(--color-error-50);
-      border: var(--border-1) solid var(--color-error-200);
-      color: var(--color-error-600);
+      background: var(--color-error-bg);
+      border: var(--border-1) solid var(--color-error-border, var(--color-border));
+      color: var(--color-error-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
     }
     .info {
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
-      color: var(--color-info-700);
+      background: var(--color-info-bg);
+      border: var(--border-1) solid var(--color-info-border, var(--color-border));
+      color: var(--color-info-fg);
       padding: var(--space-3);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
@@ -463,13 +462,13 @@
       <div id="error" class="error" style="display:none;"></div>
 
       <!-- Pending Invitations -->
-      <div id="invitationsSection" class="invitations-section" style="display: none;">
+      <div id="invitationsSection" class="invitations-section ds-alert ds-alert-info ds-alert-ring" style="display: none;">
         <h3>You have pending invitations</h3>
         <div id="invitationsList"></div>
       </div>
 
       <!-- Claim a sales-touched prospect org by domain -->
-      <div id="claimOrgSection" class="invitations-section" style="display: none;">
+      <div id="claimOrgSection" class="invitations-section ds-alert ds-alert-info ds-alert-ring" style="display: none;">
         <h3>We've been tracking your company</h3>
         <p style="color: var(--color-text-secondary); margin-bottom: var(--space-3); font-size: var(--text-sm);">
           A record exists for <strong id="claimOrgName"></strong> based on your email domain. Claim it to consolidate the work

--- a/server/public/org-index-old.html
+++ b/server/public/org-index-old.html
@@ -11,7 +11,7 @@
   <meta property="og:url" content="https://agenticadvertising.org">
   <meta property="og:image" content="https://agenticadvertising.org/img/aao-social-card.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script type="application/ld+json">
   {

--- a/server/public/perspectives/article.html
+++ b/server/public/perspectives/article.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title id="pageTitle">Loading... | AgenticAdvertising.org</title>
   <meta name="description" id="pageDescription" content="Loading...">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" id="canonicalUrl" href="">
 
   <!-- Open Graph / Facebook (updated dynamically) -->
@@ -342,9 +342,9 @@
     }
 
     .like-button.liked {
-      background: var(--color-error-50);
-      border-color: var(--color-error-500);
-      color: var(--color-error-500);
+      background: var(--color-error-bg);
+      border-color: var(--color-error-border, var(--color-border));
+      color: var(--color-error-fg);
     }
 
     .like-button svg {

--- a/server/public/perspectives/index.html
+++ b/server/public/perspectives/index.html
@@ -5,6 +5,7 @@
   <meta http-equiv="refresh" content="0;url=/stories">
   <link rel="canonical" href="https://agenticadvertising.org/stories">
   <title>Redirecting to Stories</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 </head>
 <body>
   <p>Redirecting to <a href="/stories">Stories</a>...</p>

--- a/server/public/policies.html
+++ b/server/public/policies.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="Advertising regulations and standards in the AdCP policy registry.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agenticadvertising.org/policies">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -69,7 +69,7 @@
     .search-box input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .filter-row {
       display: flex;
@@ -217,8 +217,8 @@
     .community-cta {
       margin-top: var(--space-8);
       padding: var(--space-8) var(--space-6);
-      background: var(--color-primary-50);
-      border: 1px solid var(--color-primary-200);
+      background: var(--color-brand-bg);
+      border: 1px solid var(--color-brand-border, var(--color-border));
       border-radius: var(--radius-lg);
       text-align: center;
     }
@@ -230,21 +230,22 @@
     }
     .community-cta__desc {
       font-size: var(--text-sm);
-      color: var(--color-text-muted);
+      color: var(--color-text);
       margin-bottom: var(--space-4);
     }
     .community-cta__primary {
       display: inline-block;
       padding: 10px 24px;
-      background: var(--color-brand);
-      color: white;
+      background: var(--color-brand-solid, var(--color-brand));
+      color: var(--color-text-on-dark);
+      box-shadow: inset 0 0 0 var(--border-1) var(--color-brand);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
       font-weight: var(--font-semibold);
       text-decoration: none;
       transition: var(--transition-colors);
     }
-    .community-cta__primary:hover { background: var(--color-brand-hover); }
+    .community-cta__primary:hover { background: var(--color-brand-solid-hover, var(--color-brand-hover)); }
     .community-cta__primary:focus-visible {
       outline: 2px solid var(--color-brand);
       outline-offset: 2px;

--- a/server/public/property-check.html
+++ b/server/public/property-check.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Property check | AgenticAdvertising.org</title>
   <meta name="description" content="Check your property list against the registry. See which domains and apps are ready for agent-based transactions.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/property-viewer.html
+++ b/server/public/property-viewer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Property Viewer - AgenticAdvertising.org</title>
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/design-system.css">
     <style>
       body {

--- a/server/public/property-viewer.html
+++ b/server/public/property-viewer.html
@@ -139,7 +139,7 @@
       .edit-form-select:focus {
         outline: none;
         border-color: var(--color-brand);
-        box-shadow: 0 0 0 3px var(--color-primary-100);
+        box-shadow: 0 0 0 3px var(--color-focus-ring);
       }
 
       .edit-form-textarea {

--- a/server/public/publisher-embed.html
+++ b/server/public/publisher-embed.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Publisher | AgenticAdvertising.org embed</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link id="api-alternate" rel="alternate" type="application/json" href="" />
     <link rel="stylesheet" href="/design-system.css" />
     <style>
@@ -107,12 +108,12 @@
         white-space: nowrap;
         user-select: none;
       }
-      .freshness--fresh  { background: var(--color-success-50);
-        color: var(--color-success-800); border-color: var(--color-success-200); }
-      .freshness--aging  { background: var(--color-warning-50);
-        color: var(--color-warning-800); border-color: var(--color-warning-200); }
-      .freshness--stale  { background: var(--color-error-50);
-        color: var(--color-error-800); border-color: var(--color-error-200); }
+      .freshness--fresh  { background: var(--color-success-bg);
+        color: var(--color-success-fg); border-color: var(--color-success-border, var(--color-border)); }
+      .freshness--aging  { background: var(--color-warning-bg);
+        color: var(--color-warning-fg); border-color: var(--color-warning-border, var(--color-border)); }
+      .freshness--stale  { background: var(--color-error-bg);
+        color: var(--color-error-fg); border-color: var(--color-error-border, var(--color-border)); }
 
       .publisher-hero__status {
         display: flex; align-items: center; gap: var(--space-2);

--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Publisher | AgenticAdvertising.org</title>
-    <link rel="icon" href="/addie-icon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <!-- Agent-discoverable JSON alternate. The href is filled in client-side
          once the domain is resolved from the URL path; agents that follow
          this link land on the rich /api/registry/publisher payload. -->
@@ -130,12 +130,12 @@
         white-space: nowrap;
         user-select: none;
       }
-      .freshness--fresh  { background: var(--color-success-50);
-        color: var(--color-success-800); border-color: var(--color-success-200); }
-      .freshness--aging  { background: var(--color-warning-50);
-        color: var(--color-warning-800); border-color: var(--color-warning-200); }
-      .freshness--stale  { background: var(--color-error-50);
-        color: var(--color-error-800); border-color: var(--color-error-200); }
+      .freshness--fresh  { background: var(--color-success-bg);
+        color: var(--color-success-fg); border-color: var(--color-success-border, var(--color-border)); }
+      .freshness--aging  { background: var(--color-warning-bg);
+        color: var(--color-warning-fg); border-color: var(--color-warning-border, var(--color-border)); }
+      .freshness--stale  { background: var(--color-error-bg);
+        color: var(--color-error-fg); border-color: var(--color-error-border, var(--color-border)); }
 
       .publisher-hero__status {
         display: flex; align-items: center; gap: var(--space-2);
@@ -161,8 +161,8 @@
       .publisher-hero__errors {
         margin-top: var(--space-3);
         padding: var(--space-3) var(--space-4);
-        background: var(--color-error-50);
-        border: var(--border-1) solid var(--color-error-200);
+        background: var(--color-error-bg);
+        border: var(--border-1) solid var(--color-error-border, var(--color-border));
         border-radius: var(--radius-md);
         font-size: var(--text-sm);
       }
@@ -290,12 +290,12 @@
         font-weight: var(--font-medium); letter-spacing: 0.02em;
         white-space: nowrap;
       }
-      .provenance--publisher    { background: var(--color-success-50);
-        color: var(--color-success-800); border-color: var(--color-success-200); }
+      .provenance--publisher    { background: var(--color-success-bg);
+        color: var(--color-success-fg); border-color: var(--color-success-border, var(--color-border)); }
       .provenance--brand        { background: var(--color-primary-50);
         color: var(--color-primary-800); border-color: var(--color-primary-200); }
-      .provenance--counterparty { background: var(--color-warning-50);
-        color: var(--color-warning-800); border-color: var(--color-warning-200); }
+      .provenance--counterparty { background: var(--color-warning-bg);
+        color: var(--color-warning-fg); border-color: var(--color-warning-border, var(--color-border)); }
 
       .on-file__empty {
         padding: var(--space-5) var(--space-6);
@@ -415,18 +415,15 @@
         color: var(--color-text-secondary);
       }
       .publisher-stat[data-tone="warning"] {
-        border-color: var(--color-warning-200);
-        background: var(--color-warning-50);
+        border-color: var(--color-warning-border, var(--color-border));
+        background: var(--color-warning-bg);
       }
 
       .publisher-catalog-note {
         grid-column: 1 / -1;
         margin: 0 0 var(--space-4);
         padding: var(--space-3) var(--space-4);
-        border: var(--border-1) solid var(--color-warning-200);
         border-radius: var(--radius-md);
-        background: var(--color-warning-50);
-        color: var(--color-warning-900);
         font-size: var(--text-sm);
       }
 
@@ -763,7 +760,7 @@
         transition: var(--transition-all);
       }
       .cross-link-card:hover {
-        border-color: var(--color-primary-200);
+        border-color: var(--color-brand-border, var(--color-border));
         box-shadow: var(--shadow-sm);
         transform: translateY(-1px);
       }
@@ -1666,7 +1663,7 @@
           ? `${formatCount(formats.length, 'canonical format')} declared across ${formatCount(props.length, 'property', 'properties')}.`
           : 'No canonical formats are declared yet.';
         const note = !agents.length && formats.length
-          ? '<p class="publisher-catalog-note"><strong>Catalog preview only.</strong> These formats describe accepted creative shapes, but no sales agent is authorized for this publisher yet.</p>'
+          ? '<p class="publisher-catalog-note ds-alert ds-alert-warning ds-alert-ring"><strong>Catalog preview only.</strong> These formats describe accepted creative shapes, but no sales agent is authorized for this publisher yet.</p>'
           : '';
         if (!formats.length) {
           grid.innerHTML = `${note}<div class="on-file__empty">No creative format declarations recorded yet.</div>`;

--- a/server/public/publishers.html
+++ b/server/public/publishers.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Properties | AgenticAdvertising.org</title>
   <meta name="description" content="Publisher properties and domains in the AdCP ecosystem.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -65,7 +65,7 @@
     .search-box input:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .filter-row {
       display: flex;

--- a/server/public/registry-tools.html
+++ b/server/public/registry-tools.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tools &amp; standards | AgenticAdvertising.org</title>
   <meta name="description" content="Standards specifications, builder tools, and developer resources for the Ad Context Protocol ecosystem.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -41,8 +41,10 @@
       gap: var(--space-6);
       align-items: start;
     }
+    /* --color-primary-200 is a fixed near-white in both themes, so it
+       painted a glaring light outline on a dark card. */
     .standard-card:hover {
-      border-color: var(--color-primary-200);
+      border-color: var(--color-brand-border, var(--color-primary-200));
     }
     .standard-card__body h3 {
       font-size: var(--text-xl);
@@ -67,34 +69,56 @@
       gap: var(--space-3);
       min-width: 160px;
     }
-    .standard-card__actions a {
-      display: block;
-      padding: 10px 20px;
-      border-radius: var(--radius-lg);
-      font-size: var(--text-sm);
-      font-weight: var(--font-semibold);
+    /* Action controls. The box geometry belongs on the classes themselves,
+       not on a .standard-card__actions descendant selector: the publisher
+       lookup form uses .action-primary / .action-secondary standalone, and
+       .action-primary is a <button>, which inherits neither font nor
+       line-height from the page. The transparent border keeps all three
+       variants the same height as the bordered secondary. */
+    .action-primary,
+    .action-secondary,
+    .action-ghost {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--btn-padding-y) var(--btn-padding-x);
+      border: var(--border-1) solid transparent;
+      border-radius: var(--btn-radius);
+      font-family: var(--font-sans);
+      font-size: var(--btn-font-size);
+      font-weight: var(--btn-font-weight);
+      line-height: var(--leading-normal);
       text-decoration: none;
       text-align: center;
+      cursor: pointer;
       transition: var(--transition-colors);
     }
+    .action-primary:focus-visible,
+    .action-secondary:focus-visible,
+    .action-ghost:focus-visible {
+      outline: 2px solid var(--color-brand);
+      outline-offset: 2px;
+    }
+    /* --color-brand goes pale in dark mode, where a white label on it is
+       3.17:1. --color-brand-solid is the design system's fill for exactly
+       this case, and is what .ds-btn-primary uses. */
     .action-primary {
-      background: var(--color-brand);
-      color: white;
+      background: var(--color-brand-solid, var(--color-brand));
+      color: var(--color-text-on-dark);
     }
     .action-primary:hover {
-      background: var(--color-brand-hover);
+      background: var(--color-brand-solid-hover, var(--color-brand-hover));
     }
     .action-secondary {
       background: var(--color-bg-card);
       color: var(--color-brand);
-      border: 1px solid var(--color-primary-200);
+      border-color: var(--color-brand-border, var(--color-primary-200));
     }
     .action-secondary:hover {
       border-color: var(--color-brand);
     }
     .action-ghost {
       color: var(--color-brand);
-      padding: 10px 20px;
     }
     .action-ghost:hover {
       text-decoration: underline;
@@ -181,7 +205,7 @@
           <form id="publisher-lookup-form" style="display: flex; gap: var(--space-3); margin-top: var(--space-4); flex-wrap: wrap;">
             <input id="publisher-lookup-input" type="text" placeholder="example.com" required pattern="[a-zA-Z0-9.\-]+" autocomplete="off"
               style="flex: 1 1 240px; padding: var(--space-2) var(--space-3); border: var(--border-1) solid var(--color-border); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: var(--text-sm);" />
-            <button type="submit" class="action-primary" style="border: none; cursor: pointer;">Open publisher page</button>
+            <button type="submit" class="action-primary">Open publisher page</button>
             <a href="/publishers" class="action-secondary">Browse all publishers</a>
           </form>
         </div>

--- a/server/public/secretariat.html
+++ b/server/public/secretariat.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>Admin - Secretariat console - AdCP Registry</title>
   <link rel="stylesheet" href="/design-system.css">
   <script src="/nav.js"></script>
@@ -111,18 +111,18 @@
       font-size: var(--text-sm);
       margin-top: var(--space-2);
       padding: var(--space-3);
-      background: var(--color-success-50);
+      background: var(--color-success-bg);
       border-radius: var(--radius-sm);
     }
     .action-error {
       font-size: var(--text-sm);
       margin-top: var(--space-2);
       padding: var(--space-3);
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
       border-radius: var(--radius-sm);
       white-space: pre-wrap;
-      color: var(--color-error-700);
+      color: var(--color-error-fg);
     }
     .payload-details { margin-top: var(--space-2); font-size: var(--text-sm); }
     .payload-details summary { cursor: pointer; color: var(--color-text-secondary); }

--- a/server/public/si-apps/a2ui-test.html
+++ b/server/public/si-apps/a2ui-test.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>A2UI Rendering Test</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/server/public/si-apps/shell.html
+++ b/server/public/si-apps/shell.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SI Agent UI</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <style>
     :root {
       --si-font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/server/public/stories/index.html
+++ b/server/public/stories/index.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="How advertising works when AI agents handle media buying, selling, and campaign management. Stories, analysis, and news from AgenticAdvertising.org.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://agenticadvertising.org/stories">
-  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>
@@ -46,7 +46,20 @@
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
       scrollbar-width: none;
-      justify-content: center;
+      /* Centring an overflowing flex row spills content into negative scroll
+         space, where it is unreachable. Start aligned; `safe center` below
+         re-centres only when the pills actually fit. */
+      justify-content: flex-start;
+      /* Soft edges, set per side by syncPillFade() so an edge stays crisp
+         until there is really more to scroll toward. A mask fades to true
+         transparency, so it needs no colour and works on any background. */
+      --pill-fade-start: 0px;
+      --pill-fade-end: 0px;
+      -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--pill-fade-start), black calc(100% - var(--pill-fade-end)), transparent 100%);
+      mask-image: linear-gradient(to right, transparent 0, black var(--pill-fade-start), black calc(100% - var(--pill-fade-end)), transparent 100%);
+    }
+    @supports (justify-content: safe center) {
+      .pill-tabs { justify-content: safe center; }
     }
     .pill-tabs::-webkit-scrollbar { display: none; }
 
@@ -497,10 +510,62 @@
         return topicStr.split(',').some(function(t) { return t.trim() === topic; });
       }
 
+      // Fade an edge only while there is more rail beyond it, so the first
+      // and last pill stay crisp at the ends of the scroll.
+      var PILL_FADE = 48;
+      function syncPillFade() {
+        var rail = document.getElementById('topic-tabs');
+        if (!rail) return;
+        var maxScroll = rail.scrollWidth - rail.clientWidth;
+        // Sub-pixel layout can leave scrollLeft a hair short of maxScroll.
+        var atStart = rail.scrollLeft <= 1;
+        var atEnd = rail.scrollLeft >= maxScroll - 1;
+        rail.style.setProperty('--pill-fade-start', (atStart ? 0 : PILL_FADE) + 'px');
+        rail.style.setProperty('--pill-fade-end', (atEnd ? 0 : PILL_FADE) + 'px');
+      }
+
+      // Async content keeps registering topics and rebuilding the rail, which
+      // resets scrollLeft. Keep re-centring across those rebuilds, but stop as
+      // soon as the reader takes over. Only real input events count -- a
+      // scroll listener would also fire for our own programmatic scrolling.
+      var railTouched = false;
+      function markRailTouched() { railTouched = true; }
+
+      // Scroll the rail itself rather than calling scrollIntoView, which
+      // would also scroll ancestors and jump the page away from the hero.
+      function centerActivePill() {
+        var rail = document.getElementById('topic-tabs');
+        if (!rail) return;
+        var active = rail.querySelector('.pill-tab.active');
+        if (!active) return;
+        // Measure against the rail itself. offsetLeft is relative to the
+        // nearest positioned ancestor, which is not this container, so it
+        // would skew the target by the rail's own page offset.
+        var railBox = rail.getBoundingClientRect();
+        var pillBox = active.getBoundingClientRect();
+        var target = rail.scrollLeft + (pillBox.left - railBox.left)
+          - (rail.clientWidth - pillBox.width) / 2;
+        rail.scrollLeft = Math.max(0, Math.min(target, rail.scrollWidth - rail.clientWidth));
+      }
+
       // Register topics from static story cards and build pills immediately
       registerTopicsFromElements('#stories-grid .card');
       buildPills();
       buildOriginFilter();
+
+      var topicRail = document.getElementById('topic-tabs');
+      if (topicRail) {
+        topicRail.addEventListener('scroll', syncPillFade, { passive: true });
+        ['wheel', 'touchstart', 'pointerdown', 'keydown'].forEach(function(evt) {
+          topicRail.addEventListener(evt, markRailTouched, { passive: true });
+        });
+        window.addEventListener('resize', function() {
+          if (!railTouched) centerActivePill();
+          syncPillFade();
+        });
+      }
+      centerActivePill();
+      syncPillFade();
 
       var pillsBuilt = true;
 
@@ -645,6 +710,9 @@
           tab.addEventListener('click', function(e) { e.preventDefault(); applyFilter(topic); });
           tabsContainer.appendChild(tab);
         });
+
+        if (!railTouched) centerActivePill();
+        syncPillFade();
       }
 
       function buildOriginFilter() {

--- a/server/public/stories/the-pitch.html
+++ b/server/public/stories/the-pitch.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="A Head of Media pitches agentic advertising to the C-suite. Three shifts that change how brands buy media.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agenticadvertising.org/stories/the-pitch">
-  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/stories/the-shelf.html
+++ b/server/public/stories/the-shelf.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="A retail media network chooses an agentic storefront over a self-service platform — exposing sponsored products, in-store screens, and closed-loop attribution to every buyer agent.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agenticadvertising.org/stories/the-shelf">
-  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/stories/the-studio.html
+++ b/server/public/stories/the-studio.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="A creator studio builds one agentic storefront to sell everything — sponsorships, placements, audience data, talent rights.">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agenticadvertising.org/stories/the-studio">
-  <link rel="icon" href="/AAo.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/study-guide.html
+++ b/server/public/study-guide.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AdCP Academy study guide - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =========================================================================

--- a/server/public/team.html
+++ b/server/public/team.html
@@ -197,7 +197,7 @@
     .form-group select:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .form-help {
       font-size: var(--text-xs);

--- a/server/public/team.html
+++ b/server/public/team.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Team Management - AdCP Registry</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     /* =============================================================================
@@ -204,8 +205,6 @@
       margin-top: var(--space-1);
     }
     .error-message {
-      background: var(--color-error-50);
-      color: var(--color-error-600);
       padding: var(--space-2_5) var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-4);
@@ -220,25 +219,21 @@
       font-size: var(--text-sm);
     }
     .info-box {
-      background: var(--color-info-50);
-      border-left: var(--border-4) solid var(--color-info-500);
       padding: var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
     }
     .info-box p {
-      color: var(--color-info-700);
+      color: var(--color-text);
       margin: 0;
     }
     .permission-warning {
-      background: var(--color-warning-50);
-      border-left: var(--border-4) solid var(--color-warning-500);
       padding: var(--space-4);
       border-radius: var(--radius-md);
       margin-bottom: var(--space-5);
     }
     .permission-warning p {
-      color: var(--color-warning-700);
+      color: var(--color-text);
       margin: 0;
     }
     /* Override dashboard-nav's container reset to keep content properly sized */
@@ -274,7 +269,7 @@
   <div id="inviteModal" class="modal-overlay">
     <div class="modal">
       <h2>Add team member</h2>
-      <div id="inviteError" class="error-message" style="display: none;"></div>
+      <div id="inviteError" class="error-message ds-alert ds-alert-error" style="display: none;"></div>
       <form id="inviteForm">
         <div class="form-group">
           <label for="inviteEmail">Email address</label>
@@ -308,7 +303,7 @@
   <div id="editRoleModal" class="modal-overlay">
     <div class="modal">
       <h2>Edit Member</h2>
-      <div id="editRoleError" class="error-message" style="display: none;"></div>
+      <div id="editRoleError" class="error-message ds-alert ds-alert-error" style="display: none;"></div>
       <form id="editRoleForm">
         <input type="hidden" id="editMembershipId">
         <input type="hidden" id="editMemberSlackLinked">
@@ -369,12 +364,12 @@
       Loading...
     </div>
 
-    <div id="permissionWarning" class="permission-warning" style="display: none;">
+    <div id="permissionWarning" class="permission-warning ds-alert ds-alert-warning" style="display: none;">
       <p>You have view-only access to this organization. Contact an admin or owner to manage team members.</p>
     </div>
 
     <!-- Personal workspace notice -->
-    <div id="personalWorkspaceNotice" class="info-box" style="display: none;">
+    <div id="personalWorkspaceNotice" class="info-box ds-alert ds-alert-info" style="display: none;">
       <p><strong>Personal workspaces don't support team features.</strong></p>
       <p style="margin-top: 8px;">Personal workspaces are for individual use only. To invite team members and claim a corporate domain, you'll need to convert this to a team workspace.</p>
       <div style="margin-top: 16px;">
@@ -525,7 +520,7 @@
           <span>Potential Members</span>
           <button id="addAllBtn" class="btn btn-primary" onclick="addAllDomainUsers()" style="display: none;">+ Add All</button>
         </h2>
-        <div class="info-box">
+        <div class="info-box ds-alert ds-alert-info">
           <p>These people are in the AgenticAdvertising.org Slack workspace with your verified domain but haven't joined your organization yet. Click "Add" to add them directly to your team.</p>
         </div>
         <div id="domainUsersContent">
@@ -881,13 +876,13 @@
       el.style.gridTemplateColumns = hasCommunitySeats ? '1fr 1fr' : '1fr';
       el.style.gap = 'var(--space-3)';
       el.innerHTML = `
-        <div style="padding: var(--space-3); background: var(--color-primary-50); border-radius: var(--radius-md); font-size: var(--text-sm);">
+        <div style="padding: var(--space-3); background: var(--color-brand-bg); border-radius: var(--radius-md); font-size: var(--text-sm);">
           <strong>${usage.contributor} / ${limits.contributor}</strong> Contributor seats
-          <div style="font-size: 10px; color: var(--color-text-muted); margin-top: 2px;">Slack, working groups, councils, summit</div>
+          <div style="font-size: 10px; color: var(--color-text-secondary); margin-top: 2px;">Slack, working groups, councils, summit</div>
         </div>
-        ${hasCommunitySeats ? `<div style="padding: var(--space-3); background: var(--color-success-50); border-radius: var(--radius-md); font-size: var(--text-sm);">
+        ${hasCommunitySeats ? `<div style="padding: var(--space-3); background: var(--color-success-bg); border-radius: var(--radius-md); font-size: var(--text-sm);">
           <strong>${usage.community_only} / ${communityLimit}</strong> Community seats
-          <div style="font-size: 10px; color: var(--color-text-muted); margin-top: 2px;">Addie, certification, training, chapters</div>
+          <div style="font-size: 10px; color: var(--color-text-secondary); margin-top: 2px;">Addie, certification, training, chapters</div>
         </div>` : ''}
       `;
     }
@@ -1329,7 +1324,7 @@
       // (the better path) vs email us to dispute.
       const sourceBadge = (source) => {
         if (source === 'brand_json') {
-          return `<span style="padding: 2px 6px; border-radius: var(--radius-1); font-size: var(--text-xs); background: var(--color-success-50); color: var(--color-success-700);" title="Self-asserted in brand.json">Asserted</span>`;
+          return `<span style="padding: 2px 6px; border-radius: var(--radius-1); font-size: var(--text-xs); background: var(--color-success-bg); color: var(--color-success-fg);" title="Self-asserted in brand.json">Asserted</span>`;
         }
         return `<span style="padding: 2px 6px; border-radius: var(--radius-1); font-size: var(--text-xs); background: var(--color-bg-subtle); color: var(--color-text-secondary);" title="Inferred by automated classification">Inferred</span>`;
       };

--- a/server/public/video-lab.html
+++ b/server/public/video-lab.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Addie Video Lab (admin) - Agentic Advertising</title>
-  <link rel="icon" type="image/svg+xml" href="/addie-icon.svg">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/design-system.css">
   <!-- Daily JS SDK loaded from CDN. Lab is admin-only and experimental;
        pin a version before promoting any of this to production. -->
@@ -74,8 +74,8 @@
       margin-left: auto;
       padding: 2px 7px;
       border-radius: 999px;
-      background: var(--color-warning-50);
-      color: var(--color-warning-700);
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
       font-size: 10px;
       font-weight: 600;
     }
@@ -411,9 +411,9 @@
 
     #error-banner {
       display: none;
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-100);
-      color: var(--color-error-600);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
+      color: var(--color-error-fg);
       padding: 12px 16px;
       border-radius: 8px;
       font-size: 13px;

--- a/server/public/video-lab.html
+++ b/server/public/video-lab.html
@@ -29,7 +29,14 @@
       align-items: center;
       gap: 12px;
     }
-    .lab-header img { width: 28px; height: auto; }
+    .lab-header img {
+      width: 32px;
+      height: 32px;
+      padding: 3px;
+      border-radius: 50%;
+      background: var(--color-avatar-disc);
+      object-fit: contain;
+    }
     .lab-header h1 { font-size: 16px; font-weight: 600; color: var(--color-text-heading); }
     .lab-badge {
       font-size: 11px;

--- a/server/public/video.html
+++ b/server/public/video.html
@@ -60,7 +60,11 @@
 
     .addie-avatar {
       width: 36px;
-      height: auto;
+      height: 36px;
+      padding: 3px;
+      border-radius: 50%;
+      background: var(--color-avatar-disc);
+      object-fit: contain;
       flex-shrink: 0;
     }
 

--- a/server/public/video.html
+++ b/server/public/video.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Video chat with Addie - Agentic Advertising</title>
-  <link rel="icon" type="image/svg+xml" href="/addie-icon.svg">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/design-system.css">
   <style>
     * {
@@ -263,11 +263,11 @@
     /* Error state */
     #error-message {
       display: none;
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-100);
+      background: var(--color-error-bg);
+      border: 1px solid var(--color-error-border, var(--color-border));
       border-radius: 8px;
       padding: 16px;
-      color: var(--color-error-600);
+      color: var(--color-error-fg);
       font-size: 14px;
       max-width: 480px;
       text-align: center;

--- a/server/public/welcome-subscribed.html
+++ b/server/public/welcome-subscribed.html
@@ -8,7 +8,7 @@
   <meta name="robots" content="noindex">
   <!-- Don't leak the confirm token to third-party assets via Referer. -->
   <meta name="referrer" content="no-referrer">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <link rel="stylesheet" href="/layout.css">
   <style>

--- a/server/public/working-groups.html
+++ b/server/public/working-groups.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Working Groups | AgenticAdvertising.org</title>
   <meta name="description" content="Collaborative working groups driving the future of agentic advertising standards.">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://agenticadvertising.org/committees?type=working_group">
   <meta http-equiv="refresh" content="0;url=/committees?type=working_group">
 </head>

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -928,7 +928,7 @@
     .form-group input:focus, .form-group textarea:focus, .form-group select:focus {
       outline: none;
       border-color: var(--color-brand);
-      box-shadow: 0 0 0 3px var(--color-primary-100);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
     }
     .form-group small {
       display: block;

--- a/server/public/working-groups/detail.html
+++ b/server/public/working-groups/detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title id="pageTitle">Loading... | AgenticAdvertising.org</title>
   <meta name="description" id="pageDescription" content="Loading...">
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="canonical" id="canonicalUrl" href="">
 
   <!-- Open Graph / Facebook (updated dynamically) -->
@@ -133,7 +133,7 @@
     .join-notice {
       flex-basis: 100%;
       padding: var(--space-3) var(--space-4);
-      border: var(--border-1) solid var(--color-warning-300);
+      border: var(--border-1) solid var(--color-warning-border, var(--color-border));
       border-radius: var(--radius-md);
       background: var(--color-warning-bg);
       color: var(--color-warning-fg);
@@ -186,9 +186,9 @@
     }
 
     .btn-danger {
-      background: var(--color-error-50);
-      color: var(--color-error-600);
-      border: var(--border-2) solid var(--color-error-200);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
+      border: var(--border-2) solid var(--color-error-border, var(--color-border));
     }
 
     .btn-danger:hover {
@@ -330,7 +330,7 @@
     }
 
     .member-item:hover {
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .member-avatar {
@@ -388,7 +388,7 @@
 
     .post-card:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .post-title {
@@ -443,7 +443,7 @@
 
     .event-card:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .event-date-badge {
@@ -532,15 +532,15 @@
     .host-event-prompt {
       margin-top: var(--space-6);
       padding: var(--space-4);
-      background: var(--color-primary-50);
-      border: var(--border-1) solid var(--color-primary-200);
+      background: var(--color-brand-bg);
+      border: var(--border-1) solid var(--color-brand-border, var(--color-border));
       border-radius: var(--radius-lg);
       text-align: center;
     }
 
     .host-event-prompt p {
       margin: 0 0 var(--space-3) 0;
-      color: var(--color-text-body);
+      color: var(--color-text);
       font-size: var(--text-sm);
     }
 
@@ -573,7 +573,7 @@
 
     .meeting-card:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .meeting-date-badge {
@@ -683,7 +683,7 @@
 
     .document-card:hover {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
+      background: var(--color-brand-bg);
     }
 
     .document-card.featured {
@@ -758,28 +758,25 @@
     }
 
     .document-status.success {
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
     }
 
     .document-status.pending {
-      background: var(--color-warning-50);
-      color: var(--color-warning-700);
+      background: var(--color-warning-bg);
+      color: var(--color-warning-fg);
     }
 
     .document-status.error {
-      background: var(--color-error-50);
-      color: var(--color-error-600);
+      background: var(--color-error-bg);
+      color: var(--color-error-fg);
     }
 
     .document-fix-banner {
       margin-top: var(--space-2);
       padding: var(--space-3);
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
       border-radius: var(--radius-md);
       font-size: var(--text-sm);
-      color: var(--color-text-secondary);
       line-height: 1.5;
     }
 
@@ -837,8 +834,8 @@
       align-items: center;
       gap: var(--space-2);
       padding: var(--space-2) var(--space-4);
-      background: var(--color-success-50);
-      color: var(--color-success-700);
+      background: var(--color-success-bg);
+      color: var(--color-success-fg);
       border-radius: var(--radius-lg);
       font-size: var(--text-sm);
       font-weight: var(--font-medium);
@@ -851,8 +848,8 @@
 
     /* Login Prompt */
     .login-prompt {
-      background: var(--color-primary-50);
-      border: var(--border-1) solid var(--color-primary-200);
+      background: var(--color-brand-bg);
+      border: var(--border-1) solid var(--color-brand-border, var(--color-border));
       border-radius: var(--radius-lg);
       padding: var(--space-4);
       text-align: center;
@@ -861,7 +858,7 @@
 
     .login-prompt p {
       margin-bottom: var(--space-3);
-      color: var(--color-text-body);
+      color: var(--color-text);
     }
 
     .login-prompt a {
@@ -986,13 +983,10 @@
     .char-count.warning { color: var(--color-warning-600); }
     .char-count.over { color: var(--color-error-600); }
     .visibility-note {
-      background: var(--color-info-50);
-      border: var(--border-1) solid var(--color-info-200);
       border-radius: var(--radius-md);
       padding: var(--space-3);
       margin-bottom: var(--space-4);
       font-size: var(--text-sm);
-      color: var(--color-info-700);
     }
     @media (max-width: 768px) {
       .form-row { grid-template-columns: 1fr; }
@@ -1319,7 +1313,7 @@
     <div class="modal">
       <h2 id="modalTitle">New Post</h2>
 
-      <div id="visibilityNote" class="visibility-note">
+      <div id="visibilityNote" class="visibility-note ds-alert ds-alert-info ds-alert-ring">
         This post will be visible to working group members only.
       </div>
 
@@ -2061,7 +2055,7 @@
                 </div>
                 ${doc.document_summary ? `<div class="document-summary">${escapeHtml(markdownToPlainText(doc.document_summary))}</div>` : ''}
                 ${doc.index_status === 'access_denied' && (isMember || isAdmin) ? `
-                  <div class="document-fix-banner">
+                  <div class="document-fix-banner ds-alert ds-alert-error ds-alert-ring">
                     <p>Addie can't read this document. To fix it:</p>
                     <ol>
                       <li>Open the document and click <strong>Share</strong></li>

--- a/server/public/working-groups/manage.html
+++ b/server/public/working-groups/manage.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title id="pageTitle">Manage Posts | Working Group | AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/design-system.css">
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -209,8 +209,8 @@
     }
     .type-toggle button.active {
       border-color: var(--color-brand);
-      background: var(--color-primary-50);
-      color: var(--color-brand);
+      background: var(--color-brand-bg);
+      color: var(--color-brand-fg, var(--color-brand));
     }
     .url-input-group {
       display: flex;
@@ -426,11 +426,8 @@
     .document-fix-hint {
       margin-top: var(--space-2);
       padding: var(--space-2) var(--space-3);
-      background: var(--color-error-50);
-      border: 1px solid var(--color-error-200);
       border-radius: var(--radius-sm);
       font-size: var(--text-sm);
-      color: var(--color-text-secondary);
       line-height: 1.5;
     }
 
@@ -1748,7 +1745,7 @@
               </div>
               ${doc.document_summary ? `<div class="document-summary-preview">${escapeHtml(doc.document_summary)}</div>` : ''}
               ${doc.index_status === 'access_denied' ? `
-                <div class="document-fix-hint">
+                <div class="document-fix-hint ds-alert ds-alert-error ds-alert-ring">
                   Share this document with <code>addie@agenticadvertising.org</code> (Viewer), then click the refresh button to retry.
                 </div>
               ` : ''}

--- a/server/scripts/seed-addie-web-thread.ts
+++ b/server/scripts/seed-addie-web-thread.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed a populated web chat thread.
+ *
+ * Local dev has no ANTHROPIC_API_KEY in docker-compose, so /chat can render
+ * the shell but never a conversation. This writes a realistic thread straight
+ * through ThreadService — same path the live chat uses — so the transcript UI,
+ * the sidebar history, per-message feedback controls, and the admin
+ * conversation viewer all have something to show.
+ *
+ * Usage (run on the host against the docker Postgres; scripts/ is not compiled
+ * into dist/, so this only runs under tsx):
+ *   DATABASE_URL="postgresql://adcp:localdev@localhost:$(docker compose port postgres 5432 | cut -d: -f2)/adcp_registry" \
+ *     ./node_modules/.bin/tsx server/scripts/seed-addie-web-thread.ts
+ *
+ *   --user <key>    dev user that owns the thread (default: admin)
+ *   --title <text>  thread title shown in the sidebar
+ */
+
+import { randomUUID } from 'crypto';
+import { initializeDatabase, closeDatabase } from '../src/db/client.js';
+import { getThreadService } from '../src/addie/thread-service.js';
+import type { ModelExecution } from '../src/addie/model-providers/model-provider.js';
+
+// Mirrors DEV_USERS in server/src/middleware/auth.ts. Duplicated rather than
+// imported so this script doesn't pull in the WorkOS SDK or the prod-boot guard.
+const DEV_USER_IDS: Record<string, { id: string; name: string }> = {
+  admin: { id: 'user_dev_admin_001', name: 'Admin' },
+  member: { id: 'user_dev_member_001', name: 'Member' },
+  personal: { id: 'user_dev_personal_001', name: 'Personal' },
+  nonmember: { id: 'user_dev_nonmember_001', name: 'Visitor' },
+  leader: { id: 'user_dev_leader_001', name: 'Committee' },
+};
+
+const MODEL = 'claude-sonnet-5';
+
+const EXECUTION: ModelExecution = {
+  source: 'provider',
+  requested_provider: 'anthropic',
+  requested_model: MODEL,
+  provider: 'anthropic',
+  model: MODEL,
+  model_resolution: 'exact',
+  fallback_reason: null,
+};
+
+interface SeedTurn {
+  user: string;
+  assistant: string;
+  tools?: string[];
+  latencyMs: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+const TURNS: SeedTurn[] = [
+  {
+    user: 'What is AdCP, and how is it different from OpenRTB?',
+    assistant:
+      "AdCP is an open standard for **advertising automation** — it gives AI agents a common vocabulary for discovering inventory, buying media, building creatives, and activating audiences.\n\nThe cleanest way to see the difference is by layer:\n\n| | OpenRTB | AdCP |\n|---|---|---|\n| **When** | Impression time (~100ms budget) | Planning time, then serve time |\n| **Who talks** | Exchange ↔ bidder | Agent ↔ agent |\n| **Shape** | One bid request, one response | Conversational tasks with state |\n\nAdCP spans two layers. The **negotiation layer** (Media Buy, Creative, Signals, Accounts, Governance, Brand) runs over MCP and A2A — that's where `get_products`, `create_media_buy`, and `build_creative` live. The **decisioning and serving layer** is the Trusted Match HTTP profile, which is where the impression-time latency budget actually applies.\n\nSo they aren't competitors. OpenRTB decides which bid wins; AdCP is how a buying agent got to the point of having something to bid on.",
+    tools: ['search_docs'],
+    latencyMs: 6420,
+    tokensIn: 12840,
+    tokensOut: 412,
+  },
+  {
+    user: 'Which tasks would a buyer agent need to implement first?',
+    assistant:
+      "Start with the discovery-to-buy spine — four tasks get you a working buyer agent:\n\n1. **`get_products`** — inventory discovery. Send a brief, get back products that match. This is the one to build first because everything downstream depends on the product IDs it returns.\n2. **`create_media_buy`** — commits to packages. Note that it's async: you get a task back and poll or receive a webhook, you don't get a confirmed buy synchronously.\n3. **`get_media_buy_delivery`** — reporting. Needed sooner than teams expect, because without it you can't tell whether step 2 actually did anything.\n4. **`get_adcp_capabilities`** — capability negotiation. Cheap to implement, and it stops you from calling tasks the sell-side agent doesn't support.\n\nCreative is a separate surface (`build_creative`, `preview_creative`) and you can defer it if you're bringing your own hosted assets.\n\nOne thing worth deciding early: MCP or A2A transport. Both are normative, but the ergonomics differ — MCP if you're plugging into an existing agent client, A2A if you're running agent-to-agent with long-lived tasks.",
+    tools: ['search_docs', 'ask_about_adcp_task'],
+    latencyMs: 8910,
+    tokensIn: 18220,
+    tokensOut: 538,
+  },
+  {
+    user: 'Is there a reference implementation I can read?',
+    assistant:
+      "Yes — a few, and they serve different purposes:\n\n- **Sell-side reference** is maintained by the [Prebid](https://www.prebid.org/) community. Spec governance (AgenticAdvertising.org) and reference-implementation development (Prebid) are deliberately separate organizations, so the reference doesn't get to define the spec by accident.\n- **`server/`** in the adcp repo is an illustrative registry/API/MCP implementation. Useful to read, explicitly *not* normative — the schemas in `static/schemas/source/` and the docs in `docs/` are the contract.\n- **Conformance** is measured independently by the grader and storyboards in `dist/compliance/`. If you want to know whether your agent is actually correct, run that rather than diffing against anyone's implementation.\n\nWant me to walk through the compliance runner setup for a buyer agent?",
+    tools: ['search_repos', 'search_docs'],
+    latencyMs: 5730,
+    tokensIn: 21460,
+    tokensOut: 356,
+  },
+];
+
+function parseArgs(): { userKey: string; title: string } {
+  const args = process.argv.slice(2);
+  let userKey = 'admin';
+  let title = 'AdCP vs OpenRTB, and where to start';
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--user' && args[i + 1]) userKey = args[++i];
+    else if (args[i] === '--title' && args[i + 1]) title = args[++i];
+  }
+  return { userKey, title };
+}
+
+async function main(): Promise<void> {
+  const { userKey, title } = parseArgs();
+
+  const devUser = DEV_USER_IDS[userKey];
+  if (!devUser) {
+    console.error(`Unknown dev user "${userKey}". Options: ${Object.keys(DEV_USER_IDS).join(', ')}`);
+    process.exit(1);
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL is required.');
+    console.error('Local docker stack: DATABASE_URL=postgresql://adcp:localdev@localhost:$(docker compose port postgres 5432 | cut -d: -f2)/adcp_registry');
+    process.exit(1);
+  }
+
+  initializeDatabase({ connectionString, ssl: false, maxPoolSize: 2 });
+
+  const threads = getThreadService();
+  const conversationId = randomUUID();
+
+  const thread = await threads.getOrCreateThread({
+    channel: 'web',
+    external_id: conversationId,
+    user_type: 'workos',
+    user_id: devUser.id,
+    user_display_name: devUser.name,
+    context: { referrer: 'https://agenticadvertising.org/', user_agent: 'seed-addie-web-thread' },
+    title,
+  });
+
+  for (const turn of TURNS) {
+    await threads.addMessage({
+      thread_id: thread.thread_id,
+      role: 'user',
+      content: turn.user,
+      user_id: devUser.id,
+      user_display_name: devUser.name,
+      message_source: 'typed',
+    });
+
+    await threads.addMessage({
+      thread_id: thread.thread_id,
+      role: 'assistant',
+      content: turn.assistant,
+      model: MODEL,
+      model_execution: EXECUTION,
+      tools_used: turn.tools,
+      latency_ms: turn.latencyMs,
+      tokens_input: turn.tokensIn,
+      tokens_output: turn.tokensOut,
+      timing: {
+        system_prompt_ms: 180,
+        total_llm_ms: Math.round(turn.latencyMs * 0.7),
+        total_tool_ms: Math.round(turn.latencyMs * 0.25),
+        iterations: turn.tools ? turn.tools.length + 1 : 1,
+      },
+    });
+  }
+
+  await threads.updateThreadTitle(thread.thread_id, title);
+  await closeDatabase();
+
+  console.log('Seeded web chat thread');
+  console.log(`  owner:           ${devUser.id} (dev user "${userKey}")`);
+  console.log(`  conversation_id: ${conversationId}`);
+  console.log(`  messages:        ${TURNS.length * 2}`);
+  console.log('');
+  console.log('To view it:');
+  console.log('  1. Sign in at http://localhost:3000/dev-login.html as the matching dev user');
+  console.log('  2. Open http://localhost:3000/chat');
+  console.log('  3. Pick the thread from the sidebar History list');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/scripts/seed-notifications.ts
+++ b/server/scripts/seed-notifications.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed in-app notifications for a dev user.
+ *
+ * Nothing in local dev produces notifications organically — they come from
+ * connection requests, WG joins, event reminders, and compliance jobs, none of
+ * which fire on a fresh docker stack. This writes a realistic spread straight
+ * into the notifications table so the bell badge, the unread-only dropdown, and
+ * the /community/notifications page (unread styling, relative timestamps,
+ * "Load more" pagination, mark-as-read) all have something to exercise.
+ *
+ * created_at is set explicitly, which NotificationDatabase.createNotification
+ * does not allow — hence the direct INSERT rather than the service layer.
+ *
+ * Usage (run on the host against the docker Postgres; scripts/ is not compiled
+ * into dist/, so this only runs under tsx):
+ *   DATABASE_URL="postgresql://adcp:localdev@localhost:$(docker compose port postgres 5432 | cut -d: -f2)/adcp_registry" \
+ *     ./node_modules/.bin/tsx server/scripts/seed-notifications.ts
+ *
+ *   --user <key>   dev user who receives them (default: admin)
+ *   --clear        delete that user's existing notifications first
+ */
+
+import { initializeDatabase, closeDatabase, query } from '../src/db/client.js';
+
+// Mirrors DEV_USERS in server/src/middleware/auth.ts. Duplicated rather than
+// imported so this script doesn't pull in the WorkOS SDK or the prod-boot guard.
+const DEV_USER_IDS: Record<string, string> = {
+  admin: 'user_dev_admin_001',
+  member: 'user_dev_member_001',
+  personal: 'user_dev_personal_001',
+  nonmember: 'user_dev_nonmember_001',
+  leader: 'user_dev_leader_001',
+  learner1: 'user_dev_learner_001',
+  builder: 'user_dev_builder_001',
+};
+
+// Actor IDs join to users.workos_user_id for the avatar initials and name.
+const ACTOR = {
+  member: 'user_dev_member_001',
+  personal: 'user_dev_personal_001',
+  leader: 'user_dev_leader_001',
+  learner: 'user_dev_learner_001',
+  builder: 'user_dev_builder_001',
+};
+
+interface SeedNotification {
+  /** Minutes ago — drives the relative-time formatting in the UI. */
+  minutesAgo: number;
+  type: string;
+  title: string;
+  url?: string;
+  actor?: string;
+  referenceId?: string;
+  referenceType?: string;
+  read?: boolean;
+}
+
+const MIN = 1;
+const HOUR = 60;
+const DAY = 24 * HOUR;
+
+// Types and title shapes copied from the real call sites (routes/community.ts,
+// db/community-db.ts, notifications/compliance.ts, addie/jobs/job-definitions.ts,
+// services/working-group-membership-service.ts) so seeded rows look like
+// production rows.
+const NOTIFICATIONS: SeedNotification[] = [
+  // --- Unread, recent: what the bell dropdown shows ---
+  {
+    minutesAgo: 0,
+    type: 'connection_request',
+    title: 'Member User sent you a connection request',
+    url: '/community/connections',
+    actor: ACTOR.member,
+    referenceType: 'connection',
+  },
+  {
+    minutesAgo: 4 * MIN,
+    type: 'wg_member_joined',
+    title: 'Personal Account (Northstar Media) joined Creative Working Group. Also active in Signals Working Group',
+    url: '/working-groups/creative',
+    actor: ACTOR.personal,
+    referenceType: 'working_group',
+  },
+  {
+    minutesAgo: 22 * MIN,
+    type: 'compliance_regression',
+    title: 'Your agent Northstar Sales Agent has compliance failures. Failing tracks: media-buy (3 failing). Creative sync returned 500 on build_creative.',
+    url: '/registry/agents/northstar-sales-agent',
+    referenceType: 'agent',
+  },
+  {
+    minutesAgo: 55 * MIN,
+    type: 'connection_accepted',
+    title: 'Committee Leader accepted your connection request',
+    url: '/community/connections',
+    actor: ACTOR.leader,
+    referenceType: 'connection',
+  },
+  {
+    minutesAgo: 2 * HOUR,
+    type: 'badge_earned',
+    title: 'You earned the "Connector" badge',
+    url: '/community',
+    referenceId: 'connector',
+    referenceType: 'badge',
+  },
+  {
+    minutesAgo: 3 * HOUR,
+    type: 'event_reminder',
+    title: 'Reminder: AdCP Community Call is tomorrow',
+    url: '/events/adcp-community-call',
+    referenceType: 'event',
+  },
+  {
+    minutesAgo: 5 * HOUR,
+    type: 'meeting_scheduled',
+    title: 'Meeting scheduled: Creative WG — format taxonomy review',
+    url: '/meetings/8f3c1d20-1111-4b0a-9a3e-2c7d5e6f7a01',
+    actor: ACTOR.leader,
+    referenceId: '8f3c1d20-1111-4b0a-9a3e-2c7d5e6f7a01',
+    referenceType: 'meeting',
+  },
+  {
+    minutesAgo: 9 * HOUR,
+    type: 'verification_earned',
+    title: 'Your agent Northstar Sales Agent is now an AAO Verified sales agent (v1.7.0).',
+    url: '/registry/agents/northstar-sales-agent',
+    referenceType: 'agent',
+  },
+  {
+    minutesAgo: 14 * HOUR,
+    type: 'waitlist_promoted',
+    title: "You're in! Your registration for Agentic Advertising Summit has been confirmed",
+    url: '/events/agentic-advertising-summit',
+    referenceType: 'event',
+  },
+  {
+    minutesAgo: 20 * HOUR,
+    type: 'connection_request',
+    title: 'Builder Member sent you a connection request',
+    url: '/community/connections',
+    actor: ACTOR.builder,
+    referenceType: 'connection',
+  },
+  // A notification with no url — renders as a non-clickable div, not an anchor.
+  {
+    minutesAgo: 26 * HOUR,
+    type: 'system_notice',
+    title: 'Scheduled maintenance on the registry API this Saturday, 02:00–03:00 UTC',
+    referenceType: 'system',
+  },
+
+  // --- Read: exercises the non-highlighted row style ---
+  {
+    minutesAgo: 30 * HOUR,
+    type: 'wg_welcome',
+    title: 'Welcome to Signals Working Group!',
+    url: '/working-groups/signals',
+    referenceType: 'working_group',
+    read: true,
+  },
+  {
+    minutesAgo: 2 * DAY,
+    type: 'compliance_recovery',
+    title: 'Your agent Northstar Sales Agent is passing all compliance tracks again.',
+    url: '/registry/agents/northstar-sales-agent',
+    referenceType: 'agent',
+    read: true,
+  },
+  {
+    minutesAgo: 2 * DAY + 5 * HOUR,
+    type: 'event_updated',
+    title: 'AdCP Community Call has been updated',
+    url: '/events/adcp-community-call',
+    referenceType: 'event',
+    read: true,
+  },
+  {
+    minutesAgo: 3 * DAY,
+    type: 'connection_accepted',
+    title: 'Learner One accepted your connection request',
+    url: '/community/connections',
+    actor: ACTOR.learner,
+    referenceType: 'connection',
+    read: true,
+  },
+  {
+    minutesAgo: 3 * DAY + 8 * HOUR,
+    type: 'badge_earned',
+    title: 'You earned the "Profile complete" badge',
+    url: '/community',
+    referenceId: 'profile_complete',
+    referenceType: 'badge',
+    read: true,
+  },
+  {
+    minutesAgo: 4 * DAY,
+    type: 'certification_nudge',
+    title: 'Your team is working toward certification — pick up where you left off',
+    url: '/certification',
+    referenceType: 'certification',
+    read: true,
+  },
+  {
+    minutesAgo: 4 * DAY + 6 * HOUR,
+    type: 'verification_lost',
+    title: 'Your agent Harbor Signals Agent lost its AAO Verified signals badge (v0.9.2). Two required tracks regressed.',
+    url: '/registry/agents/harbor-signals-agent',
+    referenceType: 'agent',
+    read: true,
+  },
+  {
+    minutesAgo: 5 * DAY,
+    type: 'event_follow_up',
+    title: 'Thanks for joining AdCP Community Call — the recording and notes are up',
+    url: '/events/adcp-community-call',
+    referenceType: 'event',
+    read: true,
+  },
+  {
+    minutesAgo: 6 * DAY,
+    type: 'wg_member_joined',
+    title: 'Learner One joined Creative Working Group',
+    url: '/working-groups/creative',
+    actor: ACTOR.learner,
+    referenceType: 'working_group',
+    read: true,
+  },
+
+  // --- Older than a week: relative time switches to an absolute date ---
+  {
+    minutesAgo: 8 * DAY,
+    type: 'compliance_extended_outage',
+    title: 'Your agent Harbor Signals Agent has been failing for 6 days. Buyers are seeing failures.',
+    url: '/registry?tab=agents',
+    referenceType: 'agent',
+    read: true,
+  },
+  {
+    minutesAgo: 11 * DAY,
+    type: 'badge_earned',
+    title: 'You earned the "Working group member" badge',
+    url: '/community',
+    referenceId: 'working_group_member',
+    referenceType: 'badge',
+    read: true,
+  },
+  {
+    minutesAgo: 14 * DAY,
+    type: 'connection_accepted',
+    title: 'Member User accepted your connection request',
+    url: '/community/connections',
+    actor: ACTOR.member,
+    referenceType: 'connection',
+    read: true,
+  },
+  {
+    minutesAgo: 18 * DAY,
+    type: 'meeting_scheduled',
+    title: 'Meeting scheduled: Signals WG — audience taxonomy kickoff',
+    url: '/meetings/8f3c1d20-2222-4b0a-9a3e-2c7d5e6f7a02',
+    actor: ACTOR.leader,
+    referenceId: '8f3c1d20-2222-4b0a-9a3e-2c7d5e6f7a02',
+    referenceType: 'meeting',
+    read: true,
+  },
+  {
+    minutesAgo: 24 * DAY,
+    type: 'wg_welcome',
+    title: 'Welcome to Creative Working Group!',
+    url: '/working-groups/creative',
+    referenceType: 'working_group',
+    read: true,
+  },
+  {
+    minutesAgo: 31 * DAY,
+    type: 'badge_earned',
+    title: 'You earned the "Contributor" badge',
+    url: '/community',
+    referenceId: 'contributor',
+    referenceType: 'badge',
+    read: true,
+  },
+];
+
+function parseArgs(): { userKey: string; clear: boolean } {
+  const args = process.argv.slice(2);
+  let userKey = 'admin';
+  let clear = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--user') {
+      userKey = args[++i];
+    } else if (args[i] === '--clear') {
+      clear = true;
+    } else {
+      console.error(`Unknown argument "${args[i]}"`);
+      process.exit(1);
+    }
+  }
+
+  return { userKey, clear };
+}
+
+async function main(): Promise<void> {
+  const { userKey, clear } = parseArgs();
+
+  const recipientId = DEV_USER_IDS[userKey];
+  if (!recipientId) {
+    console.error(`Unknown dev user "${userKey}". Options: ${Object.keys(DEV_USER_IDS).join(', ')}`);
+    process.exit(1);
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL is required.');
+    console.error('Local docker stack: DATABASE_URL=postgresql://adcp:localdev@localhost:$(docker compose port postgres 5432 | cut -d: -f2)/adcp_registry');
+    process.exit(1);
+  }
+
+  initializeDatabase({ connectionString, ssl: false, maxPoolSize: 2 });
+
+  if (clear) {
+    const deleted = await query('DELETE FROM notifications WHERE recipient_user_id = $1', [recipientId]);
+    console.log(`Cleared ${deleted.rowCount ?? 0} existing notification(s) for ${recipientId}`);
+  }
+
+  for (const n of NOTIFICATIONS) {
+    await query(
+      `INSERT INTO notifications
+         (recipient_user_id, actor_user_id, type, reference_id, reference_type, title, url, is_read, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() - ($9 || ' minutes')::interval)`,
+      [
+        recipientId,
+        n.actor ?? null,
+        n.type,
+        n.referenceId ?? null,
+        n.referenceType ?? null,
+        n.title,
+        n.url ?? null,
+        n.read ?? false,
+        String(n.minutesAgo),
+      ]
+    );
+  }
+
+  const unread = NOTIFICATIONS.filter((n) => !n.read).length;
+  await closeDatabase();
+
+  console.log(`Seeded ${NOTIFICATIONS.length} notifications`);
+  console.log(`  recipient: ${recipientId} (dev user "${userKey}")`);
+  console.log(`  unread:    ${unread} (bell badge count)`);
+  console.log(`  read:      ${NOTIFICATIONS.length - unread}`);
+  console.log('');
+  console.log('To view them:');
+  console.log(`  1. Sign in at http://localhost:3000/dev-login.html as the "${userKey}" dev user`);
+  console.log('  2. Click the bell in the navbar — the dropdown lists the 10 newest unread');
+  console.log('  3. Open http://localhost:3000/community/notifications for the full list');
+  console.log('');
+  console.log('Note: unread counts are cached in-process for 30s, so the badge may lag');
+  console.log('a re-run by up to half a minute.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/scripts/seed-notifications.ts
+++ b/server/scripts/seed-notifications.ts
@@ -60,10 +60,10 @@ const MIN = 1;
 const HOUR = 60;
 const DAY = 24 * HOUR;
 
-// Types and title shapes copied from the real call sites (routes/community.ts,
+// Types and title shapes follow the real call sites (routes/community.ts,
 // db/community-db.ts, notifications/compliance.ts, addie/jobs/job-definitions.ts,
-// services/working-group-membership-service.ts) so seeded rows look like
-// production rows.
+// services/working-group-membership-service.ts), with canonical organization
+// naming, so seeded rows look like production rows without carrying legacy copy.
 const NOTIFICATIONS: SeedNotification[] = [
   // --- Unread, recent: what the bell dropdown shows ---
   {
@@ -124,7 +124,7 @@ const NOTIFICATIONS: SeedNotification[] = [
   {
     minutesAgo: 9 * HOUR,
     type: 'verification_earned',
-    title: 'Your agent Northstar Sales Agent is now an AAO Verified sales agent (v1.7.0).',
+    title: 'Your agent Northstar Sales Agent is now an AgenticAdvertising.org Verified sales agent (v1.7.0).',
     url: '/registry/agents/northstar-sales-agent',
     referenceType: 'agent',
   },
@@ -205,7 +205,7 @@ const NOTIFICATIONS: SeedNotification[] = [
   {
     minutesAgo: 4 * DAY + 6 * HOUR,
     type: 'verification_lost',
-    title: 'Your agent Harbor Signals Agent lost its AAO Verified signals badge (v0.9.2). Two required tracks regressed.',
+    title: 'Your agent Harbor Signals Agent lost its AgenticAdvertising.org Verified signals badge (v0.9.2). Two required tracks regressed.',
     url: '/registry/agents/harbor-signals-agent',
     referenceType: 'agent',
     read: true,

--- a/server/scripts/seed-notifications.ts
+++ b/server/scripts/seed-notifications.ts
@@ -21,7 +21,7 @@
  *   --clear        delete that user's existing notifications first
  */
 
-import { initializeDatabase, closeDatabase, query } from '../src/db/client.js';
+import { initializeDatabase, closeDatabase, getClient } from '../src/db/client.js';
 
 // Mirrors DEV_USERS in server/src/middleware/auth.ts. Duplicated rather than
 // imported so this script doesn't pull in the WorkOS SDK or the prod-boot guard.
@@ -321,32 +321,56 @@ async function main(): Promise<void> {
 
   initializeDatabase({ connectionString, ssl: false, maxPoolSize: 2 });
 
-  if (clear) {
-    const deleted = await query('DELETE FROM notifications WHERE recipient_user_id = $1', [recipientId]);
-    console.log(`Cleared ${deleted.rowCount ?? 0} existing notification(s) for ${recipientId}`);
+  const client = await getClient();
+  let clearedCount = 0;
+  try {
+    await client.query('BEGIN');
+
+    if (clear) {
+      const deleted = await client.query(
+        'DELETE FROM notifications WHERE recipient_user_id = $1',
+        [recipientId]
+      );
+      clearedCount = deleted.rowCount ?? 0;
+    }
+
+    for (const n of NOTIFICATIONS) {
+      await client.query(
+        `INSERT INTO notifications
+           (recipient_user_id, actor_user_id, type, reference_id, reference_type, title, url, is_read, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() - ($9 || ' minutes')::interval)`,
+        [
+          recipientId,
+          n.actor ?? null,
+          n.type,
+          n.referenceId ?? null,
+          n.referenceType ?? null,
+          n.title,
+          n.url ?? null,
+          n.read ?? false,
+          String(n.minutesAgo),
+        ]
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      console.error('Failed to roll back notification seed transaction:', rollbackError);
+    }
+    throw error;
+  } finally {
+    client.release();
+    await closeDatabase();
   }
 
-  for (const n of NOTIFICATIONS) {
-    await query(
-      `INSERT INTO notifications
-         (recipient_user_id, actor_user_id, type, reference_id, reference_type, title, url, is_read, created_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() - ($9 || ' minutes')::interval)`,
-      [
-        recipientId,
-        n.actor ?? null,
-        n.type,
-        n.referenceId ?? null,
-        n.referenceType ?? null,
-        n.title,
-        n.url ?? null,
-        n.read ?? false,
-        String(n.minutesAgo),
-      ]
-    );
+  if (clear) {
+    console.log(`Cleared ${clearedCount} existing notification(s) for ${recipientId}`);
   }
 
   const unread = NOTIFICATIONS.filter((n) => !n.read).length;
-  await closeDatabase();
 
   console.log(`Seeded ${NOTIFICATIONS.length} notifications`);
   console.log(`  recipient: ${recipientId} (dev user "${userKey}")`);

--- a/server/src/routes/account-linking.ts
+++ b/server/src/routes/account-linking.ts
@@ -534,7 +534,7 @@ function renderConfirmPage(res: Response, opts: { targetEmail: string; hasMerge:
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Confirm Email Link - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -598,7 +598,7 @@ function renderVerifyPage(res: Response, opts: { success: boolean; message: stri
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(title)} - AgenticAdvertising.org</title>
-  <link rel="icon" href="/addie-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## Summary

A visual/theming pass over the web app, plus two dev-only seed scripts. No protocol-scoped files are touched, so there is no changeset (per `.agents/playbook.md`: website/admin UI and internal tooling are changeset-exempt).

Three strands, in two commits:

### 1. Dark-mode token coverage (`design-system.css` + ~80 pages)

The dark theme was partly assembled from **fixed palette steps** — `--color-info-50`, `--color-warning-500`, `--color-error-600` — which do not swap between themes. Each was correct in light mode and wrong in dark: light panels inheriting light body text, a near-white focus halo on the dark page, placeholder text at 3.2:1.

This adds the semantic tokens that were the missing siblings of ones already present, each defined in **all four theme blocks** (`:root`, `@media (prefers-color-scheme: dark)`, and both `html[data-theme]` overrides) so they actually swap:

| Token | Why |
|---|---|
| `--color-brand-{fg,solid,solid-hover,border}` | The raw brand hue measures 4.00:1 on `--color-brand-bg` |
| `--color-{success,warning,error,info}-border` | Tinted 1px ring for a status surface, alongside the existing `-bg`/`-fg` pair |
| `--color-focus-ring` | Replaces `--color-primary-100`, a fixed step that drew a near-white halo on the dark page |
| `--color-text-placeholder` | 4.83:1 light / 5.78:1 dark. `--color-text-muted` is gray-400 in *both* themes and measures 2.54:1 on a white card |
| `--color-code-{bg,text,border}` | Recessed field for a literal value (URL, ID, snippet) |
| `--color-drop-scrim` | Scrim behind the new chat overlay |

Four tokens are **deliberately fixed**, mirroring the existing `--color-text-on-dark`:

- `--color-brand-on-light` / `--color-text-on-light` — ink for the always-light surfaces sitting on saturated hero backgrounds. A swapping brand blue drops to 3.17:1 there in dark mode.
- `--color-pill-neutral-bg` — the judgement-free counterpart to the fixed `-100` pill backgrounds.
- `--color-avatar-disc` — fixed for the *opposite* reason: Addie's mark artwork is dark navy, so a swapping plate would hide it.

Base styles now also cover **unclassed** controls. Text-entry inputs get `--color-bg-card` (Chrome's dark default is a neutral `#3b3b3b` that clashes with the blue-tinted scale) and `::placeholder` gets the new token. The input list is explicit so checkbox/radio/file/color/range keep native rendering, and it sets `background-color` rather than the shorthand so `.ds-select` keeps its chevron.

`.ds-alert-*` also gains an explicit `color` — the tints swap, so inheriting the page body color put light text on a light panel.

### 2. Favicon

Adds `favicon.svg`, referenced from every page and from the two server-rendered account-linking pages. Redrawn from the AAo wordmark with **solid glyphs**, because the wordmark's hairline strokes fall below a pixel at 16px, and carrying a plate so one file stays legible on both a light and a dark tab strip.

`addie-icon.svg` is **retained** for its non-favicon uses: the certification badge embed, the chat notification icon, and the newsletter admin icon. Also adds `addie-mark-on-brand.svg` for the Addie CTAs on the members page.

### 3. Chat drag-and-drop overlay (`chat.html`)

The old affordance was a 2px inset ring on the composer — it said nothing about what would be accepted and appeared far from the cursor. Replaced by a full-viewport overlay that names the accepted types and per-message limits, and turns into a **refusal state** when the dragged MIME types are unsupported, the attachment cap is reached, or the conversation is read-only.

Only the MIME type is legible mid-drag (never the filename or byte size), so **size** errors still surface after release via `showError()`.

Two drag traps shape the code, and both are commented in place:

1. `dragleave` bubbles from every element the pointer crosses, so naively hiding on it strobes the overlay. Depth counting tracks entries against exits, and a 120ms debounce absorbs browsers that fire `dragleave` *before* `dragenter` at a boundary.
2. A drag ending outside the page fires no balancing `dragleave`, which would strand the overlay on screen. A null `relatedTarget`, `dragend`, and window `blur` all force a reset.

The overlay is `pointer-events: none` — one that hit-tests fires `dragleave` on the very frame it appears — and `aria-hidden`, since dragging is pointer-only and the paperclip button is the keyboard path.

Alongside it, the video-call button and theme toggle move into a shared `.chat-header-actions` block so they can no longer overlap, and the header is hidden in the welcome state, where the toggle was its only content.

### 4. Dev seed scripts (second commit)

Nothing in local dev produces notifications or a populated Addie thread organically — they come from connection requests, WG joins, event reminders and compliance jobs, none of which fire on a fresh docker stack. Both scripts write a realistic spread straight into Postgres so the bell badge, the unread-only dropdown, and the notifications page (unread styling, relative timestamps, "Load more" pagination, mark-as-read) have something to exercise.

`seed-notifications.ts` sets `created_at` explicitly, which `NotificationDatabase.createNotification` does not allow — hence the direct `INSERT` rather than the service layer. Dev user IDs are duplicated from `DEV_USERS` rather than imported so the script does not pull in the WorkOS SDK or the prod-boot guard. Both live in `server/scripts/`, outside the server tsconfig include and not compiled into `dist/`, so they run under `tsx` only.

## Testing

- `tsc --project server/tsconfig.json --noEmit` — clean, on the rebased tree
- Both seed scripts typecheck standalone (they sit outside the project include)
- Both new SVGs parse as well-formed XML
- Verified every swapping token is defined in all four theme blocks, and that the intentionally-fixed ones are defined once (or identically across blocks, for `--color-avatar-disc`)
- Confirmed no `rel="icon"` reference to `addie-icon.svg` remains, and that its three legitimate non-favicon uses still resolve

## Notes for review

- This is a **wide but shallow** diff: 46 of the 130 files are the one-line favicon swap alone. The substantive changes are `design-system.css`, `chat.html`, `nav.js`, `member-card.js` and `layout.css`.
- The favicon swap and the token swaps are interleaved within the same files, so they could not be split into separate commits without per-hunk staging across 80+ files.
- Opened from a fork — I have read-only access to this repo.

Rebased onto `main` at the time of opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
