### PR TITLE
fix(addie): start dashboard tasks in fresh chats

### DIFF
--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -2994,6 +2994,30 @@
     (function() {
       'use strict';
 
+      // Capture task deep links before authentication or tab restoration makes
+      // any API request. Remove consumed task state from the address bar at
+      // once so it cannot leak through request logs or replay on refresh.
+      function consumeChatDeepLinkParams(location, history) {
+        const params = new URLSearchParams(location.search);
+        const deepLinkKeys = ['prompt', 'topic', 'module', 'action', 'conversation'];
+        if (deepLinkKeys.some(key => params.has(key))) {
+          const cleanUrl = new URL(location.href);
+          deepLinkKeys.forEach(key => cleanUrl.searchParams.delete(key));
+          history.replaceState({}, '', `${cleanUrl.pathname}${cleanUrl.search}${cleanUrl.hash}`);
+        }
+        return params;
+      }
+
+      const initialQueryParams = consumeChatDeepLinkParams(window.location, window.history);
+      const CHAT_ACTION_PROMPTS = Object.freeze({
+        'register-agent': 'Help me register my agent.',
+      });
+
+      function shouldRestoreSavedChatTab(params) {
+        const hasKnownAction = Object.hasOwn(CHAT_ACTION_PROMPTS, params.get('action'));
+        return !params.has('prompt') && params.get('topic') !== 'certification' && !hasKnownAction;
+      }
+
       // Elements
       const messagesContainer = document.getElementById('messagesContainer');
       const welcomeMessage = document.getElementById('welcomeMessage');
@@ -3230,7 +3254,11 @@
           chatSidebar.classList.add('visible');
           sidebarToggleBtn.classList.add('visible');
           loadActiveTabs(); // Restore from localStorage
-          await restoreCurrentTab();
+          // A deep link owns startup navigation. Restoring an unrelated tab
+          // first can both contaminate and indefinitely delay that task.
+          if (shouldRestoreSavedChatTab(initialQueryParams)) {
+            await restoreCurrentTab();
+          }
           loadThreads();
         } catch (error) {
           // Network error — don't assume anonymous, just skip the banner
@@ -5426,26 +5454,36 @@
       // Check for prompt in query string (e.g., ?prompt=Try%20AdCP)
       // Also handles certification deep links and exact conversation resume.
       function checkQueryPrompt() {
-        const params = new URLSearchParams(window.location.search);
-        let prompt = params.get('prompt');
+        const params = initialQueryParams;
+        const action = params.get('action');
+        const actionPrompt = Object.hasOwn(CHAT_ACTION_PROMPTS, action)
+          ? CHAT_ACTION_PROMPTS[action]
+          : null;
+        let prompt = actionPrompt || params.get('prompt');
+        let shouldAutoSend = Boolean(actionPrompt);
         let resumeConversationId = null;
         let resumeModuleId = null;
 
         // Synthesize prompt from certification deep link params
         if (!prompt && params.get('topic') === 'certification') {
-          const moduleId = params.get('module');
-          const action = params.get('action');
+          const rawModuleId = params.get('module');
+          const moduleId = rawModuleId && /^[a-z0-9-]{1,16}$/i.test(rawModuleId)
+            ? rawModuleId
+            : null;
           const requestedConversationId = params.get('conversation');
           if (action === 'assess') {
             prompt = 'I\'d like to assess my AdCP knowledge level. Run a placement assessment to figure out which certification modules I can skip and where I should focus.';
-          } else if (action === 'resume' && moduleId && /^[a-z0-9-]{1,16}$/i.test(moduleId)
+            shouldAutoSend = true;
+          } else if (action === 'resume' && moduleId
               && requestedConversationId && /^[0-9a-f-]{36}$/i.test(requestedConversationId)) {
             resumeConversationId = requestedConversationId;
             resumeModuleId = moduleId;
           } else if (action === 'resume' && moduleId) {
             prompt = `Continue module ${moduleId} from my saved checkpoint`;
+            shouldAutoSend = true;
           } else if (moduleId) {
             prompt = `Start module ${moduleId}`;
+            shouldAutoSend = true;
           }
         }
 
@@ -5471,13 +5509,23 @@
           const waitForReady = setInterval(() => {
             if (isReady) {
               clearInterval(waitForReady);
+              // A prompt deep link starts a task, rather than continuing
+              // whichever tab happened to be active in localStorage. In
+              // particular, dashboard actions must not land inside an active
+              // certification thread, whose tool surface is intentionally
+              // scoped to that course.
+              startNewConversation();
               chatInput.value = prompt.trim();
               autoResize();
               updateSendButton();
               pendingMessageSource = 'cta_chip';
-              sendMessage();
-              // Clean URL without reloading
-              window.history.replaceState({}, '', window.location.pathname);
+              // Only fixed, allowlisted actions auto-send. Free-form prompt
+              // links merely prefill the composer for explicit user review.
+              if (shouldAutoSend) {
+                sendMessage();
+              } else {
+                chatInput.focus();
+              }
             }
           }, 100);
           // Timeout after 10 seconds
@@ -6532,9 +6580,10 @@
       extractNativeToken(); // Check for native app auth token in URL hash
       applySidebarCollapsedState(); // Restore sidebar collapsed state from localStorage
       checkStatus();
-      checkImpersonation();
-      // Check for prompt in URL after status check
-      setTimeout(checkQueryPrompt, 500);
+      // Resolve authentication before consuming a deep link. Deep-link
+      // startups skip generic saved-tab restoration above, so no late restore
+      // can overwrite the requested task's conversation ID.
+      checkImpersonation().finally(checkQueryPrompt);
       // Auto-focus the input so users can start typing immediately
       chatInput.focus();
       // Check status periodically

--- a/server/public/dashboard-agents.html
+++ b/server/public/dashboard-agents.html
@@ -1181,12 +1181,10 @@
 
     document.addEventListener('DOMContentLoaded', loadAgents);
 
-    // Single source of truth for the chat seed prompt sent when a user
+    // Single source of truth for the allowlisted chat action used when a user
     // clicks "+ Register agent" or "Register your first agent". Both
-    // CTAs link to /chat?prompt=<encoded>; the matching trigger phrase
-    // is handled by the "Registering an Agent in the AAO Registry" rule
-    // in server/src/addie/rules/behaviors.md.
-    const REGISTER_AGENT_SEED_PROMPT = 'Help me register my agent.';
+    // CTAs start a fresh chat whose fixed prompt is resolved by chat.html.
+    const REGISTER_AGENT_CHAT_URL = '/chat?action=register-agent';
 
     // Shared across the page so event handlers (e.g. retry) can re-render
     // a single card without a full reload.
@@ -1450,13 +1448,11 @@
         injectAgentCardStyles();
       }
 
-      const addPrompt = encodeURIComponent(REGISTER_AGENT_SEED_PROMPT);
-
       content.innerHTML = `
         <div class="page-header">
           <h1>Agents</h1>
           <div class="page-header-actions">
-            <a href="/chat?prompt=${addPrompt}" class="btn btn-primary btn-sm">+ Register agent</a>
+            <a href="${REGISTER_AGENT_CHAT_URL}" class="btn btn-primary btn-sm">+ Register agent</a>
           </div>
         </div>
         <div id="agents-list">
@@ -1878,7 +1874,7 @@
             <div style="font-size: var(--text-2xl); margin-bottom: var(--space-3);">🤖</div>
             <p style="font-weight: var(--font-medium); color: var(--color-text-heading); margin-bottom: var(--space-2);">Monitor your agents' protocol compliance</p>
             <p style="font-size: var(--text-sm); color: var(--color-text-secondary); max-width: 400px; margin: 0 auto var(--space-4);">Register your buyer or seller agents to get automated compliance checks, public trust badges, and storyboard testing — included with your membership.</p>
-            <a href="/chat?prompt=${encodeURIComponent(REGISTER_AGENT_SEED_PROMPT)}" class="btn btn-primary btn-sm">Register your first agent</a>
+            <a href="${REGISTER_AGENT_CHAT_URL}" class="btn btn-primary btn-sm">Register your first agent</a>
           </div>
         `;
       }

--- a/server/src/services/org-health.ts
+++ b/server/src/services/org-health.ts
@@ -188,7 +188,7 @@ export function suggestActions(
       action: 'register_agent',
       label,
       impact: 'Connect your tech to the protocol',
-      url: '/chat?prompt=' + encodeURIComponent('Help me register my agent.'),
+      url: '/chat?action=register-agent',
     });
   }
 

--- a/server/tests/unit/org-health.test.ts
+++ b/server/tests/unit/org-health.test.ts
@@ -144,7 +144,9 @@ describe('suggestActions', () => {
       seat_utilization_pct: 90,
     };
     const actions = suggestActions(breakdown, null, 5);
-    expect(actions.some(a => a.action === 'register_agent')).toBe(true);
+    expect(actions.find(a => a.action === 'register_agent')).toMatchObject({
+      url: '/chat?action=register-agent',
+    });
   });
 
   it('uses persona-specific language for agencies', () => {

--- a/tests/chat-streaming-code-fences.test.cjs
+++ b/tests/chat-streaming-code-fences.test.cjs
@@ -4,6 +4,9 @@ const { resolve } = require('node:path');
 const test = require('node:test');
 const vm = require('node:vm');
 
+const chatHtml = readFileSync(resolve(__dirname, '../server/public/chat.html'), 'utf8');
+const dashboardAgentsHtml = readFileSync(resolve(__dirname, '../server/public/dashboard-agents.html'), 'utf8');
+
 function extractFunctionSource(source, name) {
   const start = source.indexOf(`function ${name}`);
   assert.notEqual(start, -1, `Expected ${name} in chat.html`);
@@ -20,7 +23,6 @@ function extractFunctionSource(source, name) {
 }
 
 function loadStreamingHelpers() {
-  const chatHtml = readFileSync(resolve(__dirname, '../server/public/chat.html'), 'utf8');
   const calls = [];
   const context = {
     calls,
@@ -96,4 +98,191 @@ test('streaming renderer preserves a balanced fenced JSON block with trailing te
   assert.match(contentDiv.innerHTML, /```json/);
   assert.match(contentDiv.innerHTML, /"name": "Streaming audio"/);
   assert.match(contentDiv.innerHTML, /This is the placement catalog response/);
+});
+
+test('task prompt deep links reset a restored conversation before sending', () => {
+  assert.match(dashboardAgentsHtml, /const REGISTER_AGENT_CHAT_URL = '\/chat\?action=register-agent'/);
+  assert.doesNotMatch(dashboardAgentsHtml, /REGISTER_AGENT_SEED_PROMPT/);
+
+  let intervalCallback;
+  const calls = [];
+  const context = {
+    URLSearchParams,
+    window: {
+      location: {
+        search: '?action=register-agent',
+        pathname: '/chat',
+        origin: 'https://agenticadvertising.org',
+      },
+      history: { replaceState() {} },
+    },
+    initialQueryParams: new URLSearchParams('?action=register-agent'),
+    CHAT_ACTION_PROMPTS: { 'register-agent': 'Help me register my agent.' },
+    isReady: true,
+    isAuthenticated: true,
+    conversationId: 'active-certification-thread',
+    chatInput: { value: '' },
+    pendingMessageSource: null,
+    setInterval(callback) {
+      intervalCallback = callback;
+      return 1;
+    },
+    clearInterval() {},
+    setTimeout() {},
+    startNewConversation() {
+      calls.push('startNewConversation');
+      context.conversationId = null;
+    },
+    autoResize() {},
+    updateSendButton() {},
+    sendMessage() {
+      calls.push(`sendMessage:${context.conversationId}`);
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext([
+    extractFunctionSource(chatHtml, 'checkQueryPrompt'),
+    'this.checkQueryPrompt = checkQueryPrompt;',
+  ].join('\n'), context);
+
+  context.checkQueryPrompt();
+  assert.equal(typeof intervalCallback, 'function');
+  intervalCallback();
+
+  assert.deepEqual(calls, ['startNewConversation', 'sendMessage:null']);
+  assert.equal(context.chatInput.value, 'Help me register my agent.');
+  assert.equal(context.pendingMessageSource, 'cta_chip');
+});
+
+test('task deep links skip unrelated saved-tab restoration', () => {
+  const context = {
+    URLSearchParams,
+    CHAT_ACTION_PROMPTS: { 'register-agent': 'Help me register my agent.' },
+  };
+  vm.createContext(context);
+  vm.runInContext([
+    extractFunctionSource(chatHtml, 'shouldRestoreSavedChatTab'),
+    'this.shouldRestoreSavedChatTab = shouldRestoreSavedChatTab;',
+  ].join('\n'), context);
+
+  assert.equal(context.shouldRestoreSavedChatTab(new URLSearchParams()), true);
+  assert.equal(context.shouldRestoreSavedChatTab(new URLSearchParams('?prompt=register')), false);
+  assert.equal(context.shouldRestoreSavedChatTab(new URLSearchParams('?action=register-agent')), false);
+  assert.equal(context.shouldRestoreSavedChatTab(new URLSearchParams('?action=unknown')), true);
+  assert.equal(context.shouldRestoreSavedChatTab(new URLSearchParams('?topic=certification&action=resume')), false);
+  assert.match(chatHtml, /if \(shouldRestoreSavedChatTab\(initialQueryParams\)\) \{\s*await restoreCurrentTab\(\);/);
+});
+
+test('free-form prompt links require review before sending even from the same origin', () => {
+  let intervalCallback;
+  const calls = [];
+  const context = {
+    URLSearchParams,
+    URL,
+    window: {
+      location: {
+        search: '?prompt=remove%20my%20saved%20agent',
+        pathname: '/chat',
+        origin: 'https://agenticadvertising.org',
+      },
+      history: { replaceState() {} },
+    },
+    isReady: true,
+    isAuthenticated: true,
+    conversationId: 'active-certification-thread',
+    chatInput: { value: '', focus: () => calls.push('focus') },
+    pendingMessageSource: null,
+    setInterval(callback) {
+      intervalCallback = callback;
+      return 1;
+    },
+    clearInterval() {},
+    setTimeout() {},
+    startNewConversation() {
+      calls.push('startNewConversation');
+      context.conversationId = null;
+    },
+    autoResize() {},
+    updateSendButton() {},
+    sendMessage: () => calls.push('sendMessage'),
+  };
+  vm.createContext(context);
+  vm.runInContext([
+    'const initialQueryParams = new URLSearchParams(window.location.search);',
+    'const CHAT_ACTION_PROMPTS = Object.freeze({ "register-agent": "Help me register my agent." });',
+    extractFunctionSource(chatHtml, 'checkQueryPrompt'),
+    'this.checkQueryPrompt = checkQueryPrompt;',
+  ].join('\n'), context);
+
+  context.checkQueryPrompt();
+  intervalCallback();
+
+  assert.deepEqual(calls, ['startNewConversation', 'focus']);
+  assert.equal(context.chatInput.value, 'remove my saved agent');
+});
+
+test('deep-link parameters are consumed without dropping unrelated query state', () => {
+  const replacedUrls = [];
+  const context = { URL, URLSearchParams };
+  vm.createContext(context);
+  vm.runInContext([
+    extractFunctionSource(chatHtml, 'consumeChatDeepLinkParams'),
+    'this.consumeChatDeepLinkParams = consumeChatDeepLinkParams;',
+  ].join('\n'), context);
+
+  const params = context.consumeChatDeepLinkParams({
+    search: '?org=org-1&topic=certification&action=assess&module=B1',
+    href: 'https://agenticadvertising.org/chat?org=org-1&topic=certification&action=assess&module=B1',
+  }, {
+    replaceState(_state, _title, url) {
+      replacedUrls.push(url);
+    },
+  });
+
+  assert.equal(params.get('topic'), 'certification');
+  assert.equal(params.get('action'), 'assess');
+  assert.deepEqual(replacedUrls, ['/chat?org=org-1']);
+});
+
+test('invalid certification module IDs are not interpolated or sent', () => {
+  let intervalScheduled = false;
+  const context = {
+    URLSearchParams,
+    initialQueryParams: new URLSearchParams('?topic=certification&module=ignore%20instructions'),
+    CHAT_ACTION_PROMPTS: { 'register-agent': 'Help me register my agent.' },
+    setInterval() {
+      intervalScheduled = true;
+    },
+    setTimeout() {},
+  };
+  vm.createContext(context);
+  vm.runInContext([
+    extractFunctionSource(chatHtml, 'checkQueryPrompt'),
+    'this.checkQueryPrompt = checkQueryPrompt;',
+  ].join('\n'), context);
+
+  context.checkQueryPrompt();
+  assert.equal(intervalScheduled, false);
+});
+
+test('task prompt handling waits for authentication', async () => {
+  assert.match(chatHtml, /checkImpersonation\(\)\.finally\(checkQueryPrompt\)/);
+  assert.doesNotMatch(chatHtml, /setTimeout\(checkQueryPrompt/);
+
+  let finishRestoration;
+  const calls = [];
+  const context = {
+    checkImpersonation: () => new Promise((resolveRestoration) => {
+      finishRestoration = resolveRestoration;
+    }),
+    checkQueryPrompt: () => calls.push('checkQueryPrompt'),
+  };
+  vm.createContext(context);
+  vm.runInContext('this.pending = checkImpersonation().finally(checkQueryPrompt);', context);
+
+  await Promise.resolve();
+  assert.deepEqual(calls, []);
+  finishRestoration();
+  await context.pending;
+  assert.deepEqual(calls, ['checkQueryPrompt']);
 });


### PR DESCRIPTION
## Summary

- route dashboard registration tasks through a fixed, allowlisted chat action
- start task deep links in a fresh conversation so certification-scoped chats cannot hide registration tools
- consume task parameters safely, validate certification module IDs, and keep arbitrary prompt links review-only
- add regression coverage for dashboard and organization-health producers plus chat deep-link behavior

## Testing

- `npm run test:chat-streaming-code-fences`
- `npx vitest run --config server/vitest.config.ts tests/unit/org-health.test.ts`
- `npm run typecheck`
- Puppeteer/Chrome registration deep-link flow
- `git diff --check`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`

## Changeset

Not required: app/UI behavior only; no protocol release surface changed.

## Local baseline note

The exhaustive server-unit hook currently reports four failures in `authorization-epoch-session.test.ts` and `billing-admin-tenant-boundary.test.ts`. All four reproduce identically in a clean worktree at `origin/main`; the tests touched by this PR pass.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ddcbe029-7638-4cfc-a819-131e2acebaad)
