### PR TITLE
fix(release): sync Python source cache candidate pin

### DIFF
--- a/.github/workflows/validate-schema-bundle.yml
+++ b/.github/workflows/validate-schema-bundle.yml
@@ -208,21 +208,31 @@ jobs:
           sdk_version = os.environ["SDK_VERSION"]
           bundle_version = os.environ["BUNDLE_VERSION"]
           replacements = {
-              "sdk/pyproject.toml": (
-                  f"_schemas/{sdk_version}/",
-                  f"_schemas/{bundle_version}/",
-              ),
-              "sdk/MANIFEST.in": (
-                  f"_schemas/{sdk_version} ",
-                  f"_schemas/{bundle_version} ",
-              ),
+              "sdk/pyproject.toml": [
+                  (
+                      f"_schemas/{sdk_version}/",
+                      f"_schemas/{bundle_version}/",
+                  ),
+              ],
+              "sdk/MANIFEST.in": [
+                  (
+                      f"_schemas/{sdk_version} ",
+                      f"_schemas/{bundle_version} ",
+                  ),
+                  (
+                      f"schemas/cache/{sdk_version} ",
+                      f"schemas/cache/{bundle_version} ",
+                  ),
+              ],
           }
-          for filename, (old, new) in replacements.items():
+          for filename, file_replacements in replacements.items():
               path = Path(filename)
               source = path.read_text()
-              if old not in source:
-                  raise SystemExit(f"{filename} does not package the pinned SDK schema {old}")
-              path.write_text(source.replace(old, new))
+              for old, new in file_replacements:
+                  if old not in source:
+                      raise SystemExit(f"{filename} does not package the pinned SDK schema {old}")
+                  source = source.replace(old, new)
+              path.write_text(source)
           PY
           mkdir -p "${RUNNER_TEMP}/protocol-host/protocol"
           cp bundle/latest.tgz "${RUNNER_TEMP}/protocol-host/protocol/${bundle_version}.tgz"

--- a/tests/release-workflow-immutability.test.cjs
+++ b/tests/release-workflow-immutability.test.cjs
@@ -112,11 +112,12 @@ assert(
   'Python candidate validation must align its disposable package-data allowlist after pinning ADCP_VERSION and before schema generation.'
 );
 assert(
-  pythonCandidateStep.includes('"sdk/pyproject.toml": (') &&
+  pythonCandidateStep.includes('"sdk/pyproject.toml": [') &&
     pythonCandidateStep.includes('f"_schemas/{sdk_version}/"') &&
-    pythonCandidateStep.includes('"sdk/MANIFEST.in": (') &&
-    pythonCandidateStep.includes('f"_schemas/{sdk_version} "'),
-  'Python candidate validation must update the distinct wheel and sdist schema allowlist syntaxes.'
+    pythonCandidateStep.includes('"sdk/MANIFEST.in": [') &&
+    pythonCandidateStep.includes('f"_schemas/{sdk_version} "') &&
+    pythonCandidateStep.includes('f"schemas/cache/{sdk_version} "'),
+  'Python candidate validation must update the wheel and both sdist schema allowlist syntaxes.'
 );
 
 const storyboardCandidateMode = trainingAgentWorkflowConfig.jobs.storyboards.steps.find(


### PR DESCRIPTION
## Summary

Update disposable Python SDK candidate validation to synchronize both `MANIFEST.in` schema pins: the wheel/source-tree `_schemas` path and the sdist `schemas/cache` path. The second pin was added by the Python packaging hardening and is now enforced by its regression test.

Without this, generated protocol candidates fail Python SDK validation after `ADCP_VERSION` advances (as seen on #7196), and RC.0 would hit the same failure.

## Validation

- `node tests/release-workflow-immutability.test.cjs`
- `npm run test:release-workflow`
- `git diff --check`

## Release sequencing

Merge this before #7199. The validator workflow is release-relevant, so the held version-packages PR will regenerate and the RC marker will be refreshed onto the fixed mainline before merge.