### PR TITLE
fix(docs): add stable llms current index

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
     "content": "AdCP 3.2 preview is available — [see what's new and try the proposal lifecycle →](/3.2)",
     "dismissible": true
   },
-  "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms.",
+  "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms. Current stable documentation index: https://docs.adcontextprotocol.org/_llms/current.md.",
   "metadata": {
     "og:site_name": "AdCP — Ad Context Protocol",
     "og:image": "https://docs.adcontextprotocol.org/images/concepts/protocol-domain-map.png",
@@ -2881,6 +2881,11 @@
     }
   },
   "redirects": [
+    {
+      "source": "/_llms/current.md",
+      "destination": "/_llms/3-1.md",
+      "permanent": false
+    },
     {
       "source": "/extensions/adcp/v3",
       "destination": "/docs/building/by-layer/L0/a2a-profile-extension"

--- a/scripts/update-release-docs-nav.mjs
+++ b/scripts/update-release-docs-nav.mjs
@@ -26,6 +26,7 @@ const RELEASE_STORY_ALIASES = new Set([
   '/docs/reference/migration/3-1-to-3-2',
   '/docs/media-buy/product-discovery/proposal-negotiation',
 ]);
+const CURRENT_LLMS_INDEX_ALIAS = '/_llms/current.md';
 // Production builds fetch versioned navigation specs reliably from public URLs;
 // release tags keep each docs version tied to the spec shipped with that release.
 const RELEASE_OPENAPI_URL = (releaseVersion) =>
@@ -132,6 +133,31 @@ function snapshotPath(releaseVersion, value) {
 
 function versionLine(value) {
   return typeof value === 'string' ? VERSION_LINE_RE.exec(value)?.[1] : undefined;
+}
+
+function updateCurrentLlmsIndexAlias(config) {
+  const versions = config?.navigation?.versions;
+  if (!Array.isArray(versions) || versions.length === 0) return;
+
+  const currentVersion = versions.find((entry) => entry.default)?.version
+    ?? versions[0]?.version;
+  if (typeof currentVersion !== 'string') return;
+
+  if (!Array.isArray(config.redirects)) config.redirects = [];
+  const destination = `/_llms/${currentVersion.replaceAll('.', '-')}.md`;
+  const existing = config.redirects.find(
+    (redirect) => redirect?.source === CURRENT_LLMS_INDEX_ALIAS
+  );
+  if (existing) {
+    existing.destination = destination;
+    existing.permanent = false;
+  } else {
+    config.redirects.unshift({
+      source: CURRENT_LLMS_INDEX_ALIAS,
+      destination,
+      permanent: false,
+    });
+  }
 }
 
 function updateReleaseStoryAliases(config, releaseVersion) {
@@ -270,6 +296,7 @@ export function updateDocsConfig(config, releaseVersion, majorMinor) {
     }
     updatePrereleaseBanner(config, releaseVersion, majorMinor);
     updateReleaseStoryAliases(config, releaseVersion);
+    updateCurrentLlmsIndexAlias(config);
     return {
       config,
       action: 'updated',
@@ -305,6 +332,7 @@ export function updateDocsConfig(config, releaseVersion, majorMinor) {
   versions.splice(insertionIndex, 0, newEntry);
   updatePrereleaseBanner(config, releaseVersion, majorMinor);
   updateReleaseStoryAliases(config, releaseVersion);
+  updateCurrentLlmsIndexAlias(config);
   return {
     config,
     action: 'added',

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -161,6 +161,28 @@ test('default version carries the Latest tag', () => {
   }
 });
 
+test('current llms index discovers and follows the default docs version', () => {
+  const aliasUrl = 'https://docs.adcontextprotocol.org/_llms/current.md';
+  const aliases = docsConfig.redirects?.filter(
+    redirect => redirect.source === '/_llms/current.md'
+  ) || [];
+  const [alias] = aliases;
+  const expectedDestination = `/_llms/${defaultVersion.replaceAll('.', '-')}.md`;
+
+  if (!docsConfig.description?.includes(aliasUrl)) {
+    throw new Error(`docs.json description must advertise ${aliasUrl} for /llms.txt clients`);
+  }
+  if (aliases.length !== 1) {
+    throw new Error('docs.json must define exactly one /_llms/current.md alias');
+  }
+  if (alias.destination !== expectedDestination || alias.permanent !== false) {
+    throw new Error(
+      `/_llms/current.md must temporarily redirect to ${expectedDestination}; ` +
+      `found ${alias.destination || '(missing destination)'}`
+    );
+  }
+});
+
 test('OpenAPI navigation uses release-pinned public sources', () => {
   const sources = collectOpenApiSources(navigation.versions);
   if (sources.length === 0) {

--- a/tests/update-release-docs-nav.test.cjs
+++ b/tests/update-release-docs-nav.test.cjs
@@ -286,6 +286,11 @@ function sampleConfig() {
 
     assert.deepEqual(config.redirects, [
       {
+        source: '/_llms/current.md',
+        destination: '/_llms/3-0.md',
+        permanent: false,
+      },
+      {
         source: '/docs/intro',
         destination: '/dist/docs/3.0.1/intro',
         permanent: false,
@@ -312,6 +317,39 @@ function sampleConfig() {
     assert.equal(result.sourceVersion, '3.0');
     assert.equal(config.navigation.versions[1].version, '3.1-rc');
     assert.equal(config.navigation.versions[1].groups[0].pages[0], 'dist/docs/3.1.0-rc.5/intro');
+  });
+
+  test('keeps the current llms index alias on the default stable docs version', () => {
+    const config = sampleConfig();
+    config.redirects = [{
+      source: '/_llms/current.md',
+      destination: '/_llms/2-5.md',
+      permanent: true,
+    }];
+
+    updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
+
+    assert.deepEqual(config.redirects[0], {
+      source: '/_llms/current.md',
+      destination: '/_llms/3-0.md',
+      permanent: false,
+    });
+  });
+
+  test('adds the current llms index alias once when redirects are absent', () => {
+    const config = sampleConfig();
+
+    updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
+    updateDocsConfig(config, '3.1.0-rc.6', '3.1-rc');
+
+    assert.deepEqual(
+      config.redirects.filter(redirect => redirect.source === '/_llms/current.md'),
+      [{
+        source: '/_llms/current.md',
+        destination: '/_llms/3-0.md',
+        permanent: false,
+      }]
+    );
   });
 
   test('carries the 3.2 story from beta to RC and retargets its public aliases', () => {
@@ -369,6 +407,7 @@ function sampleConfig() {
     assert.deepEqual(
       config.redirects.map((redirect) => redirect.destination),
       [
+        '/_llms/3-0.md',
         '/dist/docs/3.2.0-rc.0/reference/whats-new-in-3-2',
         '/dist/docs/3.2.0-rc.0/media-buy/product-discovery/proposal-negotiation',
       ]


### PR DESCRIPTION
## Summary

- add a stable `/_llms/current.md` entry point for the default AdCP documentation line
- advertise that entry point in the Mintlify-generated `/llms.txt` description
- keep the alias synchronized during release-doc navigation updates
- fail docs-nav CI if a manual GA default flip leaves discovery or the alias stale

## Why

Mintlify's top-level `llms.txt` is a multi-version hub. Generic flat-index consumers can otherwise select archived 2.5 pages or the highest prerelease. The explicit current alias follows the configured stable default instead of semver ordering and resolves today to AdCP 3.1, build 3.1.20.

## Verification

- `npm run test:release-docs-nav` (14/14)
- `npm run test:docs-nav` (55/55)
- `npm run test:owned-links` (20/20)
- full pre-commit unit suite (1057 tests), lint gates, and typecheck
- isolated Mintlify preview: `/_llms/current.md` returns 307 to `/_llms/3-1.md`
- production versioned target currently returns 200

## Expert review

Independent documentation, code, and Node.js testing reviews are clear. Review findings around `/llms.txt` discoverability, manual GA default flips, insertion coverage, and duplicate aliases are incorporated.

No changeset: this is non-normative docs/release tooling.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/02f8e225-a4f3-49a7-a2b6-3da971ca06b8)
