### PR TITLE
docs(creative): include VAST 4.3 in the video channel example

### DIFF
--- a/.changeset/video-vast-versions-include-4-3.md
+++ b/.changeset/video-vast-versions-include-4-3.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Include VAST 4.3 in the video channel product `vast_versions` example so it matches the enum added in #6763 / #6141.

--- a/.changeset/video-vast-versions-include-4-3.md
+++ b/.changeset/video-vast-versions-include-4-3.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Include VAST 4.3 in the video channel product `vast_versions` example so it matches the enum added in #6763 / #6141.

--- a/docs/creative/channels/video.mdx
+++ b/docs/creative/channels/video.mdx
@@ -53,7 +53,7 @@ AdCP separates hosted video bytes (`video_hosted`) from VAST delivery (`video_va
   "format_kind": "video_vast",
   "params": {
     "duration_ms_range": [15000, 30000],
-    "vast_versions": ["3.0", "4.0", "4.1", "4.2"],
+    "vast_versions": ["3.0", "4.0", "4.1", "4.2", "4.3"],
     "media_file_requirements": {
       "delivery_methods": ["progressive"],
       "mime_types": ["video/mp4"],


### PR DESCRIPTION
## Summary
- The video channel product example still listed `vast_versions` through `4.2` after #6763 / #6141 added `4.3` to the enum.
- The example now includes `4.3` so the docs match the accepted set.

## Test plan
- [x] Docs navigation / schema-link pre-push checks
- [ ] Confirm the example on `/docs/creative/channels/video` lists `4.3`

I have read the IPR Policy.