### PR TITLE
fix(build): key vendor_metric_values uniqueness on qualifier as the spec requires

### DIFF
--- a/.changeset/vendor-metric-uniqueness-qualifier.md
+++ b/.changeset/vendor-metric-uniqueness-qualifier.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix the build-time vendor-metric uniqueness lint so `vendor_metric_values` rows key on `(vendor.domain, vendor.brand_id, metric_id, qualifier)` — the rule `delivery-metrics.json` already states — instead of collapsing qualifier-distinct rows (7-day vs 30-day attribution windows) into false duplicates. Qualifier canonicalization is key-sorted deep equality, matching the structured-qualifier join rule on `committed-metric.json`. `reporting_capabilities.vendor_metrics` declarations keep the 3-tuple. No wire change.

--- a/scripts/build-schemas.cjs
+++ b/scripts/build-schemas.cjs
@@ -612,7 +612,15 @@ function lintErrorCodeEnumMetadata(sourceDir) {
 // describe the same brand). This lint enforces the MUST constraint by
 // normalizing the semantic tuple and checking for duplicates.
 //
-// Key normalization: use `|`-delimited string `domain|brand_id|metric_id`.
+// Key normalization: use `|`-delimited string `domain|brand_id|metric_id` for
+// `vendor_metrics` declarations, and `domain|brand_id|metric_id|qualifier` for
+// `vendor_metric_values` rows — delivery-metrics.json allows the same vendor
+// metric on multiple rows when each carries a distinct qualifier (7-day vs
+// 30-day attribution windows), so the qualifier is part of the row key (#7234).
+// The qualifier component is the key-sorted JSON of the qualifier object (deep
+// equality, order-insensitive); unqualified rows keep the historical 3-part key
+// (no trailing separator). The qualifier is placed last because serialized JSON
+// may legally contain `|` inside string values.
 // The `|` separator is safe because domain (`[a-z0-9.-]`), brand_id
 // (`[a-z0-9_]`), and metric_id (`[a-z][a-z0-9_]*`) cannot contain `|`. Absent
 // brand_id normalizes to "" (empty string) — the empty string is distinct from
@@ -627,6 +635,27 @@ function lintErrorCodeEnumMetadata(sourceDir) {
 //      metric data. TS scanning would require a parser — deferred until a
 //      fixture adds vendor metrics, at which point build failures will surface
 //      the gap. See #3502 item 1 for the tracking comment.
+
+
+/**
+ * Canonical string for a structured qualifier: keys sorted recursively so
+ * `{interval:14,unit:'days'}` and `{unit:'days',interval:14}` produce the same
+ * string — the join rule stated on committed-metric.json. Absent/empty
+ * qualifier → "" and callers omit the separator, so unqualified rows keep the
+ * historical 3-part key.
+ */
+function canonicalQualifier(q) {
+  if (!q || typeof q !== 'object' || Array.isArray(q)) return '';
+  const sort = (v) => {
+    if (Array.isArray(v)) return v.map(sort);
+    if (v && typeof v === 'object') {
+      return Object.keys(v).sort().reduce((acc, k) => { acc[k] = sort(v[k]); return acc; }, {});
+    }
+    return v;
+  };
+  const keys = Object.keys(q);
+  return keys.length ? JSON.stringify(sort(q)) : '';
+}
 
 /**
  * Recursively collect all `examples` values that contain vendor metric arrays.
@@ -648,7 +677,10 @@ function collectVendorMetricExamples(obj, schemaPath, out = []) {
       const domain = typeof entry.vendor.domain === 'string' ? entry.vendor.domain : '';
       const brandId = typeof entry.vendor.brand_id === 'string' ? entry.vendor.brand_id : '';
       const metricId = typeof entry.metric_id === 'string' ? entry.metric_id : '';
-      tuples.push(`${domain}|${brandId}|${metricId}`);
+      const key = `${domain}|${brandId}|${metricId}`;
+      // Rows (vendor_metric_values) partition on qualifier; declarations do not.
+      const q = field === 'vendor_metric_values' ? canonicalQualifier(entry.qualifier) : '';
+      tuples.push(q ? `${key}|${q}` : key);
     }
     if (tuples.length > 0) out.push({ schemaPath, arrayField: field, tuples });
   }
@@ -695,7 +727,8 @@ function lintVendorMetricSemanticUniqueness(sourceDir) {
     throw new Error(
       `Vendor metric uniqueness lint: ${violations.length} duplicate tuple(s) found in schema examples.\n\n` +
       lines.join('\n') +
-      `\n\nFix: each (vendor.domain, vendor.brand_id, metric_id) tuple MUST appear at most once per array.\n` +
+      `\n\nFix: each (vendor.domain, vendor.brand_id, metric_id) tuple MUST appear at most once per vendor_metrics array,\n` +
+      `and each (vendor.domain, vendor.brand_id, metric_id, qualifier) tuple at most once per vendor_metric_values array.\n` +
       `See static/schemas/source/core/reporting-capabilities.json and delivery-metrics.json for the\n` +
       `normative uniqueness constraint. Issue: adcontextprotocol/adcp#3502.`
     );
@@ -2686,6 +2719,7 @@ module.exports = {
   buildTaskResultResolution,
   validateManifestToolRelationships,
   collectVendorMetricExamples,
+  canonicalQualifier,
   lintVendorMetricSemanticUniqueness,
 };
 

--- a/scripts/lint-vendor-metric-uniqueness.cjs
+++ b/scripts/lint-vendor-metric-uniqueness.cjs
@@ -12,7 +12,10 @@
  * fixtures. The companion check in scripts/build-schemas.cjs enforces the same
  * constraint on schema file `examples` arrays. Issue: adcontextprotocol/adcp#3502.
  *
- * Key normalization: `domain|brand_id|metric_id` where absent brand_id → "".
+ * Key normalization: `domain|brand_id|metric_id` where absent brand_id → "" for
+ * `vendor_metrics` declarations; `vendor_metric_values` rows append `|qualifier`
+ * (key-sorted JSON of the qualifier; omitted entirely when absent) because delivery-metrics.json
+ * allows the same vendor metric on multiple rows with distinct qualifiers (#7234).
  * The `|` separator is safe: domain (`[a-z0-9.-]`), brand_id (`[a-z0-9_]`), and
  * metric_id (`[a-z][a-z0-9_]*`) cannot contain `|`. Absent brand_id is the empty
  * string — distinct from any valid brand_id so `{domain:"x"}` and
@@ -67,12 +70,39 @@ function iterSteps(doc) {
  * Build the semantic key string for a vendor metric entry.
  * Normalizes absent brand_id to "" so {domain:"x"} ≠ {domain:"x",brand_id:"sub"}.
  */
-function vendorMetricKey(entry) {
+/**
+ * Canonical string for a structured qualifier: keys sorted recursively so
+ * `{interval:14,unit:'days'}` and `{unit:'days',interval:14}` produce the same
+ * string — the join rule stated on committed-metric.json. Absent/empty
+ * qualifier → "" and callers omit the separator, so unqualified rows keep the
+ * historical 3-part key.
+ */
+function canonicalQualifier(q) {
+  if (!q || typeof q !== 'object' || Array.isArray(q)) return '';
+  const sort = (v) => {
+    if (Array.isArray(v)) return v.map(sort);
+    if (v && typeof v === 'object') {
+      return Object.keys(v).sort().reduce((acc, k) => { acc[k] = sort(v[k]); return acc; }, {});
+    }
+    return v;
+  };
+  const keys = Object.keys(q);
+  return keys.length ? JSON.stringify(sort(q)) : '';
+}
+
+/**
+ * Build the semantic key string for a vendor metric entry.
+ * `includeQualifier` is true for `vendor_metric_values` rows, which partition on
+ * qualifier; declarations (`vendor_metrics`) never carry one.
+ */
+function vendorMetricKey(entry, includeQualifier = false) {
   if (!entry || typeof entry !== 'object' || !entry.vendor) return null;
   const domain = typeof entry.vendor.domain === 'string' ? entry.vendor.domain : '';
   const brandId = typeof entry.vendor.brand_id === 'string' ? entry.vendor.brand_id : '';
   const metricId = typeof entry.metric_id === 'string' ? entry.metric_id : '';
-  return `${domain}|${brandId}|${metricId}`;
+  const key = `${domain}|${brandId}|${metricId}`;
+  const q = includeQualifier ? canonicalQualifier(entry.qualifier) : '';
+  return q ? `${key}|${q}` : key;
 }
 
 /**
@@ -87,7 +117,7 @@ function findDuplicatesInPayload(payload) {
     if (!Array.isArray(arr) || arr.length < 2) continue;
     const seen = new Set();
     for (const entry of arr) {
-      const key = vendorMetricKey(entry);
+      const key = vendorMetricKey(entry, field === 'vendor_metric_values');
       if (key === null) continue;
       if (seen.has(key)) duplicates.push(`${field}[]: "${key}"`);
       seen.add(key);
@@ -156,4 +186,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { lint, findDuplicatesInPayload, vendorMetricKey };
+module.exports = { lint, findDuplicatesInPayload, vendorMetricKey, canonicalQualifier };

--- a/tests/build-schemas-vendor-metric-uniqueness.test.cjs
+++ b/tests/build-schemas-vendor-metric-uniqueness.test.cjs
@@ -31,6 +31,7 @@ const path = require('node:path');
 const {
   collectVendorMetricExamples,
   lintVendorMetricSemanticUniqueness,
+  canonicalQualifier,
 } = require('../scripts/build-schemas.cjs');
 
 function writeJson(filePath, value) {
@@ -256,4 +257,63 @@ test('lintVendorMetricSemanticUniqueness: reports one violation per duplicate ar
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }
+});
+
+
+// ── qualifier-aware row keys (#7234) ──────────────────────────────────────
+
+function valueRow(metricId, extra = {}) {
+  return { vendor: { domain: 'v.example' }, metric_id: metricId, value: 1, ...extra };
+}
+
+test('collectVendorMetricExamples: vendor_metric_values rows with distinct qualifiers are NOT duplicates', () => {
+  const schema = { examples: [{ vendor_metric_values: [
+    valueRow('conversions', { qualifier: { attribution_window: { interval: 7, unit: 'days' } } }),
+    valueRow('conversions', { qualifier: { attribution_window: { interval: 30, unit: 'days' } } }),
+  ] }] };
+  const out = collectVendorMetricExamples(schema, 'core/delivery-metrics.json');
+  assert.equal(out.length, 1);
+  assert.equal(new Set(out[0].tuples).size, 2);
+});
+
+test('collectVendorMetricExamples: qualifier key order does not create distinct rows', () => {
+  const schema = { examples: [{ vendor_metric_values: [
+    valueRow('conversions', { qualifier: { attribution_window: { interval: 14, unit: 'days' } } }),
+    valueRow('conversions', { qualifier: { attribution_window: { unit: 'days', interval: 14 } } }),
+  ] }] };
+  const out = collectVendorMetricExamples(schema, 'core/delivery-metrics.json');
+  assert.equal(new Set(out[0].tuples).size, 1, 'order-only qualifier difference must still collide');
+});
+
+test('collectVendorMetricExamples: rows differing only in a non-key field are still duplicates', () => {
+  const schema = { examples: [{ vendor_metric_values: [
+    valueRow('gaze_attention_seconds', { vendor_relationship: 'first_party' }),
+    valueRow('gaze_attention_seconds', { vendor_relationship: 'third_party' }),
+  ] }] };
+  const out = collectVendorMetricExamples(schema, 'core/delivery-metrics.json');
+  assert.equal(new Set(out[0].tuples).size, 1);
+});
+
+test('collectVendorMetricExamples: unqualified rows keep the historical 3-part key shape', () => {
+  const schema = { examples: [{ vendor_metric_values: [ valueRow('a'), valueRow('b') ] }] };
+  const out = collectVendorMetricExamples(schema, 'core/delivery-metrics.json');
+  assert.deepEqual(out[0].tuples, ['v.example||a', 'v.example||b']);
+});
+
+test('collectVendorMetricExamples: vendor_metrics declarations ignore qualifier entirely', () => {
+  const schema = { examples: [{ vendor_metrics: [
+    { ...vendorMetric('v.example', undefined, 'x'), qualifier: { lift_dimension: 'awareness' } },
+    { ...vendorMetric('v.example', undefined, 'x'), qualifier: { lift_dimension: 'consideration' } },
+  ] }] };
+  const out = collectVendorMetricExamples(schema, 'core/reporting-capabilities.json');
+  assert.equal(new Set(out[0].tuples).size, 1, 'declarations have no qualifier partition');
+});
+
+test('canonicalQualifier: sorts keys recursively and treats absent/empty as ""', () => {
+  assert.equal(canonicalQualifier(undefined), '');
+  assert.equal(canonicalQualifier({}), '');
+  assert.equal(
+    canonicalQualifier({ attribution_window: { unit: 'days', interval: 14 }, attribution_methodology: 'modeled' }),
+    canonicalQualifier({ attribution_methodology: 'modeled', attribution_window: { interval: 14, unit: 'days' } })
+  );
 });

--- a/tests/lint-vendor-metric-uniqueness.test.cjs
+++ b/tests/lint-vendor-metric-uniqueness.test.cjs
@@ -141,3 +141,34 @@ test('findDuplicatesInPayload: empty arrays produce no violations', () => {
   assert.deepEqual(findDuplicatesInPayload({ vendor_metric_values: [] }), []);
   assert.deepEqual(findDuplicatesInPayload({ vendor_metrics: [] }), []);
 });
+
+
+// ── qualifier-aware row keys (#7234) ──────────────────────────────────────
+
+test('findDuplicatesInPayload: vendor_metric_values rows with distinct qualifiers are allowed', () => {
+  const row = (q) => ({ vendor: { domain: 'v.example' }, metric_id: 'conversions', value: 1, qualifier: { attribution_window: q } });
+  const dups = findDuplicatesInPayload({ vendor_metric_values: [row({ interval: 7, unit: 'days' }), row({ interval: 30, unit: 'days' })] });
+  assert.deepEqual(dups, []);
+});
+
+test('findDuplicatesInPayload: qualifier key order does not evade the duplicate check', () => {
+  const dups = findDuplicatesInPayload({ vendor_metric_values: [
+    { vendor: { domain: 'v.example' }, metric_id: 'conversions', value: 1, qualifier: { attribution_window: { interval: 14, unit: 'days' } } },
+    { vendor: { domain: 'v.example' }, metric_id: 'conversions', value: 2, qualifier: { attribution_window: { unit: 'days', interval: 14 } } },
+  ] });
+  assert.equal(dups.length, 1);
+});
+
+test('findDuplicatesInPayload: vendor_metrics declarations never partition on qualifier', () => {
+  const dups = findDuplicatesInPayload({ vendor_metrics: [
+    { vendor: { domain: 'v.example' }, metric_id: 'x', qualifier: { lift_dimension: 'awareness' } },
+    { vendor: { domain: 'v.example' }, metric_id: 'x', qualifier: { lift_dimension: 'consideration' } },
+  ] });
+  assert.equal(dups.length, 1);
+});
+
+test('vendorMetricKey: includeQualifier appends canonical qualifier, default keeps 3-part key', () => {
+  const e = { vendor: { domain: 'v.example' }, metric_id: 'm', qualifier: { attribution_window: { unit: 'days', interval: 7 } } };
+  assert.equal(vendorMetricKey(e), 'v.example||m');
+  assert.equal(vendorMetricKey(e, true), 'v.example||m|{"attribution_window":{"interval":7,"unit":"days"}}');
+});


### PR DESCRIPTION
Fixes #7234. Surfaced while answering review question 2 on #7177.

**Bug.** `delivery-metrics.json` states one row per `(vendor.domain, vendor.brand_id, metric_id, qualifier)` and explicitly allows the same vendor metric on multiple rows with distinct qualifiers (7-day vs 30-day attribution windows). Both uniqueness lints — `collectVendorMetricExamples` in `scripts/build-schemas.cjs` (schema `examples`) and `vendorMetricKey` / `findDuplicatesInPayload` in `scripts/lint-vendor-metric-uniqueness.cjs` (storyboard `sample_request` / `params`) — keyed on the 3-tuple only, so they rejected rows the spec permits.

**Fix.** `vendor_metric_values` rows append the canonical qualifier (recursively key-sorted JSON, so `{interval:14,unit:days}` ≡ `{unit:days,interval:14}` per the join rule on `committed-metric.json`) to the key. Unqualified rows keep the historical 3-part key with no trailing separator, so existing fixtures, messages, and the documented normalization for the runner are unchanged. `vendor_metrics` declarations carry no qualifier and are untouched.

**Tests.** Added: qualifier-distinct rows accepted; key-order-only difference still a duplicate; rows differing only in a non-key field (e.g. `vendor_relationship`) still a duplicate; declarations ignore qualifier; canonicalization is order-insensitive and treats absent/empty as none. Full `build:schemas`, the storyboard lint, and `test:schemas` pass.

Tooling-only, no wire change; `patch` changeset because `scripts/build-schemas.cjs` is protocol-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)