### PR TITLE
fix(docs): move llms alias outside reserved route

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
     "content": "AdCP 3.2 preview is available — [see what's new and try the proposal lifecycle →](/3.2)",
     "dismissible": true
   },
-  "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms. Current stable documentation index: https://docs.adcontextprotocol.org/_llms/current.md.",
+  "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms. Current stable documentation index: https://docs.adcontextprotocol.org/llms-current.md.",
   "metadata": {
     "og:site_name": "AdCP — Ad Context Protocol",
     "og:image": "https://docs.adcontextprotocol.org/images/concepts/protocol-domain-map.png",
@@ -2882,7 +2882,7 @@
   },
   "redirects": [
     {
-      "source": "/_llms/current.md",
+      "source": "/llms-current.md",
       "destination": "/_llms/3-1.md",
       "permanent": false
     },

--- a/scripts/check-owned-links.js
+++ b/scripts/check-owned-links.js
@@ -10,6 +10,9 @@ const FETCH_TIMEOUT_MS = 10_000;
 const CONCURRENCY = 8;
 const MANUAL_RETRIES = 2;
 const MAX_STABLE_DOC_REDIRECTS = 8;
+const CURRENT_LLMS_INDEX_URL = 'https://docs.adcontextprotocol.org/llms-current.md';
+const LLMS_PROPAGATION_RETRIES = 12;
+const LLMS_PROPAGATION_DELAY_MS = 30_000;
 const URLS_RULES_FILE = 'server/src/addie/rules/urls.md';
 
 export const URL_CLASS = Object.freeze({
@@ -42,6 +45,7 @@ export function getCandidateFiles(root = ROOT) {
     [
       'docs/**/*.{md,mdx}',
       'dist/docs/**/*.{md,mdx}',
+      'docs.json',
       'README.md',
       'server/src/addie/rules/*.md',
       'server/src/addie/**/*.ts',
@@ -270,6 +274,7 @@ export async function fetchManualGet(
       const result = {
         status: response.status,
         location: response.headers.get('location'),
+        contentType: response.headers.get('content-type'),
       };
       await cancelBody(response);
 
@@ -287,6 +292,44 @@ export async function fetchManualGet(
     }
   }
   throw new Error(`fetchManualGet exhausted retries without returning for ${url}`);
+}
+
+async function fetchTextGet(url, { fetchImpl = globalThis.fetch } = {}) {
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    redirect: 'follow',
+    headers: {
+      'User-Agent': 'adcp-owned-link-check/1.0',
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type'),
+    body: await response.text(),
+  };
+}
+
+function textAdvertisesUrl(text, url) {
+  let offset = 0;
+  while (offset < text.length) {
+    const index = text.indexOf(url, offset);
+    if (index === -1) return false;
+
+    const next = text[index + url.length];
+    const afterNext = text[index + url.length + 1];
+    if (
+      next === undefined ||
+      ' \t\r\n)]}>'.includes(next) ||
+      ('.,;:!?'.includes(next) && (
+        afterNext === undefined || ' \t\r\n'.includes(afterNext)
+      ))
+    ) {
+      return true;
+    }
+    offset = index + 1;
+  }
+  return false;
 }
 
 function resolveLocation(
@@ -480,6 +523,114 @@ export async function checkStableDocsAlias(
   }
 }
 
+export async function checkCurrentLlmsIndexAlias(
+  url,
+  {
+    expectedDestination,
+    fetchImpl = globalThis.fetch,
+    sleep = (ms) => new Promise((done) => setTimeout(done, ms)),
+    propagationRetries = LLMS_PROPAGATION_RETRIES,
+    propagationDelayMs = LLMS_PROPAGATION_DELAY_MS,
+  } = {},
+) {
+  const expectedUrl = new URL(expectedDestination, url).href;
+  const hubUrl = new URL('/llms.txt', url).href;
+  let lastFailure;
+
+  for (let attempt = 0; attempt <= propagationRetries; attempt += 1) {
+    let source;
+    try {
+      source = await fetchManualGet(url, 0, { fetchImpl, sleep });
+    } catch (error) {
+      lastFailure = `GET failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+
+    if (source?.status >= 300 && source.status < 400) {
+      const location = resolveLocation(
+        url,
+        source.location,
+        source.status,
+        'CURRENT LLMS INDEX DRIFT',
+      );
+      if (!location.ok) return { ok: false, status: source.status, error: location.error };
+      if (location.url !== expectedUrl) {
+        return {
+          ok: false,
+          status: source.status,
+          location: location.url,
+          error: `CURRENT LLMS INDEX DRIFT: ${url} → ${location.url} (expected ${expectedUrl})`,
+        };
+      }
+
+      let target;
+      try {
+        target = await fetchManualGet(expectedUrl, 0, { fetchImpl, sleep });
+      } catch (error) {
+        lastFailure = `target GET failed: ${error instanceof Error ? error.message : String(error)}`;
+      }
+      if (
+        target?.status >= 200 &&
+        target.status < 300 &&
+        /^text\/markdown(?:\s*;|$)/i.test(target.contentType ?? '')
+      ) {
+        let hub;
+        try {
+          hub = await fetchTextGet(hubUrl, { fetchImpl });
+        } catch (error) {
+          lastFailure = `hub GET failed: ${error instanceof Error ? error.message : String(error)}`;
+        }
+        if (
+          hub?.status >= 200 &&
+          hub.status < 300 &&
+          /^text\/(?:markdown|plain)(?:\s*;|$)/i.test(hub.contentType ?? '') &&
+          textAdvertisesUrl(hub.body, url)
+        ) {
+          return {
+            ok: true,
+            status: target.status,
+            method: 'GET',
+            location: expectedUrl,
+            redirects: 1,
+          };
+        }
+        if (hub) {
+          lastFailure = `hub GET ${hub.status} with Content-Type ${hub.contentType || '(missing)'} did not advertise ${url}`;
+        }
+      }
+      if (
+        target &&
+        !(
+          target.status >= 200 &&
+          target.status < 300 &&
+          /^text\/markdown(?:\s*;|$)/i.test(target.contentType ?? '')
+        )
+      ) {
+        lastFailure = `target GET ${target.status} with Content-Type ${target.contentType || '(missing)'}`;
+      }
+    } else if (source) {
+      lastFailure = `alias GET ${source.status} (expected a redirect to ${expectedUrl})`;
+    }
+
+    if (attempt < propagationRetries) await sleep(propagationDelayMs);
+  }
+
+  return {
+    ok: false,
+    error: `Current documentation index did not become healthy after bounded propagation retries: ${lastFailure}`,
+  };
+}
+
+function currentLlmsIndexDestination(root) {
+  const docsConfig = JSON.parse(readFileSync(join(root, 'docs.json'), 'utf8'));
+  const versions = docsConfig?.navigation?.versions;
+  const currentVersion = versions?.find((entry) => entry.default)?.version
+    ?? versions?.[0]?.version;
+  if (typeof currentVersion !== 'string') {
+    throw new Error('docs.json does not define a current documentation version');
+  }
+  return `/_llms/${currentVersion.replaceAll('.', '-')}.md`;
+}
+
 export async function mapWithConcurrency(items, task, concurrency = CONCURRENCY) {
   const results = new Array(items.length);
   let cursor = 0;
@@ -535,11 +686,25 @@ export async function main({
 
   const catalogUrls = new Set(catalog.map(({ url }) => url));
   const urls = [...urlSources.keys()].sort();
+  let expectedCurrentLlmsDestination;
+  if (urls.includes(CURRENT_LLMS_INDEX_URL)) {
+    try {
+      expectedCurrentLlmsDestination = currentLlmsIndexDestination(root);
+    } catch (error) {
+      output.error(`Invalid current documentation index configuration: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+  }
 
   // One shared pool bounds total network concurrency even though direct and
   // stable-alias entries receive an additional policy-specific GET.
   const checks = [
-    ...urls.map((url) => ({ kind: 'reachability', url })),
+    ...urls
+      .filter((url) => url !== CURRENT_LLMS_INDEX_URL)
+      .map((url) => ({ kind: 'reachability', url })),
+    ...(urls.includes(CURRENT_LLMS_INDEX_URL)
+      ? [{ kind: 'current-llms-index', url: CURRENT_LLMS_INDEX_URL }]
+      : []),
     ...catalog
       .filter(({ classification }) => classification === URL_CLASS.DIRECT)
       .map(({ url }) => ({ kind: URL_CLASS.DIRECT, url })),
@@ -550,8 +715,16 @@ export async function main({
   const results = await mapWithConcurrency(checks, ({ kind, url }) => {
     const options = { fetchImpl };
     if (sleep) options.sleep = sleep;
+    if (kind === 'current-llms-index') {
+      return checkCurrentLlmsIndexAlias(url, {
+        ...options,
+        expectedDestination: expectedCurrentLlmsDestination,
+      });
+    }
     if (kind === URL_CLASS.DIRECT) return checkDirectUrl(url, options);
-    if (kind === URL_CLASS.STABLE_DOCS) return checkStableDocsAlias(url, options);
+    if (kind === URL_CLASS.STABLE_DOCS) {
+      return checkStableDocsAlias(url, options);
+    }
     return checkUrl(url, {
       ...options,
       root,

--- a/scripts/update-release-docs-nav.mjs
+++ b/scripts/update-release-docs-nav.mjs
@@ -26,7 +26,11 @@ const RELEASE_STORY_ALIASES = new Set([
   '/docs/reference/migration/3-1-to-3-2',
   '/docs/media-buy/product-discovery/proposal-negotiation',
 ]);
-const CURRENT_LLMS_INDEX_ALIAS = '/_llms/current.md';
+// Mintlify Cloud reserves /_llms/* for generated version indexes and handles
+// those requests before docs.json redirects. Keep the stable alias at the root
+// so production applies the redirect as well as the local CLI.
+const CURRENT_LLMS_INDEX_ALIAS = '/llms-current.md';
+const LEGACY_RESERVED_LLMS_INDEX_ALIAS = '/_llms/current.md';
 // Production builds fetch versioned navigation specs reliably from public URLs;
 // release tags keep each docs version tied to the spec shipped with that release.
 const RELEASE_OPENAPI_URL = (releaseVersion) =>
@@ -144,10 +148,15 @@ function updateCurrentLlmsIndexAlias(config) {
   if (typeof currentVersion !== 'string') return;
 
   if (!Array.isArray(config.redirects)) config.redirects = [];
+  let existing;
+  config.redirects = config.redirects.filter((redirect) => {
+    if (redirect?.source === LEGACY_RESERVED_LLMS_INDEX_ALIAS) return false;
+    if (redirect?.source !== CURRENT_LLMS_INDEX_ALIAS) return true;
+    if (existing) return false;
+    existing = redirect;
+    return true;
+  });
   const destination = `/_llms/${currentVersion.replaceAll('.', '-')}.md`;
-  const existing = config.redirects.find(
-    (redirect) => redirect?.source === CURRENT_LLMS_INDEX_ALIAS
-  );
   if (existing) {
     existing.destination = destination;
     existing.permanent = false;

--- a/tests/check-owned-links.test.cjs
+++ b/tests/check-owned-links.test.cjs
@@ -5,19 +5,29 @@ const { spawnSync } = require('node:child_process');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-function mockResponse(status, location, onCancel = () => {}) {
+function mockResponse(
+  status,
+  location,
+  onCancel = () => {},
+  contentType = null,
+  bodyText = '',
+) {
   return {
     status,
     headers: {
       get(name) {
-        if (name.toLowerCase() !== 'location') return null;
-        return location ?? null;
+        if (name.toLowerCase() === 'location') return location ?? null;
+        if (name.toLowerCase() === 'content-type') return contentType;
+        return null;
       },
     },
     body: {
       async cancel() {
         onCancel();
       },
+    },
+    async text() {
+      return bodyText;
     },
   };
 }
@@ -51,6 +61,7 @@ function outputCollector() {
 (async () => {
   const {
     URL_CLASS,
+    checkCurrentLlmsIndexAlias,
     checkDirectUrl,
     checkStableDocsAlias,
     checkUrl,
@@ -138,6 +149,145 @@ Prose may mention https://agenticadvertising.org/not-an-entry.
     );
 
     assert.deepEqual(result, { ok: true, status: 200, method: 'GET' });
+  });
+
+  test('checks the current llms alias redirect, target, content type, and propagation', async () => {
+    const source = 'https://docs.adcontextprotocol.org/llms-current.md';
+    const target = 'https://docs.adcontextprotocol.org/_llms/3-1.md';
+    const calls = [];
+    const waits = [];
+    let sourceAttempts = 0;
+    const result = await checkCurrentLlmsIndexAlias(source, {
+      expectedDestination: '/_llms/3-1.md',
+      propagationRetries: 1,
+      propagationDelayMs: 25,
+      sleep: async (ms) => waits.push(ms),
+      fetchImpl: async (url) => {
+        calls.push(url);
+        if (url === source && sourceAttempts++ === 0) return mockResponse(404);
+        if (url === source) return mockResponse(307, '/_llms/3-1.md');
+        if (url === target) {
+          return mockResponse(200, null, () => {}, 'text/markdown; charset=utf-8');
+        }
+        return mockResponse(
+          200,
+          null,
+          () => {},
+          'text/plain; charset=utf-8',
+          `Current stable documentation index: ${source}.\n`,
+        );
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      status: 200,
+      method: 'GET',
+      location: target,
+      redirects: 1,
+    });
+    assert.deepEqual(calls, [source, source, target, 'https://docs.adcontextprotocol.org/llms.txt']);
+    assert.deepEqual(waits, [25]);
+  });
+
+  test('rejects current llms alias drift and non-Markdown targets', async () => {
+    const source = 'https://docs.adcontextprotocol.org/llms-current.md';
+    const drift = await checkCurrentLlmsIndexAlias(source, {
+      expectedDestination: '/_llms/3-1.md',
+      propagationRetries: 0,
+      fetchImpl: async () => mockResponse(307, '/_llms/3-2-beta.md'),
+    });
+    let calls = 0;
+    const html = await checkCurrentLlmsIndexAlias(source, {
+      expectedDestination: '/_llms/3-1.md',
+      propagationRetries: 0,
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1
+          ? mockResponse(307, '/_llms/3-1.md')
+          : mockResponse(200, null, () => {}, 'text/html');
+      },
+    });
+
+    assert.equal(drift.ok, false);
+    assert.match(drift.error, /CURRENT LLMS INDEX DRIFT/);
+    assert.equal(html.ok, false);
+    assert.match(html.error, /Content-Type text\/html/);
+  });
+
+  test('rejects a current llms alias that is missing from the public hub', async () => {
+    const source = 'https://docs.adcontextprotocol.org/llms-current.md';
+    let calls = 0;
+    const result = await checkCurrentLlmsIndexAlias(source, {
+      expectedDestination: '/_llms/3-1.md',
+      propagationRetries: 0,
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) return mockResponse(307, '/_llms/3-1.md');
+        if (calls === 2) {
+          return mockResponse(200, null, () => {}, 'text/markdown; charset=utf-8');
+        }
+        return mockResponse(
+          200,
+          null,
+          () => {},
+          'text/plain; charset=utf-8',
+          `Near match only: ${source}.old`,
+        );
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /did not advertise/);
+  });
+
+  test('main discovers and policy-checks the current llms alias from docs.json', async () => {
+    const source = 'https://docs.adcontextprotocol.org/llms-current.md';
+    const target = 'https://docs.adcontextprotocol.org/_llms/3-1.md';
+    const root = makeCatalogRoot(`
+## Direct destinations — no redirects
+
+## Action entry points — redirects expected
+
+## Stable documentation aliases — keep unversioned
+`, {
+      'docs.json': JSON.stringify({
+        description: `Current stable documentation index: ${source}.`,
+        navigation: { versions: [{ version: '3.1', default: true }] },
+      }),
+    });
+    const calls = [];
+    const captured = outputCollector();
+
+    try {
+      const ok = await main({
+        root,
+        output: captured.output,
+        fetchImpl: async (url, options) => {
+          calls.push({ url, redirect: options.redirect });
+          if (url === source) return mockResponse(307, '/_llms/3-1.md');
+          if (url === target) {
+            return mockResponse(200, null, () => {}, 'text/markdown; charset=utf-8');
+          }
+          return mockResponse(
+            200,
+            null,
+            () => {},
+            'text/plain; charset=utf-8',
+            `Current stable documentation index: ${source}.\n`,
+          );
+        },
+      });
+
+      assert.equal(ok, true);
+      assert.deepEqual(calls, [
+        { url: source, redirect: 'manual' },
+        { url: target, redirect: 'manual' },
+        { url: 'https://docs.adcontextprotocol.org/llms.txt', redirect: 'follow' },
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('accepts an equivalent snapshot redirect at an arbitrary semver release', async () => {

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -162,9 +162,9 @@ test('default version carries the Latest tag', () => {
 });
 
 test('current llms index discovers and follows the default docs version', () => {
-  const aliasUrl = 'https://docs.adcontextprotocol.org/_llms/current.md';
+  const aliasUrl = 'https://docs.adcontextprotocol.org/llms-current.md';
   const aliases = docsConfig.redirects?.filter(
-    redirect => redirect.source === '/_llms/current.md'
+    redirect => redirect.source === '/llms-current.md'
   ) || [];
   const [alias] = aliases;
   const expectedDestination = `/_llms/${defaultVersion.replaceAll('.', '-')}.md`;
@@ -173,11 +173,14 @@ test('current llms index discovers and follows the default docs version', () => 
     throw new Error(`docs.json description must advertise ${aliasUrl} for /llms.txt clients`);
   }
   if (aliases.length !== 1) {
-    throw new Error('docs.json must define exactly one /_llms/current.md alias');
+    throw new Error('docs.json must define exactly one /llms-current.md alias');
+  }
+  if (docsConfig.redirects?.some(redirect => redirect.source === '/_llms/current.md')) {
+    throw new Error('docs.json must not define aliases inside Mintlify\'s reserved /_llms namespace');
   }
   if (alias.destination !== expectedDestination || alias.permanent !== false) {
     throw new Error(
-      `/_llms/current.md must temporarily redirect to ${expectedDestination}; ` +
+      `/llms-current.md must temporarily redirect to ${expectedDestination}; ` +
       `found ${alias.destination || '(missing destination)'}`
     );
   }

--- a/tests/update-release-docs-nav.test.cjs
+++ b/tests/update-release-docs-nav.test.cjs
@@ -286,7 +286,7 @@ function sampleConfig() {
 
     assert.deepEqual(config.redirects, [
       {
-        source: '/_llms/current.md',
+        source: '/llms-current.md',
         destination: '/_llms/3-0.md',
         permanent: false,
       },
@@ -322,7 +322,7 @@ function sampleConfig() {
   test('keeps the current llms index alias on the default stable docs version', () => {
     const config = sampleConfig();
     config.redirects = [{
-      source: '/_llms/current.md',
+      source: '/llms-current.md',
       destination: '/_llms/2-5.md',
       permanent: true,
     }];
@@ -330,10 +330,56 @@ function sampleConfig() {
     updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
 
     assert.deepEqual(config.redirects[0], {
-      source: '/_llms/current.md',
+      source: '/llms-current.md',
       destination: '/_llms/3-0.md',
       permanent: false,
     });
+  });
+
+  test('migrates the legacy reserved current index alias to the root route', () => {
+    const config = sampleConfig();
+    config.redirects = [{
+      source: '/_llms/current.md',
+      destination: '/_llms/2-5.md',
+      permanent: false,
+    }];
+
+    updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
+
+    assert.deepEqual(config.redirects, [{
+      source: '/llms-current.md',
+      destination: '/_llms/3-0.md',
+      permanent: false,
+    }]);
+  });
+
+  test('deduplicates root aliases while removing the legacy reserved alias', () => {
+    const config = sampleConfig();
+    config.redirects = [
+      {
+        source: '/llms-current.md',
+        destination: '/_llms/2-5.md',
+        permanent: true,
+      },
+      {
+        source: '/_llms/current.md',
+        destination: '/_llms/2-5.md',
+        permanent: false,
+      },
+      {
+        source: '/llms-current.md',
+        destination: '/_llms/3-2-beta.md',
+        permanent: false,
+      },
+    ];
+
+    updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
+
+    assert.deepEqual(config.redirects, [{
+      source: '/llms-current.md',
+      destination: '/_llms/3-0.md',
+      permanent: false,
+    }]);
   });
 
   test('adds the current llms index alias once when redirects are absent', () => {
@@ -343,9 +389,9 @@ function sampleConfig() {
     updateDocsConfig(config, '3.1.0-rc.6', '3.1-rc');
 
     assert.deepEqual(
-      config.redirects.filter(redirect => redirect.source === '/_llms/current.md'),
+      config.redirects.filter(redirect => redirect.source === '/llms-current.md'),
       [{
-        source: '/_llms/current.md',
+        source: '/llms-current.md',
         destination: '/_llms/3-0.md',
         permanent: false,
       }]


### PR DESCRIPTION
## Summary

- replace the broken reserved `/_llms/current.md` redirect with `/llms-current.md`
- keep release automation pointed at the default stable docs version and self-heal legacy or duplicate aliases
- add a bounded post-merge production gate covering `/llms.txt` discovery, exact redirect destination, and Markdown response

Follow-up to #7221 after Mintlify Cloud proved that reserved `/_llms/*` routes bypass configured redirects.

## Verification

- expert docs, code, and test reviews approved
- full precommit suite: 68 files / 1,057 tests
- focused alias, docs navigation, and release automation tests
- local Mintlify redirect smoke
- git diff --check

No changeset: docs routing and release tooling only.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/02f8e225-a4f3-49a7-a2b6-3da971ca06b8)
