### PR TITLE
chore(auth): stage referral codes authorization ceiling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -40,7 +40,7 @@ primary_region = 'iad'
   # Deployment-time ceiling for the issue #6827 read-only authorization canary.
   # The database runtime gate remains independently disabled until explicitly armed.
   ORG_AUTHORIZATION_ENFORCEMENT_ENABLED = "true"
-  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read,organization_domains_read,organization_pending_join_request_count_read,organization_pending_join_requests_read"
+  ORG_AUTHORIZATION_ENFORCEMENT_BOUNDARIES = "organization_roles_read,organization_domains_read,organization_pending_join_request_count_read,organization_pending_join_requests_read,organization_referral_codes_read"
   # Use pre-cloned repos from Docker build, skip runtime git fetch.
   # Production image has no git binary — unsetting this degrades gracefully
   # (repos skip indexing) but does not crash.


### PR DESCRIPTION
## Summary

- append `organization_referral_codes_read` to the production deployment ceiling
- keep the audited database runtime setting unchanged at the existing four boundaries

Part of #6827.

## Safety and rollout

- this PR changes exactly one `fly.toml` line
- the new boundary remains disabled after deployment because runtime and environment gates must both select it
- activation will occur separately only after deployment convergence and a clean disabled soak
- fast rollback after later activation is runtime removal of only `organization_referral_codes_read`

## Verification

- focused organization authorization canary suite: 37 passed
- repository precommit unit and policy-lint suites: passed
- typecheck: passed
- `git diff --check`: passed
- no protocol release-surface change; no changeset

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a8312209-4013-4671-9e03-64cdd993a89f)
