### PR TITLE
feat(brand): make canonical identity authoritative

### DIFF
--- a/server/src/addie/mcp/brand-tools.ts
+++ b/server/src/addie/mcp/brand-tools.ts
@@ -268,7 +268,8 @@ export function createBrandToolHandlers(): Map<string, (args: Record<string, unk
               ...(result.raw?.isNsfw ? { is_nsfw: true } : {}),
             },
             has_brand_manifest: true,
-            source_type: result.highQuality !== false ? 'enriched' : 'community',
+            source_type: 'enriched',
+            enrichment_provider: 'brandfetch',
           });
         } catch (err) {
           logger.warn({ err, domain }, 'Failed to cache enrichment result');

--- a/server/src/db/brand-db.ts
+++ b/server/src/db/brand-db.ts
@@ -379,6 +379,8 @@ export interface UpsertDiscoveredBrandInput {
    */
   classification?: TrustedBrandClassification;
   source_type: 'brand_json' | 'community' | 'enriched' | 'stub';
+  /** Provider that supplied this record when source_type is enriched. */
+  enrichment_provider?: string;
   expires_at?: Date;
   house_domain_audit?: BrandHouseDomainAuditContext;
 }
@@ -411,6 +413,27 @@ export interface ListBrandsOptions {
  */
 const OWNER_HOSTED_SQL =
   `(brands.workos_organization_id IS NOT NULL AND brands.domain_verified = true)`;
+/**
+ * Discovered-brand writes are monotonic: an unverified writer may refresh the
+ * same tier or promote a weaker row, but it may not replace owner-hosted or
+ * stronger-origin identity. This predicate is evaluated by PostgreSQL while
+ * holding the conflicting row lock, so a stale enrichment cannot race a
+ * canonical write and win afterward.
+ */
+const DISCOVERED_BRAND_WRITE_ALLOWED_SQL = `(
+  NOT ${OWNER_HOSTED_SQL}
+  AND CASE EXCLUDED.source_type
+    WHEN 'brand_json' THEN 2
+    WHEN 'community' THEN 3
+    WHEN 'enriched' THEN 4
+    ELSE 5
+  END <= CASE brands.source_type
+    WHEN 'brand_json' THEN 2
+    WHEN 'community' THEN 3
+    WHEN 'enriched' THEN 4
+    ELSE 5
+  END
+)`;
 /** Control of the domain was demonstrated, by owner verification or by serving a valid brand.json from it. */
 const DOMAIN_CONTROL_VERIFIED_SQL =
   `(${OWNER_HOSTED_SQL} OR brands.source_type = 'brand_json')`;
@@ -557,6 +580,7 @@ export class BrandDatabase {
     }
     if (input.origin_validated === true) {
       updates.push(`source_type = 'brand_json'`);
+      updates.push(`enrichment_provider = NULL`);
       updates.push(`last_validated = NOW()`);
     }
     if (input.verification_token !== undefined) {
@@ -855,12 +879,13 @@ export class BrandDatabase {
         `INSERT INTO brands (
           domain, brand_id, canonical_domain, house_domain, brand_name, brand_names,
           keller_type, parent_brand, brand_agent_url, brand_agent_capabilities,
-          has_brand_manifest, brand_manifest, source_type, last_validated, expires_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14)
+          has_brand_manifest, brand_manifest, source_type, enrichment_provider,
+          last_validated, expires_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW(), $15)
         ON CONFLICT (domain) DO UPDATE SET
           brand_id = COALESCE(EXCLUDED.brand_id, brands.brand_id),
           canonical_domain = EXCLUDED.canonical_domain,
-          house_domain = CASE WHEN $15::boolean THEN EXCLUDED.house_domain ELSE brands.house_domain END,
+          house_domain = CASE WHEN $16::boolean THEN EXCLUDED.house_domain ELSE brands.house_domain END,
           brand_name = EXCLUDED.brand_name,
           brand_names = EXCLUDED.brand_names,
           keller_type = EXCLUDED.keller_type,
@@ -870,8 +895,14 @@ export class BrandDatabase {
           has_brand_manifest = COALESCE(EXCLUDED.has_brand_manifest, brands.has_brand_manifest),
           brand_manifest = COALESCE(EXCLUDED.brand_manifest, brands.brand_manifest),
           source_type = EXCLUDED.source_type,
+          enrichment_provider = CASE
+            WHEN EXCLUDED.source_type = 'enriched'
+              THEN COALESCE(EXCLUDED.enrichment_provider, brands.enrichment_provider)
+            ELSE NULL
+          END,
           last_validated = NOW(),
           expires_at = EXCLUDED.expires_at
+        WHERE ${DISCOVERED_BRAND_WRITE_ALLOWED_SQL}
         RETURNING *`,
         [
           canonicalDomain,
@@ -887,16 +918,28 @@ export class BrandDatabase {
           input.has_brand_manifest != null ? input.has_brand_manifest : null,
           persistedManifest ? JSON.stringify(persistedManifest) : null,
           input.source_type,
+          input.source_type === 'enriched' ? input.enrichment_provider || null : null,
           input.expires_at || null,
           input.house_domain !== undefined,
         ],
       );
 
-      if (input.house_domain !== undefined) {
+      // ON CONFLICT intentionally performs no update when the incumbent has
+      // stronger provenance. Return that winner so callers cannot mistake a
+      // rejected lower-tier write for missing data.
+      const persistedBrand = result.rows[0] ?? (await client.query<DiscoveredBrand>(
+        'SELECT * FROM brands WHERE domain = $1',
+        [canonicalDomain],
+      )).rows[0];
+      if (!persistedBrand) {
+        throw new Error(`Brand upsert did not return a row: ${canonicalDomain}`);
+      }
+
+      if (result.rows[0] && input.house_domain !== undefined) {
         await recordBrandHouseDomainChange(client, {
           domain: canonicalDomain,
           prior_house_domain: priorHouseDomain,
-          new_house_domain: result.rows[0].house_domain ?? null,
+          new_house_domain: persistedBrand.house_domain ?? null,
           audit: input.house_domain_audit ?? {
             actor_user_id: 'system:brand-database',
             source: 'upsert_discovered_brand',
@@ -905,7 +948,7 @@ export class BrandDatabase {
       }
 
       await client.query('COMMIT');
-      return this.deserializeDiscoveredBrand(result.rows[0]);
+      return this.deserializeDiscoveredBrand(persistedBrand);
     } catch (error) {
       try { await client.query('ROLLBACK'); } catch { /* preserve original error */ }
       throw error;
@@ -1761,6 +1804,7 @@ export class BrandDatabase {
       if (current.source_type === 'enriched' && promotesContent && !isSystemEditor) {
         updates.push(`source_type = $${paramIndex++}`);
         values.push('community');
+        updates.push(`enrichment_provider = NULL`);
       }
 
       if (updates.length === 0) {

--- a/server/src/db/migrations/577_brand_enrichment_provider.sql
+++ b/server/src/db/migrations/577_brand_enrichment_provider.sql
@@ -1,0 +1,14 @@
+-- Attribute provisional brand identity to the enrichment writer without
+-- constraining the registry contract to a particular vendor. Existing rows
+-- remain NULL because source_type='enriched' alone does not prove who wrote
+-- them; current writers populate the column on their next successful fetch.
+
+ALTER TABLE brands
+  ADD COLUMN IF NOT EXISTS enrichment_provider TEXT;
+
+ALTER TABLE brands
+  ADD CONSTRAINT brands_enrichment_provider_source_check
+  CHECK (source_type = 'enriched' OR enrichment_provider IS NULL);
+
+COMMENT ON COLUMN brands.enrichment_provider IS
+  'Provider identifier for source_type=enriched; NULL when not enriched or historically unknown';

--- a/server/src/mcp-tools.ts
+++ b/server/src/mcp-tools.ts
@@ -1405,7 +1405,9 @@ export class MCPToolHandler {
                       cached: true,
                       manifest,
                       source_type: existingBrand.source_type,
-                      enrichment_provider: "brandfetch",
+                      ...(existingBrand.source_type === 'enriched' && existingBrand.enrichment_provider
+                        ? { enrichment_provider: existingBrand.enrichment_provider }
+                        : {}),
                     }, null, 2),
                   },
                 },
@@ -1447,7 +1449,7 @@ export class MCPToolHandler {
               ...(enrichment.company ? { company: enrichment.company } : {}),
             }
           : undefined;
-        const sourceType = enrichment.highQuality !== false ? 'enriched' : 'community';
+        const sourceType = 'enriched' as const;
 
         // Save enrichment to DB for future cache hits
         if (enrichment.success && enrichment.manifest) {
@@ -1457,6 +1459,7 @@ export class MCPToolHandler {
             brand_manifest: manifest,
             has_brand_manifest: true,
             source_type: sourceType,
+            enrichment_provider: 'brandfetch',
           }).catch((err) => {
             logger.warn({ err, domain: enrichDomain }, 'Failed to cache enrichment result');
           });

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -1170,11 +1170,42 @@ const RESOLVED_BRAND_SOURCE_PRIORITY: Record<ResolvedBrandResponse["source"], nu
   stub: 5,
 };
 
+const BRAND_PROVENANCE_BY_SOURCE = {
+  hosted: "canonical",
+  brand_json: "canonical",
+  community: "community",
+  enriched: "enriched",
+} as const;
+
+/**
+ * Keep the stable caller-facing tier separate from the detailed source label.
+ * The only enrichment writer today is Brandfetch; the response contract keeps
+ * the provider open-ended so a future writer can supply its own identifier.
+ */
+function withBrandResolutionProvenance(
+  brand: ResolvedBrandResponse,
+): ResolvedBrandResponse {
+  const provenance = brand.source === "stub"
+    ? undefined
+    : BRAND_PROVENANCE_BY_SOURCE[brand.source];
+  const response = { ...brand };
+  const provenanceProvider = response.provenance_provider;
+  delete response.provenance;
+  delete response.provenance_provider;
+  return {
+    ...response,
+    ...(provenance ? { provenance } : {}),
+    ...(provenance === "enriched" && provenanceProvider
+      ? { provenance_provider: provenanceProvider }
+      : {}),
+  };
+}
+
 function storedBrandResolutionResponse(
   brand: StoredBrandResolutionRecord,
   liveValidation?: ReturnType<typeof serializeBrandValidation>,
 ): ResolvedBrandResponse {
-  return {
+  return withBrandResolutionProvenance({
     canonical_id: brand.canonical_domain || brand.domain,
     canonical_domain: brand.canonical_domain || brand.domain,
     brand_name: brand.brand_name || brand.domain,
@@ -1183,9 +1214,12 @@ function storedBrandResolutionResponse(
     ...(brand.parent_brand ? { parent_brand: brand.parent_brand } : {}),
     ...(brand.brand_agent_url ? { brand_agent_url: brand.brand_agent_url } : {}),
     source: resolvedStoredBrandSource(brand),
+    ...(brand.enrichment_provider
+      ? { provenance_provider: brand.enrichment_provider }
+      : {}),
     brand_manifest: stripLegacyBrandContext(brand.brand_manifest),
     ...(liveValidation ? { live_brand_json: liveValidation } : {}),
-  };
+  });
 }
 
 /**
@@ -1202,12 +1236,14 @@ function selectResolvedBrandResponse(
   // A private or orphaned row is not a public resolution candidate. In
   // particular, it must never replace a valid live-origin response merely
   // because its provenance would otherwise rank higher.
-  if (!stored || stored.manifest_orphaned || stored.is_public === false) return live;
+  if (!stored || stored.manifest_orphaned || stored.is_public === false) {
+    return withBrandResolutionProvenance(live);
+  }
   const storedCandidate = storedBrandResolutionResponse(stored);
   const storedPriority = RESOLVED_BRAND_SOURCE_PRIORITY[storedCandidate.source];
   const livePriority = RESOLVED_BRAND_SOURCE_PRIORITY[live.source];
   if (storedPriority > livePriority || (storedPriority === livePriority && fresh)) {
-    return live;
+    return withBrandResolutionProvenance(live);
   }
 
   // Identity provenance and persisted identity fields come from the selected
@@ -1215,7 +1251,7 @@ function selectResolvedBrandResponse(
   // diagnostics are computed by the live resolver for the requested domain;
   // retain them instead of collapsing a verified edge to "unknown" merely
   // because a higher-provenance stored identity exists.
-  return { ...live, ...storedCandidate };
+  return withBrandResolutionProvenance({ ...live, ...storedCandidate });
 }
 
 registry.registerPath({
@@ -5366,11 +5402,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
 
       // Return cached enrichment if still fresh (avoids Brandfetch API cost)
       const existing = await brandDb.getDiscoveredBrandByDomain(domain);
-      if (existing?.has_brand_manifest && existing.brand_manifest && existing.last_validated) {
-        const ageMs = Date.now() - new Date(existing.last_validated).getTime();
+      const existingIsCanonical = existing?.source_type === 'brand_json'
+        || (existing?.workos_organization_id != null && existing.domain_verified === true);
+      if (existing?.has_brand_manifest && existing.brand_manifest
+        && (existingIsCanonical || existing.last_validated)) {
+        const ageMs = existing.last_validated
+          ? Date.now() - new Date(existing.last_validated).getTime()
+          : Number.POSITIVE_INFINITY;
         const manifest = stripLegacyBrandContext(existing.brand_manifest) || {};
         const company = (manifest as { company?: unknown }).company;
-        if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
+        if (existingIsCanonical || ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
           const contextResult = includeContext && isBrandfetchConfigured()
             ? await fetchBrandContext(domain)
             : undefined;
@@ -5409,18 +5450,16 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
             ...(enrichment.company ? { company: enrichment.company } : {}),
           }
         : undefined;
-      const sourceType = enrichment.raw
-        ? (enrichment.highQuality !== false ? 'enriched' : 'community')
-        : undefined;
+      const sourceType = enrichment.raw ? 'enriched' : undefined;
 
       if (enrichment.raw && enrichment.manifest) {
-        const persistedSourceType = enrichment.highQuality !== false ? 'enriched' : 'community';
         brandDb.upsertDiscoveredBrand({
           domain: enrichment.domain,
           brand_name: enrichment.manifest.name,
           brand_manifest: manifest,
           has_brand_manifest: true,
-          source_type: persistedSourceType,
+          source_type: 'enriched',
+          enrichment_provider: 'brandfetch',
         }).catch((err) => logger.warn({ err, domain }, 'Failed to save enrichment result'));
       }
 

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -631,6 +631,12 @@ export const ResolvedBrandSchema = z
     source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]).openapi({
       description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence.",
     }),
+    provenance: z.enum(["canonical", "community", "enriched"]).optional().openapi({
+      description: "Caller-facing trust tier for the selected identity. `canonical` covers owner-hosted and origin-published brand.json records; `community` is member-contributed; `enriched` is provisional third-party data. Absent means the record has no recognized provenance tier. Use `source` when the distinction between hosted and origin-published canonical records is needed.",
+    }),
+    provenance_provider: z.string().optional().openapi({
+      description: "Provider identifier for provisional third-party enrichment. Present only when `provenance` is `enriched`; the provider is intentionally not constrained to a vendor-specific enum.",
+    }),
     live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
       description: "This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.",
     }),

--- a/server/src/services/brand-enrichment.ts
+++ b/server/src/services/brand-enrichment.ts
@@ -121,7 +121,8 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
   if (existing?.source_type === 'enriched' && existing.has_brand_manifest) {
     return { domain, status: 'skipped', brand_name: existing.brand_name, error: 'Already enriched' };
   }
-  // Skip community brands with fresh manifests (e.g., recently downgraded from enriched due to low quality)
+  // Skip fresh community-curated manifests; enrichment must not churn a
+  // stronger human-contributed identity.
   if (existing?.source_type === 'community' && existing.has_brand_manifest && existing.last_validated) {
     const ageMs = Date.now() - new Date(existing.last_validated).getTime();
     if (ageMs < ENRICHMENT_CACHE_MAX_AGE_MS) {
@@ -210,8 +211,9 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
     ? await downloadAndCacheLogos(domain, result.manifest.logos)
     : result.manifest.logos;
 
-  // Determine source_type: only mark as 'enriched' if Brandfetch returned meaningful data
-  const sourceType = result.highQuality !== false ? 'enriched' : 'community';
+  // Brandfetch remains enrichment regardless of data quality. Quality affects
+  // review/usefulness, not who supplied the identity.
+  const sourceType = 'enriched' as const;
 
   // Map to discovered brand input. `classification` flows through the
   // dedicated typed field (UpsertDiscoveredBrandInput.classification), NOT
@@ -235,6 +237,7 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
     },
     has_brand_manifest: true,
     source_type: sourceType,
+    enrichment_provider: 'brandfetch',
     // Apply classification fields if available
     ...(classification ? {
       keller_type: classification.keller_type,
@@ -270,14 +273,13 @@ export async function enrichBrand(domain: string): Promise<BrandEnrichmentResult
 
   logger.info(
     { domain, brandName, sourceType, keller_type: classification?.keller_type },
-    sourceType === 'enriched' ? 'Brand enriched' : 'Brand saved as community (low-quality Brandfetch data)'
+    'Brand enriched'
   );
   return {
     domain,
-    status: sourceType === 'enriched' ? 'enriched' : 'skipped',
+    status: 'enriched',
     brand_name: brandName,
     classification: classification || undefined,
-    error: sourceType === 'community' ? 'Low-quality Brandfetch result saved as community' : undefined,
   };
 }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -615,6 +615,8 @@ export interface DiscoveredBrand {
   has_brand_manifest: boolean;
   brand_manifest?: Record<string, unknown>;
   source_type: 'brand_json' | 'community' | 'enriched' | 'stub';
+  /** Provider that supplied an enriched record; absent for legacy/unknown provenance. */
+  enrichment_provider?: string;
   review_status?: 'pending' | 'approved';
   discovered_at: Date;
   last_validated?: Date;
@@ -664,6 +666,9 @@ export interface ResolvedBrand {
   brand_agent_url?: string;
   brand_manifest?: Record<string, unknown>;
   source: 'hosted' | 'brand_json' | 'community' | 'enriched' | 'stub';
+  provenance?: 'canonical' | 'community' | 'enriched';
+  /** Present only for enriched provenance when the writer is known. */
+  provenance_provider?: string;
 }
 
 /**

--- a/server/tests/integration/brand-provenance-precedence.test.ts
+++ b/server/tests/integration/brand-provenance-precedence.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Pool } from 'pg';
+import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
+import { runMigrations } from '../../src/db/migrate.js';
+import { BrandDatabase } from '../../src/db/brand-db.js';
+
+const ENRICHED_DOMAIN = 'provenance-enriched.test';
+const CANONICAL_DOMAIN = 'provenance-canonical.test';
+const HOSTED_DOMAIN = 'provenance-hosted.test';
+const HOSTED_ORG_ID = 'org_provenance_owner';
+const TEST_DOMAINS = [ENRICHED_DOMAIN, CANONICAL_DOMAIN, HOSTED_DOMAIN];
+
+describe('brand provenance write precedence', () => {
+  let pool: Pool;
+  const db = new BrandDatabase();
+
+  beforeAll(async () => {
+    pool = initializeDatabase({
+      connectionString: process.env.DATABASE_URL || 'postgresql://adcp:localdev@localhost:5432/adcp_test',
+    });
+    await runMigrations();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM brands WHERE domain = ANY($1)', [TEST_DOMAINS]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [HOSTED_ORG_ID]);
+    await pool.query(
+      `INSERT INTO organizations (workos_organization_id, name, subscription_status, created_at, updated_at)
+       VALUES ($1, 'Provenance Owner', 'active', NOW(), NOW())`,
+      [HOSTED_ORG_ID],
+    );
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query('DELETE FROM brands WHERE domain = ANY($1)', [TEST_DOMAINS]);
+    await pool.query('DELETE FROM organizations WHERE workos_organization_id = $1', [HOSTED_ORG_ID]);
+    await closeDatabase();
+  });
+
+  it('round-trips known enrichment attribution and clears it on community promotion', async () => {
+    await db.upsertDiscoveredBrand({
+      domain: ENRICHED_DOMAIN,
+      brand_name: 'Provider Identity',
+      source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
+    });
+
+    // An older/alternate enrichment writer must not erase known attribution.
+    await db.upsertDiscoveredBrand({
+      domain: ENRICHED_DOMAIN,
+      brand_name: 'Provider Refresh',
+      source_type: 'enriched',
+    });
+    expect(await db.getDiscoveredBrandByDomain(ENRICHED_DOMAIN)).toMatchObject({
+      source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
+    });
+
+    await db.upsertDiscoveredBrand({
+      domain: ENRICHED_DOMAIN,
+      brand_name: 'Community Identity',
+      source_type: 'community',
+    });
+    const promoted = await db.getDiscoveredBrandByDomain(ENRICHED_DOMAIN);
+    expect(promoted).toMatchObject({
+      brand_name: 'Community Identity',
+      source_type: 'community',
+    });
+    expect(promoted?.enrichment_provider).toBeNull();
+  });
+
+  it('does not let enrichment replace an origin-published canonical identity', async () => {
+    await db.upsertDiscoveredBrand({
+      domain: CANONICAL_DOMAIN,
+      brand_name: 'Origin Canonical',
+      brand_manifest: { name: 'Origin Canonical' },
+      has_brand_manifest: true,
+      source_type: 'brand_json',
+    });
+
+    const winner = await db.upsertDiscoveredBrand({
+      domain: CANONICAL_DOMAIN,
+      brand_name: 'Vendor Replacement',
+      brand_manifest: { name: 'Vendor Replacement' },
+      has_brand_manifest: true,
+      source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
+    });
+
+    expect(winner).toMatchObject({
+      brand_name: 'Origin Canonical',
+      source_type: 'brand_json',
+    });
+    expect(winner.enrichment_provider).toBeNull();
+  });
+
+  it('does not let enrichment replace a verified-owner identity', async () => {
+    await pool.query(
+      `INSERT INTO brands (
+        domain, brand_name, brand_manifest, has_brand_manifest, source_type,
+        workos_organization_id, domain_verified
+      ) VALUES ($1, 'Owner Canonical', $2::jsonb, true, 'community', $3, true)`,
+      [HOSTED_DOMAIN, JSON.stringify({ name: 'Owner Canonical' }), HOSTED_ORG_ID],
+    );
+
+    const winner = await db.upsertDiscoveredBrand({
+      domain: HOSTED_DOMAIN,
+      brand_name: 'Vendor Replacement',
+      brand_manifest: { name: 'Vendor Replacement' },
+      has_brand_manifest: true,
+      source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
+    });
+
+    expect(winner).toMatchObject({
+      brand_name: 'Owner Canonical',
+      workos_organization_id: HOSTED_ORG_ID,
+      domain_verified: true,
+    });
+    expect(winner.brand_manifest).toEqual({ name: 'Owner Canonical' });
+    expect(winner.enrichment_provider).toBeNull();
+  });
+});

--- a/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
+++ b/server/tests/unit/brand-enrichment-expand-house-tool-use.test.ts
@@ -182,6 +182,7 @@ describe('expandHouse: tool_use contract', () => {
 
     expect(result.status).toBe('enriched');
     expect(mocks.upsertDiscoveredBrand).toHaveBeenCalledWith(expect.objectContaining({
+      enrichment_provider: 'brandfetch',
       house_domain: null,
       house_domain_audit: {
         actor_user_id: 'system:brand-classifier',

--- a/server/tests/unit/brand-house-domain-audit.test.ts
+++ b/server/tests/unit/brand-house-domain-audit.test.ts
@@ -108,7 +108,7 @@ describe('brand house-domain audit trail (#3419)', () => {
     const insert = client.query.mock.calls.find(call =>
       typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
     )!;
-    expect((insert[1] as unknown[])[14]).toBe(false);
+    expect((insert[1] as unknown[])[15]).toBe(false);
     expect(client.query.mock.calls.some(call =>
       typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
     )).toBe(false);
@@ -141,7 +141,7 @@ describe('brand house-domain audit trail (#3419)', () => {
     const insert = client.query.mock.calls.find(call =>
       typeof call[0] === 'string' && call[0].includes('INSERT INTO brands'),
     )!;
-    expect((insert[1] as unknown[])[14]).toBe(true);
+    expect((insert[1] as unknown[])[15]).toBe(true);
     const audit = client.query.mock.calls.find(call =>
       typeof call[0] === 'string' && call[0].includes('registry_audit_log'),
     )!;

--- a/server/tests/unit/brandfetch-cache.test.ts
+++ b/server/tests/unit/brandfetch-cache.test.ts
@@ -172,6 +172,7 @@ describe('Brandfetch DB caching', () => {
           brand_name: 'Save Corp',
           has_brand_manifest: true,
           source_type: 'enriched',
+          enrichment_provider: 'brandfetch',
           brand_manifest: expect.objectContaining({
             name: 'Save Corp',
             url: 'https://save.com',
@@ -217,7 +218,7 @@ describe('Brandfetch DB caching', () => {
   describe('research_brand quality validation', () => {
     const handler = () => handlers.get('research_brand')!;
 
-    it('saves low-quality Brandfetch results as community', async () => {
+    it('keeps low-quality Brandfetch results labeled as enrichment', async () => {
       mockGetDiscoveredBrandByDomain.mockResolvedValue(null);
 
       mockFetchBrandData.mockResolvedValue({
@@ -238,7 +239,8 @@ describe('Brandfetch DB caching', () => {
       expect(mockUpsertDiscoveredBrand).toHaveBeenCalledWith(
         expect.objectContaining({
           domain: 'lowquality.com',
-          source_type: 'community',
+          source_type: 'enriched',
+          enrichment_provider: 'brandfetch',
         })
       );
     });
@@ -265,6 +267,7 @@ describe('Brandfetch DB caching', () => {
         expect.objectContaining({
           domain: 'highquality.com',
           source_type: 'enriched',
+          enrichment_provider: 'brandfetch',
         })
       );
     });

--- a/server/tests/unit/mcp-enrich-brand-context.test.ts
+++ b/server/tests/unit/mcp-enrich-brand-context.test.ts
@@ -66,6 +66,7 @@ describe('MCP enrich_brand Brand Context boundary', () => {
       has_brand_manifest: true,
       last_validated: new Date(),
       source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
       brand_manifest: {
         name: 'Acme',
         url: 'https://acme.com',
@@ -93,6 +94,24 @@ describe('MCP enrich_brand Brand Context boundary', () => {
     expect(mocks.fetchBrandData).not.toHaveBeenCalled();
   });
 
+  it('does not invent Brandfetch attribution for a cached canonical record', async () => {
+    mocks.getDiscoveredBrandByDomain.mockResolvedValue({
+      domain: 'origin.example',
+      has_brand_manifest: true,
+      last_validated: new Date(),
+      source_type: 'brand_json',
+      brand_manifest: { name: 'Origin', url: 'https://origin.example' },
+    });
+
+    const handler = new MCPToolHandler();
+    const result = await handler.handleToolCall('enrich_brand', { domain: 'origin.example' });
+    const body = parseResource(result);
+
+    expect(body.source_type).toBe('brand_json');
+    expect(body.enrichment_provider).toBeUndefined();
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
+  });
+
   it('does not emit or persist Brand Context from fresh enrichment results', async () => {
     mocks.getDiscoveredBrandByDomain.mockResolvedValue(null);
     mocks.fetchBrandData.mockResolvedValue({
@@ -107,7 +126,7 @@ describe('MCP enrich_brand Brand Context boundary', () => {
       context: {
         brand: { voice: { summary: 'private context' } },
       },
-      highQuality: true,
+      highQuality: false,
     });
 
     const handler = new MCPToolHandler();
@@ -126,6 +145,7 @@ describe('MCP enrich_brand Brand Context boundary', () => {
       domain: 'acme.com',
       brand_name: 'Acme',
       source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
       brand_manifest: {
         name: 'Acme',
         url: 'https://acme.com',

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -70,6 +70,7 @@ function discoveredBrandWithContext() {
     canonical_domain: 'acme.com',
     brand_name: 'Acme',
     source_type: 'enriched',
+    enrichment_provider: 'brandfetch',
     is_public: true,
     manifest_orphaned: false,
     brand_manifest: {
@@ -212,6 +213,32 @@ describe('GET /api/brands/enrich', () => {
     expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
   });
 
+  it('never refreshes a stale verified-owner identity from enrichment', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        id: 'brand-owner',
+        domain: 'owner.example',
+        has_brand_manifest: true,
+        brand_manifest: { name: 'Owner Canonical', url: 'https://owner.example' },
+        source_type: 'community',
+        workos_organization_id: 'org_owner',
+        domain_verified: true,
+        last_validated: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/enrich?domain=owner.example');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      cached: true,
+      manifest: { name: 'Owner Canonical', url: 'https://owner.example' },
+    });
+    expect(mocks.fetchBrandData).not.toHaveBeenCalled();
+    expect(brandDb.upsertDiscoveredBrand).not.toHaveBeenCalled();
+  });
+
   it('persists only Brand API fields while returning Brand Context as ephemeral response context', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
@@ -249,6 +276,7 @@ describe('GET /api/brands/enrich', () => {
       domain: 'acme.com',
       brand_name: 'Acme',
       source_type: 'enriched',
+      enrichment_provider: 'brandfetch',
       brand_manifest: {
         name: 'Acme',
         url: 'https://acme.com',
@@ -325,6 +353,11 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
+    expect(res.body).toMatchObject({
+      source: 'enriched',
+      provenance: 'enriched',
+      provenance_provider: 'brandfetch',
+    });
   });
 
   it('reports verified owner-registered fallback records as hosted', async () => {
@@ -342,6 +375,24 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('hosted');
+    expect(res.body.provenance).toBe('canonical');
+    expect(res.body.provenance_provider).toBeUndefined();
+  });
+
+  it('does not guess the provider for a legacy enriched record', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        enrichment_provider: undefined,
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.provenance).toBe('enriched');
+    expect(res.body.provenance_provider).toBeUndefined();
   });
 
   it('does not report an unverified organization-attributed record as hosted', async () => {
@@ -359,6 +410,24 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('community');
+    expect(res.body.provenance).toBe('community');
+  });
+
+  it('omits provenance instead of inventing an unknown tier for stubs', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
+        ...discoveredBrandWithContext(),
+        source_type: 'stub',
+      }),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('stub');
+    expect(res.body.provenance).toBeUndefined();
+    expect(res.body.provenance_provider).toBeUndefined();
   });
 
   it('keeps identical live and stored records on the same provenance label', async () => {
@@ -469,6 +538,7 @@ describe('public registry brand read paths', () => {
     expect(res.body).toMatchObject({
       canonical_id: 'acme-live',
       source: 'brand_json',
+      provenance: 'canonical',
       promoted_from_schema: live.promoted_from_schema,
       migration_warnings: live.migration_warnings,
     });
@@ -500,7 +570,7 @@ describe('public registry brand read paths', () => {
     })).get('/api/brands/resolve?domain=acme.com');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(live);
+    expect(res.body).toEqual({ ...live, provenance: 'canonical' });
   });
 
   it('rejects path and port lookup inputs before brand resolution', async () => {
@@ -541,6 +611,8 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('enriched');
+    expect(res.body.provenance).toBe('enriched');
+    expect(res.body.provenance_provider).toBe('brandfetch');
     expect(res.body.live_brand_json).toEqual({
       valid: false,
       url: validation.url,
@@ -595,6 +667,11 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.results['acme.com'].brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
+    expect(res.body.results['acme.com']).toMatchObject({
+      source: 'enriched',
+      provenance: 'enriched',
+      provenance_provider: 'brandfetch',
+    });
   });
 
   it('rejects non-hostname inputs from bulk resolution', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -146,6 +146,16 @@ components:
             - enriched
             - stub
           description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence."
+        provenance:
+          type: string
+          enum:
+            - canonical
+            - community
+            - enriched
+          description: Caller-facing trust tier for the selected identity. `canonical` covers owner-hosted and origin-published brand.json records; `community` is member-contributed; `enriched` is provisional third-party data. Absent means the record has no recognized provenance tier. Use `source` when the distinction between hosted and origin-published canonical records is needed.
+        provenance_provider:
+          type: string
+          description: Provider identifier for provisional third-party enrichment. Present only when `provenance` is `enriched`; the provider is intentionally not constrained to a vendor-specific enum.
         live_brand_json:
           type: object
           properties:


### PR DESCRIPTION
## Summary

- expose canonical, community, and enriched provenance without changing the existing detailed source field
- make registry writes monotonic so anonymous discovery and enrichment cannot overwrite verified or higher-authority identity
- persist enrichment provider metadata and clear it whenever identity becomes non-enriched
- keep canonical hosted and owner-verified identity authoritative in the enrichment route

## Verification

- npm run typecheck
- npm run test:migrations
- 56 focused registry, MCP, enrichment, and audit unit tests
- 3 real-Postgres precedence and provider-lifecycle integration tests
- Docker image build, clean migration application, and HTTP provenance smoke tests
- npm run build:openapi (idempotent)
- changeset protocol scope and diff checks

The repository-wide pre-commit run completed 8,026 server tests successfully; four unrelated authorization/billing tests fail reproducibly on current main as well.

Closes #7231

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f6f3a822-a9a1-4f74-819f-07bba087ebb3)
