### PR TITLE
fix(certification): restore credential share links

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.37';
+export const CODE_VERSION = '2026.09.38';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -660,6 +660,7 @@ async function checkAndFormatCredentials(
   const RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
   const now = Date.now();
   const existing = await certDb.getUserCredentials(userId);
+  const existingByCredentialId = new Map(existing.map(c => [c.credential_id, c]));
   const deferred = existing
     .filter(c =>
       !c.certifier_credential_id &&
@@ -669,7 +670,21 @@ async function checkAndFormatCredentials(
     )
     .map(c => c.credential_id);
 
-  const toProcess = [...new Set([...awarded, ...deferred])];
+  // Link rendering is independent of Certifier delivery. In particular,
+  // credentials without a Certifier group (such as Decision-Makers) are
+  // still useful on LinkedIn long after the issuance-retry window closes.
+  // Keep this set distinct from `deferred`: adding these records to the
+  // issuance queue would defeat the corrupt-row double-issuance defense.
+  const shareOnly = existing
+    .filter(c =>
+      !c.certifier_credential_id &&
+      !awarded.includes(c.credential_id) &&
+      !deferred.includes(c.credential_id) &&
+      (allowPaidCredentials || (credMap.get(c.credential_id)?.tier ?? Number.POSITIVE_INFINITY) <= 1),
+    )
+    .map(c => c.credential_id);
+
+  const toProcess = [...new Set([...awarded, ...deferred, ...shareOnly])];
   if (toProcess.length === 0) return [];
 
   const lines: string[] = [''];
@@ -677,13 +692,16 @@ async function checkAndFormatCredentials(
   for (const credId of toProcess) {
     const cred = credMap.get(credId);
     if (cred) {
+      const shouldIssue = awarded.includes(credId) || deferred.includes(credId);
       // External issuance is its own authorization boundary. Recheck directly
       // before each paid badge call so membership ending during assessment or
       // an earlier network request cannot reuse a stale positive decision.
-      if (cred.tier > 1 && !(await certDb.hasEffectiveMembershipForUser(userId))) {
+      if (shouldIssue && cred.tier > 1 && !(await certDb.hasEffectiveMembershipForUser(userId))) {
         continue;
       }
-      const result = await issueCertifierBadge(userId, credId, cred, memberContext);
+      const result = shouldIssue
+        ? await issueCertifierBadge(userId, credId, cred, memberContext)
+        : existingByCredentialId.get(credId)?.certifier_public_id ?? null;
       if (result === NAME_REQUIRED_MARKER) {
         nameRequired = true;
         // Don't post "Credential earned!" or share links or specialist
@@ -692,10 +710,16 @@ async function checkAndFormatCredentials(
         continue;
       }
       lines.push(`**Credential earned: ${cred.name}!**`);
-      lines.push(...buildShareLinks(cred.name, result));
+      lines.push(...buildShareLinks(
+        cred.name,
+        result,
+        existingByCredentialId.get(credId)?.awarded_at
+          ? new Date(existingByCredentialId.get(credId)!.awarded_at)
+          : undefined,
+      ));
 
       // Post immediate Slack notification for Specialist (tier 3) credentials
-      if (cred.tier === 3) {
+      if (shouldIssue && cred.tier === 3) {
         const wu = memberContext?.workos_user;
         const userName = wu ? ((wu.first_name || '') + ' ' + (wu.last_name || '')).trim() || 'A member' : 'A member';
         notifySpecialistCredential(userName, cred.name).catch(err => {

--- a/server/tests/unit/certification-deferred-badge-membership.test.ts
+++ b/server/tests/unit/certification-deferred-badge-membership.test.ts
@@ -147,4 +147,59 @@ describe('deferred certification badge membership gate', () => {
     expect(result).not.toContain('&certId=');
     expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
   });
+
+  it('renders links for an older credential with no Certifier group', async () => {
+    const awardedAt = '2026-08-01T00:00:00.000Z';
+    mocks.getCredentials.mockResolvedValue([{
+      id: 'decision_makers',
+      name: 'AdCP for Decision-Makers',
+      tier: 1,
+      certifier_group_id: null,
+    }]);
+    mocks.getUserCredentials.mockResolvedValue([{
+      credential_id: 'decision_makers',
+      certifier_credential_id: null,
+      certifier_public_id: null,
+      awarded_at: awardedAt,
+    }]);
+
+    const handlers = createCertificationToolHandlers({
+      is_member: false,
+      workos_user: {
+        workos_user_id: 'user_decision_maker',
+        email: 'learner@example.test',
+      },
+    } as any);
+
+    const result = await handlers.get('check_credentials')?.({});
+
+    expect(result).toContain('Credential earned: AdCP for Decision-Makers!');
+    expect(result).toContain('[Add to LinkedIn profile](https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME');
+    expect(result).toContain('&issueYear=2026&issueMonth=8');
+    expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
+  });
+
+  it('does not retry an older configured credential while still rendering its links', async () => {
+    mocks.hasEffectiveMembershipForUser.mockResolvedValue(true);
+    mocks.getUserCredentials.mockResolvedValue([{
+      credential_id: 'practitioner',
+      certifier_credential_id: null,
+      certifier_public_id: null,
+      awarded_at: '2026-08-01T00:00:00.000Z',
+    }]);
+
+    const handlers = createCertificationToolHandlers({
+      is_member: true,
+      workos_user: {
+        workos_user_id: 'user_lapsed',
+        email: 'learner@example.test',
+      },
+    } as any);
+
+    const result = await handlers.get('check_credentials')?.({});
+
+    expect(result).toContain('Credential earned: AdCP Practitioner!');
+    expect(result).toContain('[Add to LinkedIn profile]');
+    expect(mocks.ensureCertifierCredential).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- return existing credential and LinkedIn share links even when an older award has no Certifier badge record
- keep external issuance retries confined to the existing 24-hour deferred window
- preserve the original award date and avoid duplicate specialist notifications
- bump the Addie code version and cover old badge-less awards with regression tests

## Verification

- targeted certification deferred-badge tests
- TypeScript typecheck
- full pre-commit suite: 1,057 general tests and 8,050 server tests
- independent code and security review

## Follow-up

The application-side share-link defect is addressed here. The specific affected production credential row/API response still needs operational confirmation.

Addresses #7218