### PR TITLE
fix(registry): clarify missing adagents file

### DIFF
--- a/server/public/publisher-home.html
+++ b/server/public/publisher-home.html
@@ -1185,14 +1185,31 @@
             body: JSON.stringify({ domain }),
           });
           const body = await res.json();
-          const errors = (body && body.data && body.data.validation && body.data.validation.errors) || [];
+          const validation = body && body.data && body.data.validation;
+          const errors = (validation && validation.errors) || [];
+          const statusCode = validation && validation.status_code;
+          const isMissingFileError = (error) =>
+            error && error.field === 'http_status'
+              && /(?:\b404\b|not found)/i.test(error.message || '');
+          const missingFile = errors.every(isMissingFileError)
+            && (statusCode === 404 || errors.some(isMissingFileError));
+          if (missingFile) {
+            const manifestUrl = `https://${domain}/.well-known/adagents.json`;
+            const builderUrl = `/adagents/builder?domain=${encodeURIComponent(domain)}`;
+            panel.innerHTML = `<h3>adagents.json not found</h3><p>No adagents.json found at <code>${escapeHtml(manifestUrl)}</code> — publish one to register your agent.</p><p><a class="ds-link-subtle" href="${builderUrl}">Open adagents.json builder →</a></p>`;
+            return;
+          }
           if (!errors.length) {
             panel.innerHTML = `<em>No structured errors returned. The fetch may have failed at the network layer — check that <code>${escapeHtml('https://' + domain + '/.well-known/adagents.json')}</code> is reachable.</em>`;
             return;
           }
+          const fieldLabels = {
+            http_status: 'HTTP error',
+            json: 'Parse error',
+          };
           const list = errors
             .slice(0, 8)
-            .map((e) => `<li><strong>${escapeHtml(e.field || 'document')}:</strong> ${escapeHtml(e.message || String(e))}</li>`)
+            .map((e) => `<li><strong>${escapeHtml(fieldLabels[e.field] || e.field || 'Document')}:</strong> ${escapeHtml(e.message || String(e))}</li>`)
             .join('');
           panel.innerHTML = `<h3>Validation errors</h3><ul>${list}</ul>`;
         } catch {

--- a/server/tests/unit/publisher-home-validation-detail.test.ts
+++ b/server/tests/unit/publisher-home-validation-detail.test.ts
@@ -1,0 +1,92 @@
+import { readFile } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function validationDetailFunction(): Promise<(domain: string) => Promise<void>> {
+  const source = await readFile(new URL('../../public/publisher-home.html', import.meta.url), 'utf8');
+  const start = source.indexOf('async function showValidationDetail(');
+  if (start < 0) throw new Error('Missing showValidationDetail');
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  let end = brace;
+  for (; end < source.length; end += 1) {
+    if (source[end] === '{') depth += 1;
+    else if (source[end] === '}' && --depth === 0) { end += 1; break; }
+  }
+  return new Function(`${source.slice(start, end)}; return showValidationDetail;`)() as
+    (domain: string) => Promise<void>;
+}
+
+function validationPanel() {
+  return {
+    classList: {
+      contains: vi.fn().mockReturnValue(true),
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+    innerHTML: '',
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('publisher validation detail', () => {
+  it('turns a missing adagents.json response into an actionable builder link', async () => {
+    const panel = validationPanel();
+    vi.stubGlobal('document', { getElementById: () => panel });
+    vi.stubGlobal('escapeHtml', (value: string) => value);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({
+        data: { validation: { status_code: 404, errors: [] } },
+      }),
+    }));
+
+    const showValidationDetail = await validationDetailFunction();
+    await showValidationDetail('publisher.example');
+
+    expect(panel.innerHTML).toContain('adagents.json not found');
+    expect(panel.innerHTML).toContain('https://publisher.example/.well-known/adagents.json');
+    expect(panel.innerHTML).toContain('/adagents/builder?domain=publisher.example');
+  });
+
+  it('labels malformed JSON as a parse error rather than exposing an internal field name', async () => {
+    const panel = validationPanel();
+    vi.stubGlobal('document', { getElementById: () => panel });
+    vi.stubGlobal('escapeHtml', (value: string) => value);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({
+        data: { validation: { status_code: 200, errors: [{ field: 'json', message: 'Invalid JSON' }] } },
+      }),
+    }));
+
+    const showValidationDetail = await validationDetailFunction();
+    await showValidationDetail('publisher.example');
+
+    expect(panel.innerHTML).toContain('<strong>Parse error:</strong> Invalid JSON');
+    expect(panel.innerHTML).not.toContain('<strong>json:</strong>');
+  });
+
+  it('preserves a delegated-manager scope error even when the direct fetch returned 404', async () => {
+    const panel = validationPanel();
+    vi.stubGlobal('document', { getElementById: () => panel });
+    vi.stubGlobal('escapeHtml', (value: string) => value);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({
+        data: {
+          validation: {
+            status_code: 404,
+            errors: [{ field: 'managerdomain_scope', message: 'Manager does not explicitly cover this publisher' }],
+          },
+        },
+      }),
+    }));
+
+    const showValidationDetail = await validationDetailFunction();
+    await showValidationDetail('publisher.example');
+
+    expect(panel.innerHTML).toContain('<h3>Validation errors</h3>');
+    expect(panel.innerHTML).toContain('Manager does not explicitly cover this publisher');
+    expect(panel.innerHTML).not.toContain('adagents.json not found');
+  });
+});


### PR DESCRIPTION
## Summary

- distinguish a missing adagents.json file from malformed JSON and other HTTP failures
- show the exact manifest URL and a direct builder action for 404 responses
- translate internal validation categories into clear user-facing labels
- add browser-function regression tests for missing and malformed manifests

## Verification

- targeted publisher validation-detail tests
- TypeScript typecheck
- headless Chrome page smoke test
- full pre-commit suite: 1,057 general tests and 8,050 server tests
- independent code and security review

## Operational follow-up

After deployment, revalidate stored results where `errors[].field = json` and `last_http_status = 404` so stale pre-differentiation cache entries receive the corrected missing-file classification.

Addresses #7219
