### PR TITLE
fix(addie): expand certification session reserve

### DIFF
--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -18,7 +18,7 @@
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "500aa3920a48d637528cd646140521858a2223880457d6ab653ac5ceb3a618b2",
-    "server/src/routes/addie-chat.ts": "58a45bea9e731bcba2a65ed6d6a228cb7a974140fd53367958359fecb505e729",
+    "server/src/routes/addie-chat.ts": "b7a9c656b05a45407b61a80c8d449f2395bfca3af00afad1bb8765ee1bd74317",
     "server/src/routes/tavus.ts": "3f7f598555ee52090eb2a26ac0bf1dea5e1fe345ea8e57764b60879d7b96cfec",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -1823,7 +1823,8 @@ export function createAddieChatRouter(options?: {
       const preTurnCertification = userId && certificationModuleContext.moduleId
         ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
         : null;
-      const completionReserveEligible = hasThreadCertCtx
+      const certificationReserveEligible = hasThreadCertCtx;
+      const certificationCompletionTurn = hasThreadCertCtx
         && (retryRequested
           || preTurnCertification?.status === 'evidence_complete'
           || preTurnCertification?.checkpoint?.current_phase === 'assessment');
@@ -1860,7 +1861,7 @@ export function createAddieChatRouter(options?: {
 
       for await (const event of activeChatClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
         ...processOptions,
-        ...(completionReserveEligible ? { maxIterations: 3, maxMessages: 12 } : {}),
+        ...(certificationCompletionTurn ? { maxIterations: 3, maxMessages: 12 } : {}),
         requestContext: [requestContext, routedWebTools?.unavailableHint].filter(Boolean).join('\n\n'),
         selectedToolSetNames: routedWebTools?.selectedToolSets,
         allowedToolNames: routedWebTools?.allowedToolNames,
@@ -1872,7 +1873,7 @@ export function createAddieChatRouter(options?: {
         ...(streamAuthedScope
           ? { costScope: {
               ...streamAuthedScope,
-              ...(completionReserveEligible ? { certificationReserveUsd: 1 } : {}),
+              ...(certificationReserveEligible ? { certificationReserveUsd: 3 } : {}),
             } }
           : externalId
             ? { costScope: { userId: `anon:${externalId}`, tier: 'anonymous' as const } }

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -730,6 +730,50 @@ describe('Addie chat conversation object authorization', () => {
     }));
   });
 
+  it('gives every active certification learning thread the expanded reserve', async () => {
+    const conversationId = '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489';
+    mocks.memberContext = {
+      is_mapped: true,
+      is_member: false,
+      slack_linked: false,
+      workos_user: { workos_user_id: 'user_attacker' },
+    };
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: conversationId,
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.getProgress.mockResolvedValue([{
+      module_id: 'A2',
+      status: 'in_progress',
+      addie_thread_id: conversationId,
+      completed_at: null,
+    }]);
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Continue the learning section',
+        conversation_id: conversationId,
+        client_request_id: '4328e677-4ac0-4b9f-900b-dc42a419b2ea',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mocks.processMessageStream).toHaveBeenCalledOnce();
+    const processOptions = mocks.processMessageStream.mock.calls[0]?.[3];
+    expect(processOptions).toEqual(expect.objectContaining({
+      costScope: {
+        userId: 'user_attacker',
+        tier: 'member_free',
+        certificationReserveUsd: 3,
+      },
+    }));
+    expect(processOptions).not.toHaveProperty('maxIterations');
+    expect(processOptions).not.toHaveProperty('maxMessages');
+  });
+
   it('denies cross-user feedback before attempting a message update', async () => {
     const response = await request(mountChatRouter())
       .post('/9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489/feedback')


### PR DESCRIPTION
## Summary

- extend the certification-specific cost reserve to the full active certification thread
- raise the reserve to cover multi-turn assessment and grading work
- preserve ownership and in-progress checks before granting the reserve
- add a regression test for ordinary turns inside an active A2 certification thread

## Verification

- targeted Addie object-authorization tests
- TypeScript typecheck
- full pre-commit suite: 1,057 general tests and 8,050 server tests
- independent code and security review

Fixes #7215