### PR TITLE
fix(reporting): disambiguate aggregate reach and frequency denominator

### DIFF
--- a/.changeset/disambiguate-aggregate-reach.md
+++ b/.changeset/disambiguate-aggregate-reach.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Disambiguate cross-buy reach as deduplicated or summed constituent reach, forbid aggregate frequency for summed reach, and preserve legacy payload validity when the new discriminator is absent.

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -71,7 +71,7 @@ Returns delivery data as per-media-buy rows:
 | `reporting_period` | Date range for report (start/end timestamps) |
 | `currency` | **Deprecated in 3.2; removed in 4.0.** Optional legacy response-wide currency for reports whose monetary values all share one denomination. Do not treat it as an aggregation currency. Prefer row or package currency. |
 | `attribution_window` | Attribution methodology: `post_click` and `post_view` (duration objects), and `model` (last_touch, first_touch, linear, time_decay, data_driven) |
-| `aggregated_totals` | **Deprecated in 3.2; removed in 4.0.** Legacy cross-buy aggregate. When present, the deprecated response-wide `currency` is required and denominates its spend. Sellers should omit it and buyers should calculate only aggregates whose row currencies and metric semantics are compatible. |
+| `aggregated_totals` | **Deprecated in 3.2; removed in 4.0.** Legacy cross-buy aggregate. When present, the deprecated response-wide `currency` is required and denominates its spend. Optional `reach_aggregation` distinguishes cross-buy deduplicated reach from a sum of constituent reach values. Sellers should omit this aggregate and buyers should calculate only aggregates whose row currencies and metric semantics are compatible. |
 | `media_buy_deliveries` | Array of delivery data per media buy |
 
 ### Media Buy Delivery Object
@@ -132,6 +132,8 @@ if (!delivery.currency) {
 ```
 
 Buyers that need cross-buy totals calculate them from `media_buy_deliveries[]`. They MUST first verify that currencies, metric qualifiers, measurement windows, finality, and deduplication semantics are compatible. Counts such as impressions are not automatically safe to add merely because they are non-monetary; reach may be deduplicated differently, and rates require their component-weighted calculation rather than summing or averaging row values.
+
+For the deprecated `aggregated_totals.reach` field, sellers producing AdCP 3.2 payloads SHOULD include `reach_aggregation` whenever aggregate reach is present. `reach_aggregation: "deduplicated"` means the seller deduplicated uniques across every included media buy. `reach_aggregation: "sum_of_constituent_reach"` means the seller added the independently unique reach values from each buy, so the same reach unit may be counted more than once. Sellers MUST omit aggregate `frequency` for `sum_of_constituent_reach`. Legacy payloads without `reach_aggregation` remain valid, but their aggregation semantics are unknown; consumers MUST NOT use that reach as a frequency denominator.
 
 ## Common Scenarios
 

--- a/static/schemas/source/enums/reach-aggregation.json
+++ b/static/schemas/source/enums/reach-aggregation.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/enums/reach-aggregation.json",
+  "title": "Reach Aggregation",
+  "description": "How reach in a cross-buy aggregate was combined. This distinction determines whether aggregate reach is a valid denominator for frequency.",
+  "type": "string",
+  "enum": [
+    "deduplicated",
+    "sum_of_constituent_reach"
+  ],
+  "enumDescriptions": {
+    "deduplicated": "Unique reach deduplicated across every media buy included in the aggregate.",
+    "sum_of_constituent_reach": "The arithmetic sum of independently unique per-buy reach values. A person, household, device, account, or cookie may therefore be counted more than once across buys."
+  }
+}

--- a/static/schemas/source/media-buy/get-media-buy-delivery-response.json
+++ b/static/schemas/source/media-buy/get-media-buy-delivery-response.json
@@ -98,6 +98,27 @@
       "type": "object",
       "description": "Deprecated in AdCP 3.2 and removed in AdCP 4.0. Legacy combined metrics across all returned media buys. When this field is present, the deprecated response-wide currency is required and denominates its spend. Cross-buy totals are unsafe when currencies, metric qualifiers, measurement windows, finality, or deduplication semantics differ. Sellers SHOULD omit this field; buyers SHOULD aggregate media_buy_deliveries[] only when the relevant row semantics are compatible.",
       "deprecated": true,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "reach_aggregation": {
+                "const": "sum_of_constituent_reach"
+              }
+            },
+            "required": [
+              "reach_aggregation"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "frequency"
+              ]
+            }
+          }
+        }
+      ],
       "properties": {
         "impressions": {
           "type": "number",
@@ -163,8 +184,16 @@
         },
         "reach": {
           "type": "number",
-          "description": "Deduplicated reach across all media buys (if the seller can deduplicate across buys; otherwise sum of per-buy reach). Only present when all media buys share the same reach_unit. Omitted when reach units are heterogeneous — use per-buy reach values instead.",
+          "description": "Reach across all media buys. Only present when all media buys share the same reach_unit. Omitted when reach units are heterogeneous — use per-buy reach values instead. The optional reach_aggregation field declares whether this value is deduplicated across buys or is a sum of constituent reach values.",
           "minimum": 0
+        },
+        "reach_aggregation": {
+          "allOf": [
+            {
+              "$ref": "/schemas/enums/reach-aggregation.json"
+            }
+          ],
+          "description": "How reach was combined across the media buys in this aggregate. When omitted, legacy reach semantics are unknown and consumers MUST NOT use reach as the denominator for frequency."
         },
         "reach_unit": {
           "allOf": [
@@ -176,7 +205,7 @@
         },
         "frequency": {
           "type": "number",
-          "description": "Average frequency per reach unit across all media buys (impressions / reach when cross-buy deduplication is available). Only present when reach is present.",
+          "description": "Average frequency per reach unit across all media buys (impressions / reach). In new payloads, only present when reach is present and reach_aggregation is deduplicated. MUST be omitted when reach_aggregation is sum_of_constituent_reach. Legacy payloads that omit reach_aggregation remain schema-valid, but consumers MUST NOT treat their reach as a safe frequency denominator.",
           "minimum": 0
         },
         "media_buy_count": {

--- a/tests/composed-schema-validation.test.cjs
+++ b/tests/composed-schema-validation.test.cjs
@@ -1817,6 +1817,51 @@ async function runTests() {
     'Delivery response requires legacy response currency to denominate aggregated totals'
   );
 
+  const deduplicatedReachTotals = JSON.parse(JSON.stringify(ambiguousAggregatedTotals));
+  Object.assign(deduplicatedReachTotals.aggregated_totals, {
+    reach: 800000,
+    reach_unit: 'individuals',
+    reach_aggregation: 'deduplicated',
+    frequency: 1.25
+  });
+  await testSchemaValidation(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    deduplicatedReachTotals,
+    'Delivery response permits frequency with explicitly deduplicated aggregate reach'
+  );
+
+  const summedReachTotals = JSON.parse(JSON.stringify(ambiguousAggregatedTotals));
+  Object.assign(summedReachTotals.aggregated_totals, {
+    reach: 850000,
+    reach_unit: 'individuals',
+    reach_aggregation: 'sum_of_constituent_reach'
+  });
+  await testSchemaValidation(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    summedReachTotals,
+    'Delivery response permits summed constituent reach when aggregate frequency is omitted'
+  );
+
+  const invalidSummedReachFrequency = JSON.parse(JSON.stringify(summedReachTotals));
+  invalidSummedReachFrequency.aggregated_totals.frequency = 1.18;
+  await testSchemaRejection(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    invalidSummedReachFrequency,
+    'Delivery response rejects aggregate frequency derived from summed constituent reach'
+  );
+
+  const legacyReachTotals = JSON.parse(JSON.stringify(ambiguousAggregatedTotals));
+  Object.assign(legacyReachTotals.aggregated_totals, {
+    reach: 800000,
+    reach_unit: 'individuals',
+    frequency: 1.25
+  });
+  await testSchemaValidation(
+    '/schemas/media-buy/get-media-buy-delivery-response.json',
+    legacyReachTotals,
+    'Delivery response preserves legacy aggregate reach and frequency without a discriminator'
+  );
+
   await testSchemaValidation(
     '/schemas/media-buy/media-buy-delivery-webhook-result.json',
     {


### PR DESCRIPTION
## Summary

- add the optional `reach_aggregation` discriminator for deprecated cross-buy aggregate reach
- forbid aggregate `frequency` when reach is a sum of independently unique constituent values
- preserve legacy payload validity when the discriminator is absent while making unsafe consumer interpretation explicitly non-conformant

## Contract

- `deduplicated`: reach is deduplicated across all included media buys and may support aggregate frequency
- `sum_of_constituent_reach`: per-buy reach values were added and aggregate frequency MUST be omitted
- absent: legacy semantics are unknown; consumers MUST NOT use reach as a frequency denominator

New AdCP 3.2 producers SHOULD declare the discriminator whenever `aggregated_totals.reach` is present. The field remains optional so existing 3.x documents stay valid.

## Verification

- 455 composed-schema cases, including the four new deduplicated/summed/negative/legacy cases
- all 977 source schemas: structure, compilation, references, registry, enums, and examples
- focused task-reference documentation validation
- protocol changeset scope check
- two independent protocol/schema reviews: clean after adding the producer SHOULD

Fixes #7251.
Related to #7240.
