### PR TITLE
fix(addie): bound unverified Tavus callbacks

### DIFF
--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
-  "profile_ids_sha256": "ac9b9c5c1c521bc3c2fe8b5b49bc01c5c28c09cfd48f6b76447d2c97cea3084b",
-  "profile_contract_sha256": "dfc32181b4e44dc330269b17128038e94e9d8c2a425c86c636b85b21aaccf96d",
+  "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
+  "profile_contract_sha256": "bc6e93bafa070d5771a3bf1cd0b27ef94f87516aeb5e347e7dfc6d14fa9b6a32",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {
@@ -66,7 +66,7 @@
     "slack_bolt_reaction:public_channel": { "custom_tool_count": 32, "wire_schema_bytes": 32016, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "slack_bolt_reaction:public_channel_admin": { "custom_tool_count": 32, "wire_schema_bytes": 32016, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },
     "tavus_voice:admin": { "custom_tool_count": 29, "wire_schema_bytes": 30911, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
-    "tavus_voice:baseline": { "custom_tool_count": 19, "wire_schema_bytes": 12257, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
+    "tavus_voice:unverified_thread": { "custom_tool_count": 5, "wire_schema_bytes": 4879, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "tavus_voice:committee_leader": { "custom_tool_count": 27, "wire_schema_bytes": 28617, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "tavus_voice:member": { "custom_tool_count": 25, "wire_schema_bytes": 25995, "maximum_provider_tool_count": 0, "maximum_provider_tool_wire_bytes": 2 },
     "web_chat:anonymous": { "custom_tool_count": 13, "wire_schema_bytes": 9196, "maximum_provider_tool_count": 1, "maximum_provider_tool_wire_bytes": 52 },

--- a/scripts/build-addie-tool-surface-inventory.ts
+++ b/scripts/build-addie-tool-surface-inventory.ts
@@ -921,6 +921,14 @@ function buildAuxiliaryProfiles(defs: Awaited<ReturnType<typeof loadDefinitions>
     ...meetings.MEETING_TOOLS,
     ...tavusTailRequest,
   ];
+  const tavusGlobalNames = new Set(tavusGlobal.map((tool) => tool.name));
+  const tavusUnverifiedThreadFallback = selectBoundedRoutedToolSets({
+    plan: null,
+    routerAvailable: false,
+    source: 'dm',
+    isAdmin: false,
+    isToolAvailable: (name) => tavusGlobalNames.has(name),
+  });
   // Authenticated Tavus turns now use the same bounded direct-response
   // selection as web chat and Slack reactions. Record each surface's actual
   // reachable maximum (one or two routed domains) and the explicit safe
@@ -1017,8 +1025,14 @@ function buildAuxiliaryProfiles(defs: Awaited<ReturnType<typeof loadDefinitions>
       conditionalMaximums: ['nonstreaming_web_search'],
     }),
     profile({
-      id: 'tavus_voice:baseline:exact', runtime: 'tavus_voice', audience: 'baseline',
-      globalTools: tavusGlobal, providerToolCount: 0,
+      id: 'tavus_voice:unverified_thread:safe_fallback',
+      runtime: 'tavus_voice',
+      audience: 'unverified_thread',
+      route: 'safe_fallback',
+      selectedToolSets: tavusUnverifiedThreadFallback.selectedToolSets,
+      allowedToolNames: tavusUnverifiedThreadFallback.allowedToolNames,
+      globalTools: tavusGlobal,
+      providerToolCount: 0,
       conditionalMaximums: ['thread_or_identity_unavailable'],
     }),
     ...buildTavusRoutedProfiles('member', false, tavusMemberRequest, ['moltbook_configured']),

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.36';
+export const CODE_VERSION = '2026.09.37';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -19,7 +19,7 @@
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "500aa3920a48d637528cd646140521858a2223880457d6ab653ac5ceb3a618b2",
     "server/src/routes/addie-chat.ts": "58a45bea9e731bcba2a65ed6d6a228cb7a974140fd53367958359fecb505e729",
-    "server/src/routes/tavus.ts": "f4371a6ac596fca464b6cc337bd5d85f812d636f541f003e385437ad6ef352c2",
+    "server/src/routes/tavus.ts": "3f7f598555ee52090eb2a26ac0bf1dea5e1fe345ea8e57764b60879d7b96cfec",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",
     "server/src/addie/jobs/shadow-replay-cohort.ts": "316d0764cd65e4c631d6efef7d090fd46a6a8fff22d4c917a40b44a7a69eee1f",
@@ -32586,48 +32586,6 @@
       "wire_schema_sha256": "6cb45b54a01be12d2e4898db6eb3e1a73dc8a86e45ea730ab863e6ace067c488"
     },
     {
-      "id": "tavus_voice:baseline:exact",
-      "runtime": "tavus_voice",
-      "audience": "baseline",
-      "conditional_maximums": [
-        "thread_or_identity_unavailable"
-      ],
-      "custom_tool_count": 19,
-      "maximum_provider_tool_count": 0,
-      "maximum_provider_tool_names": [],
-      "maximum_provider_tool_wire_bytes": 2,
-      "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 12236,
-      "tool_reference_bytes": 9912,
-      "tool_reference_sha256": "0baee05986d2980ea7d194a3f3976894e70ebe0fa373b3ac1dc210d4a707afca",
-      "overridden_tool_count": 0,
-      "conflicting_override_count": 0,
-      "conflicting_override_names": [],
-      "ordered_tool_names": [
-        "search_docs",
-        "get_doc",
-        "search_repos",
-        "search_resources",
-        "bookmark_resource",
-        "get_recent_news",
-        "list_members",
-        "get_member",
-        "list_agents",
-        "get_agent",
-        "validate_agent",
-        "lookup_domain",
-        "list_publishers",
-        "research_brand",
-        "resolve_brand",
-        "save_brand",
-        "list_brands",
-        "list_missing_brands",
-        "upload_brand_logo"
-      ],
-      "ordered_tool_names_sha256": "72bc532442ca60dc3c96c2dd609e1852772974b5046f570a005504eb921401fc",
-      "wire_schema_sha256": "a261daafacf0c57cd73ed4b119dbba4b9c647885bee76056583a89ad89139ca0"
-    },
-    {
       "id": "tavus_voice:committee_leader:maximum",
       "runtime": "tavus_voice",
       "audience": "committee_leader",
@@ -32998,6 +32956,40 @@
       ],
       "ordered_tool_names_sha256": "a20441feac2a05c2f7cd0a850ca34d443c1e8eebfe1c7631d3952498ee62fad8",
       "wire_schema_sha256": "6cb45b54a01be12d2e4898db6eb3e1a73dc8a86e45ea730ab863e6ace067c488"
+    },
+    {
+      "id": "tavus_voice:unverified_thread:safe_fallback",
+      "runtime": "tavus_voice",
+      "audience": "unverified_thread",
+      "route": "safe_fallback",
+      "selected_tool_sets": [
+        "knowledge",
+        "community_research",
+        "schema_reference"
+      ],
+      "conditional_maximums": [
+        "thread_or_identity_unavailable"
+      ],
+      "custom_tool_count": 5,
+      "maximum_provider_tool_count": 0,
+      "maximum_provider_tool_names": [],
+      "maximum_provider_tool_wire_bytes": 2,
+      "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "wire_schema_bytes": 4879,
+      "tool_reference_bytes": 6502,
+      "tool_reference_sha256": "05e232e109925f998e832613b979f0997a8bdfbeab5ebc11b79bea3d01ae28d9",
+      "overridden_tool_count": 0,
+      "conflicting_override_count": 0,
+      "conflicting_override_names": [],
+      "ordered_tool_names": [
+        "search_docs",
+        "get_doc",
+        "search_repos",
+        "search_resources",
+        "get_recent_news"
+      ],
+      "ordered_tool_names_sha256": "8882389bcae6bed6b1ac32ab5c4a95ea50b4cc0d0b12eb3f930fd1397183839e",
+      "wire_schema_sha256": "c0d7006aac4888dadb8fb4245db01cdbef382594e6efae45bd91fc98fa4a60a2"
     },
     {
       "id": "web_chat:anonymous:maximum",
@@ -38631,9 +38623,9 @@
         "maximum_provider_tool_count": 0,
         "maximum_provider_tool_wire_bytes": 2
       },
-      "tavus_voice:baseline": {
-        "custom_tool_count": 19,
-        "wire_schema_bytes": 12257,
+      "tavus_voice:unverified_thread": {
+        "custom_tool_count": 5,
+        "wire_schema_bytes": 4879,
         "maximum_provider_tool_count": 0,
         "maximum_provider_tool_wire_bytes": 2
       },
@@ -38668,12 +38660,12 @@
         "maximum_provider_tool_wire_bytes": 52
       }
     },
-    "profile_ids_sha256": "ac9b9c5c1c521bc3c2fe8b5b49bc01c5c28c09cfd48f6b76447d2c97cea3084b",
-    "profile_contract_sha256": "dfc32181b4e44dc330269b17128038e94e9d8c2a425c86c636b85b21aaccf96d",
+    "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
+    "profile_contract_sha256": "bc6e93bafa070d5771a3bf1cd0b27ef94f87516aeb5e347e7dfc6d14fa9b6a32",
     "status": "within_budget"
   },
   "profile_contract": {
-    "profile_ids_sha256": "ac9b9c5c1c521bc3c2fe8b5b49bc01c5c28c09cfd48f6b76447d2c97cea3084b",
-    "profile_contract_sha256": "dfc32181b4e44dc330269b17128038e94e9d8c2a425c86c636b85b21aaccf96d"
+    "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
+    "profile_contract_sha256": "bc6e93bafa070d5771a3bf1cd0b27ef94f87516aeb5e347e7dfc6d14fa9b6a32"
   }
 }

--- a/server/src/routes/tavus.ts
+++ b/server/src/routes/tavus.ts
@@ -787,6 +787,29 @@ export function createTavusRouter(options?: {
       }
     }
 
+    // Tavus's shared-secret LLM endpoint can be reached without a verified
+    // video thread (for example, an abandoned or malformed callback). Keep
+    // that degraded path useful for public knowledge questions, but never
+    // let it inherit the mutable global registry wholesale. In particular,
+    // unauthenticated callbacks must not see globally registered brand
+    // mutations. The normal selection boundary below intersects the safe
+    // read-only fallback with definitions that were paired at startup.
+    if (!pendingVoiceToolSelection) {
+      let globalToolNames: readonly string[] | undefined;
+      try {
+        globalToolNames = activeVoiceClient.getRegisteredTools?.();
+      } catch (error) {
+        logger.warn({ error, threadId }, 'Tavus: Could not inspect global tools for unverified-thread fallback');
+      }
+      pendingVoiceToolSelection = {
+        memberContext: null,
+        isAAOAdmin: false,
+        requestTools: { tools: [], handlers: new Map() },
+        globalToolNames,
+        forceSafeFallback: true,
+      };
+    }
+
     // Keep the spoken transcript separate from prompt decoration. Logging and
     // filler classification must reflect what the caller actually said.
     const spokenMessage = currentMessage;

--- a/server/tests/unit/tavus-session-guidance-route.test.ts
+++ b/server/tests/unit/tavus-session-guidance-route.test.ts
@@ -530,6 +530,53 @@ describe("Tavus session guidance route boundary", () => {
     expect([...requestTools.handlers.keys()]).toEqual([]);
   });
 
+  it('bounds a callback without a verified video thread to the read-only fallback', async () => {
+    const router = {
+      quickMatch: () => null,
+      route: vi.fn().mockResolvedValue({
+        action: 'respond' as const,
+        tool_sets: ['brand_registry_identity'],
+        confidence: 'high' as const,
+        reason: 'brand request',
+        decision_method: 'llm' as const,
+      }),
+    };
+
+    const response = await request(mountApp(router))
+      .post('/api/addie/v1/chat/completions')
+      .set('Authorization', 'Bearer test-llm-secret')
+      .send({
+        messages: [
+          { role: 'user', content: 'Please save this brand and upload its logo.' },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(mocks.getThread).not.toHaveBeenCalled();
+    expect(router.route).not.toHaveBeenCalled();
+    expect(mocks.checkCostCap).toHaveBeenCalledWith(
+      expect.stringMatching(/^tavus:ip:/),
+      'anonymous',
+      expect.objectContaining({ selection: expect.objectContaining({ provider: 'anthropic' }) }),
+    );
+    const [_message, _history, requestTools, options] = mocks.processMessageStream.mock.calls[0] as [
+      string,
+      unknown,
+      { tools: Array<{ name: string }>; handlers: Map<string, unknown> },
+      { selectedToolSetNames: string[]; allowedToolNames: string[] },
+    ];
+    expect(options.selectedToolSetNames).toEqual(['knowledge', 'community_research', 'schema_reference']);
+    expect(options.allowedToolNames).toEqual(expect.arrayContaining([
+      'search_docs',
+      'get_doc',
+      'search_repos',
+    ]));
+    expect(options.allowedToolNames).not.toContain('save_brand');
+    expect(options.allowedToolNames).not.toContain('upload_brand_logo');
+    expect(requestTools.tools).toEqual([]);
+    expect([...requestTools.handlers.keys()]).toEqual([]);
+  });
+
   it.each(['error_event', 'throw'] as const)(
     'does not persist partial assistant text after %s before terminal done',
     async (failureMode) => {


### PR DESCRIPTION
## Summary

- force Tavus LLM callbacks without a verified video thread through the existing read-only fallback
- prevent the degraded callback path from inheriting the mutable 19-tool global registry, including brand mutations
- model and ratchet the exact unverified-thread surface in the generated inventory

## Surface impact

- unverified Tavus callback: 19 custom tools / 12,257 schema bytes -> 5 read-only tools / 4,879 bytes
- live routing is skipped without verified thread identity
- anonymous cost admission remains in place before model dispatch
- no numeric ceiling was raised; the replacement surface ceiling is pinned to the new lower values

## Validation

- Tavus focused suites: 34 passed
- repository commit gate: 550 files, 8,086 tests passed; 32 skipped
- `npm run test:addie-tools`: passed (249 tools / 67 visible sets)
- inventory portability: passed
- typecheck: passed
- pre-push version and changeset-policy checks: passed

No provider activation, delivery, authentication, billing policy, cost cap, or verified-session behavior changes. Addie-only change, so no protocol changeset is required.

Relates to #6845.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
