### PR TITLE
fix(registry): make brand resolution caches source-aware

### DIFF
--- a/docs/registry/index.mdx
+++ b/docs/registry/index.mdx
@@ -119,8 +119,9 @@ These endpoints resolve domains to brand identities. The `source` field identifi
 | `brand_json` | Resolved from the domain's `/.well-known/brand.json` file |
 | `enriched` | Enriched via Brandfetch API |
 | `community` | Submitted by a community member |
+| `stub` | Minimal organization-derived placeholder awaiting stronger evidence |
 
-All sources produce the same resolution response structure, but they are not equivalent evidence. `hosted` and `brand_json` are backed by domain control; `community` and `enriched` describe what the registry has learned without proving that the domain operator asserted it. `source` is identity provenance, not proof of a house relationship—use `relationship_trust` for that. To get full brand identity data (logos, colors, tone), use `/api/brands/enrich` or look up the brand in the registry.
+All sources produce the same resolution response structure, but they are not equivalent evidence. `hosted` and `brand_json` are backed by domain control; `community` and `enriched` describe what the registry has learned without proving that the domain operator asserted it. `source` is the authoritative response provenance, not proof of a house relationship—use `relationship_trust` for that. `enrichment_provider`, when present, is the preferred open-ended attribution/diagnostic identifier and is only emitted for `source: "enriched"`; clients must not treat it as a trust tier or behavioral switch. `provenance_provider` is temporarily also emitted with the same value as a deprecated compatibility alias for enriched responses. To get full brand identity data (logos, colors, tone), use `/api/brands/enrich` or look up the brand in the registry.
 
 #### Reading trust
 
@@ -148,7 +149,31 @@ An absent `relationship_trust` is not the same as `standalone`: it means the sel
 
 Following a redirect never lets a domain adopt a house's identity. When a domain's brand.json points at a house that does not name the domain back — in `properties[]` as `relationship: "owned"`, or in `brand_refs[]` — the response carries the claim (`claimed_house_domain` with `relationship_trust: leaf_only`) and no brand identity. A house that lists a domain with `direct`, `delegated`, or `ad_network` is declaring a monetization path, not ownership, so it does not resolve that domain's identity either. If you expected an identity here, the house is missing its half of the relationship.
 
-`fresh=true` bypasses the resolution cache and refetches from the origin. When that fetch fails and a stored record is returned instead, `live_brand_json` carries that request's failed-fetch diagnostics so you can distinguish "stored evidence returned" from "origin checked successfully." Apply your own freshness policy to that fallback rather than silently treating it as live.
+`fresh=true` bypasses the resolution cache and refetches from the origin. Its response is `Cache-Control: no-store`, so an HTTP intermediary cannot satisfy an explicit origin-read request from cache. When that fetch fails and a stored record is returned instead, `live_brand_json` carries that request's failed-fetch diagnostics so you can distinguish "stored evidence returned" from "origin checked successfully." Apply your own freshness policy to that fallback rather than silently treating it as live.
+
+#### Cache behavior and provenance surfaces
+
+The registry keeps successful origin validation/resolution in `BrandManager` for 24 hours. It keeps failed origin validation and resolution misses for only five minutes, so a negative entry cannot hide a newly published origin document after the resolution-miss TTL has elapsed. Stored `community` and `enriched` rows are selected from the database on each resolver request; they do **not** live in `BrandManager.resolutionCache`.
+
+| Surface and outcome | Cache-Control / in-process TTL |
+|---|---|
+| `BrandManager`: successful origin validation or resolution | 24 hours |
+| `BrandManager`: failed validation or resolution miss | 5 minutes |
+| `GET /brands/:domain/brand.json`: `brand_json` | `public, max-age=3600` (1 hour) |
+| `GET /brands/:domain/brand.json`: `community` | `public, max-age=900` (15 minutes) |
+| `GET /brands/:domain/brand.json`: `enriched` | `public, max-age=300` (5 minutes) |
+| `GET /brands/:domain/brand.json`: 404 miss | `public, max-age=60` (1 minute) |
+| `GET /brands/:domain/brand.json`: failure | `no-store` |
+| `GET /api/brands/resolve`: `hosted` or `brand_json` | `public, max-age=300` (5 minutes) |
+| `GET /api/brands/resolve`: `community` | `public, max-age=120` (2 minutes) |
+| `GET /api/brands/resolve`: `enriched` or `stub` | `public, max-age=60` (1 minute) |
+| `GET /api/brands/resolve`: miss | `public, max-age=30` (30 seconds) |
+| `GET /api/brands/resolve`: error or `fresh=true` | `no-store` |
+| `POST /api/brands/resolve/bulk` | `no-store` (a shared cache cannot safely key public POST responses by request body) |
+
+`GET /brands/:domain/brand.json` and `GET /api/brands/resolve` intentionally report provenance on different surfaces. The public `brand.json` mirror puts its stored source type (`brand_json`, `community`, or `enriched`) in `X-AAO-Source`; its body stays a clean brand.json document. The resolver carries the exact selected source (`hosted`, `brand_json`, `community`, `enriched`, or `stub`) in its JSON body and conditionally adds preferred `enrichment_provider` plus its deprecated `provenance_provider` compatibility alias only for enriched results. Do not infer one endpoint's response shape from the other.
+
+For operational monitoring, each single result and each entry in a bulk result emits the fixed-cardinality `brand_resolution_outcome` event with one `outcome` value: `hosted`, `brand_json`, `community`, `enriched`, `stub`, `miss`, or `error`. Domains and provider identifiers are intentionally excluded from that event.
 
 Pre-v3 documents are promoted to canonical v3 identity for the response, flagged with `promoted_from_schema` and `migration_warnings`. Promotion covers identity only; legacy relationship data is preserved opaquely and never becomes a trust claim. In particular, a warning with `field: "house"` means the legacy house object was moved to `legacy_metadata.legacy_house` and did **not** establish `house_domain`. The publisher must add `house_domain` to the leaf document and a reciprocal `brand_refs[]` entry to the house document.
 

--- a/server/src/brand-manager.ts
+++ b/server/src/brand-manager.ts
@@ -18,6 +18,10 @@ import {
   observeBrandRelationshipDeclaration,
   type BrandRelationshipDeclaration,
 } from './db/brand-relationship-db.js';
+import {
+  BRAND_MANAGER_CACHE_TTL_SECONDS,
+  brandManagerResolutionTtlMs,
+} from './services/brand-resolution-cache-policy.js';
 
 export interface BrandValidationError {
   field: string;
@@ -194,18 +198,18 @@ export interface BrandAgentValidationResult {
 export class BrandManager {
   // Cache for successful brand.json lookups (24 hours)
   private validationCache: Cache<BrandValidationResult>;
-  // Cache for resolved brands (24 hours)
+  // Cache for resolved origin evidence (24 hours) and misses (5 minutes).
   private resolutionCache: Cache<ResolvedBrand | null>;
-  // Cache for failed lookups (1 hour)
+  // Cache for failed lookups (5 minutes, never longer than a resolution miss)
   private failedLookupCache: Cache<BrandValidationResult>;
   private observeRelationshipDeclaration: RelationshipDeclarationObserver;
 
   constructor(options: {
     observeRelationshipDeclaration?: RelationshipDeclarationObserver;
   } = {}) {
-    this.validationCache = new Cache<BrandValidationResult>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
-    this.resolutionCache = new Cache<ResolvedBrand | null>(24 * 60, BRAND_CACHE_MAX_ENTRIES); // 24 hours
-    this.failedLookupCache = new Cache<BrandValidationResult>(60, BRAND_FAILED_CACHE_MAX_ENTRIES); // 1 hour
+    this.validationCache = new Cache<BrandValidationResult>(BRAND_MANAGER_CACHE_TTL_SECONDS.origin / 60, BRAND_CACHE_MAX_ENTRIES);
+    this.resolutionCache = new Cache<ResolvedBrand | null>(BRAND_MANAGER_CACHE_TTL_SECONDS.origin / 60, BRAND_CACHE_MAX_ENTRIES);
+    this.failedLookupCache = new Cache<BrandValidationResult>(BRAND_MANAGER_CACHE_TTL_SECONDS.negative / 60, BRAND_FAILED_CACHE_MAX_ENTRIES);
     this.observeRelationshipDeclaration = options.observeRelationshipDeclaration
       ?? observeBrandRelationshipDeclaration;
   }
@@ -228,6 +232,15 @@ export class BrandManager {
       resolution: this.resolutionCache.size(),
       failed: this.failedLookupCache.size(),
     };
+  }
+
+  /** Cache origin resolutions long-term but keep negative outcomes brief. */
+  private cacheResolution(cacheKey: string, result: ResolvedBrand | null): void {
+    this.resolutionCache.set(
+      cacheKey,
+      result,
+      brandManagerResolutionTtlMs(result?.source ?? null),
+    );
   }
 
   /**
@@ -501,7 +514,7 @@ export class BrandManager {
           message: statusMessage,
           severity: 'error',
         });
-        // Cache failed lookups for 1 hour
+        // Cache failed lookups briefly so a new origin document is not hidden.
         this.failedLookupCache.set(cacheKey, result);
         return result;
       }
@@ -537,10 +550,10 @@ export class BrandManager {
 
     // Cache the result
     if (result.valid) {
-      // Cache successful lookups for 24 hours
+      // Cache successful origin evidence for 24 hours.
       this.validationCache.set(cacheKey, result);
     } else {
-      // Cache failed lookups for 1 hour
+      // Cache failed lookups briefly so a new origin document is not hidden.
       this.failedLookupCache.set(cacheKey, result);
     }
 
@@ -1124,7 +1137,7 @@ export class BrandManager {
       const cached = this.resolutionCache.get(cacheKey);
       if (cached !== undefined) {
         const aged = this.applyDeclarationAgeCeiling(cached);
-        if (aged !== cached) this.resolutionCache.set(cacheKey, aged);
+        if (aged !== cached) this.cacheResolution(cacheKey, aged);
         return aged;
       }
     }
@@ -1149,7 +1162,7 @@ export class BrandManager {
       }
 
       if (!validationResult.valid || !validationResult.raw_data) {
-        if (!skipCache) this.resolutionCache.set(cacheKey, null);
+        if (!skipCache) this.cacheResolution(cacheKey, null);
         return null;
       }
 
@@ -1164,7 +1177,7 @@ export class BrandManager {
             redirectCount++;
             continue;
           } catch {
-            if (!skipCache) this.resolutionCache.set(cacheKey, null);
+            if (!skipCache) this.cacheResolution(cacheKey, null);
             return null;
           }
         }
@@ -1184,7 +1197,7 @@ export class BrandManager {
           const agentData = data as BrandAgentVariant;
           const agent = agentData.brand_agent ?? agentData.agents?.find((entry) => entry.type === 'brand');
           if (!agent) {
-            if (!skipCache) this.resolutionCache.set(cacheKey, null);
+            if (!skipCache) this.cacheResolution(cacheKey, null);
             return null;
           }
           // A house's agent is authoritative for the house. Reached through a
@@ -1204,7 +1217,7 @@ export class BrandManager {
             ...this.promotionMetadata(validationResult),
             source: 'brand_json',
           };
-          this.resolutionCache.set(cacheKey, result);
+          this.cacheResolution(cacheKey, result);
           return result;
         }
 
@@ -1231,7 +1244,7 @@ export class BrandManager {
               ...this.promotionMetadata(validationResult),
               source: 'brand_json',
             };
-            this.resolutionCache.set(cacheKey, result);
+            this.cacheResolution(cacheKey, result);
             return result;
           }
 
@@ -1247,7 +1260,7 @@ export class BrandManager {
             );
             // Same rule as every other branch: a fresh probe that fails must
             // not overwrite a live entry with a negative one.
-            if (pointed || !skipCache) this.resolutionCache.set(cacheKey, pointed);
+            if (pointed || !skipCache) this.cacheResolution(cacheKey, pointed);
             return pointed;
           }
 
@@ -1276,7 +1289,7 @@ export class BrandManager {
                 ...this.promotionMetadata(validationResult),
                 source: 'brand_json',
               };
-              this.resolutionCache.set(cacheKey, result);
+              this.cacheResolution(cacheKey, result);
               return result;
             }
           }
@@ -1287,11 +1300,11 @@ export class BrandManager {
               redirectedHouseDomain,
               validationResult
             );
-            this.resolutionCache.set(cacheKey, claim);
+            this.cacheResolution(cacheKey, claim);
             return claim;
           }
 
-          if (!skipCache) this.resolutionCache.set(cacheKey, null);
+          if (!skipCache) this.cacheResolution(cacheKey, null);
           return null;
         }
 
@@ -1305,7 +1318,7 @@ export class BrandManager {
               redirectedHouseDomain,
               validationResult
             );
-            this.resolutionCache.set(cacheKey, claim);
+            this.cacheResolution(cacheKey, claim);
             return claim;
           }
           const freshResolution = await this.resolveCanonicalDocument(
@@ -1322,17 +1335,17 @@ export class BrandManager {
             freshResolution.result,
             freshResolution.retainCachedMutual,
           );
-          this.resolutionCache.set(cacheKey, result);
+          this.cacheResolution(cacheKey, result);
           return result;
         }
 
         default:
-          if (!skipCache) this.resolutionCache.set(cacheKey, null);
+          if (!skipCache) this.cacheResolution(cacheKey, null);
           return null;
       }
     }
 
-    if (!skipCache) this.resolutionCache.set(cacheKey, null);
+    if (!skipCache) this.cacheResolution(cacheKey, null);
     return null; // Max redirects exceeded
   }
 

--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -14,7 +14,10 @@ export class Cache<T> {
     this.maxEntries = maxEntries;
   }
 
-  set(key: string, value: T): void {
+  set(key: string, value: T, ttlMs: number = this.ttlMs): void {
+    if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+      throw new Error('ttlMs must be a non-negative finite number');
+    }
     // Only a bounded cache needs this: it keeps expired entries from consuming
     // the entry budget and evicting a live one. An unbounded cache never
     // evicts, so scanning the whole map on every write would be pure cost —
@@ -30,7 +33,7 @@ export class Cache<T> {
     }
     this.cache.set(key, {
       value,
-      expiresAt: Date.now() + this.ttlMs,
+      expiresAt: Date.now() + ttlMs,
     });
   }
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -52,6 +52,7 @@ import { BrandDatabase, canSurfaceBrandForMember, resolveBrandFromJson } from ".
 import { CatalogEventsDatabase } from "./db/catalog-events-db.js";
 import { AgentInventoryProfilesDatabase } from "./db/agent-inventory-profiles-db.js";
 import { BrandManager } from "./brand-manager.js";
+import { brandJsonCacheControl } from "./services/brand-resolution-cache-policy.js";
 import { PropertyDatabase } from "./db/property-db.js";
 import * as manifestRefsDb from "./db/manifest-refs-db.js";
 import { JoinRequestDatabase } from "./db/join-request-db.js";
@@ -1905,9 +1906,13 @@ export class HTTPServer {
     // Accessible at /brands/:domain/brand.json (no /api prefix — this is a public resource URL).
     this.app.get('/brands/:domain/brand.json', async (req, res) => {
       const domain = req.params.domain.toLowerCase();
+      const notFound = () => {
+        res.setHeader('Cache-Control', brandJsonCacheControl('miss'));
+        return res.status(404).json({ error: 'Brand not found' });
+      };
       try {
         const brand = await this.brandDb.getDiscoveredBrandByDomain(domain);
-        if (!brand || brand.is_public === false) return res.status(404).json({ error: 'Brand not found' });
+        if (!brand || brand.is_public === false) return notFound();
 
         // Serve brand_json (brand-attested), community (human-curated), and enriched
         // (Brandfetch-derived) source types. Provenance is signaled to consumers via
@@ -1915,14 +1920,14 @@ export class HTTPServer {
         // place in each row — the JSON body itself stays clean of non-spec fields.
         const ALLOWED_SOURCE_TYPES = new Set(['brand_json', 'community', 'enriched']);
         if (!ALLOWED_SOURCE_TYPES.has(brand.source_type as string)) {
-          return res.status(404).json({ error: 'Brand not found' });
+          return notFound();
         }
 
         const manifest = brand.brand_manifest as Record<string, unknown> | undefined;
-        if (!manifest) return res.status(404).json({ error: 'Brand not found' });
+        if (!manifest) return notFound();
 
         if (brand.source_type === 'community' && brand.review_status === 'pending') {
-          return res.status(404).json({ error: 'Brand not found' });
+          return notFound();
         }
 
         const schemaUrl = 'https://adcontextprotocol.org/schemas/v3/brand.json';
@@ -1933,11 +1938,15 @@ export class HTTPServer {
             : { $schema: schemaUrl, ...publicManifest };
 
         res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Cache-Control', 'public, max-age=300');
+        res.setHeader(
+          'Cache-Control',
+          brandJsonCacheControl(brand.source_type as 'brand_json' | 'community' | 'enriched'),
+        );
         res.setHeader('X-AAO-Source', brand.source_type as string);
         return res.json(brandJson);
       } catch (error) {
         logger.error({ err: error, domain }, 'Failed to serve brand.json');
+        res.setHeader('Cache-Control', brandJsonCacheControl('error'));
         return res.status(500).json({ error: 'Failed to retrieve brand' });
       }
     });

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -64,7 +64,12 @@ import { buildAaoVerificationBlock } from "../services/aao-verification-enrichme
 import { PUBLIC_TEST_AGENT } from "../config/test-agent.js";
 import * as policiesDb from "../db/policies-db.js";
 import { createLogger } from "../logger.js";
+import { captureEvent } from "../utils/posthog.js";
 import { validateCrawlDomain, validateExternalUrl, safeFetchAxiosLike } from "../utils/url-security.js";
+import {
+  brandResolveCacheControl,
+  type BrandResolutionOutcome,
+} from "../services/brand-resolution-cache-policy.js";
 import { verifySupplyPath, parseInventoryPartnerDomains } from "../services/supply-path-verifier.js";
 import { canonicalizePublisherDomain } from "../services/publisher-domain.js";
 import { AAO_UA_VALIDATOR } from "../config/user-agents.js";
@@ -862,6 +867,7 @@ registry.registerPath({
     "",
     "A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.",
     "Record selection is deterministic: `hosted` > `brand_json` > `community` > `enriched`. `source` reports provenance only and must not be used as a substitute for `relationship_trust`.",
+    "HTTP cache lifetimes are source-aware. `fresh=true` responses are `no-store` so an intermediary cannot satisfy an explicit origin-read request from its cache.",
     "The v3 hierarchy is one level deep. There is no ordered-chain endpoint: third-party verifiers use the reciprocated `house_domain` edge returned here. `claimed_house_domain` is unilateral and never extends trust.",
     "",
     "**Rate limit:** 60 requests per minute per IP address.",
@@ -871,7 +877,7 @@ registry.registerPath({
     query: z.object({
       domain: z.string().openapi({ example: "acmecorp.com" }),
       fresh: z.enum(["true", "false"]).optional().openapi({
-        description: "Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.",
+        description: "Bypass the resolution cache and refetch from the origin. `fresh=true` responses are `Cache-Control: no-store`. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.",
       }),
     }),
   },
@@ -1170,35 +1176,34 @@ const RESOLVED_BRAND_SOURCE_PRIORITY: Record<ResolvedBrandResponse["source"], nu
   stub: 5,
 };
 
-const BRAND_PROVENANCE_BY_SOURCE = {
-  hosted: "canonical",
-  brand_json: "canonical",
-  community: "community",
-  enriched: "enriched",
-} as const;
-
 /**
- * Keep the stable caller-facing tier separate from the detailed source label.
- * The only enrichment writer today is Brandfetch; the response contract keeps
- * the provider open-ended so a future writer can supply its own identifier.
+ * The exact source is response provenance. Provider attribution is intentionally
+ * open-ended diagnostic metadata and only applies to enriched responses.
+ * `enrichment_provider` is preferred; `provenance_provider` is its temporary
+ * deprecated compatibility alias.
  */
 function withBrandResolutionProvenance(
   brand: ResolvedBrandResponse,
 ): ResolvedBrandResponse {
-  const provenance = brand.source === "stub"
-    ? undefined
-    : BRAND_PROVENANCE_BY_SOURCE[brand.source];
   const response = { ...brand };
-  const provenanceProvider = response.provenance_provider;
-  delete response.provenance;
+  const enrichmentProvider = response.enrichment_provider ?? response.provenance_provider;
+  delete response.enrichment_provider;
   delete response.provenance_provider;
   return {
     ...response,
-    ...(provenance ? { provenance } : {}),
-    ...(provenance === "enriched" && provenanceProvider
-      ? { provenance_provider: provenanceProvider }
+    ...(response.source === "enriched" && enrichmentProvider
+      ? {
+        enrichment_provider: enrichmentProvider,
+        provenance_provider: enrichmentProvider,
+      }
       : {}),
   };
+}
+
+function recordBrandResolutionOutcome(outcome: BrandResolutionOutcome): void {
+  // Deliberately fixed-cardinality: never attach the requested domain or a
+  // provider identifier to this aggregate operational event.
+  captureEvent("server-metrics", "brand_resolution_outcome", { outcome });
 }
 
 function storedBrandResolutionResponse(
@@ -1215,7 +1220,7 @@ function storedBrandResolutionResponse(
     ...(brand.brand_agent_url ? { brand_agent_url: brand.brand_agent_url } : {}),
     source: resolvedStoredBrandSource(brand),
     ...(brand.enrichment_provider
-      ? { provenance_provider: brand.enrichment_provider }
+      ? { enrichment_provider: brand.enrichment_provider }
       : {}),
     brand_manifest: stripLegacyBrandContext(brand.brand_manifest),
     ...(liveValidation ? { live_brand_json: liveValidation } : {}),
@@ -5204,6 +5209,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
         : '';
       const fresh = req.query.fresh === "true";
       if (!isValidDomain(domain)) {
+        res.setHeader("Cache-Control", brandResolveCacheControl("error", fresh));
         return res.status(400).json({ error: "Invalid domain format" });
       }
 
@@ -5220,16 +5226,21 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
           registryRequestsDb
             .markResolved("brand", domain, discovered.canonical_domain || discovered.domain)
             .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
-          return res.json(storedBrandResolutionResponse(
+          const selected = storedBrandResolutionResponse(
             discovered,
             liveValidation ? serializeBrandValidation(liveValidation) : undefined,
-          ));
+          );
+          res.setHeader("Cache-Control", brandResolveCacheControl(selected.source, fresh));
+          recordBrandResolutionOutcome(selected.source);
+          return res.json(selected);
         }
         registryRequestsDb
           .trackRequest("brand", domain)
           .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
 
         const validation = liveValidation ?? await brandManager.validateDomain(domain);
+        res.setHeader("Cache-Control", brandResolveCacheControl("miss", fresh));
+        recordBrandResolutionOutcome("miss");
         return res.status(404).json({
           error: "Brand not found",
           domain,
@@ -5241,9 +5252,13 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
       registryRequestsDb
         .markResolved("brand", domain, selected.canonical_domain)
         .catch((err) => logger.debug({ err }, "Registry request tracking failed"));
+      res.setHeader("Cache-Control", brandResolveCacheControl(selected.source, fresh));
+      recordBrandResolutionOutcome(selected.source);
       return res.json(selected);
     } catch (error) {
       logger.error({ error }, "Failed to resolve brand");
+      res.setHeader("Cache-Control", brandResolveCacheControl("error"));
+      recordBrandResolutionOutcome("error");
       return res.status(500).json({ error: "Failed to resolve brand" });
     }
   });
@@ -5479,7 +5494,12 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
     }
   });
 
-  router.post("/brands/resolve/bulk", bulkResolveRateLimiter, brandBulkDomainRateLimiter, async (req, res) => {
+  router.post("/brands/resolve/bulk", (_req, res, next) => {
+    // Shared HTTP caches do not safely key public POST responses by request
+    // body. Set this before rate limiters so every bulk outcome is no-store.
+    res.setHeader("Cache-Control", "no-store");
+    next();
+  }, bulkResolveRateLimiter, brandBulkDomainRateLimiter, async (req, res) => {
     try {
       const { domains } = req.body;
 
@@ -5512,6 +5532,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
               return {
                 domain,
                 result: selected,
+                outcome: selected.source,
               };
             }
 
@@ -5522,20 +5543,27 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
               return {
                 domain,
                 result: storedBrandResolutionResponse(discovered),
+                outcome: resolvedStoredBrandSource(discovered),
               };
             }
 
             registryRequestsDb.trackRequest("brand", domain).catch((err) => logger.debug({ err }, "Registry request tracking failed"));
-            return { domain, result: null };
+            return { domain, result: null, outcome: "miss" as const };
           })
         );
 
         for (const outcome of settled) {
           if (outcome.status === "fulfilled") {
             results[outcome.value.domain] = outcome.value.result;
+            recordBrandResolutionOutcome(outcome.value.outcome);
           } else if (outcome.reason instanceof SemaphoreOverloadedError) {
             // Shedding one domain means the process is saturated; say so rather
             // than returning a partial map that reads as unresolvable domains.
+            throw outcome.reason;
+          } else {
+            // A partial bulk map would make an internal failure look like an
+            // ordinary miss and could be cached as a success. Fail the whole
+            // request so its no-store error policy and telemetry are accurate.
             throw outcome.reason;
           }
         }
@@ -5546,12 +5574,14 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
       if (error instanceof SemaphoreOverloadedError) {
         logger.warn({ ip: req.ip }, "Brand bulk resolve shed load");
         res.setHeader("Retry-After", "5");
+        recordBrandResolutionOutcome("error");
         return res.status(503).json({
           error: "Brand resolution is busy",
           message: "Too much resolution work is already queued. Retry shortly.",
         });
       }
       logger.error({ error }, "Failed to bulk resolve brands");
+      recordBrandResolutionOutcome("error");
       return res.status(500).json({ error: "Failed to bulk resolve brands" });
     }
   });

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -631,11 +631,12 @@ export const ResolvedBrandSchema = z
     source: z.enum(["hosted", "brand_json", "community", "enriched", "stub"]).openapi({
       description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence.",
     }),
-    provenance: z.enum(["canonical", "community", "enriched"]).optional().openapi({
-      description: "Caller-facing trust tier for the selected identity. `canonical` covers owner-hosted and origin-published brand.json records; `community` is member-contributed; `enriched` is provisional third-party data. Absent means the record has no recognized provenance tier. Use `source` when the distinction between hosted and origin-published canonical records is needed.",
+    enrichment_provider: z.string().optional().openapi({
+      description: "Preferred open-ended attribution/diagnostic identifier for the enrichment writer. Present only when `source` is `enriched`; it is not a trust tier or behavioral switch.",
     }),
     provenance_provider: z.string().optional().openapi({
-      description: "Provider identifier for provisional third-party enrichment. Present only when `provenance` is `enriched`; the provider is intentionally not constrained to a vendor-specific enum.",
+      description: "Deprecated compatibility alias for `enrichment_provider`. Present only when `source` is `enriched`; it is not a trust tier or behavioral switch.",
+      deprecated: true,
     }),
     live_brand_json: LiveBrandJsonValidationSchema.optional().openapi({
       description: "This request's origin-validation diagnostics when `fresh=true` falls back to a stored registry record. Presence means the response is stored evidence, not a successful live-origin read.",

--- a/server/src/services/brand-resolution-cache-policy.ts
+++ b/server/src/services/brand-resolution-cache-policy.ts
@@ -1,0 +1,85 @@
+/**
+ * Cache policy for the registry's brand-resolution surfaces.
+ *
+ * Origin-attested identity changes comparatively rarely, while registry
+ * contributions and third-party enrichment are advisory and can be corrected
+ * independently. Negative results are deliberately brief: keeping either a
+ * miss or a failed validation longer would hide a newly published origin
+ * document. Keep callers on these helpers so implementation, tests, and the
+ * published policy stay aligned.
+ */
+
+export type BrandResolutionSource =
+  | 'hosted'
+  | 'brand_json'
+  | 'community'
+  | 'enriched'
+  | 'stub';
+
+export type BrandResolutionOutcome = BrandResolutionSource | 'miss' | 'error';
+
+/** Outcomes exposed by the public AgenticAdvertising.org-hosted brand.json mirror. */
+export type BrandJsonCacheOutcome =
+  | 'brand_json'
+  | 'community'
+  | 'enriched'
+  | 'miss'
+  | 'error';
+
+/** In-process BrandManager TTLs, in seconds. */
+export const BRAND_MANAGER_CACHE_TTL_SECONDS = {
+  /** Successfully validated origin evidence and its resolved identity. */
+  origin: 24 * 60 * 60,
+  /** Origin failures and resolution misses must never outlive each other. */
+  negative: 5 * 60,
+} as const;
+
+/** Public AgenticAdvertising.org-hosted /brands/:domain/brand.json HTTP TTLs, in seconds. */
+export const BRAND_JSON_HTTP_CACHE_TTL_SECONDS = {
+  brand_json: 60 * 60,
+  community: 15 * 60,
+  enriched: 5 * 60,
+  /** Genuine not-found results are briefly cacheable to reduce repeated lookups. */
+  miss: 60,
+} as const;
+
+/** /api/brands/resolve HTTP success and miss TTLs, in seconds. */
+export const BRAND_RESOLVE_HTTP_CACHE_TTL_SECONDS = {
+  hosted: 5 * 60,
+  brand_json: 5 * 60,
+  community: 2 * 60,
+  enriched: 60,
+  stub: 60,
+  miss: 30,
+} as const;
+
+export function brandManagerResolutionTtlMs(brand: BrandResolutionSource | null): number {
+  return 1000 * (brand === null
+    ? BRAND_MANAGER_CACHE_TTL_SECONDS.negative
+    : BRAND_MANAGER_CACHE_TTL_SECONDS.origin);
+}
+
+function publicCacheControl(maxAge: number): string {
+  return `public, max-age=${maxAge}`;
+}
+
+export function brandJsonCacheControl(
+  outcome: BrandJsonCacheOutcome,
+): string {
+  // A transient database/server failure must never be replayed after recovery.
+  if (outcome === 'error') return 'no-store';
+  return publicCacheControl(BRAND_JSON_HTTP_CACHE_TTL_SECONDS[outcome]);
+}
+
+/**
+ * `fresh=true` is an explicit origin-read request, so intermediaries must not
+ * reuse or retain it. Resolver errors are likewise never retained. Normal
+ * successes and misses use the shortest relevant source/outcome policy.
+ */
+export function brandResolveCacheControl(
+  outcome: BrandResolutionOutcome,
+  fresh = false,
+): string {
+  if (fresh || outcome === 'error') return 'no-store';
+  return publicCacheControl(BRAND_RESOLVE_HTTP_CACHE_TTL_SECONDS[outcome]);
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -666,8 +666,9 @@ export interface ResolvedBrand {
   brand_agent_url?: string;
   brand_manifest?: Record<string, unknown>;
   source: 'hosted' | 'brand_json' | 'community' | 'enriched' | 'stub';
-  provenance?: 'canonical' | 'community' | 'enriched';
-  /** Present only for enriched provenance when the writer is known. */
+  /** Preferred provider attribution; present only when source is enriched and the writer is known. */
+  enrichment_provider?: string;
+  /** @deprecated Use enrichment_provider. Present only when source is enriched. */
   provenance_provider?: string;
 }
 

--- a/server/tests/unit/brand-json-endpoint-gate.test.ts
+++ b/server/tests/unit/brand-json-endpoint-gate.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { brandJsonCacheControl } from '../../src/services/brand-resolution-cache-policy.js';
 
 // The endpoint is registered inside HTTPServer.start, but the handler logic is
 // what we want to pin — re-register it on a bare router with a stubbed brandDb.
@@ -24,25 +25,35 @@ function mountGate(brandDb: {
 }) {
   const app = express();
   app.get('/brands/:domain/brand.json', async (req, res) => {
-    const domain = req.params.domain.toLowerCase();
-    const brand: any = await brandDb.getDiscoveredBrandByDomain(domain);
-    if (!brand || brand.is_public === false) return res.status(404).json({ error: 'Brand not found' });
-    const ALLOWED_SOURCE_TYPES = new Set(['brand_json', 'community', 'enriched']);
-    if (!ALLOWED_SOURCE_TYPES.has(brand.source_type)) {
-      return res.status(404).json({ error: 'Brand not found' });
+    try {
+      const domain = req.params.domain.toLowerCase();
+      const brand: any = await brandDb.getDiscoveredBrandByDomain(domain);
+      const notFound = () => {
+        res.setHeader('Cache-Control', brandJsonCacheControl('miss'));
+        return res.status(404).json({ error: 'Brand not found' });
+      };
+      if (!brand || brand.is_public === false) return notFound();
+      const ALLOWED_SOURCE_TYPES = new Set(['brand_json', 'community', 'enriched']);
+      if (!ALLOWED_SOURCE_TYPES.has(brand.source_type)) {
+        return notFound();
+      }
+      const manifest = brand.brand_manifest as Record<string, unknown> | undefined;
+      if (!manifest) return notFound();
+      if (brand.source_type === 'community' && brand.review_status === 'pending') {
+        return notFound();
+      }
+      const schemaUrl = 'https://adcontextprotocol.org/schemas/v3/brand.json';
+      const brandJson: Record<string, unknown> =
+        typeof manifest.$schema === 'string' && manifest.$schema.startsWith('https://')
+          ? { ...manifest }
+          : { $schema: schemaUrl, ...manifest };
+      res.setHeader('X-AAO-Source', brand.source_type);
+      res.setHeader('Cache-Control', brandJsonCacheControl(brand.source_type));
+      return res.json(brandJson);
+    } catch {
+      res.setHeader('Cache-Control', brandJsonCacheControl('error'));
+      return res.status(500).json({ error: 'Failed to retrieve brand' });
     }
-    const manifest = brand.brand_manifest as Record<string, unknown> | undefined;
-    if (!manifest) return res.status(404).json({ error: 'Brand not found' });
-    if (brand.source_type === 'community' && brand.review_status === 'pending') {
-      return res.status(404).json({ error: 'Brand not found' });
-    }
-    const schemaUrl = 'https://adcontextprotocol.org/schemas/v3/brand.json';
-    const brandJson: Record<string, unknown> =
-      typeof manifest.$schema === 'string' && manifest.$schema.startsWith('https://')
-        ? { ...manifest }
-        : { $schema: schemaUrl, ...manifest };
-    res.setHeader('X-AAO-Source', brand.source_type);
-    return res.json(brandJson);
   });
   return app;
 }
@@ -52,6 +63,14 @@ describe('GET /brands/:domain/brand.json gate', () => {
     const app = mountGate({ getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null) });
     const res = await request(app).get('/brands/missing.example/brand.json');
     expect(res.status).toBe(404);
+    expect(res.headers['cache-control']).toBe(brandJsonCacheControl('miss'));
+  });
+
+  it('does not cache transient failures', async () => {
+    const app = mountGate({ getDiscoveredBrandByDomain: vi.fn().mockRejectedValue(new Error('database unavailable')) });
+    const res = await request(app).get('/brands/acme.com/brand.json');
+    expect(res.status).toBe(500);
+    expect(res.headers['cache-control']).toBe('no-store');
   });
 
   it('serves enriched (Brandfetch) rows with X-AAO-Source: enriched so agents can tell unattested data apart from brand-attested', async () => {
@@ -66,6 +85,7 @@ describe('GET /brands/:domain/brand.json gate', () => {
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('SBS Australia');
     expect(res.headers['x-aao-source']).toBe('enriched');
+    expect(res.headers['cache-control']).toBe(brandJsonCacheControl('enriched'));
   });
 
   it('404s unknown source_types (e.g. hosted) — only the explicit allowlist is served', async () => {
@@ -101,6 +121,7 @@ describe('GET /brands/:domain/brand.json gate', () => {
     expect(res.body.colors.accent).toBe('#dcfc01');
     expect(res.body.$schema).toBe('https://adcontextprotocol.org/schemas/v3/brand.json');
     expect(res.headers['x-aao-source']).toBe('community');
+    expect(res.headers['cache-control']).toBe(brandJsonCacheControl('community'));
   });
 
   it('serves brand_json source rows untouched', async () => {
@@ -115,6 +136,7 @@ describe('GET /brands/:domain/brand.json gate', () => {
     expect(res.status).toBe(200);
     expect(res.body.house.domain).toBe('acme.com');
     expect(res.headers['x-aao-source']).toBe('brand_json');
+    expect(res.headers['cache-control']).toBe(brandJsonCacheControl('brand_json'));
   });
 
   it('404s community brands still pending review', async () => {

--- a/server/tests/unit/brand-manager-cache.test.ts
+++ b/server/tests/unit/brand-manager-cache.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/utils/url-security.js', async (importOriginal) => {
 
 import { BrandManager } from '../../src/brand-manager.js';
 import { safeFetchAxiosLike } from '../../src/utils/url-security.js';
+import { BRAND_MANAGER_CACHE_TTL_SECONDS } from '../../src/services/brand-resolution-cache-policy.js';
 
 const mockedSafeFetch = vi.mocked(safeFetchAxiosLike);
 
@@ -45,6 +46,7 @@ describe('BrandManager caching', () => {
 
   afterEach(() => {
     manager.clearCache();
+    vi.useRealTimers();
   });
 
   describe('validateDomain caching', () => {
@@ -573,6 +575,19 @@ describe('BrandManager caching', () => {
       const result2 = await manager.resolveBrand('notfound.com');
       expect(result2).toBeNull();
       expect(mockedSafeFetch).not.toHaveBeenCalled();
+    });
+
+    it('expires a resolution miss with its failed validation cache', async () => {
+      vi.useFakeTimers();
+      mockedSafeFetch.mockResolvedValue({ status: 404, data: null });
+
+      expect(await manager.resolveBrand('new-origin.example')).toBeNull();
+      expect(await manager.resolveBrand('new-origin.example')).toBeNull();
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(BRAND_MANAGER_CACHE_TTL_SECONDS.negative * 1000 + 1);
+      expect(await manager.resolveBrand('new-origin.example')).toBeNull();
+      expect(mockedSafeFetch).toHaveBeenCalledTimes(2);
     });
 
     it('bypasses cache with skipCache option', async () => {

--- a/server/tests/unit/brand-resolution-cache-policy.test.ts
+++ b/server/tests/unit/brand-resolution-cache-policy.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  BRAND_JSON_HTTP_CACHE_TTL_SECONDS,
+  BRAND_MANAGER_CACHE_TTL_SECONDS,
+  BRAND_RESOLVE_HTTP_CACHE_TTL_SECONDS,
+  brandJsonCacheControl,
+  brandResolveCacheControl,
+} from '../../src/services/brand-resolution-cache-policy.js';
+
+describe('brand resolution cache policy', () => {
+  it('uses conservative source and outcome-aware TTLs', () => {
+    expect(BRAND_MANAGER_CACHE_TTL_SECONDS).toEqual({
+      origin: 86_400,
+      negative: 300,
+    });
+    expect(BRAND_JSON_HTTP_CACHE_TTL_SECONDS).toEqual({
+      brand_json: 3_600,
+      community: 900,
+      enriched: 300,
+      miss: 60,
+    });
+    expect(BRAND_RESOLVE_HTTP_CACHE_TTL_SECONDS).toEqual({
+      hosted: 300,
+      brand_json: 300,
+      community: 120,
+      enriched: 60,
+      stub: 60,
+      miss: 30,
+    });
+  });
+
+  it('does not cache fresh resolver responses', () => {
+    expect(brandJsonCacheControl('brand_json')).toBe('public, max-age=3600');
+    expect(brandJsonCacheControl('miss')).toBe('public, max-age=60');
+    expect(brandJsonCacheControl('error')).toBe('no-store');
+    expect(brandResolveCacheControl('hosted')).toBe('public, max-age=300');
+    expect(brandResolveCacheControl('enriched')).toBe('public, max-age=60');
+    expect(brandResolveCacheControl('miss')).toBe('public, max-age=30');
+    expect(brandResolveCacheControl('brand_json', true)).toBe('no-store');
+    expect(brandResolveCacheControl('error')).toBe('no-store');
+  });
+
+  it('keeps the published TTL table aligned with this policy', () => {
+    const docs = readFileSync(new URL('../../../docs/registry/index.mdx', import.meta.url), 'utf8');
+    expect(docs).toContain('| `BrandManager`: successful origin validation or resolution | 24 hours |');
+    expect(docs).toContain('| `BrandManager`: failed validation or resolution miss | 5 minutes |');
+    expect(docs).toContain(`| \`GET /brands/:domain/brand.json\`: \`brand_json\` | \`${brandJsonCacheControl('brand_json')}\` (1 hour) |`);
+    expect(docs).toContain(`| \`GET /brands/:domain/brand.json\`: \`community\` | \`${brandJsonCacheControl('community')}\` (15 minutes) |`);
+    expect(docs).toContain(`| \`GET /brands/:domain/brand.json\`: \`enriched\` | \`${brandJsonCacheControl('enriched')}\` (5 minutes) |`);
+    expect(docs).toContain(`| \`GET /brands/:domain/brand.json\`: 404 miss | \`${brandJsonCacheControl('miss')}\` (1 minute) |`);
+    expect(docs).toContain('| `GET /brands/:domain/brand.json`: failure | `no-store` |');
+    expect(docs).toContain(`| \`GET /api/brands/resolve\`: \`hosted\` or \`brand_json\` | \`${brandResolveCacheControl('hosted')}\` (5 minutes) |`);
+    expect(docs).toContain(`| \`GET /api/brands/resolve\`: \`community\` | \`${brandResolveCacheControl('community')}\` (2 minutes) |`);
+    expect(docs).toContain(`| \`GET /api/brands/resolve\`: \`enriched\` or \`stub\` | \`${brandResolveCacheControl('enriched')}\` (1 minute) |`);
+    expect(docs).toContain(`| \`GET /api/brands/resolve\`: miss | \`${brandResolveCacheControl('miss')}\` (30 seconds) |`);
+    expect(docs).toContain('| `GET /api/brands/resolve`: error or `fresh=true` | `no-store` |');
+  });
+});

--- a/server/tests/unit/registry-brand-enrich-route.test.ts
+++ b/server/tests/unit/registry-brand-enrich-route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   fetchBrandData: vi.fn(),
   fetchBrandContext: vi.fn(),
   isBrandfetchConfigured: vi.fn(),
+  captureEvent: vi.fn(),
 }));
 
 vi.hoisted(() => {
@@ -20,7 +21,12 @@ vi.mock('../../src/services/brandfetch.js', () => ({
   ENRICHMENT_CACHE_MAX_AGE_MS: 30 * 24 * 60 * 60 * 1000,
 }));
 
+vi.mock('../../src/utils/posthog.js', () => ({
+  captureEvent: mocks.captureEvent,
+}));
+
 import { createRegistryApiRouter, type RegistryApiConfig } from '../../src/routes/registry-api.js';
+import { brandResolveCacheControl } from '../../src/services/brand-resolution-cache-policy.js';
 
 function buildApp(
   brandDb: Pick<RegistryApiConfig['brandDb'], 'getDiscoveredBrandByDomain' | 'upsertDiscoveredBrand'>,
@@ -355,9 +361,18 @@ describe('public registry brand read paths', () => {
     expect(res.body.brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
     expect(res.body).toMatchObject({
       source: 'enriched',
-      provenance: 'enriched',
+      enrichment_provider: 'brandfetch',
       provenance_provider: 'brandfetch',
     });
+    expect(res.body.provenance).toBeUndefined();
+    expect(res.headers['cache-control']).toBe(brandResolveCacheControl('enriched'));
+    expect(mocks.captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'brand_resolution_outcome',
+      { outcome: 'enriched' },
+    );
+    expect(JSON.stringify(mocks.captureEvent.mock.calls)).not.toContain('acme.com');
+    expect(JSON.stringify(mocks.captureEvent.mock.calls)).not.toContain('brandfetch');
   });
 
   it('reports verified owner-registered fallback records as hosted', async () => {
@@ -375,8 +390,10 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('hosted');
-    expect(res.body.provenance).toBe('canonical');
+    expect(res.body.provenance).toBeUndefined();
+    expect(res.body.enrichment_provider).toBeUndefined();
     expect(res.body.provenance_provider).toBeUndefined();
+    expect(res.headers['cache-control']).toBe(brandResolveCacheControl('hosted'));
   });
 
   it('does not guess the provider for a legacy enriched record', async () => {
@@ -391,7 +408,7 @@ describe('public registry brand read paths', () => {
     const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=acme.com');
 
     expect(res.status).toBe(200);
-    expect(res.body.provenance).toBe('enriched');
+    expect(res.body.enrichment_provider).toBeUndefined();
     expect(res.body.provenance_provider).toBeUndefined();
   });
 
@@ -410,10 +427,12 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('community');
-    expect(res.body.provenance).toBe('community');
+    expect(res.body.provenance).toBeUndefined();
+    expect(res.body.enrichment_provider).toBeUndefined();
+    expect(res.body.provenance_provider).toBeUndefined();
   });
 
-  it('omits provenance instead of inventing an unknown tier for stubs', async () => {
+  it('does not attach provider metadata to non-enriched stubs', async () => {
     const brandDb = {
       getDiscoveredBrandByDomain: vi.fn().mockResolvedValue({
         ...discoveredBrandWithContext(),
@@ -426,7 +445,7 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('stub');
-    expect(res.body.provenance).toBeUndefined();
+    expect(res.body.enrichment_provider).toBeUndefined();
     expect(res.body.provenance_provider).toBeUndefined();
   });
 
@@ -538,7 +557,6 @@ describe('public registry brand read paths', () => {
     expect(res.body).toMatchObject({
       canonical_id: 'acme-live',
       source: 'brand_json',
-      provenance: 'canonical',
       promoted_from_schema: live.promoted_from_schema,
       migration_warnings: live.migration_warnings,
     });
@@ -570,7 +588,7 @@ describe('public registry brand read paths', () => {
     })).get('/api/brands/resolve?domain=acme.com');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ...live, provenance: 'canonical' });
+    expect(res.body).toEqual(live);
   });
 
   it('rejects path and port lookup inputs before brand resolution', async () => {
@@ -584,6 +602,7 @@ describe('public registry brand read paths', () => {
       .get('/api/brands/resolve?domain=public.example%3A8443%2Fadmin');
 
     expect(res.status).toBe(400);
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(resolveBrand).not.toHaveBeenCalled();
     expect(brandDb.getDiscoveredBrandByDomain).not.toHaveBeenCalled();
   });
@@ -611,8 +630,10 @@ describe('public registry brand read paths', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.source).toBe('enriched');
-    expect(res.body.provenance).toBe('enriched');
+    expect(res.body.provenance).toBeUndefined();
+    expect(res.body.enrichment_provider).toBe('brandfetch');
     expect(res.body.provenance_provider).toBe('brandfetch');
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(res.body.live_brand_json).toEqual({
       valid: false,
       url: validation.url,
@@ -653,6 +674,24 @@ describe('public registry brand read paths', () => {
     expect(res.status).toBe(404);
     expect(res.body.file_status).toBe(503);
     expect(validateDomain).not.toHaveBeenCalled();
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
+  it('gives ordinary resolution misses a short cache policy', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn().mockResolvedValue(null),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+
+    const res = await request(buildApp(brandDb)).get('/api/brands/resolve?domain=missing.example');
+
+    expect(res.status).toBe(404);
+    expect(res.headers['cache-control']).toBe(brandResolveCacheControl('miss'));
+    expect(mocks.captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'brand_resolution_outcome',
+      { outcome: 'miss' },
+    );
   });
 
   it('strips legacy brand_context from /api/brands/resolve/bulk fallback manifests', async () => {
@@ -669,9 +708,11 @@ describe('public registry brand read paths', () => {
     expect(res.body.results['acme.com'].brand_manifest).toEqual({ name: 'Acme', url: 'https://acme.com' });
     expect(res.body.results['acme.com']).toMatchObject({
       source: 'enriched',
-      provenance: 'enriched',
+      enrichment_provider: 'brandfetch',
       provenance_provider: 'brandfetch',
     });
+    expect(res.body.results['acme.com'].provenance).toBeUndefined();
+    expect(res.headers['cache-control']).toBe('no-store');
   });
 
   it('rejects non-hostname inputs from bulk resolution', async () => {
@@ -701,8 +742,29 @@ describe('public registry brand read paths', () => {
       .send({ domains: Array.from({ length: 26 }, (_, i) => `brand-${i}.example`) });
 
     expect(res.status).toBe(400);
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(res.body.error).toBe('Maximum 25 domains per request');
     expect(resolveBrand).not.toHaveBeenCalled();
+  });
+
+  it('does not return a cacheable partial result when one bulk resolution fails', async () => {
+    const brandDb = {
+      getDiscoveredBrandByDomain: vi.fn(),
+      upsertDiscoveredBrand: vi.fn(),
+    };
+    const res = await request(buildApp(brandDb, false, {
+      resolveBrand: vi.fn().mockRejectedValue(new Error('resolver unavailable')),
+    }))
+      .post('/api/brands/resolve/bulk')
+      .send({ domains: ['broken.example'] });
+
+    expect(res.status).toBe(500);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(mocks.captureEvent).toHaveBeenCalledWith(
+      'server-metrics',
+      'brand_resolution_outcome',
+      { outcome: 'error' },
+    );
   });
 
   it('shares one concurrency ceiling across simultaneous bulk requests', async () => {

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -146,16 +146,13 @@ components:
             - enriched
             - stub
           description: "Provenance of the selected record, not relationship authorization. Deterministic precedence is `hosted` > `brand_json` > `community` > `enriched` > `stub`; normal reads prefer the durable stored winner on a source tie, while `fresh=true` lets a successful live origin read win a tie. `brand_json`: the domain's own /.well-known/brand.json. `hosted`: registered by an owner whose control of the domain was verified. `community`: contributed by a member. `enriched`: third-party enrichment. `stub`: a minimal organization-derived placeholder awaiting stronger evidence."
-        provenance:
+        enrichment_provider:
           type: string
-          enum:
-            - canonical
-            - community
-            - enriched
-          description: Caller-facing trust tier for the selected identity. `canonical` covers owner-hosted and origin-published brand.json records; `community` is member-contributed; `enriched` is provisional third-party data. Absent means the record has no recognized provenance tier. Use `source` when the distinction between hosted and origin-published canonical records is needed.
+          description: Preferred open-ended attribution/diagnostic identifier for the enrichment writer. Present only when `source` is `enriched`; it is not a trust tier or behavioral switch.
         provenance_provider:
           type: string
-          description: Provider identifier for provisional third-party enrichment. Present only when `provenance` is `enriched`; the provider is intentionally not constrained to a vendor-specific enum.
+          description: Deprecated compatibility alias for `enrichment_provider`. Present only when `source` is `enriched`; it is not a trust tier or behavioral switch.
+          deprecated: true
         live_brand_json:
           type: object
           properties:
@@ -5730,6 +5727,7 @@ paths:
 
         A domain is authoritative for its own identity, so `source` tells you who published the record and `relationship_trust` tells you whether a brand-to-house relationship was confirmed by both sides. Only `mutual` and `inline` are reciprocated; treat everything else as a claim.
         Record selection is deterministic: `hosted` > `brand_json` > `community` > `enriched`. `source` reports provenance only and must not be used as a substitute for `relationship_trust`.
+        HTTP cache lifetimes are source-aware. `fresh=true` responses are `no-store` so an intermediary cannot satisfy an explicit origin-read request from its cache.
         The v3 hierarchy is one level deep. There is no ordered-chain endpoint: third-party verifiers use the reciprocated `house_domain` edge returned here. `claimed_house_domain` is unilateral and never extends trust.
 
         **Rate limit:** 60 requests per minute per IP address.
@@ -5747,9 +5745,9 @@ paths:
             enum:
               - "true"
               - "false"
-            description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
+            description: "Bypass the resolution cache and refetch from the origin. `fresh=true` responses are `Cache-Control: no-store`. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics."
           required: false
-          description: Bypass the resolution cache and refetch from the origin. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics.
+          description: "Bypass the resolution cache and refetch from the origin. `fresh=true` responses are `Cache-Control: no-store`. When a fresh fetch fails and a stored record is returned instead, `live_brand_json` carries that fetch's diagnostics."
           name: fresh
           in: query
       responses:


### PR DESCRIPTION
## Summary

- Remove the redundant `provenance` response field while retaining exact `source` and adding conditional, open-ended `enrichment_provider` for enriched results; the existing `provenance_provider` remains a deprecated compatibility alias.
- Centralize source/outcome-aware cache policy across BrandManager, the public brand.json mirror, and single resolution; bulk resolution is deliberately never stored.
- Add fixed-cardinality `brand_resolution_outcome` telemetry without domains or provider identifiers.

## Cache TTLs

| Surface and outcome | Cache-Control / in-process TTL |
|---|---|
| BrandManager successful origin validation or resolution | 24 hours |
| BrandManager failed validation or resolution miss | 5 minutes |
| GET /brands/:domain/brand.json brand_json | public, max-age=3600 (1 hour) |
| GET /brands/:domain/brand.json community | public, max-age=900 (15 minutes) |
| GET /brands/:domain/brand.json enriched | public, max-age=300 (5 minutes) |
| GET /brands/:domain/brand.json 404 miss | public, max-age=60 (1 minute) |
| GET /brands/:domain/brand.json failure | no-store |
| GET /api/brands/resolve hosted or brand_json | public, max-age=300 (5 minutes) |
| GET /api/brands/resolve community | public, max-age=120 (2 minutes) |
| GET /api/brands/resolve enriched or stub | public, max-age=60 (1 minute) |
| GET /api/brands/resolve miss | public, max-age=30 (30 seconds) |
| GET /api/brands/resolve error or fresh=true | no-store |
| POST /api/brands/resolve/bulk (all outcomes) | no-store (a shared cache cannot safely key public POST responses by request body) |

Stored community/enriched rows continue to be selected from the database per resolver request; they are not in BrandManager.resolutionCache.

## Instrumentation

Emits `brand_resolution_outcome` with the sole fixed-cardinality property `outcome`: `hosted`, `brand_json`, `community`, `enriched`, `stub`, `miss`, or `error`. Domains and provider values are deliberately excluded.

## Verification

- npm run typecheck
- npm run test:migrations
- Focused Vitest cache, public mirror, and resolver tests: 108 passed
- npm run build:openapi twice; output hash unchanged on the second run
- git diff --check
- node scripts/check-changeset-protocol-scope.cjs origin/main
- Push hook: version sync, changeset scope, schema-link, and docs navigation checks passed

Attempted the real-Postgres brand-provenance-precedence integration test, but this cloud VM has no reachable PostgreSQL service and no Docker daemon.

## Compatibility

Apart from immediately removing the just-added redundant `provenance` field, this preserves response compatibility. Exact `source` remains authoritative; enriched responses now expose preferred `enrichment_provider` and retain `provenance_provider` as a deprecated compatibility alias with the same value. Both fields are attribution/diagnostic metadata rather than trust or behavior controls. No protocol changeset is included because the repository scope check found no protocol-scoped changes.

Closes #7250
