### PR TITLE
fix(admin): audit AAO site-admin access

### DIFF
--- a/docs/aao/aao-admins.mdx
+++ b/docs/aao/aao-admins.mdx
@@ -15,7 +15,13 @@ For end-user docs see [AAO for Members](/docs/aao/users). For org-admin docs see
 
 ## Becoming an AAO admin
 
-AAO admin status is granted via `ADMIN_EMAILS` env var on the deployed app and (separately) the `is_aao_admin` column on the user record. Both must be set for full access — `ADMIN_EMAILS` lets you call admin tools from Addie; `is_aao_admin` lets you use the admin web UI at `/admin`.
+Site-admin access is granted through membership in the server-pinned `aao-admin` working group. Manage that membership from the existing people/working-group administration views; WorkOS organization roles never grant AgenticAdvertising.org platform administration.
+
+`ADMIN_EMAILS` is an environment-managed break-glass path. It is not shown or edited in the UI. Keep its list minimal, rotate it through the deployment-secret process, and remove emergency entries as soon as the incident is resolved. When removing an entry, deploy the changed environment to every application replica and verify that the former address can no longer use an admin route.
+
+Every site-admin grant or revoke requires a written reason and writes an append-only event with the actor, target, access mechanism, reason, and timestamp. The revoke and its audit event commit together, so deleting the active membership cannot delete its forensic record.
+
+The replica that performs a grant or revoke clears that user's local admin-status cache immediately. Other replicas cache a positive `aao-admin` membership decision for at most 60 seconds, so emergency revocation takes effect there within that bound. Negative and failed checks remain fail-closed.
 
 ## Escalation triage
 
@@ -57,7 +63,7 @@ Admin moderation uses the admin portrait API:
 
 ## Internal flags and gates
 
-- `ADMIN_EMAILS` — comma-separated env var, controls Addie admin tool registration.
+- `ADMIN_EMAILS` — comma-separated, environment-managed break-glass access. Rotate and remove entries through deployment secrets; do not treat it as a UI-managed role.
 - `ALLOW_INSECURE_COOKIES` — dev only; do not set in prod.
 - `ANTHROPIC_API_KEY` — required for Addie chat to function at all.
 - `ANONYMOUS_DAILY_LIMIT_USD` — daily anonymous usage cap; gates `anonymousChat` model.

--- a/server/public/admin-people.html
+++ b/server/public/admin-people.html
@@ -360,6 +360,8 @@
 
       <div class="detail-stats" id="detailStats"></div>
 
+      <div id="detailSiteAdminAccess" style="margin-top: var(--space-4);"></div>
+
       <div id="detailSignInActions" style="margin-top: var(--space-4);"></div>
 
       <div class="timeline">
@@ -533,6 +535,7 @@
 
         // Sign-in credentials (Phase 2b admin tools)
         const signInActions = document.getElementById('detailSignInActions');
+        renderSiteAdminAccess(document.getElementById('detailSiteAdminAccess'), r);
         if (r.workos_user_id) {
           await renderSignInCredentials(signInActions, r);
         } else {
@@ -548,6 +551,22 @@
       } catch (e) {
         console.error('Failed to load person detail', e);
       }
+    }
+
+    function renderSiteAdminAccess(container, relationship) {
+      if (!relationship.workos_user_id) {
+        container.innerHTML = '';
+        return;
+      }
+
+      const href = '/admin/working-groups?tab=members&group=aao-admin&user=' + encodeURIComponent(relationship.workos_user_id);
+      container.innerHTML = `
+        <h3 style="margin: 0 0 var(--space-2); font-size: var(--text-base);">AAO site-admin access</h3>
+        <p style="margin: 0 0 var(--space-2); color: var(--color-text-secondary); font-size: var(--text-sm);">
+          WorkOS organization roles never grant AgenticAdvertising.org platform administration.
+        </p>
+        <a class="btn btn-secondary" href="${href}">Manage in working-group membership</a>
+      `;
     }
 
     async function renderSignInCredentials(container, r) {

--- a/server/public/admin-working-groups.html
+++ b/server/public/admin-working-groups.html
@@ -654,6 +654,7 @@
         groups = await response.json();
         renderGroupsList();
         populateMemberGroupFilter();
+        applyMembershipDeepLink();
 
         document.getElementById('loading').style.display = 'none';
         document.getElementById('content').style.display = 'block';
@@ -686,6 +687,21 @@
           loadAllMemberships();
         }
       }
+    }
+
+    // The People admin panel links here instead of creating another membership
+    // editor. Keep the site-admin context in the established membership view.
+    function applyMembershipDeepLink() {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('tab') !== 'members') return;
+
+      const groupSlug = params.get('group');
+      const group = groups.find((candidate) => candidate.slug === groupSlug);
+      if (group) document.getElementById('memberGroupFilter').value = group.id;
+
+      const userId = params.get('user');
+      if (userId) document.getElementById('memberSearchInput').value = userId;
+      showPageTab('allMembers');
     }
 
     // Load all memberships for the All Members tab
@@ -731,7 +747,8 @@
           (m.user_name && m.user_name.toLowerCase().includes(searchTerm)) ||
           (m.user_email && m.user_email.toLowerCase().includes(searchTerm)) ||
           (m.user_org_name && m.user_org_name.toLowerCase().includes(searchTerm)) ||
-          (m.working_group_name && m.working_group_name.toLowerCase().includes(searchTerm))
+          (m.working_group_name && m.working_group_name.toLowerCase().includes(searchTerm)) ||
+          (m.workos_user_id && m.workos_user_id.toLowerCase().includes(searchTerm))
         );
       }
 
@@ -1194,11 +1211,22 @@
     async function addMember(userId, name, email, orgName) {
       if (!editingGroup) return;
 
+      const isAAOAdminGroup = editingGroup.slug === 'aao-admin';
+      const reason = isAAOAdminGroup
+        ? prompt('Why are you granting AAO site-admin access? This reason is recorded in the audit history.')
+        : null;
+      if (isAAOAdminGroup && (!reason || !reason.trim())) return;
+
       try {
-        const response = await fetch(`/api/admin/working-groups/${editingGroup.id}/members`, {
+        const response = await fetch(isAAOAdminGroup
+          ? '/api/admin/aao-admin/grant'
+          : `/api/admin/working-groups/${editingGroup.id}/members`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
+          body: JSON.stringify(isAAOAdminGroup ? {
+            workos_user_id: userId,
+            reason: reason.trim(),
+          } : {
             workos_user_id: userId,
             user_name: name,
             user_email: email,
@@ -1218,11 +1246,24 @@
     // Remove member
     async function removeMember(userId) {
       if (!editingGroup) return;
-      if (!confirm('Remove this member from the working group?')) return;
+      const isAAOAdminGroup = editingGroup.slug === 'aao-admin';
+      if (!confirm(isAAOAdminGroup
+        ? 'Revoke this person\'s AAO site-admin access?'
+        : 'Remove this member from the working group?')) return;
+      const reason = isAAOAdminGroup
+        ? prompt('Why are you revoking AAO site-admin access? This reason is recorded in the audit history.')
+        : null;
+      if (isAAOAdminGroup && (!reason || !reason.trim())) return;
 
       try {
-        const response = await fetch(`/api/admin/working-groups/${editingGroup.id}/members/${userId}`, {
-          method: 'DELETE'
+        const response = await fetch(isAAOAdminGroup
+          ? '/api/admin/aao-admin/revoke'
+          : `/api/admin/working-groups/${editingGroup.id}/members/${userId}`, {
+          method: isAAOAdminGroup ? 'POST' : 'DELETE',
+          ...(isAAOAdminGroup ? {
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workos_user_id: userId, reason: reason.trim() }),
+          } : {}),
         });
 
         if (!response.ok) throw new Error('Failed to remove member');

--- a/server/src/addie/admin-status-lookup.ts
+++ b/server/src/addie/admin-status-lookup.ts
@@ -17,11 +17,26 @@
 import { createLogger } from '../logger.js';
 import { WorkingGroupDatabase } from '../db/working-group-db.js';
 import { getWebAdminStatusCache } from './admin-status-cache.js';
+import {
+  decideAAOAdminAccess,
+  type AAOAdminAccessDecision,
+  type AAOAdminAccessMechanism,
+} from '../auth/admin-access.js';
+
+export {
+  decideAAOAdminAccess,
+  type AAOAdminAccessDecision,
+  type AAOAdminAccessMechanism,
+} from '../auth/admin-access.js';
 
 const logger = createLogger('admin-status-lookup');
 
 const AAO_ADMIN_WORKING_GROUP_SLUG = 'aao-admin';
-const ADMIN_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+// This is deliberately short: invalidation only reaches the instance that
+// performed an admin grant/revoke. Other replicas must therefore re-check
+// membership quickly enough for an emergency revocation to take effect.
+export const AAO_ADMIN_POSITIVE_CACHE_TTL_MS = 60 * 1000;
+const AAO_ADMIN_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 const wgDb = new WorkingGroupDatabase();
 
@@ -38,16 +53,31 @@ export async function isWebUserAAOAdmin(workosUserId: string): Promise<boolean> 
       logger.warn('AAO Admin working group not found');
       // Cache the negative result for a shorter time so a missing
       // admin group doesn't pin everyone to non-admin for 30 minutes.
-      cache.set(workosUserId, { isAdmin: false, expiresAt: Date.now() + 5 * 60 * 1000 });
+      cache.set(workosUserId, { isAdmin: false, expiresAt: Date.now() + AAO_ADMIN_NEGATIVE_CACHE_TTL_MS });
       return false;
     }
 
     const isAdmin = await wgDb.isMember(adminGroup.id, workosUserId);
-    cache.set(workosUserId, { isAdmin, expiresAt: Date.now() + ADMIN_CACHE_TTL_MS });
+    cache.set(workosUserId, {
+      isAdmin,
+      expiresAt: Date.now() + (isAdmin ? AAO_ADMIN_POSITIVE_CACHE_TTL_MS : AAO_ADMIN_NEGATIVE_CACHE_TTL_MS),
+    });
     logger.debug({ workosUserId, isAdmin }, 'Checked web user admin status');
     return isAdmin;
   } catch (error) {
     logger.error({ error, workosUserId }, 'Error checking if web user is admin');
     return false;
   }
+}
+
+/**
+ * Resolve platform-admin access and retain the authority mechanism for audit
+ * and diagnostics. Working-group membership is primary; `ADMIN_EMAILS` is
+ * only the environment-managed break-glass fallback.
+ */
+export async function resolveWebUserAAOAdminAccess(
+  workosUserId: string,
+  email: string | null | undefined,
+): Promise<AAOAdminAccessDecision> {
+  return decideAAOAdminAccess(await isWebUserAAOAdmin(workosUserId), email);
 }

--- a/server/src/addie/mcp/admin-tools.ts
+++ b/server/src/addie/mcp/admin-tools.ts
@@ -197,7 +197,11 @@ const AAO_ADMIN_WORKING_GROUP_SLUG = "aao-admin";
 const KITCHEN_CABINET_SLUG = "kitchen-cabinet";
 
 // Cache for admin status checks - admin status rarely changes
-const ADMIN_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+// Site-admin membership can be revoked on another replica. Keep successful
+// membership decisions short-lived so every replica rechecks within a minute.
+const ADMIN_POSITIVE_CACHE_TTL_MS = 60 * 1000;
+const ADMIN_NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
+const COUNCIL_CACHE_TTL_MS = 30 * 60 * 1000;
 // Shared cache module — invalidators can be called without dragging the
 // rest of admin-tools (and its Anthropic-instantiating dependencies)
 // into unrelated import graphs.
@@ -206,7 +210,8 @@ const adminStatusCache = getSlackAdminStatusCache();
 /**
  * Check if a Slack user is an admin
  * Looks up their WorkOS user ID via Slack mapping and checks membership in aao-admin working group
- * Results are cached for 30 minutes to reduce DB load
+ * Positive results are cached for at most 60 seconds so a revoke propagates
+ * across replicas without a shared cache invalidation channel.
  */
 export async function isSlackUserAAOAdmin(
   slackUserId: string,
@@ -228,7 +233,7 @@ export async function isSlackUserAAOAdmin(
       );
       adminStatusCache.set(slackUserId, {
         isAdmin: false,
-        expiresAt: Date.now() + ADMIN_CACHE_TTL_MS,
+        expiresAt: Date.now() + ADMIN_NEGATIVE_CACHE_TTL_MS,
       });
       return false;
     }
@@ -254,7 +259,7 @@ export async function isSlackUserAAOAdmin(
     // Cache the result
     adminStatusCache.set(slackUserId, {
       isAdmin,
-      expiresAt: Date.now() + ADMIN_CACHE_TTL_MS,
+      expiresAt: Date.now() + (isAdmin ? ADMIN_POSITIVE_CACHE_TTL_MS : ADMIN_NEGATIVE_CACHE_TTL_MS),
     });
 
     logger.info(
@@ -330,7 +335,7 @@ export async function isWebUserAAOCouncil(
     const isCouncil = await wgDb.isMember(group.id, workosUserId);
     webCouncilStatusCache.set(workosUserId, {
       isCouncil,
-      expiresAt: Date.now() + ADMIN_CACHE_TTL_MS,
+      expiresAt: Date.now() + COUNCIL_CACHE_TTL_MS,
     });
 
     logger.debug(
@@ -6768,6 +6773,9 @@ export function createAdminToolHandlers(
       if (!committee) {
         return `❌ Committee "${committeeSlug}" not found. Use list_working_groups, list_chapters, or list_industry_gatherings to find the correct slug.`;
       }
+      if (committee.slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+        return '⚠️ AAO site-admin membership must be changed through the dedicated audited admin workflow.';
+      }
 
       // Check if already a leader (use canonical_user_id for Slack/WorkOS resolution)
       const leaders = await wgDb.getLeaders(committee.id);
@@ -6985,6 +6993,9 @@ Use add_committee_leader to assign a leader.`;
       if (!group) {
         return `❌ Committee "${committeeSlug}" not found. Use list_working_groups to find the correct slug.`;
       }
+      if (group.slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+        return '⚠️ AAO site-admin membership must be changed through the dedicated audited admin workflow.';
+      }
 
       // Check if already a member
       const existing = await wgDb.getMembership(group.id, userId);
@@ -7074,6 +7085,9 @@ Use add_committee_leader to assign a leader.`;
       if (!group) {
         return `❌ Committee "${committeeSlug}" not found. Use list_working_groups to find the correct slug.`;
       }
+      if (group.slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+        return '⚠️ AAO site-admin membership must be changed through the dedicated audited admin workflow.';
+      }
 
       const existing = await wgDb.getMembership(group.id, userId);
       if (!existing || existing.status !== "active") {
@@ -7116,6 +7130,9 @@ Use add_committee_leader to assign a leader.`;
       const wg = await wgDb.getWorkingGroupBySlug(slug);
       if (!wg) {
         return `❌ Working group with slug "${slug}" not found.`;
+      }
+      if (wg.slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+        return '⚠️ The AAO site-admin working group cannot be renamed. Its membership is changed only through the dedicated audited admin workflow.';
       }
 
       const generatedSlug =

--- a/server/src/addie/mcp/committee-leader-tools.ts
+++ b/server/src/addie/mcp/committee-leader-tools.ts
@@ -255,6 +255,9 @@ export function createCommitteeLeaderToolHandlers(
       return `⚠️ ${permCheck.error}`;
     }
     const committee = permCheck.committee!;
+    if (committeeSlug === 'aao-admin') {
+      return '⚠️ AAO site-admin membership must be changed through the dedicated audited admin workflow.';
+    }
 
     try {
       // Resolve to canonical ID for consistent comparison

--- a/server/src/auth/admin-access.ts
+++ b/server/src/auth/admin-access.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared platform-admin authority vocabulary.
+ *
+ * `ADMIN_EMAILS` is deliberately configuration-only break-glass access. Keep
+ * its parsing and decision labels here so audit and diagnostics cannot drift
+ * from enforcement.
+ */
+
+export type AAOAdminAccessMechanism =
+  | 'aao_admin_working_group'
+  | 'break_glass_admin_email'
+  | 'static_admin_api_key'
+  | 'development';
+
+export interface AAOAdminAccessDecision {
+  isAdmin: boolean;
+  mechanism: AAOAdminAccessMechanism | null;
+}
+
+export function isBreakGlassAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail) return false;
+
+  return (process.env.ADMIN_EMAILS ?? '')
+    .split(',')
+    .some((configuredEmail) => configuredEmail.trim().toLowerCase() === normalizedEmail);
+}
+
+/** Classify a membership result without duplicating break-glass interpretation. */
+export function decideAAOAdminAccess(
+  isAdminByWorkingGroup: boolean,
+  email: string | null | undefined,
+): AAOAdminAccessDecision {
+  if (isAdminByWorkingGroup) return { isAdmin: true, mechanism: 'aao_admin_working_group' };
+  if (isBreakGlassAdminEmail(email)) return { isAdmin: true, mechanism: 'break_glass_admin_email' };
+  return { isAdmin: false, mechanism: null };
+}

--- a/server/src/db/migrations/578_aao_admin_access_events.sql
+++ b/server/src/db/migrations/578_aao_admin_access_events.sql
@@ -1,0 +1,28 @@
+-- Append-only audit history for AgenticAdvertising.org site-admin grants and revocations.
+-- This intentionally has no foreign keys: a later account or membership deletion
+-- must not erase the forensic record of elevated access.
+
+CREATE TABLE IF NOT EXISTS aao_admin_access_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL CHECK (event_type IN ('granted', 'revoked')),
+  actor_user_id TEXT NOT NULL,
+  target_user_id TEXT NOT NULL,
+  mechanism TEXT NOT NULL CHECK (mechanism = 'aao_admin_working_group'),
+  actor_authorization_mechanism TEXT NOT NULL CHECK (actor_authorization_mechanism IN (
+    'aao_admin_working_group',
+    'break_glass_admin_email',
+    'static_admin_api_key',
+    'development'
+  )),
+  reason TEXT NOT NULL CHECK (length(btrim(reason)) > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_aao_admin_access_events_target_created
+  ON aao_admin_access_events(target_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_aao_admin_access_events_actor_created
+  ON aao_admin_access_events(actor_user_id, created_at DESC);
+
+COMMENT ON TABLE aao_admin_access_events IS
+  'Append-only forensic history for site-admin membership grants and revocations.';

--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -1,4 +1,5 @@
 import { query, getPool } from './client.js';
+import type { PoolClient } from 'pg';
 import { computeJourneyStage } from '../addie/services/journey-computation.js';
 import { CommunityDatabase } from './community-db.js';
 import { createLogger } from '../logger.js';
@@ -25,6 +26,21 @@ import type {
 } from '../types.js';
 
 const logger = createLogger('working-group-db');
+
+const AAO_ADMIN_WORKING_GROUP_SLUG = 'aao-admin';
+
+export type AAOAdminMembershipAuditMechanism =
+  | 'aao_admin_working_group'
+  | 'break_glass_admin_email'
+  | 'static_admin_api_key'
+  | 'development';
+
+interface AAOAdminMembershipMutationInput {
+  targetUserId: string;
+  actorUserId: string;
+  actorAuthorizationMechanism: AAOAdminMembershipAuditMechanism;
+  reason: string;
+}
 
 /**
  * Escape LIKE pattern wildcards to prevent SQL injection
@@ -74,6 +90,28 @@ function extractSlackChannelId(url: string | null | undefined): string | null {
  */
 export class WorkingGroupDatabase {
   /**
+   * Generic working-group mutations must never change the platform-admin
+   * group. The audited grant/revoke methods below are the intentionally
+   * narrow bypass: they resolve the server-owned slug in their transaction
+   * and do not call this generic mutation surface.
+   */
+  private async assertGenericMutationAllowed(workingGroupId: string): Promise<void> {
+    const result = await query<{ slug: string }>(
+      'SELECT slug FROM working_groups WHERE id = $1',
+      [workingGroupId],
+    );
+    if (result.rows[0]?.slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+      throw new Error('AAO site-admin group can only be changed through the dedicated audited workflow');
+    }
+  }
+
+  private assertGenericSlugAllowed(slug: string | undefined): void {
+    if (slug === AAO_ADMIN_WORKING_GROUP_SLUG) {
+      throw new Error('The aao-admin slug is reserved for the dedicated audited site-admin workflow');
+    }
+  }
+
+  /**
    * Resolve a user ID to its canonical WorkOS user ID.
    * If the ID is a Slack user ID with a linked WorkOS account, returns the WorkOS ID.
    * Otherwise returns the original ID unchanged.
@@ -94,6 +132,7 @@ export class WorkingGroupDatabase {
    * Create a new working group
    */
   async createWorkingGroup(input: CreateWorkingGroupInput): Promise<WorkingGroup> {
+    this.assertGenericSlugAllowed(input.slug);
     // Auto-extract channel ID from URL if not explicitly provided
     const channelId = input.slack_channel_id || extractSlackChannelId(input.slack_channel_url);
 
@@ -180,6 +219,9 @@ export class WorkingGroupDatabase {
     id: string,
     updates: UpdateWorkingGroupInput
   ): Promise<WorkingGroup | null> {
+    this.assertGenericSlugAllowed(updates.slug);
+    await this.assertGenericMutationAllowed(id);
+
     // Auto-extract channel ID from URL if URL is being updated and channel_id isn't explicitly set
     if (updates.slack_channel_url !== undefined && updates.slack_channel_id === undefined) {
       updates.slack_channel_id = extractSlackChannelId(updates.slack_channel_url) ?? undefined;
@@ -269,6 +311,7 @@ export class WorkingGroupDatabase {
    * Deactivate a working group by setting status to 'inactive'
    */
   async deactivateWorkingGroup(id: string): Promise<boolean> {
+    await this.assertGenericMutationAllowed(id);
     const result = await query(
       `UPDATE working_groups SET status = 'inactive', updated_at = NOW() WHERE id = $1`,
       [id]
@@ -280,6 +323,7 @@ export class WorkingGroupDatabase {
    * Reactivate a working group by setting status to 'active'
    */
   async reactivateWorkingGroup(id: string): Promise<boolean> {
+    await this.assertGenericMutationAllowed(id);
     const result = await query(
       `UPDATE working_groups SET status = 'active', updated_at = NOW() WHERE id = $1`,
       [id]
@@ -851,6 +895,7 @@ export class WorkingGroupDatabase {
    * Add a member to a working group
    */
   async addMembership(input: AddWorkingGroupMemberInput): Promise<WorkingGroupMembership> {
+    await this.assertGenericMutationAllowed(input.working_group_id);
     // Resolve Slack IDs to canonical WorkOS IDs to prevent duplicates
     const canonicalUserId = await this.resolveToCanonicalUserId(input.workos_user_id);
 
@@ -890,6 +935,7 @@ export class WorkingGroupDatabase {
    * Remove a member from a working group (soft delete by setting status to inactive)
    */
   async removeMembership(workingGroupId: string, userId: string): Promise<boolean> {
+    await this.assertGenericMutationAllowed(workingGroupId);
     const canonicalUserId = await this.resolveToCanonicalUserId(userId);
     const result = await query(
       `UPDATE working_group_memberships
@@ -915,6 +961,7 @@ export class WorkingGroupDatabase {
    * Hard delete a membership record
    */
   async deleteMembership(workingGroupId: string, userId: string): Promise<boolean> {
+    await this.assertGenericMutationAllowed(workingGroupId);
     const canonicalUserId = await this.resolveToCanonicalUserId(userId);
     const result = await query(
       `DELETE FROM working_group_memberships
@@ -933,6 +980,111 @@ export class WorkingGroupDatabase {
     }
 
     return (result.rowCount || 0) > 0;
+  }
+
+  /**
+   * Grant the fixed site-admin working-group membership and append its audit
+   * record in one transaction. The group is resolved by its server-owned
+   * slug; callers never supply a working-group ID for this authority.
+   */
+  async grantAAOAdminMembership(
+    input: AAOAdminMembershipMutationInput,
+  ): Promise<WorkingGroupMembership> {
+    const client = await getPool().connect();
+    try {
+      await client.query('BEGIN');
+      const groupResult = await client.query<{ id: string }>(
+        'SELECT id FROM working_groups WHERE slug = $1 FOR SHARE',
+        [AAO_ADMIN_WORKING_GROUP_SLUG],
+      );
+      const group = groupResult.rows[0];
+      if (!group) throw new Error('AAO admin working group not found');
+
+      const targetUserId = await this.resolveCanonicalUserIdWithClient(client, input.targetUserId);
+      const membershipResult = await client.query<WorkingGroupMembership>(
+        `INSERT INTO working_group_memberships (
+          working_group_id, workos_user_id, added_by_user_id
+        ) VALUES ($1, $2, $3)
+        ON CONFLICT (working_group_id, workos_user_id)
+        DO UPDATE SET status = 'active', updated_at = NOW(), added_by_user_id = EXCLUDED.added_by_user_id
+        RETURNING *`,
+        [group.id, targetUserId, input.actorUserId],
+      );
+      await client.query(
+        `INSERT INTO aao_admin_access_events (
+          event_type, actor_user_id, target_user_id, mechanism,
+          actor_authorization_mechanism, reason
+        ) VALUES ('granted', $1, $2, 'aao_admin_working_group', $3, $4)`,
+        [input.actorUserId, targetUserId, input.actorAuthorizationMechanism, input.reason],
+      );
+      await client.query('COMMIT');
+      return membershipResult.rows[0];
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError }, 'AAO admin grant rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Revoke the fixed site-admin membership and preserve an immutable event
+   * before committing the membership deletion.
+   */
+  async revokeAAOAdminMembership(input: AAOAdminMembershipMutationInput): Promise<string | null> {
+    const client = await getPool().connect();
+    try {
+      await client.query('BEGIN');
+      const groupResult = await client.query<{ id: string }>(
+        'SELECT id FROM working_groups WHERE slug = $1 FOR SHARE',
+        [AAO_ADMIN_WORKING_GROUP_SLUG],
+      );
+      const group = groupResult.rows[0];
+      if (!group) throw new Error('AAO admin working group not found');
+
+      const targetUserId = await this.resolveCanonicalUserIdWithClient(client, input.targetUserId);
+      const deleted = await client.query<{ workos_user_id: string }>(
+        `DELETE FROM working_group_memberships
+         WHERE working_group_id = $1 AND workos_user_id = $2 AND status = 'active'
+         RETURNING workos_user_id`,
+        [group.id, targetUserId],
+      );
+      if (deleted.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return null;
+      }
+
+      await client.query(
+        `INSERT INTO aao_admin_access_events (
+          event_type, actor_user_id, target_user_id, mechanism,
+          actor_authorization_mechanism, reason
+        ) VALUES ('revoked', $1, $2, 'aao_admin_working_group', $3, $4)`,
+        [input.actorUserId, targetUserId, input.actorAuthorizationMechanism, input.reason],
+      );
+      await client.query('COMMIT');
+      return targetUserId;
+    } catch (error) {
+      await client.query('ROLLBACK').catch((rollbackError) => {
+        logger.warn({ err: rollbackError }, 'AAO admin revoke rollback failed');
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async resolveCanonicalUserIdWithClient(
+    client: PoolClient,
+    userId: string,
+  ): Promise<string> {
+    const result = await client.query<{ workos_user_id: string }>(
+      `SELECT workos_user_id FROM slack_user_mappings
+       WHERE slack_user_id = $1 AND workos_user_id IS NOT NULL`,
+      [userId],
+    );
+    return result.rows[0]?.workos_user_id ?? userId;
   }
 
   /**
@@ -1184,6 +1336,7 @@ export class WorkingGroupDatabase {
    * Set leaders for a working group (replaces existing leaders)
    */
   async setLeaders(workingGroupId: string, userIds: string[]): Promise<void> {
+    await this.assertGenericMutationAllowed(workingGroupId);
     // Resolve all Slack IDs to canonical WorkOS IDs to prevent duplicates
     const canonicalUserIds = await Promise.all(
       userIds.map(id => this.resolveToCanonicalUserId(id))
@@ -1236,6 +1389,7 @@ export class WorkingGroupDatabase {
    * Add a leader to a working group
    */
   async addLeader(workingGroupId: string, userId: string): Promise<void> {
+    await this.assertGenericMutationAllowed(workingGroupId);
     // Resolve Slack IDs to canonical WorkOS IDs to prevent duplicates
     const canonicalUserId = await this.resolveToCanonicalUserId(userId);
 
@@ -1268,6 +1422,7 @@ export class WorkingGroupDatabase {
    * Remove a leader from a working group
    */
   async removeLeader(workingGroupId: string, userId: string): Promise<void> {
+    await this.assertGenericMutationAllowed(workingGroupId);
     const canonicalUserId = await this.resolveToCanonicalUserId(userId);
     await query(
       'DELETE FROM working_group_leaders WHERE working_group_id = $1 AND user_id = $2',
@@ -1841,6 +1996,7 @@ export class WorkingGroupDatabase {
     interest_level?: EventInterestLevel;
     interest_source?: EventInterestSource;
   }): Promise<WorkingGroupMembership> {
+    await this.assertGenericMutationAllowed(input.working_group_id);
     // Resolve Slack IDs to canonical WorkOS IDs to prevent duplicates
     const canonicalUserId = await this.resolveToCanonicalUserId(input.workos_user_id);
 

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -105,6 +105,8 @@ import { invalidateMembershipCache, findClaimableProspectOrgForDomain } from "./
 import * as relationshipDb from "./db/relationship-db.js";
 import * as personEvents from "./db/person-events-db.js";
 import { isWebUserAAOAdmin } from "./addie/mcp/admin-tools.js";
+import { resolveWebUserAAOAdminAccess } from "./addie/admin-status-lookup.js";
+import { isBreakGlassAdminEmail } from "./auth/admin-access.js";
 import { createSlackRouter } from "./routes/slack.js";
 import { createWebhooksRouter } from "./routes/webhooks.js";
 import { createWorkOSWebhooksRouter } from "./routes/workos-webhooks.js";
@@ -1083,8 +1085,7 @@ function buildAppConfig(user?: { id?: string; email: string; firstName?: string 
     if (typeof user.isAdmin === 'boolean') {
       isAdmin = user.isAdmin;
     } else {
-      const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-      isAdmin = adminEmails.includes(user.email.toLowerCase());
+      isAdmin = isBreakGlassAdminEmail(user.email);
     }
   }
 
@@ -8603,13 +8604,9 @@ ${p.category ? `<category>${p.category}</category>\n` : ''}<url>${publishedUrl}<
           throw error;
         }
 
-        // Check if user is admin via aao-admin working group (primary) or
-        // ADMIN_EMAILS env var (fallback). Must match requireAdmin middleware
-        // so the admin UI and backend agree on who sees admin surfaces.
-        const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-        const isAdminByEmail = adminEmails.includes(user.email.toLowerCase());
-        const isAdminByWorkingGroup = await isWebUserAAOAdmin(user.id);
-        const isAdmin = isAdminByWorkingGroup || isAdminByEmail;
+        // Match requireAdmin: working-group authority with an explicit,
+        // environment-managed break-glass fallback.
+        const isAdmin = (await resolveWebUserAAOAdminAccess(user.id, user.email)).isAdmin;
         // Check Slack sync status, seat type, and read DB names (user may have
         // set a display name that differs from the WorkOS session values)
         let isLinkedToSlack = false;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -4,6 +4,11 @@ import { WorkOS } from '@workos-inc/node';
 import { CompanyDatabase } from '../db/company-db.js';
 import type { WorkOSUser, Company, CompanyUser, Ban } from '../types.js';
 import { createLogger } from '../logger.js';
+import {
+  decideAAOAdminAccess,
+  isBreakGlassAdminEmail,
+  type AAOAdminAccessMechanism,
+} from '../auth/admin-access.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
 import { bansDb } from '../db/bans-db.js';
 import { isWorkOSApiKeyFormat } from './api-key-format.js';
@@ -216,6 +221,8 @@ declare global {
       accessToken?: string;
       company?: Company;
       companyUser?: CompanyUser;
+      /** Authority path used by requireAdmin, retained for audited mutations. */
+      adminAccessMechanism?: AAOAdminAccessMechanism;
     }
   }
 }
@@ -1506,6 +1513,7 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
 
   // Check for static admin API key (set by requireAuth)
   if ((req as Request & { isStaticAdminApiKey?: boolean }).isStaticAdminApiKey) {
+    req.adminAccessMechanism = 'static_admin_api_key';
     logger.debug({ path: req.path, method: req.method }, 'Admin access via static admin API key');
     return next();
   }
@@ -1584,6 +1592,7 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
         current_user: devUser.email,
       });
     }
+    req.adminAccessMechanism = 'development';
     return next();
   }
 
@@ -1597,14 +1606,12 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
     });
   }
 
-  // Check admin access via aao-admin working group membership (primary)
-  // or ADMIN_EMAILS env var (fallback for emergency access)
-  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-  const isAdminByEmail = adminEmails.includes(req.user.email.toLowerCase());
-  const isAdminByWorkingGroup = await isWebUserAAOAdmin(req.user.id);
-  const isAdmin = isAdminByWorkingGroup || isAdminByEmail;
+  const decision = decideAAOAdminAccess(
+    await isWebUserAAOAdmin(req.user.id),
+    req.user.email,
+  );
 
-  if (!isAdmin) {
+  if (!decision.isAdmin) {
     logger.warn({ userId: req.user.id, email: req.user.email }, 'Non-admin user attempted to access admin endpoint');
     if (isHtmlRequest) {
       return res.status(403).send(`
@@ -1637,7 +1644,8 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
     });
   }
 
-  logger.debug({ userId: req.user.id, email: req.user.email }, 'Admin access granted');
+  req.adminAccessMechanism = decision.mechanism!;
+  logger.debug({ userId: req.user.id, email: req.user.email, mechanism: decision.mechanism }, 'Admin access granted');
   next();
 }
 
@@ -1736,8 +1744,7 @@ export function createRequireWorkingGroupLeader(
     }
 
     // Check if user is a site admin first (admins can manage all groups)
-    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-    const isAdmin = adminEmails.includes(req.user.email.toLowerCase());
+    const isAdmin = isBreakGlassAdminEmail(req.user.email);
 
     if (isAdmin) {
       logger.debug({ userId: req.user.id, slug }, 'Admin access granted to working group');
@@ -1801,8 +1808,7 @@ export function createRequireWorkingGroupMember(
     }
 
     // Check if user is a site admin first
-    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-    const isAdmin = adminEmails.includes(req.user.email.toLowerCase());
+    const isAdmin = isBreakGlassAdminEmail(req.user.email);
 
     if (isAdmin) {
       logger.debug({ userId: req.user.id, slug }, 'Admin access granted to working group');

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -2,6 +2,7 @@ import rateLimit from 'express-rate-limit';
 import type { IncrementResponse, Options, Store } from 'express-rate-limit';
 import type { Request, Response } from 'express';
 import { createLogger } from '../logger.js';
+import { isBreakGlassAdminEmail } from '../auth/admin-access.js';
 import { CachedPostgresStore, PostgresStore, type WeightedIncrementStore } from './pg-rate-limit-store.js';
 
 const logger = createLogger('rate-limit');
@@ -105,8 +106,7 @@ async function skipForAdmins(req: Request): Promise<boolean> {
 
   if (user.isAdmin === true) return true;
 
-  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) ?? [];
-  if (user.email && adminEmails.includes(user.email.toLowerCase())) {
+  if (isBreakGlassAdminEmail(user.email)) {
     return true;
   }
 

--- a/server/src/routes/aao-admin.ts
+++ b/server/src/routes/aao-admin.ts
@@ -1,0 +1,103 @@
+/**
+ * Dedicated site-admin access mutations.
+ *
+ * These routes deliberately do not share the generic working-group membership
+ * endpoints: the target group is security-sensitive and is always resolved by
+ * the database from the server-owned `aao-admin` slug.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { invalidateAllAdminStatusCaches } from '../addie/admin-status-cache.js';
+import type { AAOAdminAccessMechanism } from '../auth/admin-access.js';
+import {
+  WorkingGroupDatabase,
+  type AAOAdminMembershipAuditMechanism,
+} from '../db/working-group-db.js';
+import { createLogger } from '../logger.js';
+import { requireGlobalAdmin } from '../middleware/auth.js';
+
+const logger = createLogger('aao-admin-routes');
+const MAX_REASON_LENGTH = 1_000;
+const MAX_USER_ID_LENGTH = 255;
+
+type AdminRequest = Request & { adminAccessMechanism?: AAOAdminAccessMechanism };
+
+function parseMutationInput(body: unknown):
+  | { targetUserId: string; reason: string }
+  | { error: string; message: string } {
+  const value = body && typeof body === 'object' ? body as Record<string, unknown> : {};
+  const targetUserId = typeof value.workos_user_id === 'string' ? value.workos_user_id.trim() : '';
+  const reason = typeof value.reason === 'string' ? value.reason.trim() : '';
+
+  if (!targetUserId) return { error: 'workos_user_id_required', message: 'workos_user_id is required' };
+  if (targetUserId.length > MAX_USER_ID_LENGTH) return { error: 'invalid_workos_user_id', message: 'workos_user_id is too long' };
+  if (!reason) return { error: 'reason_required', message: 'reason must not be blank' };
+  if (reason.length > MAX_REASON_LENGTH) return { error: 'reason_too_long', message: `reason exceeds ${MAX_REASON_LENGTH} characters` };
+  return { targetUserId, reason };
+}
+
+function isMutationInput(input: ReturnType<typeof parseMutationInput>): input is { targetUserId: string; reason: string } {
+  return 'targetUserId' in input;
+}
+
+function requireAuditMechanism(req: AdminRequest, res: Response): AAOAdminMembershipAuditMechanism | null {
+  if (req.adminAccessMechanism) return req.adminAccessMechanism;
+  logger.error({ actorUserId: req.user?.id }, 'Refused AAO site-admin mutation without audit attribution');
+  res.status(500).json({
+    error: 'admin_authorization_unavailable',
+    message: 'Unable to determine the administrator authorization mechanism',
+  });
+  return null;
+}
+
+/** Mount the global-admin-only site-admin grant and revoke endpoints. */
+export function createAAOAdminRouter(): Router {
+  const router = Router();
+  const workingGroupDb = new WorkingGroupDatabase();
+
+  router.post('/grant', ...requireGlobalAdmin, async (req: AdminRequest, res: Response) => {
+    const input = parseMutationInput(req.body);
+    if (!isMutationInput(input)) return res.status(400).json(input);
+    const actorAuthorizationMechanism = requireAuditMechanism(req, res);
+    if (!actorAuthorizationMechanism) return;
+
+    try {
+      const membership = await workingGroupDb.grantAAOAdminMembership({
+        targetUserId: input.targetUserId,
+        actorUserId: req.user!.id,
+        actorAuthorizationMechanism,
+        reason: input.reason,
+      });
+      // This replica stops honoring an existing positive result immediately.
+      invalidateAllAdminStatusCaches();
+      return res.status(201).json({ membership });
+    } catch (error) {
+      logger.error({ err: error, actorUserId: req.user?.id }, 'AAO site-admin grant failed');
+      return res.status(500).json({ error: 'aao_admin_grant_failed', message: 'Failed to grant site-admin access' });
+    }
+  });
+
+  router.post('/revoke', ...requireGlobalAdmin, async (req: AdminRequest, res: Response) => {
+    const input = parseMutationInput(req.body);
+    if (!isMutationInput(input)) return res.status(400).json(input);
+    const actorAuthorizationMechanism = requireAuditMechanism(req, res);
+    if (!actorAuthorizationMechanism) return;
+
+    try {
+      const revokedUserId = await workingGroupDb.revokeAAOAdminMembership({
+        targetUserId: input.targetUserId,
+        actorUserId: req.user!.id,
+        actorAuthorizationMechanism,
+        reason: input.reason,
+      });
+      if (!revokedUserId) return res.status(404).json({ error: 'aao_admin_membership_not_found', message: 'User does not have site-admin access' });
+      invalidateAllAdminStatusCaches();
+      return res.json({ success: true });
+    } catch (error) {
+      logger.error({ err: error, actorUserId: req.user?.id }, 'AAO site-admin revoke failed');
+      return res.status(500).json({ error: 'aao_admin_revoke_failed', message: 'Failed to revoke site-admin access' });
+    }
+  });
+
+  return router;
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -41,6 +41,7 @@ import { setupAddieCostRoutes } from "./admin/addie-costs.js";
 import { setupPromptMetricsRoutes } from "./admin/prompt-metrics.js";
 import { setupIntegrityRoutes } from "./admin/integrity.js";
 import { setupAdminAgentsRoutes } from "./admin/agents.js";
+import { createAAOAdminRouter } from "./aao-admin.js";
 import { getAllNewsletters } from "../newsletters/registry.js";
 import { createNewsletterAdminRoutes } from "../newsletters/admin-routes.js";
 // Ensure newsletters register themselves before routes mount
@@ -70,6 +71,10 @@ const workos = AUTH_ENABLED
 export function createAdminRouter(): { pageRouter: Router; apiRouter: Router } {
   const pageRouter = Router();
   const apiRouter = Router();
+
+  // Site-admin membership is a separate authority surface. Its router applies
+  // requireGlobalAdmin itself rather than inheriting broad admin middleware.
+  apiRouter.use('/aao-admin', createAAOAdminRouter());
 
   // =========================================================================
   // ADMIN PAGE ROUTES (mounted at /admin)

--- a/server/src/routes/committees.ts
+++ b/server/src/routes/committees.ts
@@ -509,6 +509,12 @@ export function createCommitteeRouters(): {
 
       // Check if we're adding/changing a Slack channel
       const existingGroup = await workingGroupDb.getWorkingGroupById(id);
+      if (existingGroup?.slug === 'aao-admin') {
+        return res.status(405).json({
+          error: 'aao_admin_dedicated_endpoint_required',
+          message: 'AAO site-admin group metadata is not managed through this endpoint',
+        });
+      }
 
       // Validate slug format and uniqueness if changing
       if (updates.slug) {
@@ -607,6 +613,10 @@ export function createCommitteeRouters(): {
       if (!isUuid(id)) {
         return res.status(400).json({ error: 'Invalid working group ID' });
       }
+      const group = await workingGroupDb.getWorkingGroupById(id);
+      if (group?.slug === 'aao-admin') {
+        return res.status(405).json({ error: 'aao_admin_dedicated_endpoint_required', message: 'AAO site-admin group cannot be deactivated' });
+      }
       const deactivated = await workingGroupDb.deactivateWorkingGroup(id);
 
       if (!deactivated) {
@@ -632,6 +642,10 @@ export function createCommitteeRouters(): {
       const { id } = req.params;
       if (!isUuid(id)) {
         return res.status(400).json({ error: 'Invalid working group ID' });
+      }
+      const group = await workingGroupDb.getWorkingGroupById(id);
+      if (group?.slug === 'aao-admin') {
+        return res.status(405).json({ error: 'aao_admin_dedicated_endpoint_required', message: 'AAO site-admin group cannot be reactivated' });
       }
       const reactivated = await workingGroupDb.reactivateWorkingGroup(id);
 
@@ -673,6 +687,17 @@ export function createCommitteeRouters(): {
       const { workos_user_id, user_email, user_name, user_org_name, workos_organization_id } = req.body;
       const user = req.user!;
 
+      // The security-sensitive site-admin group may only be changed through
+      // its slug-pinned, reason-required endpoint. Do not let this generic
+      // route turn a client-supplied ID into platform authority.
+      const group = await workingGroupDb.getWorkingGroupById(id);
+      if (group?.slug === 'aao-admin') {
+        return res.status(405).json({
+          error: 'aao_admin_dedicated_endpoint_required',
+          message: 'Use the dedicated AAO site-admin grant endpoint',
+        });
+      }
+
       if (!workos_user_id) {
         return res.status(400).json({
           error: 'Missing required field',
@@ -694,7 +719,6 @@ export function createCommitteeRouters(): {
       invalidateWebAdminStatusCache(workos_user_id);
 
       // Auto-invite new member to the group's Slack channel (fire-and-forget)
-      const group = await workingGroupDb.getWorkingGroupById(id);
       if (group?.slack_channel_id) {
         const slackDb = new SlackDatabase();
         slackDb.getByWorkosUserId(workos_user_id).then(mapping => {
@@ -719,6 +743,13 @@ export function createCommitteeRouters(): {
   adminApiRouter.delete('/:id/members/:userId', async (req: Request, res: Response) => {
     try {
       const { id, userId } = req.params;
+      const group = await workingGroupDb.getWorkingGroupById(id);
+      if (group?.slug === 'aao-admin') {
+        return res.status(405).json({
+          error: 'aao_admin_dedicated_endpoint_required',
+          message: 'Use the dedicated AAO site-admin revoke endpoint',
+        });
+      }
       const deleted = await workingGroupDb.deleteMembership(id, userId);
 
       if (!deleted) {
@@ -1348,6 +1379,10 @@ export function createCommitteeRouters(): {
           error: 'Working group not found',
           message: `No working group found with slug: ${slug}`,
         });
+      }
+
+      if (group.slug === 'aao-admin') {
+        return res.status(403).json({ error: 'aao_admin_dedicated_endpoint_required', message: 'AAO site-admin access cannot be self-revoked here' });
       }
 
       const isLeader = group.leaders?.some(l => l.canonical_user_id === user.id) ?? false;

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -40,7 +40,8 @@ import { WorkingGroupDatabase } from "../db/working-group-db.js";
 import { createChannel, setChannelPurpose, sendDirectMessage } from "../slack/client.js";
 import { SlackDatabase } from "../db/slack-db.js";
 import { EmailPreferencesDatabase } from "../db/email-preferences-db.js";
-import { isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
+import { isWebUserAAOAdmin } from "../addie/admin-status-lookup.js";
+import { isBreakGlassAdminEmail } from "../auth/admin-access.js";
 import { getWorkos } from "../auth/workos-client.js";
 import { resolveUserOrgMembership } from "../utils/resolve-user-org-membership.js";
 
@@ -1740,9 +1741,8 @@ export function createEventsRouter(): {
       let isDraftPreview = false;
       if (!["published", "completed"].includes(event.status)) {
         const user = req.user;
-        const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
         const isAdmin = !!user && (
-          adminEmails.includes(user.email.toLowerCase()) ||
+          isBreakGlassAdminEmail(user.email) ||
           await isWebUserAAOAdmin(user.id)
         );
         if (!isAdmin) {

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -189,6 +189,7 @@ import { getRequestLog, getRequestCount, logOutboundRequest } from "../db/outbou
 import { enrichUserWithMembership } from "../utils/html-config.js";
 import { classifyProbeError } from "../utils/probe-error.js";
 import { isWebUserAAOAdmin } from "../addie/admin-status-lookup.js";
+import { isBreakGlassAdminEmail } from "../auth/admin-access.js";
 import { getDevUser, isDevModeEnabled } from "../middleware/auth.js";
 import { OrganizationDatabase, hasApiAccess, resolveMembershipTier } from "../db/organization-db.js";
 import { resolveCallerOrgId } from "./helpers/resolve-caller-org.js";
@@ -7305,8 +7306,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
     const devUser = isDevModeEnabled() ? getDevUser(req) : null;
     if (devUser?.isAdmin === true) return true;
 
-    const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) ?? [];
-    if (user.email && adminEmails.includes(user.email.toLowerCase())) return true;
+    if (isBreakGlassAdminEmail(user.email)) return true;
     if (!user.id) return false;
     return isWebUserAAOAdmin(user.id);
   }

--- a/server/src/services/working-group-membership-service.ts
+++ b/server/src/services/working-group-membership-service.ts
@@ -170,6 +170,13 @@ export async function joinWorkingGroup({ user, slug }: JoinWorkingGroupInput): P
     throw new WorkingGroupMembershipError('group_not_found', `No working group found with slug: ${slug}`, { slug });
   }
 
+  if (group.slug === 'aao-admin') {
+    throw new WorkingGroupMembershipError('group_private', 'This working group is private and requires an invitation', {
+      slug: group.slug,
+      groupName: group.name,
+    });
+  }
+
   if (group.is_private) {
     throw new WorkingGroupMembershipError('group_private', 'This working group is private and requires an invitation', {
       slug: group.slug,

--- a/server/src/slack/events.ts
+++ b/server/src/slack/events.ts
@@ -363,6 +363,17 @@ async function autoAddToWorkingGroup(
       return;
     }
 
+    // A Slack invite or channel join must never become an alternate grant
+    // mechanism for platform administration. Site-admin membership is only
+    // mutable through the globally authorized, reasoned, audited endpoint.
+    if (workingGroup.slug === 'aao-admin') {
+      logger.warn(
+        { workingGroupId: workingGroup.id, channelId, userId: workosUserId },
+        'Refused Slack channel join auto-add for AAO site-admin group',
+      );
+      return;
+    }
+
     // Skip auto-add for private committees unless the Slack channel is also private
     // (private Slack channels already enforce access control)
     if (workingGroup.is_private && !isPrivateSlackChannel) {

--- a/server/src/slack/sync.ts
+++ b/server/src/slack/sync.ts
@@ -212,6 +212,19 @@ export async function syncWorkingGroupMembersFromSlack(
     };
   }
 
+  if (workingGroup.slug === 'aao-admin') {
+    return {
+      working_group_id: workingGroupId,
+      working_group_name: workingGroup.name,
+      slack_channel_id: workingGroup.slack_channel_id || '',
+      total_channel_members: 0,
+      members_added: 0,
+      members_already_in_group: 0,
+      unmapped_slack_users: 0,
+      errors: ['AAO site-admin membership must use the dedicated audited grant endpoint'],
+    };
+  }
+
   if (!workingGroup.slack_channel_id) {
     return {
       working_group_id: workingGroupId,
@@ -410,6 +423,11 @@ export async function syncUserToChaptersFromSlackChannels(
     // since a public channel shouldn't grant access to a private committee
     for (const group of workingGroups) {
       if (!group.slack_channel_id) continue;
+
+      // The fixed platform-admin group must never be populated by Slack
+      // discovery, even if a future configuration accidentally makes it
+      // public. Its dedicated audited grant route is the only authority path.
+      if (group.slug === 'aao-admin') continue;
 
       // Skip private committees (we only have public channel data from getUserChannels)
       if (group.is_private) continue;

--- a/server/src/utils/html-config.ts
+++ b/server/src/utils/html-config.ts
@@ -14,7 +14,10 @@ import { fileURLToPath } from "url";
 import { resolveEffectiveMembership } from "../db/org-filters.js";
 import { resolvePrimaryOrganization } from "../db/users-db.js";
 import { createLogger } from "../logger.js";
-import { isWebUserAAOAdmin } from "../addie/mcp/admin-tools.js";
+import {
+  resolveWebUserAAOAdminAccess,
+} from "../addie/admin-status-lookup.js";
+import { isBreakGlassAdminEmail } from "../auth/admin-access.js";
 
 const logger = createLogger('html-config');
 
@@ -58,8 +61,7 @@ export function buildAppConfig(user?: AppUser | null): {
     if (typeof user.isAdmin === 'boolean') {
       isAdmin = user.isAdmin;
     } else {
-      const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-      isAdmin = adminEmails.includes(user.email.toLowerCase());
+      isAdmin = isBreakGlassAdminEmail(user.email);
     }
   }
 
@@ -164,22 +166,17 @@ export function getPublicFilePath(filename: string): string {
 
 /**
  * Resolve the admin flag for a user using the same rules as the requireAdmin
- * middleware: ADMIN_EMAILS env var OR membership in the aao-admin working
- * group. If the user already has isAdmin set (e.g. a dev user), trust it.
+ * middleware: site-admin working-group membership, with `ADMIN_EMAILS` as an
+ * environment-managed break-glass fallback. If the user already has isAdmin
+ * set (e.g. a dev user), trust it.
  */
 export async function enrichUserWithAdmin(user: AppUser | null | undefined): Promise<AppUser | null | undefined> {
   if (!user) return user;
   if (typeof user.isAdmin === 'boolean') return user;
 
-  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map(e => e.trim().toLowerCase()) || [];
-  if (adminEmails.includes(user.email.toLowerCase())) {
-    user.isAdmin = true;
-    return user;
-  }
-
   if (user.id) {
     try {
-      user.isAdmin = await isWebUserAAOAdmin(user.id);
+      user.isAdmin = (await resolveWebUserAAOAdminAccess(user.id, user.email)).isAdmin;
     } catch (error) {
       logger.warn({ error, userId: user.id }, 'Failed to resolve isAdmin via working group; defaulting to false');
       user.isAdmin = false;

--- a/server/tests/integration/events-draft-preview.test.ts
+++ b/server/tests/integration/events-draft-preview.test.ts
@@ -59,13 +59,11 @@ vi.mock('../../src/middleware/csrf.js', () => ({
 }));
 
 const adminState = { isAdmin: false };
-vi.mock('../../src/addie/mcp/admin-tools.js', async (importOriginal) => {
-  const actual = await importOriginal() as Record<string, unknown>;
-  return {
-    ...actual,
-    isWebUserAAOAdmin: vi.fn(async () => adminState.isAdmin),
-  };
-});
+// Draft preview authorization reads the thin membership-status seam directly.
+// Mock it before HTTPServer is imported so the module graph sees test state.
+vi.mock('../../src/addie/admin-status-lookup.js', () => ({
+  isWebUserAAOAdmin: vi.fn(async () => adminState.isAdmin),
+}));
 
 vi.mock('../../src/billing/stripe-client.js', () => ({
   stripe: null,

--- a/server/tests/unit/aao-admin-membership-audit.test.ts
+++ b/server/tests/unit/aao-admin-membership-audit.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clientQuery: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: vi.fn(),
+  getPool: () => ({
+    connect: vi.fn().mockResolvedValue({ query: mocks.clientQuery, release: mocks.release }),
+  }),
+}));
+
+vi.mock('../../src/addie/services/journey-computation.js', () => ({
+  computeJourneyStage: vi.fn(),
+}));
+
+import { WorkingGroupDatabase } from '../../src/db/working-group-db.js';
+
+function queryResult(rows: unknown[] = [], rowCount = rows.length) {
+  return { rows, rowCount };
+}
+
+describe('AAO site-admin membership audit transaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return Promise.resolve(queryResult());
+      if (sql.includes('SELECT id FROM working_groups')) return Promise.resolve(queryResult([{ id: 'wg_aao_admin' }]));
+      if (sql.includes('FROM slack_user_mappings')) return Promise.resolve(queryResult([{ workos_user_id: 'user_canonical' }]));
+      if (sql.includes('INSERT INTO working_group_memberships')) {
+        return Promise.resolve(queryResult([{ workos_user_id: 'user_canonical', working_group_id: 'wg_aao_admin' }]));
+      }
+      if (sql.includes('DELETE FROM working_group_memberships')) return Promise.resolve(queryResult([{ workos_user_id: 'user_canonical' }]));
+      if (sql.includes('INSERT INTO aao_admin_access_events')) return Promise.resolve(queryResult());
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+  });
+
+  it('commits the membership grant and immutable audit event together', async () => {
+    const membership = await new WorkingGroupDatabase().grantAAOAdminMembership({
+      targetUserId: 'slack_alias',
+      actorUserId: 'admin_1',
+      actorAuthorizationMechanism: 'break_glass_admin_email',
+      reason: 'Temporary incident coverage',
+    });
+
+    expect(membership.workos_user_id).toBe('user_canonical');
+    const auditCall = mocks.clientQuery.mock.calls.find(([sql]) => sql.includes('INSERT INTO aao_admin_access_events'));
+    expect(auditCall?.[1]).toEqual([
+      'admin_1',
+      'user_canonical',
+      'break_glass_admin_email',
+      'Temporary incident coverage',
+    ]);
+    expect(mocks.clientQuery.mock.calls.map(([sql]) => sql)).toContain('COMMIT');
+    expect(mocks.release).toHaveBeenCalledOnce();
+  });
+
+  it('records the revocation in the same transaction as the active-membership delete', async () => {
+    const revokedUserId = await new WorkingGroupDatabase().revokeAAOAdminMembership({
+      targetUserId: 'slack_alias',
+      actorUserId: 'admin_1',
+      actorAuthorizationMechanism: 'aao_admin_working_group',
+      reason: 'Offboarding',
+    });
+
+    expect(revokedUserId).toBe('user_canonical');
+    const calls = mocks.clientQuery.mock.calls.map(([sql]) => sql as string);
+    expect(calls.findIndex((sql) => sql.includes('DELETE FROM working_group_memberships')))
+      .toBeLessThan(calls.findIndex((sql) => sql.includes('INSERT INTO aao_admin_access_events')));
+    expect(calls[calls.length - 1]).toBe('COMMIT');
+  });
+
+  it('rolls the membership write back when the audit insert fails', async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes('INSERT INTO aao_admin_access_events')) return Promise.reject(new Error('audit storage unavailable'));
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') return Promise.resolve(queryResult());
+      if (sql.includes('SELECT id FROM working_groups')) return Promise.resolve(queryResult([{ id: 'wg_aao_admin' }]));
+      if (sql.includes('FROM slack_user_mappings')) return Promise.resolve(queryResult());
+      if (sql.includes('INSERT INTO working_group_memberships')) return Promise.resolve(queryResult([{ workos_user_id: 'user_target' }]));
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+
+    await expect(new WorkingGroupDatabase().grantAAOAdminMembership({
+      targetUserId: 'user_target',
+      actorUserId: 'admin_1',
+      actorAuthorizationMechanism: 'aao_admin_working_group',
+      reason: 'Coverage rotation',
+    })).rejects.toThrow('audit storage unavailable');
+
+    expect(mocks.clientQuery.mock.calls.map(([sql]) => sql)).toContain('ROLLBACK');
+    expect(mocks.clientQuery.mock.calls.map(([sql]) => sql)).not.toContain('COMMIT');
+  });
+
+  it('rolls an active-membership delete back when its revoke audit insert fails', async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes('INSERT INTO aao_admin_access_events')) return Promise.reject(new Error('audit storage unavailable'));
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') return Promise.resolve(queryResult());
+      if (sql.includes('SELECT id FROM working_groups')) return Promise.resolve(queryResult([{ id: 'wg_aao_admin' }]));
+      if (sql.includes('FROM slack_user_mappings')) return Promise.resolve(queryResult());
+      if (sql.includes('DELETE FROM working_group_memberships')) return Promise.resolve(queryResult([{ workos_user_id: 'user_target' }]));
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+
+    await expect(new WorkingGroupDatabase().revokeAAOAdminMembership({
+      targetUserId: 'user_target',
+      actorUserId: 'admin_1',
+      actorAuthorizationMechanism: 'aao_admin_working_group',
+      reason: 'Offboarding',
+    })).rejects.toThrow('audit storage unavailable');
+
+    const calls = mocks.clientQuery.mock.calls.map(([sql]) => sql as string);
+    expect(calls).toContain('ROLLBACK');
+    expect(calls).not.toContain('COMMIT');
+  });
+});

--- a/server/tests/unit/aao-admin-protected-group-db.test.ts
+++ b/server/tests/unit/aao-admin-protected-group-db.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ query: vi.fn() }));
+
+vi.mock('../../src/db/client.js', () => ({
+  query: mocks.query,
+  getPool: vi.fn(),
+}));
+vi.mock('../../src/addie/services/journey-computation.js', () => ({
+  computeJourneyStage: vi.fn(),
+}));
+
+import { WorkingGroupDatabase } from '../../src/db/working-group-db.js';
+
+describe('protected AAO site-admin generic database mutation boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.query.mockResolvedValue({ rows: [{ slug: 'aao-admin' }], rowCount: 1 });
+  });
+
+  it('rejects a generic rename of the protected group before its UPDATE', async () => {
+    await expect(new WorkingGroupDatabase().updateWorkingGroup('wg_aao_admin', {
+      name: 'Renamed authority group',
+      slug: 'renamed-authority-group',
+    })).rejects.toThrow('dedicated audited workflow');
+
+    expect(mocks.query).toHaveBeenCalledWith(
+      'SELECT slug FROM working_groups WHERE id = $1',
+      ['wg_aao_admin'],
+    );
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes('UPDATE working_groups'))).toBe(false);
+  });
+
+  it('rejects assigning the reserved slug to an ordinary group before lookup or UPDATE', async () => {
+    await expect(new WorkingGroupDatabase().updateWorkingGroup('wg_ordinary', {
+      slug: 'aao-admin',
+    })).rejects.toThrow('reserved');
+
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects generic membership and leader mutations by the protected group ID', async () => {
+    const db = new WorkingGroupDatabase();
+
+    await expect(db.addMembership({
+      working_group_id: 'wg_aao_admin',
+      workos_user_id: 'user_target',
+    })).rejects.toThrow('dedicated audited workflow');
+    await expect(db.setLeaders('wg_aao_admin', ['user_target']))
+      .rejects.toThrow('dedicated audited workflow');
+    await expect(db.deactivateWorkingGroup('wg_aao_admin'))
+      .rejects.toThrow('dedicated audited workflow');
+
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes('working_group_memberships'))).toBe(false);
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes('working_group_leaders'))).toBe(false);
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes("SET status = 'inactive'"))).toBe(false);
+  });
+});

--- a/server/tests/unit/aao-admin-routes.test.ts
+++ b/server/tests/unit/aao-admin-routes.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  grant: vi.fn(),
+  revoke: vi.fn(),
+  invalidate: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireGlobalAdmin: [
+    (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      req.user = { id: 'admin_1', email: 'admin@example.test' } as never;
+      if (req.get('X-Test-Omit-Admin-Mechanism') !== 'true') {
+        req.adminAccessMechanism = 'break_glass_admin_email';
+      }
+      next();
+    },
+  ],
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class WorkingGroupDatabase {
+    grantAAOAdminMembership = mocks.grant;
+    revokeAAOAdminMembership = mocks.revoke;
+  },
+}));
+
+vi.mock('../../src/addie/admin-status-cache.js', () => ({
+  invalidateAllAdminStatusCaches: mocks.invalidate,
+}));
+
+import { createAAOAdminRouter } from '../../src/routes/aao-admin.js';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/aao-admin', createAAOAdminRouter());
+  return app;
+}
+
+describe('AAO site-admin mutation routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.grant.mockResolvedValue({ workos_user_id: 'user_target' });
+    mocks.revoke.mockResolvedValue('user_target');
+  });
+
+  it('rejects a blank reason before it attempts a grant', async () => {
+    const response = await request(createApp())
+      .post('/api/admin/aao-admin/grant')
+      .send({ workos_user_id: 'user_target', reason: '   ' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('reason_required');
+    expect(mocks.grant).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when middleware does not provide an audit authorization mechanism', async () => {
+    const response = await request(createApp())
+      .post('/api/admin/aao-admin/grant')
+      .set('X-Test-Omit-Admin-Mechanism', 'true')
+      .send({ workos_user_id: 'user_target', reason: 'Coverage rotation' });
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe('admin_authorization_unavailable');
+    expect(mocks.grant).not.toHaveBeenCalled();
+  });
+
+  it('grants through the dedicated slug-pinned database operation and clears the local cache', async () => {
+    const response = await request(createApp())
+      .post('/api/admin/aao-admin/grant')
+      .send({ workos_user_id: ' user_target ', reason: 'Coverage rotation' , working_group_id: 'attacker-controlled' });
+
+    expect(response.status).toBe(201);
+    expect(mocks.grant).toHaveBeenCalledWith({
+      targetUserId: 'user_target',
+      actorUserId: 'admin_1',
+      actorAuthorizationMechanism: 'break_glass_admin_email',
+      reason: 'Coverage rotation',
+    });
+    expect(mocks.invalidate).toHaveBeenCalledOnce();
+  });
+
+  it('records a revoke through the dedicated operation and invalidates its canonical target', async () => {
+    const response = await request(createApp())
+      .post('/api/admin/aao-admin/revoke')
+      .send({ workos_user_id: 'slack_alias', reason: 'Offboarding' });
+
+    expect(response.status).toBe(200);
+    expect(mocks.revoke).toHaveBeenCalledWith(expect.objectContaining({
+      targetUserId: 'slack_alias',
+      reason: 'Offboarding',
+    }));
+    expect(mocks.invalidate).toHaveBeenCalledOnce();
+  });
+
+  it('does not clear a cache entry when no active membership was revoked', async () => {
+    mocks.revoke.mockResolvedValue(null);
+    const response = await request(createApp())
+      .post('/api/admin/aao-admin/revoke')
+      .send({ workos_user_id: 'user_target', reason: 'Offboarding' });
+
+    expect(response.status).toBe(404);
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/aao-admin-status.test.ts
+++ b/server/tests/unit/aao-admin-status.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getWorkingGroupBySlug: vi.fn(),
+  isMember: vi.fn(),
+}));
+
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class WorkingGroupDatabase {
+    getWorkingGroupBySlug = mocks.getWorkingGroupBySlug;
+    isMember = mocks.isMember;
+  },
+}));
+
+import {
+  AAO_ADMIN_POSITIVE_CACHE_TTL_MS,
+  isWebUserAAOAdmin,
+  resolveWebUserAAOAdminAccess,
+} from '../../src/addie/admin-status-lookup.js';
+import { isBreakGlassAdminEmail } from '../../src/auth/admin-access.js';
+import {
+  getSlackAdminStatusCache,
+  getWebAdminStatusCache,
+  invalidateAllAdminStatusCaches,
+  invalidateWebAdminStatusCache,
+} from '../../src/addie/admin-status-cache.js';
+
+describe('site-admin access decisions', () => {
+  const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    vi.clearAllMocks();
+    invalidateAllAdminStatusCaches();
+    process.env.ADMIN_EMAILS = ' break-glass@example.test , other@example.test ';
+    mocks.getWorkingGroupBySlug.mockResolvedValue({ id: 'wg_aao_admin' });
+    mocks.isMember.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    invalidateAllAdminStatusCaches();
+    if (originalAdminEmails === undefined) delete process.env.ADMIN_EMAILS;
+    else process.env.ADMIN_EMAILS = originalAdminEmails;
+  });
+
+  it('bounds cached positive membership decisions to one minute', async () => {
+    await expect(isWebUserAAOAdmin('user_admin')).resolves.toBe(true);
+    const cached = getWebAdminStatusCache().get('user_admin');
+
+    expect(cached?.expiresAt).toBe(Date.now() + AAO_ADMIN_POSITIVE_CACHE_TTL_MS);
+    vi.advanceTimersByTime(AAO_ADMIN_POSITIVE_CACHE_TTL_MS + 1);
+    await isWebUserAAOAdmin('user_admin');
+    expect(mocks.isMember).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the current process cache immediately', async () => {
+    await isWebUserAAOAdmin('user_admin');
+    invalidateWebAdminStatusCache('user_admin');
+    mocks.isMember.mockResolvedValue(false);
+
+    await expect(isWebUserAAOAdmin('user_admin')).resolves.toBe(false);
+    expect(mocks.isMember).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears both web and Slack process-local admin cache forms', () => {
+    getWebAdminStatusCache().set('user_admin', { isAdmin: true, expiresAt: Date.now() + 60_000 });
+    getSlackAdminStatusCache().set('slack_admin', { isAdmin: true, expiresAt: Date.now() + 60_000 });
+
+    invalidateAllAdminStatusCaches();
+
+    expect(getWebAdminStatusCache().size).toBe(0);
+    expect(getSlackAdminStatusCache().size).toBe(0);
+  });
+
+  it('identifies the environment-only break-glass mechanism separately', async () => {
+    mocks.isMember.mockResolvedValue(false);
+    expect(isBreakGlassAdminEmail('BREAK-GLASS@example.test')).toBe(true);
+    await expect(resolveWebUserAAOAdminAccess('user_no_membership', 'break-glass@example.test'))
+      .resolves.toEqual({ isAdmin: true, mechanism: 'break_glass_admin_email' });
+  });
+});

--- a/server/tests/unit/aao-admin-ui.test.ts
+++ b/server/tests/unit/aao-admin-ui.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const peopleUi = readFileSync(resolve(process.cwd(), 'server/public/admin-people.html'), 'utf8');
+const workingGroupsUi = readFileSync(resolve(process.cwd(), 'server/public/admin-working-groups.html'), 'utf8');
+
+describe('site-admin membership UI affordance', () => {
+  it('reuses the working-group membership view with target and group context', () => {
+    expect(peopleUi).toContain('AAO site-admin access');
+    expect(peopleUi).toContain('group=aao-admin&user=');
+    expect(peopleUi).toContain('WorkOS organization roles never grant AgenticAdvertising.org platform administration.');
+    expect(workingGroupsUi).toContain('function applyMembershipDeepLink()');
+    expect(workingGroupsUi).toContain("params.get('tab') !== 'members'");
+    expect(workingGroupsUi).toContain('m.workos_user_id');
+    expect(workingGroupsUi).toContain('/api/admin/aao-admin/grant');
+    expect(workingGroupsUi).toContain('/api/admin/aao-admin/revoke');
+    expect(workingGroupsUi).toContain('reason.trim()');
+  });
+});

--- a/server/tests/unit/aao-slack-events.test.ts
+++ b/server/tests/unit/aao-slack-events.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getBySlackUserId: vi.fn(),
   recordActivity: vi.fn(),
+  getWorkingGroupBySlackChannelId: vi.fn(),
+  addMembershipWithInterest: vi.fn(),
 }));
 
 vi.mock('../../src/logger.js', () => ({ logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
@@ -13,7 +15,13 @@ vi.mock('../../src/db/slack-db.js', () => ({
   },
 }));
 vi.mock('../../src/db/addie-db.js', () => ({ AddieDatabase: class {} }));
-vi.mock('../../src/db/working-group-db.js', () => ({ WorkingGroupDatabase: class {} }));
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    getWorkingGroupBySlackChannelId = (...args: unknown[]) => mocks.getWorkingGroupBySlackChannelId(...args);
+    addMembershipWithInterest = (...args: unknown[]) => mocks.addMembershipWithInterest(...args);
+    isMember = vi.fn();
+  },
+}));
 vi.mock('../../src/db/client.js', () => ({ getPool: vi.fn() }));
 vi.mock('../../src/slack/client.js', () => ({ getSlackUser: vi.fn(), getChannelInfo: vi.fn() }));
 vi.mock('../../src/slack/sync.js', () => ({ syncUserToChaptersFromSlackChannels: vi.fn() }));
@@ -27,13 +35,14 @@ vi.mock('../../src/services/prospect-triage.js', () => ({ triageAndCreateProspec
 vi.mock('../../src/notifications/welcome-social-posts.js', () => ({ sendWelcomeSocialPosts: vi.fn() }));
 vi.mock('../../src/notifications/marketing-optin-dm.js', () => ({ sendMarketingOptInDM: vi.fn() }));
 
-import { handleMessage } from '../../src/slack/events.js';
+import { handleMemberJoinedChannel, handleMessage } from '../../src/slack/events.js';
 
 describe('AAO Slack message activity', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getBySlackUserId.mockResolvedValue(null);
     mocks.recordActivity.mockResolvedValue(undefined);
+    mocks.getWorkingGroupBySlackChannelId.mockResolvedValue(null);
   });
 
   it('continues recording direct-message activity without dispatching Addie', async () => {
@@ -52,5 +61,28 @@ describe('AAO Slack message activity', () => {
       channel_id: 'D_MEMBER',
       metadata: expect.objectContaining({ channel_type: 'im', message_length: 5 }),
     }));
+  });
+
+  it('does not grant AAO site-admin membership from a Slack channel join', async () => {
+    mocks.getBySlackUserId.mockResolvedValue({
+      workos_user_id: 'user_target',
+      slack_email: 'target@example.test',
+    });
+    mocks.getWorkingGroupBySlackChannelId.mockResolvedValue({
+      id: 'wg_aao_admin',
+      slug: 'aao-admin',
+      name: 'AAO Admin',
+      is_private: true,
+    });
+
+    await handleMemberJoinedChannel({
+      type: 'member_joined_channel',
+      user: 'U_TARGET',
+      channel: 'G_AAO_ADMIN',
+      channel_type: 'G',
+      team: 'T_AAO',
+    });
+
+    expect(mocks.addMembershipWithInterest).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/aao-slack-sync.test.ts
+++ b/server/tests/unit/aao-slack-sync.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getUserChannels: vi.fn(),
+  isSlackConfigured: vi.fn(),
+  getBySlackUserId: vi.fn(),
+  listWorkingGroupsWithSlackChannel: vi.fn(),
+  isMember: vi.fn(),
+  addMembershipWithInterest: vi.fn(),
+}));
+
+vi.mock('../../src/logger.js', () => ({ logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock('../../src/slack/client.js', () => ({
+  getSlackUsers: vi.fn(),
+  getChannelMembers: vi.fn(),
+  getUserChannels: mocks.getUserChannels,
+  isSlackConfigured: mocks.isSlackConfigured,
+}));
+vi.mock('../../src/db/slack-db.js', () => ({
+  SlackDatabase: class {
+    getBySlackUserId = mocks.getBySlackUserId;
+    markSlackUserDeleted = vi.fn();
+  },
+}));
+vi.mock('../../src/db/working-group-db.js', () => ({
+  WorkingGroupDatabase: class {
+    listWorkingGroupsWithSlackChannel = mocks.listWorkingGroupsWithSlackChannel;
+    isMember = mocks.isMember;
+    addMembershipWithInterest = mocks.addMembershipWithInterest;
+  },
+}));
+vi.mock('../../src/cache/unified-users.js', () => ({ invalidateUnifiedUsersCache: vi.fn() }));
+vi.mock('../../src/addie/index.js', () => ({ invalidateMemberContextCache: vi.fn() }));
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({ invalidateAdminStatusCache: vi.fn(), invalidateWebAdminStatusCache: vi.fn() }));
+vi.mock('../../src/db/client.js', () => ({ getPool: vi.fn() }));
+vi.mock('../../src/auth/workos-client.js', () => ({ getWorkos: vi.fn() }));
+vi.mock('../../src/utils/email-domain.js', () => ({ isFreeEmailDomain: vi.fn() }));
+
+import { syncUserToChaptersFromSlackChannels } from '../../src/slack/sync.js';
+
+describe('AAO site-admin Slack channel synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isSlackConfigured.mockReturnValue(true);
+    mocks.getUserChannels.mockResolvedValue(['C_AAO_ADMIN']);
+    mocks.getBySlackUserId.mockResolvedValue({ slack_email: 'target@example.test' });
+    mocks.listWorkingGroupsWithSlackChannel.mockResolvedValue([{
+      id: 'wg_aao_admin',
+      slug: 'aao-admin',
+      name: 'AAO Admin',
+      slack_channel_id: 'C_AAO_ADMIN',
+      // Deliberately false: the slug guard must not depend on private config.
+      is_private: false,
+      committee_type: 'working_group',
+    }]);
+  });
+
+  it('does not grant AAO site-admin membership during channel discovery', async () => {
+    const result = await syncUserToChaptersFromSlackChannels('user_target', 'U_TARGET');
+
+    expect(result.chapters_joined).toBe(0);
+    expect(mocks.isMember).not.toHaveBeenCalled();
+    expect(mocks.addMembershipWithInterest).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/working-group-admin-global-auth.test.ts
+++ b/server/tests/unit/working-group-admin-global-auth.test.ts
@@ -13,9 +13,13 @@ const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
   listWorkingGroups: vi.fn(),
   addMembership: vi.fn(),
+  grantAAOAdminMembership: vi.fn(),
+  revokeAAOAdminMembership: vi.fn(),
   getWorkingGroupById: vi.fn(),
   getWorkingGroupBySlug: vi.fn(),
   isMember: vi.fn(),
+  updateWorkingGroup: vi.fn(),
+  removeMembership: vi.fn(),
   invalidateMemberContextCache: vi.fn(),
   invalidateWebAdminStatusCache: vi.fn(),
 }));
@@ -72,23 +76,31 @@ vi.mock('../../src/db/working-group-db.js', () => ({
   WorkingGroupDatabase: class WorkingGroupDatabase {
     listWorkingGroups = mocks.listWorkingGroups;
     addMembership = mocks.addMembership;
+    grantAAOAdminMembership = mocks.grantAAOAdminMembership;
+    revokeAAOAdminMembership = mocks.revokeAAOAdminMembership;
     getWorkingGroupById = mocks.getWorkingGroupById;
     getWorkingGroupBySlug = mocks.getWorkingGroupBySlug;
     isMember = mocks.isMember;
+    updateWorkingGroup = mocks.updateWorkingGroup;
+    removeMembership = mocks.removeMembership;
   },
 }));
 
 const { createCommitteeRouters } = await import('../../src/routes/committees.js');
+const { createAAOAdminRouter } = await import('../../src/routes/aao-admin.js');
 const { stopAuthTimers } = await import('../../src/middleware/auth.js');
 const { csrfProtection } = await import('../../src/middleware/csrf.js');
+const { invalidateWebAdminStatusCache: clearWebAdminStatusCache } = await import('../../src/addie/admin-status-cache.js');
 
 function createApp() {
   const app = express();
   app.use(cookieParser());
   app.use(csrfProtection);
   app.use(express.json());
-  const { adminApiRouter } = createCommitteeRouters();
+  const { adminApiRouter, publicApiRouter } = createCommitteeRouters();
   app.use('/api/admin/working-groups', adminApiRouter);
+  app.use('/api/admin/aao-admin', createAAOAdminRouter());
+  app.use('/api/working-groups', publicApiRouter);
   return app;
 }
 
@@ -108,6 +120,7 @@ describe('working-group real global-admin boundary', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearWebAdminStatusCache();
     mocks.createValidation.mockImplementation(
       ({ value }: { value: string }) => Promise.resolve(
         validatedTenantKey(value.includes('read') ? 'admin:read' : 'admin:*'),
@@ -152,6 +165,8 @@ describe('working-group real global-admin boundary', () => {
       workos_user_id: 'user_new_member',
     });
     mocks.getWorkingGroupById.mockResolvedValue(null);
+    mocks.grantAAOAdminMembership.mockResolvedValue({ workos_user_id: 'user_new_member' });
+    mocks.revokeAAOAdminMembership.mockResolvedValue('user_new_member');
   });
 
   it.each(['admin:*', 'admin:read'] as const)(
@@ -164,6 +179,34 @@ describe('working-group real global-admin boundary', () => {
       expect(response.status).toBe(403);
       expect(response.body.error).toBe('global_admin_required');
       expect(mocks.listWorkingGroups).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before a dedicated site-admin revoke',
+    async (permission) => {
+      const response = await request(app)
+        .post('/api/admin/aao-admin/revoke')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`)
+        .send({ workos_user_id: 'user_new_member', reason: 'Offboarding' });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.revokeAAOAdminMembership).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['admin:*', 'admin:read'] as const)(
+    'refuses a tenant key with %s before a dedicated site-admin grant',
+    async (permission) => {
+      const response = await request(app)
+        .post('/api/admin/aao-admin/grant')
+        .set('Authorization', `Bearer sk_tenant_${permission === 'admin:read' ? 'read' : 'full'}`)
+        .send({ workos_user_id: 'user_new_member', reason: 'Coverage rotation' });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('global_admin_required');
+      expect(mocks.grantAAOAdminMembership).not.toHaveBeenCalled();
     },
   );
 
@@ -196,20 +239,52 @@ describe('working-group real global-admin boundary', () => {
     expect(mocks.listWorkingGroups).toHaveBeenCalledOnce();
   });
 
-  it('allows a static global admin key to add a member to aao-admin', async () => {
+  it('refuses generic membership writes to aao-admin even for a static global admin key', async () => {
+    mocks.getWorkingGroupById.mockResolvedValueOnce({ id: 'wg_aao_admin', slug: 'aao-admin' });
     const response = await request(app)
       .post('/api/admin/working-groups/wg_aao_admin/members')
       .set('Authorization', 'Bearer static-global-admin-key')
       .send({ workos_user_id: 'user_new_member' });
 
-    expect(response.status).toBe(201);
-    expect(mocks.addMembership).toHaveBeenCalledWith(
-      expect.objectContaining({
-        working_group_id: 'wg_aao_admin',
-        workos_user_id: 'user_new_member',
-        added_by_user_id: 'admin_api_key',
-      }),
-    );
+    expect(response.status).toBe(405);
+    expect(response.body.error).toBe('aao_admin_dedicated_endpoint_required');
+    expect(mocks.addMembership).not.toHaveBeenCalled();
+  });
+
+  it('refuses generic leader updates to aao-admin even for a static global admin key', async () => {
+    mocks.getWorkingGroupById.mockResolvedValueOnce({ id: 'wg_aao_admin', slug: 'aao-admin' });
+    const response = await request(app)
+      .put('/api/admin/working-groups/wg_aao_admin')
+      .set('Authorization', 'Bearer static-global-admin-key')
+      .send({ leader_user_ids: ['user_new_member'] });
+
+    expect(response.status).toBe(405);
+    expect(response.body.error).toBe('aao_admin_dedicated_endpoint_required');
+    expect(mocks.updateWorkingGroup).not.toHaveBeenCalled();
+  });
+
+  it('refuses an otherwise authenticated non-admin before a dedicated grant', async () => {
+    mocks.isMember.mockResolvedValue(false);
+    const csrfToken = 'a'.repeat(64);
+    const response = await request(app)
+      .post('/api/admin/aao-admin/grant')
+      .set('Cookie', [`wos-session=valid-sso-admin-session`, `csrf-token=${csrfToken}`])
+      .set('X-CSRF-Token', csrfToken)
+      .send({ workos_user_id: 'user_new_member', reason: 'Coverage rotation' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('Admin access required');
+    expect(mocks.grantAAOAdminMembership).not.toHaveBeenCalled();
+  });
+
+  it('refuses self-revocation through the public working-group leave route', async () => {
+    const response = await request(app)
+      .delete('/api/working-groups/aao-admin/leave')
+      .set('Authorization', 'Bearer static-global-admin-key');
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('aao_admin_dedicated_endpoint_required');
+    expect(mocks.removeMembership).not.toHaveBeenCalled();
   });
 
   it('rejects an SSO cookie write without a matching CSRF token', async () => {
@@ -228,5 +303,6 @@ describe('working-group real global-admin boundary', () => {
 });
 
 afterAll(() => {
+  clearWebAdminStatusCache();
   stopAuthTimers();
 });

--- a/tests/addie/admin-tools.test.ts
+++ b/tests/addie/admin-tools.test.ts
@@ -26,6 +26,8 @@ const {
   mockInvalidateMembershipCache,
   mockPickMembershipSubWithProductFetch,
   mockBuildSubscriptionUpdate,
+  mockGetWorkingGroupBySlug,
+  mockUpdateWorkingGroup,
 } = vi.hoisted(() => {
   const mockPoolQuery = vi.fn();
   const mockPoolConnect = vi.fn();
@@ -43,6 +45,8 @@ const {
   const mockInvalidateMembershipCache = vi.fn();
   const mockPickMembershipSubWithProductFetch = vi.fn();
   const mockBuildSubscriptionUpdate = vi.fn();
+  const mockGetWorkingGroupBySlug = vi.fn();
+  const mockUpdateWorkingGroup = vi.fn();
   return {
     mockPoolQuery,
     mockPoolConnect,
@@ -59,6 +63,8 @@ const {
     mockInvalidateMembershipCache,
     mockPickMembershipSubWithProductFetch,
     mockBuildSubscriptionUpdate,
+    mockGetWorkingGroupBySlug,
+    mockUpdateWorkingGroup,
   };
 });
 
@@ -100,7 +106,10 @@ vi.mock("../../server/src/db/slack-db.js", () => ({
 
 // ── working group db ──────────────────────────────────────────────────────────
 vi.mock("../../server/src/db/working-group-db.js", () => ({
-  WorkingGroupDatabase: class {},
+  WorkingGroupDatabase: class {
+    getWorkingGroupBySlug = mockGetWorkingGroupBySlug;
+    updateWorkingGroup = mockUpdateWorkingGroup;
+  },
 }));
 
 // ── member db ─────────────────────────────────────────────────────────────────
@@ -609,6 +618,30 @@ describe("ADMIN_TOOLS definitions", () => {
         expect(ADMIN_TOOLS.some((candidate) => candidate.name === legacyName)).toBe(false);
       }
     });
+  });
+});
+
+describe("protected working-group mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuses to rename the server-pinned AAO site-admin group", async () => {
+    mockGetWorkingGroupBySlug.mockResolvedValue({
+      id: "wg_aao_admin",
+      slug: "aao-admin",
+      name: "AAO Admin",
+      committee_type: "working_group",
+    });
+
+    const result = await createAdminToolHandlers(adminMemberContext)
+      .get("rename_working_group")!({
+        working_group_slug: "aao-admin",
+        new_name: "Renamed authority group",
+      });
+
+    expect(result).toContain("cannot be renamed");
+    expect(mockUpdateWorkingGroup).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #7249

## Summary

- Adds global-admin-only, slug-pinned AAO site-admin grant and revoke endpoints with nonblank reasons.
- Protects `aao-admin` at the database mutation seam: generic create/update/status, membership, interest-backed membership, and leader mutations reject the protected group ID or reserved slug. The dedicated audited grant/revoke transaction is the only bypass.
- Prevents all other web, Slack, and Addie paths from mutating `aao-admin`; Addie explicitly rejects rename, and all three Slack membership discovery/sync paths explicitly reject its slug. The existing People view links into the working-group membership view instead of creating a second editor.
- Centralizes `ADMIN_EMAILS` as environment-managed break-glass authority in `auth/admin-access`; lightweight consumers import it there, and audit attribution fails closed if middleware does not provide a mechanism.

## Migration and audit design

Migration `578_aao_admin_access_events.sql` creates append-only forensic events containing actor, target, site-admin mechanism, actor authorization mechanism, reason, and timestamp. Grant/revoke membership changes and their event insert occur in one transaction; a failed audit insert rolls back the membership mutation, and the audit table intentionally has no foreign keys so later account or membership removal cannot erase history.

## Cache semantics

Successful dedicated mutations clear both local web and Slack admin-status caches immediately. Positive `aao-admin` membership decisions are capped at 60 seconds on every replica; negative/error decisions remain fail-closed.

## Verification

- `env -u DEV_USER_EMAIL -u DEV_USER_ID ./node_modules/.bin/vitest run --config server/vitest.config.ts` covering the authority seam, dedicated routes, break-glass import consumers, and all Slack paths (47 passed)
- `env -u DEV_USER_EMAIL -u DEV_USER_ID ./node_modules/.bin/vitest run tests/addie/admin-tools.test.ts` (31 passed)
- Earlier focused authorization/audit/cache/UI/Slack set (29 passed)
- `env -u DEV_USER_EMAIL -u DEV_USER_ID npm run typecheck`; `npm run test:migrations`; `npm run test:addie-tools`; `node scripts/check-changeset-protocol-scope.cjs origin/main`
- Required code and security reviews; all findings addressed.
- Full server-unit run was started after the mock-import cleanup. It produced no completion summary before reproducing the known Vitest process leak; SIGQUIT was sent once (core dumps disabled) and the process was terminated. CI remains the clean full-suite gate.

## Residual risks

- No shared cache-invalidation transport exists, so a remote replica can honor a preexisting positive decision for up to 60 seconds after revocation.
- Runtime browser/API verification could not be run in this VM because Docker is unavailable and the repository browser helper is not installed.