### PR TITLE
fix(auth): honor aao-admin membership in working-group leader/member bypass

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -6,7 +6,6 @@ import type { WorkOSUser, Company, CompanyUser, Ban } from '../types.js';
 import { createLogger } from '../logger.js';
 import {
   decideAAOAdminAccess,
-  isBreakGlassAdminEmail,
   type AAOAdminAccessMechanism,
 } from '../auth/admin-access.js';
 import { isWebUserAAOAdmin } from '../addie/mcp/admin-tools.js';
@@ -1743,10 +1742,15 @@ export function createRequireWorkingGroupLeader(
       });
     }
 
-    // Check if user is a site admin first (admins can manage all groups)
-    const isAdmin = isBreakGlassAdminEmail(req.user.email);
+    // Match the platform-admin authority decision: aao-admin membership is
+    // primary and ADMIN_EMAILS remains a centralized break-glass fallback.
+    // isWebUserAAOAdmin fails closed to false when its membership lookup fails.
+    const decision = decideAAOAdminAccess(
+      await isWebUserAAOAdmin(req.user.id),
+      req.user.email,
+    );
 
-    if (isAdmin) {
+    if (decision.isAdmin) {
       logger.debug({ userId: req.user.id, slug }, 'Admin access granted to working group');
       return next();
     }
@@ -1807,10 +1811,15 @@ export function createRequireWorkingGroupMember(
       });
     }
 
-    // Check if user is a site admin first
-    const isAdmin = isBreakGlassAdminEmail(req.user.email);
+    // Match the platform-admin authority decision: aao-admin membership is
+    // primary and ADMIN_EMAILS remains a centralized break-glass fallback.
+    // isWebUserAAOAdmin fails closed to false when its membership lookup fails.
+    const decision = decideAAOAdminAccess(
+      await isWebUserAAOAdmin(req.user.id),
+      req.user.email,
+    );
 
-    if (isAdmin) {
+    if (decision.isAdmin) {
       logger.debug({ userId: req.user.id, slug }, 'Admin access granted to working group');
       return next();
     }

--- a/server/tests/unit/working-group-leader-admin-bypass.test.ts
+++ b/server/tests/unit/working-group-leader-admin-bypass.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Focused unit tests for the site-admin bypass in the working-group leader
+ * and member middleware factories (#7269).
+ *
+ * The bypass must recognize BOTH aao-admin working group membership (the
+ * deployed primary authority, via isWebUserAAOAdmin) and the ADMIN_EMAILS
+ * break-glass list — matching requireAdmin. A membership-lookup failure
+ * degrades to non-admin (isWebUserAAOAdmin fails closed) without disabling a
+ * valid break-glass grant.
+ */
+
+const mocks = vi.hoisted(() => ({
+  isWebUserAAOAdmin: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.WORKOS_API_KEY = 'sk_test_wg_leader_bypass';
+  process.env.WORKOS_CLIENT_ID = 'client_test_wg_leader_bypass';
+  process.env.WORKOS_COOKIE_PASSWORD =
+    'test-cookie-password-at-least-32-characters';
+  delete process.env.DEV_USER_EMAIL;
+  delete process.env.DEV_USER_ID;
+});
+
+vi.mock('@workos-inc/node', () => ({
+  WorkOS: class WorkOS {
+    apiKeys = { createValidation: vi.fn() };
+    userManagement = { loadSealedSession: vi.fn() };
+  },
+}));
+
+vi.mock('../../src/addie/mcp/admin-tools.js', () => ({
+  isWebUserAAOAdmin: mocks.isWebUserAAOAdmin,
+}));
+
+const {
+  createRequireWorkingGroupLeader,
+  createRequireWorkingGroupMember,
+  stopAuthTimers,
+} = await import('../../src/middleware/auth.js');
+
+const WG = { id: 'wg_signals', slug: 'signals' };
+
+function createWorkingGroupDb(overrides?: {
+  isLeader?: boolean;
+  isMember?: boolean;
+  group?: { id: string } | null;
+}) {
+  return {
+    getWorkingGroupBySlug: vi
+      .fn()
+      .mockResolvedValue(overrides?.group === undefined ? WG : overrides.group),
+    isLeader: vi.fn().mockResolvedValue(overrides?.isLeader ?? false),
+    isMember: vi.fn().mockResolvedValue(overrides?.isMember ?? false),
+  };
+}
+
+function createReqRes(email = 'user@example.test') {
+  const req = {
+    user: { id: 'user_web', email },
+    params: { slug: 'signals' },
+  } as unknown as Request;
+
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  } as unknown as Response & { statusCode: number; body: unknown };
+
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, next };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.ADMIN_EMAILS;
+  mocks.isWebUserAAOAdmin.mockResolvedValue(false);
+});
+
+afterAll(() => {
+  stopAuthTimers();
+});
+
+describe.each([
+  {
+    label: 'leader',
+    factory: createRequireWorkingGroupLeader,
+    grantKey: 'isLeader' as const,
+  },
+  {
+    label: 'member',
+    factory: createRequireWorkingGroupMember,
+    grantKey: 'isMember' as const,
+  },
+])('createRequireWorkingGroup$label admin bypass', ({ factory, grantKey }) => {
+  it('allows an aao-admin member without a working-group grant', async () => {
+    mocks.isWebUserAAOAdmin.mockResolvedValue(true);
+    const db = createWorkingGroupDb();
+    const { req, res, next } = createReqRes();
+
+    await factory(db)(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(mocks.isWebUserAAOAdmin).toHaveBeenCalledWith('user_web');
+    // Admin short-circuits before any group lookup.
+    expect(db.getWorkingGroupBySlug).not.toHaveBeenCalled();
+  });
+
+  it('allows an ADMIN_EMAILS break-glass user', async () => {
+    process.env.ADMIN_EMAILS = 'ops@example.test, admin@example.test';
+    mocks.isWebUserAAOAdmin.mockResolvedValue(false);
+    const db = createWorkingGroupDb();
+    const { req, res, next } = createReqRes('ADMIN@example.test');
+
+    await factory(db)(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(db.getWorkingGroupBySlug).not.toHaveBeenCalled();
+  });
+
+  it('denies an ordinary non-leader/non-member', async () => {
+    const db = createWorkingGroupDb({ isLeader: false, isMember: false });
+    const { req, res, next } = createReqRes();
+
+    await factory(db)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect((res as unknown as { statusCode: number }).statusCode).toBe(403);
+  });
+
+  it('allows a working-group grant even when not an admin', async () => {
+    const db = createWorkingGroupDb({ [grantKey]: true });
+    const { req, res, next } = createReqRes();
+
+    await factory(db)(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('denies when the admin membership lookup fails (fail closed)', async () => {
+    // isWebUserAAOAdmin fails closed to `false` on lookup error; a non-leader,
+    // non-break-glass user must then be denied rather than granted.
+    mocks.isWebUserAAOAdmin.mockResolvedValue(false);
+    const db = createWorkingGroupDb({ isLeader: false, isMember: false });
+    const { req, res, next } = createReqRes();
+
+    await factory(db)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect((res as unknown as { statusCode: number }).statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Problem

`createRequireWorkingGroupLeader` (and its twin `createRequireWorkingGroupMember`) documented a site-admin bypass but checked only `ADMIN_EMAILS`. The deployed primary AgenticAdvertising.org site-admin authority is membership in the private `aao-admin` working group, as enforced by `requireAdmin`.

This caused an authorization inconsistency: an administrator granted through the intended database-backed authority (`aao-admin` membership) could not use working-group leader/member routes unless separately a leader/member, while a break-glass email could.

Fixes #7269.

## Change

Both middleware factories now delegate to the shared platform-admin authority decision introduced in #7272:

```js
const decision = decideAAOAdminAccess(
  await isWebUserAAOAdmin(req.user.id),
  req.user.email,
);
if (decision.isAdmin) return next();
```

- `aao-admin` membership (primary) **OR** the centrally parsed `ADMIN_EMAILS` break-glass fallback.
- `isWebUserAAOAdmin` fails closed (returns `false` on lookup error), so an unavailable membership lookup never grants access; a separately valid break-glass grant still works.
- No inline `ADMIN_EMAILS` parsing is reintroduced.

## Boundary

This does not change who may become an AgenticAdvertising.org site admin. It aligns two middleware factories with the deployed authority model and #7272's central authority vocabulary. UI, grant/revoke audit history, and cache-bound work landed in #7272.

## Tests

Adds `server/tests/unit/working-group-leader-admin-bypass.test.ts` — the five cases from the issue, run against **both** the leader and member factories:

- `aao-admin` member allowed (short-circuits before target-group lookup)
- `ADMIN_EMAILS` break-glass user allowed (case-insensitive)
- ordinary non-leader/non-member denied (403)
- working-group leader/member still allowed
- admin membership lookup failure (fail-closed to `false`) denied

## Notes

- **No changeset** — `admin-tool`/server middleware, not the published protocol surface (verified with `check-changeset-protocol-scope.cjs`).
- Potential `3.1.x` backport if the stable line is separately deployed — deferring that call to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
