### PR TITLE
feat(training-agent): validate inline VAST documents at sync_creatives

### DIFF
--- a/.changeset/training-vast-document-validation.md
+++ b/.changeset/training-vast-document-validation.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Have the training seller advertise `creative_specs.vast_validation: document` and apply that contract at `sync_creatives`: parse inline VAST XML and return `VAST_PARSE_FAILED` / `VAST_VERSION_MISMATCH` with the required details. URL-delivered tags stay opaque (no outbound fetch). Wrapper-chain resolution remains a later slice.

--- a/.changeset/training-vast-document-validation.md
+++ b/.changeset/training-vast-document-validation.md
@@ -1,5 +1,0 @@
----
-"adcontextprotocol": patch
----
-
-Have the training seller advertise `creative_specs.vast_validation: document` and apply that contract at `sync_creatives`: parse inline VAST XML and return `VAST_PARSE_FAILED` / `VAST_VERSION_MISMATCH` with the required details. URL-delivered tags stay opaque (no outbound fetch). Wrapper-chain resolution remains a later slice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "posthog-node": "^5.51.3",
         "resend": "^6.24.0",
         "rss-parser": "^3.13.0",
+        "saxes": "^6.0.0",
         "semver": "^7.8.5",
         "sharp": "^0.35.4",
         "stripe": "^22.6.0",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
     "posthog-node": "^5.51.3",
     "resend": "^6.24.0",
     "rss-parser": "^3.13.0",
+    "saxes": "^6.0.0",
     "semver": "^7.8.5",
     "sharp": "^0.35.4",
     "stripe": "^22.6.0",

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -61,6 +61,11 @@ import {
 } from './account-scope.js';
 import { encodeOffsetCursor, decodeOffsetCursor } from './pagination.js';
 import {
+  TRAINING_SELLER_VAST_VERSIONS,
+  resolveProductVastVersions,
+  validateCreativeVastDocuments,
+} from './vast-document-validation.js';
+import {
   captureReportingMediaBuyCandidateDurably,
   getCoreRevisionContentPageForAccountDurably,
   hasCoreRevisionContentForAccountDurably,
@@ -15886,6 +15891,27 @@ export async function handleSyncCreatives(args: ToolArgs, ctx: TrainingContext) 
       }
     }
 
+    if (!isThreeZeroStoryboardCompat(ctx)) {
+      const vastError = validateCreativeVastDocuments({
+        assets: candidateManifest?.assets ?? creativeShape.assets,
+        fieldPrefix: `creatives[${creativeId}]`,
+        productVastVersions: resolveProductVastVersions(
+          identity.formatOptionRef,
+          productValidationMap.values(),
+        ),
+        sellerVastVersions: TRAINING_SELLER_VAST_VERSIONS,
+      });
+      if (vastError) {
+        results.push({
+          creative_id: creativeId,
+          action: 'failed',
+          errors: [vastError],
+        });
+        stagedCreativeManifests.delete(creativeId);
+        continue;
+      }
+    }
+
     if (!isDryRun) {
       const manifest = candidateManifest;
       const storedCreative: CreativeState = {
@@ -17879,6 +17905,12 @@ export async function handleGetAdcpCapabilities(args: ToolArgs, ctx: TrainingCon
           keyword_targets: { supported_match_types: ['broad', 'phrase', 'exact'] },
           negative_keywords: { supported_match_types: ['broad', 'phrase', 'exact'] },
         },
+        ...(includeThreeOneFields(ctx) && {
+          creative_specs: {
+            vast_validation: 'document',
+            vast_versions: [...TRAINING_SELLER_VAST_VERSIONS],
+          },
+        }),
       },
     },
     creative: {

--- a/server/src/training-agent/vast-document-validation.ts
+++ b/server/src/training-agent/vast-document-validation.ts
@@ -1,0 +1,247 @@
+/**
+ * Document-level VAST validation for the training seller.
+ *
+ * Implements `creative_specs.vast_validation: "document"` from the video
+ * channel contract: parse inline XML, require a `<VAST>` root, compare the
+ * submitted document's version with the asset declaration, and apply the
+ * product ∩ seller acceptance intersection when both sets are known.
+ * Wrapper-chain resolution is out of scope (that is the `wrapper` level).
+ * URL-delivered assets stay opaque here so the training agent does not fetch
+ * buyer-supplied URLs.
+ */
+
+import { DOMParser } from 'linkedom';
+
+export const TRAINING_SELLER_VAST_VERSIONS = ['2.0', '3.0', '4.0', '4.1', '4.2', '4.3'] as const;
+
+export type TrainingSellerVastVersion = (typeof TRAINING_SELLER_VAST_VERSIONS)[number];
+
+export type VastDocumentValidationError = {
+  code: 'VAST_PARSE_FAILED' | 'VAST_VERSION_MISMATCH';
+  message: string;
+  field: string;
+  recovery: 'correctable';
+  details: Record<string, unknown>;
+};
+
+type VastAssetRecord = {
+  asset_type?: unknown;
+  delivery_type?: unknown;
+  content?: unknown;
+  url?: unknown;
+  vast_version?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function elementName(node: { localName?: string; tagName?: string }): string {
+  const raw = typeof node.localName === 'string' && node.localName.length > 0
+    ? node.localName
+    : typeof node.tagName === 'string'
+      ? node.tagName.replace(/^.*:/, '')
+      : '';
+  return raw.toLowerCase();
+}
+
+function walkElements(node: { childNodes?: ArrayLike<unknown> } | null | undefined): Array<{ localName?: string; tagName?: string; childNodes?: ArrayLike<unknown> }> {
+  const found: Array<{ localName?: string; tagName?: string; childNodes?: ArrayLike<unknown> }> = [];
+  if (!node?.childNodes) return found;
+  for (const child of Array.from(node.childNodes)) {
+    if (!child || typeof child !== 'object') continue;
+    const element = child as { nodeType?: number; localName?: string; tagName?: string; childNodes?: ArrayLike<unknown> };
+    if (element.nodeType === 1 || element.localName || element.tagName) {
+      found.push(element);
+      found.push(...walkElements(element));
+    }
+  }
+  return found;
+}
+
+function namedDescendants(
+  root: { childNodes?: ArrayLike<unknown> },
+  name: string,
+): Array<{ localName?: string; tagName?: string }> {
+  return walkElements(root).filter(node => elementName(node) === name);
+}
+
+export function formatOptionVastVersions(params: unknown): string[] | undefined {
+  if (!isRecord(params)) return undefined;
+  if (Array.isArray(params.vast_versions)) {
+    const versions = params.vast_versions.filter((value): value is string => typeof value === 'string');
+    return versions.length > 0 ? versions : undefined;
+  }
+  if (typeof params.vast_version === 'string' && params.vast_version.length > 0) {
+    return [params.vast_version];
+  }
+  return undefined;
+}
+
+export function resolveProductVastVersions(
+  formatOptionRef: Record<string, unknown> | undefined,
+  products: Iterable<{ format_options?: unknown }>,
+): string[] | undefined {
+  const optionId = typeof formatOptionRef?.format_option_id === 'string'
+    ? formatOptionRef.format_option_id
+    : undefined;
+  if (!optionId) return undefined;
+  for (const product of products) {
+    if (!Array.isArray(product.format_options)) continue;
+    for (const option of product.format_options) {
+      if (!isRecord(option)) continue;
+      if (option.format_option_id !== optionId) continue;
+      return formatOptionVastVersions(option.params);
+    }
+  }
+  return undefined;
+}
+
+function collectInlineVastAssets(
+  assets: unknown,
+): Array<{ groupId: string; asset: VastAssetRecord }> {
+  if (!isRecord(assets)) return [];
+  const found: Array<{ groupId: string; asset: VastAssetRecord }> = [];
+  for (const [groupId, value] of Object.entries(assets)) {
+    if (!isRecord(value) || value.asset_type !== 'vast') continue;
+    found.push({ groupId, asset: value });
+  }
+  return found;
+}
+
+export function validateInlineVastDocument(args: {
+  xml: string;
+  field: string;
+  assetVastVersion?: string;
+  productVastVersions?: string[];
+  sellerVastVersions: readonly string[];
+}): VastDocumentValidationError | null {
+  const { xml, field, assetVastVersion, productVastVersions, sellerVastVersions } = args;
+  const trimmed = xml.trim();
+  if (!trimmed.startsWith('<')) {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document is not well-formed XML',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'not_xml' },
+    };
+  }
+
+  const document = new DOMParser().parseFromString(trimmed, 'text/xml');
+  const root = document.documentElement;
+  if (!root || elementName(root) === 'parsererror') {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document is not well-formed XML',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'not_xml' },
+    };
+  }
+  if (elementName(root) !== 'vast') {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document root element is not <VAST>',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'no_vast_root' },
+    };
+  }
+
+  const observedVersion = root.getAttribute('version');
+  const observedDocumentVastVersion = observedVersion === null || observedVersion === ''
+    ? null
+    : observedVersion;
+
+  if (assetVastVersion) {
+    if (observedDocumentVastVersion !== assetVastVersion) {
+      return {
+        code: 'VAST_VERSION_MISMATCH',
+        message: 'Submitted VAST document version does not match the asset declaration',
+        field,
+        recovery: 'correctable',
+        details: {
+          mismatch_reason: 'document_version_mismatch',
+          asset_vast_version: assetVastVersion,
+          observed_document_vast_version: observedDocumentVastVersion,
+          document_role: 'submitted',
+        },
+      };
+    }
+
+    const productSet = productVastVersions && productVastVersions.length > 0
+      ? productVastVersions
+      : undefined;
+    const sellerSet = sellerVastVersions.length > 0 ? [...sellerVastVersions] : undefined;
+    if (productSet && sellerSet && !productSet.filter(version => sellerSet.includes(version)).includes(assetVastVersion)) {
+      return {
+        code: 'VAST_VERSION_MISMATCH',
+        message: 'VAST asset version is outside the product and seller compatibility intersection',
+        field,
+        recovery: 'correctable',
+        details: {
+          mismatch_reason: 'asset_outside_acceptance',
+          asset_vast_version: assetVastVersion,
+          product_vast_versions: productSet,
+          seller_vast_versions: sellerSet,
+        },
+      };
+    }
+  }
+
+  if (namedDescendants(root, 'ad').length === 0) {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document contains no <Ad> element',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'no_ad' },
+    };
+  }
+
+  const hasInlineLinear = namedDescendants(root, 'inline').length > 0
+    && namedDescendants(root, 'linear').length > 0;
+  if (hasInlineLinear && namedDescendants(root, 'mediafile').length === 0) {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'Inline linear VAST creative carries no <MediaFile>',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'no_media_file' },
+    };
+  }
+
+  return null;
+}
+
+export function validateCreativeVastDocuments(args: {
+  assets: unknown;
+  fieldPrefix: string;
+  productVastVersions?: string[];
+  sellerVastVersions?: readonly string[];
+}): VastDocumentValidationError | null {
+  const sellerVastVersions = args.sellerVastVersions ?? TRAINING_SELLER_VAST_VERSIONS;
+  for (const { groupId, asset } of collectInlineVastAssets(args.assets)) {
+    if (asset.delivery_type !== 'inline') continue;
+    const field = `${args.fieldPrefix}.assets.${groupId}`;
+    if (typeof asset.content !== 'string') {
+      return {
+        code: 'VAST_PARSE_FAILED',
+        message: 'Inline VAST asset is missing XML content',
+        field,
+        recovery: 'correctable',
+        details: { reason: 'not_xml' },
+      };
+    }
+    const error = validateInlineVastDocument({
+      xml: asset.content,
+      field,
+      assetVastVersion: typeof asset.vast_version === 'string' ? asset.vast_version : undefined,
+      productVastVersions: args.productVastVersions,
+      sellerVastVersions,
+    });
+    if (error) return error;
+  }
+  return null;
+}

--- a/server/src/training-agent/vast-document-validation.ts
+++ b/server/src/training-agent/vast-document-validation.ts
@@ -11,6 +11,7 @@
  */
 
 import { DOMParser } from 'linkedom';
+import { SaxesParser } from 'saxes';
 
 export const TRAINING_SELLER_VAST_VERSIONS = ['2.0', '3.0', '4.0', '4.1', '4.2', '4.3'] as const;
 
@@ -64,6 +65,20 @@ function namedDescendants(
   name: string,
 ): Array<{ localName?: string; tagName?: string }> {
   return walkElements(root).filter(node => elementName(node) === name);
+}
+
+function isWellFormedXml(xml: string): boolean {
+  let parseError: Error | undefined;
+  const parser = new SaxesParser({ xmlns: true });
+  parser.on('error', error => {
+    parseError ??= error;
+  });
+  try {
+    parser.write(xml).close();
+  } catch {
+    return false;
+  }
+  return parseError === undefined;
 }
 
 export function formatOptionVastVersions(params: unknown): string[] | undefined {
@@ -128,7 +143,28 @@ export function validateInlineVastDocument(args: {
     };
   }
 
-  const document = new DOMParser().parseFromString(trimmed, 'text/xml');
+  if (!isWellFormedXml(trimmed)) {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document is not well-formed XML',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'not_xml' },
+    };
+  }
+
+  let document: ReturnType<DOMParser['parseFromString']>;
+  try {
+    document = new DOMParser().parseFromString(trimmed, 'text/xml');
+  } catch {
+    return {
+      code: 'VAST_PARSE_FAILED',
+      message: 'VAST document is not well-formed XML',
+      field,
+      recovery: 'correctable',
+      details: { reason: 'not_xml' },
+    };
+  }
   const root = document.documentElement;
   if (!root || elementName(root) === 'parsererror') {
     return {

--- a/server/tests/unit/training-agent-vast-validation.test.ts
+++ b/server/tests/unit/training-agent-vast-validation.test.ts
@@ -58,6 +58,20 @@ describe('validateInlineVastDocument', () => {
     })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'not_xml' } });
   });
 
+  it.each([
+    '<VAST version="4.2"><Ad>',
+    '<VAST version="4.2"><Ad></VAST>',
+    '<VAST version="4.2"><Ad></Ad></VAST>trailing text',
+    '<VAST version="4.2"><Ad>&unknown;</Ad></VAST>',
+  ])('rejects malformed XML that a lenient DOM parser repairs: %s', xml => {
+    expect(validateInlineVastDocument({
+      xml,
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'not_xml' } });
+  });
+
   it('rejects a non-VAST root', () => {
     expect(validateInlineVastDocument({
       xml: '<VMAP version="1.0"></VMAP>',

--- a/server/tests/unit/training-agent-vast-validation.test.ts
+++ b/server/tests/unit/training-agent-vast-validation.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  handleGetAdcpCapabilities,
+  handleSyncCreatives,
+} from '../../src/training-agent/task-handlers.js';
+import { clearSessions, runWithSessionContext } from '../../src/training-agent/state.js';
+import {
+  TRAINING_SELLER_VAST_VERSIONS,
+  validateCreativeVastDocuments,
+  validateInlineVastDocument,
+} from '../../src/training-agent/vast-document-validation.js';
+import type { TrainingContext } from '../../src/training-agent/types.js';
+
+const CTX: TrainingContext = { mode: 'open', authenticatedAgentUrl: 'https://buyer.example' };
+
+function vastXml(opts: { version?: string; ad?: boolean; media?: boolean } = {}): string {
+  const version = opts.version ?? '4.2';
+  const includeAd = opts.ad !== false;
+  const includeMedia = opts.media !== false;
+  const media = includeMedia
+    ? '<MediaFiles><MediaFile delivery="progressive" type="video/mp4" width="1920" height="1080"><![CDATA[https://cdn.acme.example/video.mp4]]></MediaFile></MediaFiles>'
+    : '';
+  const ad = includeAd
+    ? `<Ad id="1"><InLine><AdSystem>Acme</AdSystem><AdTitle>Trail</AdTitle><Impression><![CDATA[https://track.acme.example/i]]></Impression><Creatives><Creative><Linear><Duration>00:00:15</Duration>${media}</Linear></Creative></Creatives></InLine></Ad>`
+    : '';
+  return `<?xml version="1.0" encoding="UTF-8"?><VAST version="${version}">${ad}</VAST>`;
+}
+
+function inlineVast(xml: string, version = '4.2') {
+  return {
+    vast_tag: {
+      asset_type: 'vast' as const,
+      delivery_type: 'inline' as const,
+      vast_version: version,
+      content: xml,
+    },
+  };
+}
+
+describe('validateInlineVastDocument', () => {
+  const seller = TRAINING_SELLER_VAST_VERSIONS;
+
+  it('accepts a well-formed inline linear VAST document', () => {
+    expect(validateInlineVastDocument({
+      xml: vastXml(),
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toBeNull();
+  });
+
+  it('rejects non-XML content', () => {
+    expect(validateInlineVastDocument({
+      xml: 'not xml',
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'not_xml' } });
+  });
+
+  it('rejects a non-VAST root', () => {
+    expect(validateInlineVastDocument({
+      xml: '<VMAP version="1.0"></VMAP>',
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'no_vast_root' } });
+  });
+
+  it('rejects a submitted document whose version differs from the asset', () => {
+    expect(validateInlineVastDocument({
+      xml: vastXml({ version: '3.0' }),
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({
+      code: 'VAST_VERSION_MISMATCH',
+      details: {
+        mismatch_reason: 'document_version_mismatch',
+        asset_vast_version: '4.2',
+        observed_document_vast_version: '3.0',
+        document_role: 'submitted',
+      },
+    });
+  });
+
+  it('rejects an asset outside the product and seller intersection', () => {
+    expect(validateInlineVastDocument({
+      xml: vastXml({ version: '4.2' }),
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      productVastVersions: ['3.0', '4.0'],
+      sellerVastVersions: seller,
+    })).toMatchObject({
+      code: 'VAST_VERSION_MISMATCH',
+      details: {
+        mismatch_reason: 'asset_outside_acceptance',
+        asset_vast_version: '4.2',
+        product_vast_versions: ['3.0', '4.0'],
+        seller_vast_versions: [...seller],
+      },
+    });
+  });
+
+  it('rejects a document with no Ad', () => {
+    expect(validateInlineVastDocument({
+      xml: vastXml({ ad: false }),
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'no_ad' } });
+  });
+
+  it('rejects an inline linear creative with no MediaFile', () => {
+    expect(validateInlineVastDocument({
+      xml: vastXml({ media: false }),
+      field: 'assets.vast_tag',
+      assetVastVersion: '4.2',
+      sellerVastVersions: seller,
+    })).toMatchObject({ code: 'VAST_PARSE_FAILED', details: { reason: 'no_media_file' } });
+  });
+
+  it('skips URL-delivered assets', () => {
+    expect(validateCreativeVastDocuments({
+      assets: {
+        vast_tag: {
+          asset_type: 'vast',
+          delivery_type: 'url',
+          url: 'https://cdn.acme.example/tag.xml',
+          vast_version: '4.2',
+        },
+      },
+      fieldPrefix: 'creatives[cr_1]',
+    })).toBeNull();
+  });
+});
+
+describe('training agent document-level VAST validation', () => {
+  beforeEach(() => clearSessions());
+  afterEach(() => clearSessions());
+
+  it('advertises document validation and the seller VAST ceiling', async () => {
+    const result = await handleGetAdcpCapabilities({}, CTX);
+    const mediaBuy = result.media_buy as Record<string, any>;
+    expect(mediaBuy.execution.creative_specs).toEqual({
+      vast_validation: 'document',
+      vast_versions: [...TRAINING_SELLER_VAST_VERSIONS],
+    });
+  });
+
+  it('creates a structurally valid inline VAST creative', async () => {
+    await runWithSessionContext(async () => {
+      const result = await handleSyncCreatives({
+        idempotency_key: 'vast-valid-0001',
+        creatives: [{
+          creative_id: 'cr_vast_ok',
+          format_kind: 'video_vast',
+          name: 'Trail 15s',
+          assets: inlineVast(vastXml()),
+        }],
+      }, CTX) as Record<string, any>;
+      expect(result.creatives).toEqual([
+        expect.objectContaining({ creative_id: 'cr_vast_ok', action: 'created' }),
+      ]);
+    });
+  });
+
+  it('returns VAST_PARSE_FAILED for a document-invalid inline tag', async () => {
+    await runWithSessionContext(async () => {
+      const result = await handleSyncCreatives({
+        idempotency_key: 'vast-parse-0001',
+        creatives: [{
+          creative_id: 'cr_vast_bad',
+          format_kind: 'video_vast',
+          name: 'Broken tag',
+          assets: inlineVast('not xml'),
+        }],
+      }, CTX) as Record<string, any>;
+      expect(result.creatives[0]).toMatchObject({
+        creative_id: 'cr_vast_bad',
+        action: 'failed',
+      });
+      expect(result.creatives[0].errors[0]).toMatchObject({
+        code: 'VAST_PARSE_FAILED',
+        details: { reason: 'not_xml' },
+        field: 'creatives[cr_vast_bad].assets.vast_tag',
+        recovery: 'correctable',
+      });
+    });
+  });
+
+  it('returns VAST_VERSION_MISMATCH when the document disagrees with the asset', async () => {
+    await runWithSessionContext(async () => {
+      const result = await handleSyncCreatives({
+        idempotency_key: 'vast-mismatch-0001',
+        creatives: [{
+          creative_id: 'cr_vast_mismatch',
+          format_kind: 'video_vast',
+          name: 'Mismatched version',
+          assets: inlineVast(vastXml({ version: '3.0' }), '4.2'),
+        }],
+      }, CTX) as Record<string, any>;
+      expect(result.creatives[0].errors[0]).toMatchObject({
+        code: 'VAST_VERSION_MISMATCH',
+        details: {
+          mismatch_reason: 'document_version_mismatch',
+          asset_vast_version: '4.2',
+          observed_document_vast_version: '3.0',
+          document_role: 'submitted',
+        },
+      });
+    });
+  });
+
+  it('still accepts video_vast creatives with no VAST document to inspect', async () => {
+    await runWithSessionContext(async () => {
+      const result = await handleSyncCreatives({
+        idempotency_key: 'vast-empty-0001',
+        creatives: [{
+          creative_id: 'cr_vast_empty',
+          format_kind: 'video_vast',
+          name: 'Empty assets',
+          assets: {},
+        }],
+      }, CTX) as Record<string, any>;
+      expect(result.creatives).toEqual([
+        expect.objectContaining({ creative_id: 'cr_vast_empty', action: 'created' }),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- The training seller advertised no `creative_specs.vast_validation`, so the specialist curriculum from #5820 could not exercise document-invalid tags.
- This slice advertises `document` and parses inline XML only: `<VAST>` root, version vs `asset.vast_version`, product ∩ seller acceptance, at least one `<Ad>`, and a `<MediaFile>` on InLine Linear. URL fetch and wrapper-chain resolution stay out.
- Advertised versions are `2.0` through `4.3`. 4.4 stays out until IAB publishes a final schema (see #7247 / InteractiveAdvertisingBureau/vast#58).

## Test plan
- [x] `vitest run --config server/vitest.config.ts tests/unit/training-agent-vast-validation.test.ts`
- [x] Pre-push storyboard matrix (current + 3.0 compat)

I have read the IPR Policy.