### PR TITLE
Fix fixed-trace canonical tool discovery

### DIFF
--- a/server/src/addie/eval/fixed-trace-tools.ts
+++ b/server/src/addie/eval/fixed-trace-tools.ts
@@ -1,0 +1,60 @@
+import { ADMIN_TOOLS } from '../mcp/admin-tools.js';
+import { BILLING_TOOLS } from '../mcp/billing-tools.js';
+import { BRAND_CANONICAL_TOOLS } from '../mcp/brand-canonical-tools.js';
+import { COMMITTEE_LEADER_TOOLS } from '../mcp/committee-leader-tools.js';
+import { DIRECTORY_TOOLS } from '../mcp/directory-tools.js';
+import { ILLUSTRATION_TOOLS } from '../mcp/illustration-tools.js';
+import { KNOWLEDGE_TOOLS } from '../mcp/knowledge-search.js';
+import { MEETING_TOOLS } from '../mcp/meeting-tools.js';
+import { MEMBER_TOOLS } from '../mcp/member-tools.js';
+import { PROPERTY_TOOLS } from '../mcp/property-tools.js';
+import { SI_HOST_TOOLS } from '../mcp/si-host-tools.js';
+import type { AddieTool } from '../types.js';
+import { FIXED_TRACE_SUITE, type FixedTraceCase } from './fixed-trace-suite.js';
+
+const FIXED_TRACE_TOOL_SOURCES: readonly (readonly AddieTool[])[] = [
+  KNOWLEDGE_TOOLS,
+  MEMBER_TOOLS,
+  ADMIN_TOOLS,
+  BILLING_TOOLS,
+  MEETING_TOOLS,
+  BRAND_CANONICAL_TOOLS,
+  COMMITTEE_LEADER_TOOLS,
+  DIRECTORY_TOOLS,
+  ILLUSTRATION_TOOLS,
+  PROPERTY_TOOLS,
+  SI_HOST_TOOLS,
+];
+
+/**
+ * Resolve the exact canonical definitions needed by the fixed suite.
+ *
+ * Fixture names are derived from the suite instead of repeated in the live
+ * runner. A new fixture therefore fails this preflight with its missing
+ * definition before any provider dispatch can consume budget.
+ */
+export function canonicalFixedTraceToolDefinitions(
+  traces: readonly FixedTraceCase[] = FIXED_TRACE_SUITE,
+): AddieTool[] {
+  const fixtureNames = [
+    ...new Set(traces.flatMap((trace) => trace.toolFixtures.map((fixture) => fixture.name))),
+  ];
+  const required = new Set(fixtureNames);
+  const definitions = new Map<string, AddieTool>();
+
+  for (const source of FIXED_TRACE_TOOL_SOURCES) {
+    for (const definition of source) {
+      if (!required.has(definition.name)) continue;
+      if (definitions.has(definition.name)) {
+        throw new Error(`Duplicate fixed-trace tool definition: ${definition.name}`);
+      }
+      definitions.set(definition.name, definition);
+    }
+  }
+
+  const missing = fixtureNames.filter((name) => !definitions.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Missing fixed-trace tool definitions: ${missing.join(', ')}`);
+  }
+  return fixtureNames.map((name) => definitions.get(name)!);
+}

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -27,6 +27,7 @@ import {
   type FixedTraceProviderStageConfig,
   type FixedTraceRunnerConfig,
 } from '../../src/addie/eval/fixed-trace-runner.js';
+import { canonicalFixedTraceToolDefinitions } from '../../src/addie/eval/fixed-trace-tools.js';
 import {
   FIXED_TRACE_SUITE,
   FIXED_TRACE_SUITE_VERSION,
@@ -61,12 +62,6 @@ import {
   GOOGLE_ROUTER_MODEL,
 } from '../../src/addie/model-providers/google-generate-content-provider.js';
 import { loadResponseStyle, loadRules } from '../../src/addie/rules/index.js';
-import { ADMIN_TOOLS } from '../../src/addie/mcp/admin-tools.js';
-import { BILLING_TOOLS } from '../../src/addie/mcp/billing-tools.js';
-import { KNOWLEDGE_TOOLS } from '../../src/addie/mcp/knowledge-search.js';
-import { MEETING_TOOLS } from '../../src/addie/mcp/meeting-tools.js';
-import { MEMBER_TOOLS } from '../../src/addie/mcp/member-tools.js';
-import type { AddieTool } from '../../src/addie/types.js';
 
 type ProviderName = ModelProviderId;
 
@@ -76,30 +71,6 @@ interface ProviderPlan {
   generation: Omit<FixedTraceProviderStageConfig, 'provider'> & { provider: ModelProvider };
   judge: FixedTraceJudgeConfig;
 }
-
-const MEETING_FULL_ADMINISTRATION_FIXTURE_NAMES = [
-  'schedule_meeting',
-  'list_upcoming_meetings',
-  'get_my_meetings',
-  'get_meeting_details',
-  'rsvp_to_meeting',
-  'cancel_meeting',
-  'cancel_meeting_series',
-  'update_meeting',
-  'add_meeting_attendee',
-  'update_topic_subscriptions',
-  'manage_committee_topics',
-] as const;
-
-const TOOL_NAMES = new Set([
-  'search_docs',
-  'get_doc',
-  'get_my_profile',
-  'find_duplicate_orgs',
-  'send_invoice',
-  'confirm_send_invoice',
-  ...MEETING_FULL_ADMINISTRATION_FIXTURE_NAMES,
-]);
 
 // The confirmed long meeting trace needs four sequential requested tools and
 // one final response. It is deliberately narrower than the synthetic loop's
@@ -156,24 +127,6 @@ function sourceBundle(): { sha256: string; files: string[] } {
     hash.update(file, 'utf8').update('\0').update(readFileSync(file)).update('\0');
   }
   return { sha256: hash.digest('hex'), files };
-}
-
-function canonicalToolDefinitions(): AddieTool[] {
-  const definitions = [
-    ...KNOWLEDGE_TOOLS,
-    ...MEMBER_TOOLS,
-    ...ADMIN_TOOLS,
-    ...BILLING_TOOLS,
-    ...MEETING_TOOLS,
-  ].filter((tool) => TOOL_NAMES.has(tool.name));
-  const byName = new Map<string, AddieTool>();
-  for (const definition of definitions) {
-    if (byName.has(definition.name)) throw new Error(`Duplicate fixed-trace tool: ${definition.name}`);
-    byName.set(definition.name, definition);
-  }
-  const missing = [...TOOL_NAMES].filter((name) => !byName.has(name));
-  if (missing.length > 0) throw new Error(`Missing fixed-trace tools: ${missing.join(', ')}`);
-  return [...TOOL_NAMES].map((name) => byName.get(name)!);
 }
 
 function stage(
@@ -348,7 +301,7 @@ const promptConfigVersion = sha256(JSON.stringify({
   rules: loadRules(),
   responseStyle: loadResponseStyle(),
 }));
-const toolDefinitions = canonicalToolDefinitions();
+const toolDefinitions = canonicalFixedTraceToolDefinitions();
 const toolSchemaSha256 = fixedTraceToolSchemaSha256(toolDefinitions);
 const budget = new FixedTraceBudget(softMaxUsd);
 const allProviderNames = [...new Set([...providerNames, ...judgeProviderNames])];

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -15,6 +15,7 @@ import {
   type FixedTraceObservation,
   type FixedTraceRunMetadata,
 } from '../../../src/addie/eval/fixed-trace-suite.js';
+import { canonicalFixedTraceToolDefinitions } from '../../../src/addie/eval/fixed-trace-tools.js';
 
 const HASH = createHash('sha256').update('fixture').digest('hex');
 
@@ -137,6 +138,13 @@ function passingObservation(trace: FixedTraceCase): FixedTraceObservation {
 }
 
 describe('fixed cross-provider trace suite', () => {
+  it('resolves one canonical definition for every fixture tool', () => {
+    const fixtureNames = [
+      ...new Set(FIXED_TRACE_SUITE.flatMap((trace) => trace.toolFixtures.map((fixture) => fixture.name))),
+    ];
+    expect(canonicalFixedTraceToolDefinitions().map((tool) => tool.name)).toEqual(fixtureNames);
+  });
+
   it('is a fixed synthetic corpus covering every required risk category', () => {
     expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v31');
     expect(FIXED_TRACE_SUITE).toHaveLength(32);


### PR DESCRIPTION
## Summary

- derive fixed-trace tool definitions directly from the suite fixtures
- fail preflight on missing or duplicate canonical definitions before provider dispatch
- assert every fixture resolves to exactly one canonical definition

This fixes the v31 live evaluator drift found while working on #6846.

## Validation

- `npm run test:addie-fixed-traces` (42 passed)
- focused fixed-trace/provider/router suite (139 passed)
- `npm run typecheck`
- precommit: 8,148 passed, 32 skipped across 559 server test files
- live v31 OpenAI replay completed from clean commit `9d5173809` with Anthropic + Google judges and $0.4394 total metered spend under the $1 cap; the replay recorded genuine rollout failures for follow-up rather than a harness preflight failure

No changeset: evaluation harness only; no protocol or runtime behavior change.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
