### PR TITLE
Preserve fixed-trace boundary evidence

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -193,6 +193,7 @@ function localStageMetadata(
   request: ModelRequest,
   config: FixedTraceProviderStageConfig,
   state: StageInvocationState,
+  usage?: ModelUsage,
 ): FixedTraceModelStageMetadata {
   return {
     source: 'local',
@@ -211,10 +212,12 @@ function localStageMetadata(
     transportRetries: 0,
     samplingMode: config.samplingMode,
     temperature: config.temperature,
-    usageKnown: false,
-    usage: null,
-    estimatedCostUsd: state.dispatched ? null : 0,
-    pricingSource: null,
+    usageKnown: usage !== undefined,
+    usage: usage ?? null,
+    estimatedCostUsd: usage
+      ? estimateCostUsd(usage, config.pricing)
+      : state.dispatched ? null : 0,
+    pricingSource: usage ? config.pricing.source : null,
     latencyMs: state.latencyMs,
   };
 }
@@ -586,6 +589,9 @@ export async function runFixedTraceCase(
     };
   } catch (error) {
     if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
+    const checkpoint = error instanceof FixedTraceToolLoopBoundaryError
+      ? error.checkpoint
+      : undefined;
     const terminalStatus = error instanceof FixedTraceBudgetAdmissionError
       ? 'not_dispatched_budget'
       : error instanceof FixedTraceToolLoopBoundaryError
@@ -597,7 +603,7 @@ export async function runFixedTraceCase(
       invocations,
       dispatched,
       latencyMs: Date.now() - startedAt,
-    });
+    }, checkpoint?.usage);
     return {
       traceId: trace.id,
       metadata: baseMetadata(config, toolSchemaSha256, routed.metadata, generation),
@@ -609,7 +615,7 @@ export async function runFixedTraceCase(
       output: fallbackOutput(terminalStatus),
       flagged: true,
       route,
-      tools: [],
+      tools: checkpoint?.tools.map(({ sequence: _sequence, ...tool }) => tool) ?? [],
     };
   } finally {
     clearTimeout(timeout);

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -34,8 +34,16 @@ export const MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS = 12;
 
 export type FixedTraceToolLoopReason = FixedTraceBoundaryReason;
 
+export interface FixedTraceToolLoopCheckpoint {
+  usage: ModelUsage;
+  tools: ReadonlyArray<FixedTraceToolExecution>;
+}
+
 export class FixedTraceToolLoopBoundaryError extends Error {
-  constructor(readonly reason: FixedTraceToolLoopReason) {
+  constructor(
+    readonly reason: FixedTraceToolLoopReason,
+    readonly checkpoint?: FixedTraceToolLoopCheckpoint,
+  ) {
     super(reason);
     this.name = 'FixedTraceToolLoopBoundaryError';
   }
@@ -182,6 +190,12 @@ export async function executeFixedTraceToolLoop(
   const seenCallIds = new Set<string>();
   const seenToolNames = new Set<string>();
   const modelLoop = new ModelTurnLoopState(iterationLimit);
+  const boundary = (reason: FixedTraceToolLoopReason): FixedTraceToolLoopBoundaryError => (
+    new FixedTraceToolLoopBoundaryError(reason, {
+      usage: modelLoop.usage,
+      tools: Object.freeze([...executions]),
+    })
+  );
 
   while (modelLoop.hasRemaining) {
     const activeTurn = modelLoop.beginNext();
@@ -207,7 +221,7 @@ export async function executeFixedTraceToolLoop(
     const turn = activeTurn.acceptResponse(response);
 
     if (turn.providerToolCalls.length > 0 || turn.providerToolResults.length > 0) {
-      throw new FixedTraceToolLoopBoundaryError('provider_continuation_not_allowed');
+      throw boundary('provider_continuation_not_allowed');
     }
     if (turn.action === 'continue') {
       appendModelTurnContinuation(messages, response);
@@ -230,7 +244,7 @@ export async function executeFixedTraceToolLoop(
     }
 
     if (executions.length + turn.toolCalls.length > trace.toolFixtures.length) {
-      throw new FixedTraceToolLoopBoundaryError('tool_call_limit_exceeded');
+      throw boundary('tool_call_limit_exceeded');
     }
     const calls = turn.toolCalls.map((call) => deepFreeze(structuredClone(call)));
     const batchCallIds = new Set<string>();
@@ -242,12 +256,12 @@ export async function executeFixedTraceToolLoop(
         || batchCallIds.has(call.id)
         || batchToolNames.has(call.name)
       ) {
-        throw new FixedTraceToolLoopBoundaryError('duplicate_tool_call');
+        throw boundary('duplicate_tool_call');
       }
       const entry = registered.get(call.name);
-      if (!entry) throw new FixedTraceToolLoopBoundaryError('unknown_tool_call');
+      if (!entry) throw boundary('unknown_tool_call');
       if (!entry.validate(call.input)) {
-        throw new FixedTraceToolLoopBoundaryError('tool_input_invalid');
+        throw boundary('tool_input_invalid');
       }
       batchCallIds.add(call.id);
       batchToolNames.add(call.name);
@@ -278,5 +292,5 @@ export async function executeFixedTraceToolLoop(
     appendModelTurnContinuation(messages, response, results);
   }
 
-  throw new FixedTraceToolLoopBoundaryError('iteration_limit_exceeded');
+  throw boundary('iteration_limit_exceeded');
 }

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -27,6 +27,7 @@ import {
   type FixedTraceProviderStageConfig,
   type FixedTraceRunnerConfig,
 } from '../../src/addie/eval/fixed-trace-runner.js';
+import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from '../../src/addie/eval/fixed-trace-tool-loop.js';
 import { canonicalFixedTraceToolDefinitions } from '../../src/addie/eval/fixed-trace-tools.js';
 import {
   FIXED_TRACE_SUITE,
@@ -71,11 +72,6 @@ interface ProviderPlan {
   generation: Omit<FixedTraceProviderStageConfig, 'provider'> & { provider: ModelProvider };
   judge: FixedTraceJudgeConfig;
 }
-
-// The confirmed long meeting trace needs four sequential requested tools and
-// one final response. It is deliberately narrower than the synthetic loop's
-// 11-tool-union ceiling, which protects the evaluator from runaway replay.
-const MEETING_FULL_REQUEST_GENERATION_TURNS = 5;
 
 const PRICING = {
   anthropicRouter: {
@@ -185,7 +181,7 @@ function providerPlans(
         ModelConfig.primary,
         'provider_default',
         900,
-        MEETING_FULL_REQUEST_GENERATION_TURNS,
+        MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS,
         PRICING.anthropicGeneration,
       ),
       judge: {
@@ -217,7 +213,7 @@ function providerPlans(
         OPENAI_ROUTER_MODEL,
         'none',
         900,
-        MEETING_FULL_REQUEST_GENERATION_TURNS,
+        MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS,
         PRICING.openai,
       ),
       judge: {
@@ -249,7 +245,7 @@ function providerPlans(
         GOOGLE_ROUTER_MODEL,
         'low',
         1_200,
-        MEETING_FULL_REQUEST_GENERATION_TURNS,
+        MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS,
         PRICING.google,
       ),
       judge: {

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -465,7 +465,25 @@ describe('fixed trace artifact runner', () => {
       terminalStatus: 'malformed',
       boundaryReason: 'duplicate_tool_call',
       flagged: true,
-      tools: [],
+      tools: [
+        {
+          name: 'list_working_groups',
+          resultStatus: 'ok',
+          simulated: true,
+        },
+        {
+          name: 'create_working_group_post',
+          resultStatus: 'ok',
+          simulated: true,
+        },
+      ],
+    });
+    expect(observation.metadata.generation).toMatchObject({
+      source: 'local',
+      usageKnown: true,
+      usage: { inputTokens: 30, outputTokens: 15 },
+      estimatedCostUsd: 0.000105,
+      pricingSource: 'Synthetic test pricing.',
     });
   });
 
@@ -669,7 +687,7 @@ describe('fixed trace artifact runner', () => {
     });
   });
 
-  it('keeps a dispatched malformed tool turn in the denominator with unknown cost', async () => {
+  it('keeps exact usage for a dispatched malformed tool turn', async () => {
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
     const generation = new ScriptedProvider([response([{
       type: 'tool_call',
@@ -689,9 +707,10 @@ describe('fixed trace artifact runner', () => {
         generation: {
           source: 'local',
           dispatched: true,
-          usageKnown: false,
-          estimatedCostUsd: null,
-          pricingSource: null,
+          usageKnown: true,
+          usage: { inputTokens: 10, outputTokens: 5 },
+          estimatedCostUsd: 0.000035,
+          pricingSource: 'Synthetic test pricing.',
         },
       },
     });

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -16,6 +16,7 @@ import {
   type FixedTraceRunMetadata,
 } from '../../../src/addie/eval/fixed-trace-suite.js';
 import { canonicalFixedTraceToolDefinitions } from '../../../src/addie/eval/fixed-trace-tools.js';
+import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from '../../../src/addie/eval/fixed-trace-tool-loop.js';
 
 const HASH = createHash('sha256').update('fixture').digest('hex');
 
@@ -143,6 +144,13 @@ describe('fixed cross-provider trace suite', () => {
       ...new Set(FIXED_TRACE_SUITE.flatMap((trace) => trace.toolFixtures.map((fixture) => fixture.name))),
     ];
     expect(canonicalFixedTraceToolDefinitions().map((tool) => tool.name)).toEqual(fixtureNames);
+  });
+
+  it('can replay every fixture tool sequentially and still request a final answer', () => {
+    const requiredIterations = Math.max(
+      ...FIXED_TRACE_SUITE.map((trace) => trace.toolFixtures.length + 1),
+    );
+    expect(MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS).toBeGreaterThanOrEqual(requiredIterations);
   });
 
   it('is a fixed synthetic corpus covering every required risk category', () => {

--- a/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
+++ b/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
@@ -306,7 +306,13 @@ describe('executeFixedTraceToolLoop', () => {
       request('claude-test'),
       trace('knowledge-task-model'),
       [tool('search_docs', ['query']), tool('get_doc')],
-    )).rejects.toEqual(new FixedTraceToolLoopBoundaryError('tool_input_invalid'));
+    )).rejects.toMatchObject({
+      reason: 'tool_input_invalid',
+      checkpoint: {
+        usage: { inputTokens: 10, outputTokens: 5 },
+        tools: [],
+      },
+    });
     expect(create).toHaveBeenCalledOnce();
   });
 
@@ -344,7 +350,13 @@ describe('executeFixedTraceToolLoop', () => {
       request('claude-test'),
       duplicateMutationTrace,
       [tool('confirm_send_invoice', ['invoice_id']), tool('get_doc')],
-    )).rejects.toEqual(new FixedTraceToolLoopBoundaryError('duplicate_tool_call'));
+    )).rejects.toMatchObject({
+      reason: 'duplicate_tool_call',
+      checkpoint: {
+        usage: { inputTokens: 10, outputTokens: 5 },
+        tools: [],
+      },
+    });
     expect(create).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary

- use the shared fixed-trace loop bound in the manual live evaluator so every sequential fixture can complete before the final answer
- retain exact cumulative usage and completed simulated tool receipts when the loop terminates at a safety boundary
- report known boundary cost in artifacts instead of losing it as `null`
- add invariant and regression coverage for duplicate, unknown-tool, and sequential-fixture boundaries

Follow-up to #6846 after the first clean live replay exposed objective evaluator truncation and missing diagnostic evidence. This does not change rollout thresholds or production Addie limits.

## Verification

- `npm run test:addie-fixed-traces` (43 passed)
- focused unit tests (68 passed)
- `npm run typecheck`
- full pre-commit gate (559 files; 8,149 passed, 32 skipped)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
