### PR TITLE
Checkpoint completed Addie tools before stream failure

### DIFF
--- a/server/src/addie/bolt-app.ts
+++ b/server/src/addie/bolt-app.ts
@@ -168,9 +168,16 @@ import {
   buildThreadSummaryForRouter,
   buildUntrustedSlackHistoryContext,
   buildAuthorizedConversationHistory,
+  unresolvedToolCheckpointsForLatestTurn,
   buildUntrustedSlackChannelMetadataContext,
   isValidWorkingGroupSlug,
 } from './thread-utils.js';
+import {
+  blockCheckpointedToolReplays,
+  buildToolResultCheckpoint,
+  type StoredToolCall,
+} from './stream-tool-checkpoints.js';
+import type { ToolExecution } from './model-providers/tool-orchestration.js';
 import { getThreadReplies, getSlackUser, getChannelInfo, getChannelHistory } from '../slack/client.js';
 import { AddieRouter, type RoutingContext, type ExecutionPlan, type ConfidenceTier } from './router.js';
 import { ProviderHealthController } from './model-providers/provider-health.js';
@@ -1993,10 +2000,12 @@ async function handleUserMessage({
   // This ensures Claude has context from previous turns in the DM thread
   const MAX_HISTORY_MESSAGES = 20;
   let conversationHistory: Array<{ user: string; text: string }> | undefined;
+  let unresolvedCheckpointToolCalls: StoredToolCall[] = [];
   let historyUnavailable = false;
   try {
     const previousMessages = await threadService.getThreadMessages(thread.thread_id);
     if (previousMessages.length > 0) {
+      unresolvedCheckpointToolCalls = unresolvedToolCheckpointsForLatestTurn(previousMessages, userId);
       // Format previous messages for Claude context
       // Only include user and assistant messages (skip system/tool)
       // Exclude the current message (we just logged it below, but it's not there yet)
@@ -2073,6 +2082,7 @@ async function handleUserMessage({
     : routedTools.requiresDepth
       ? ModelConfig.depth
       : AddieModelConfig.chat;
+  const toolReplayPolicy = blockCheckpointedToolReplays(unresolvedCheckpointToolCalls);
   // Resolve the cost-cap identity + tier (#2790 / #2945 f/u).
   // Prefers a mapped WorkOS user ID (aao_team for AAO admins,
   // member_paid for active subs); falls back to `slack:${userId}` at
@@ -2093,13 +2103,14 @@ async function handleUserMessage({
     threadId: thread.thread_id,
     ...(await buildSlackCostOptions(memberContext, userId)),
     currentSpeakerName: resolveSpeakerDisplayName(memberContext),
+    ...(toolReplayPolicy ? { toolExecutionPolicy: toolReplayPolicy } : {}),
   };
 
   // Process with Claude using streaming
   let response: AddieResponse | undefined;
   let fullText = '';
   let toolsUsed: string[] = [];
-  let toolExecutions: { tool_name: string; parameters: Record<string, unknown>; result: string }[] = [];
+  let toolExecutions: ToolExecution[] = [];
   // Mid-stream upstream failure tracking (#4797). When set, we render a recovery
   // banner in Slack and skip persisting the partial turn so prompt assembly for
   // the next turn doesn't feed the model a truncated assistant message.
@@ -2157,6 +2168,28 @@ async function handleUserMessage({
         continuationBuffer = streamState.continuationBuffer;
         streamWasInterrupted = streamState.streamWasInterrupted;
         streamInterruptCategory = streamState.streamInterruptCategory;
+        if (event.type === 'tool_end') {
+          try {
+            await threadService.addMessage(buildToolResultCheckpoint({
+              threadId: thread.thread_id,
+              execution: event.execution,
+              requestedModel: dmEffectiveModel,
+            }));
+          } catch (checkpointError) {
+            logger.error(
+              { checkpointError, threadId: thread.thread_id, toolName: event.tool_name },
+              'Addie Bolt: Tool result checkpoint failed — stopping stream before further actions',
+            );
+            streamWasInterrupted = true;
+            streamInterruptCategory = 'checkpoint_persistence_failed';
+            try {
+              await say("I completed an action but couldn't safely save its result. Please review the result above before asking again.");
+            } catch (recoveryError) {
+              logger.error({ recoveryError }, 'Addie Bolt: Tool checkpoint recovery notice failed');
+            }
+            break;
+          }
+        }
         if (shouldStopSlackDmStream(streamState)) break;
       }
 
@@ -2400,12 +2433,7 @@ async function handleUserMessage({
       // output. Never persist it under a local provenance label.
       text: STREAM_COMPLETION_MISSING_NOTICE,
       tools_used: toolsUsed,
-      tool_executions: toolExecutions.map((t, i) => ({
-        ...t,
-        is_error: false,
-        duration_ms: 0,
-        sequence: i + 1,
-      })),
+      tool_executions: toolExecutions,
       flagged: true,
       flag_reason: 'Streaming completed without done event',
       model_execution: {

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -855,6 +855,8 @@ export type StreamEvent =
       result: string;
       is_error: boolean;
       normalized_result?: ToolResultPresentation;
+      /** Exact completed receipt used by delivery adapters for checkpoints. */
+      execution: ToolExecution;
     }
   | { type: 'retry'; attempt: number; maxRetries: number; delayMs: number; reason: string }
   | {
@@ -2424,6 +2426,7 @@ export class AddieClaudeClient {
               result: event.recorded.execution.result,
               is_error: event.recorded.execution.is_error,
               normalized_result: event.recorded.execution.normalized_result,
+              execution: event.recorded.execution,
             };
             logger.debug(
               {
@@ -2462,6 +2465,7 @@ export class AddieClaudeClient {
               result: event.executed.execution.result,
               is_error: event.executed.execution.is_error,
               normalized_result: event.executed.execution.normalized_result,
+              execution: event.executed.execution,
             };
           }
         }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -64,7 +64,7 @@
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "050ffcc96af1af737c594cbc773b37483641f4d756d09a252c8aec569b9d3119",
-    "server/src/routes/addie-chat.ts": "a6d95cd4e03cefcc85ee4118e6b4435a98d598ba982ea25b90c6d87663ed2cc9",
+    "server/src/routes/addie-chat.ts": "f07553c08ee2bae8ccb0163e2dc6c352b7ca282bea0a3d528243fca06ac4a8fd",
     "server/src/routes/tavus.ts": "3f7f598555ee52090eb2a26ac0bf1dea5e1fe345ea8e57764b60879d7b96cfec",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,13 +58,13 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "59c7837d61651012d7c4362c962c527aaf4ae186ec4d55b9d6f7817a2d70d632",
+    "server/src/addie/claude-client.ts": "57cc16b025506e09d03855d62dd7daea976e28fc48fe170be4baa9975b336848",
     "server/src/addie/prompts.ts": "f091b8d7dd9c3b09b9630d858370c4dff00260e05bdbf0fb2c94b9bb9ae958fa",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
-    "server/src/addie/bolt-app.ts": "500aa3920a48d637528cd646140521858a2223880457d6ab653ac5ceb3a618b2",
-    "server/src/routes/addie-chat.ts": "b7a9c656b05a45407b61a80c8d449f2395bfca3af00afad1bb8765ee1bd74317",
+    "server/src/addie/bolt-app.ts": "050ffcc96af1af737c594cbc773b37483641f4d756d09a252c8aec569b9d3119",
+    "server/src/routes/addie-chat.ts": "a6d95cd4e03cefcc85ee4118e6b4435a98d598ba982ea25b90c6d87663ed2cc9",
     "server/src/routes/tavus.ts": "3f7f598555ee52090eb2a26ac0bf1dea5e1fe345ea8e57764b60879d7b96cfec",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/slack-dm-stream.ts
+++ b/server/src/addie/slack-dm-stream.ts
@@ -1,5 +1,5 @@
 import type { AddieResponse, StreamEvent } from './claude-client.js';
-import type { ToolResultPresentation } from './tool-result-contract.js';
+import type { ToolExecution } from './model-providers/tool-orchestration.js';
 import {
   DEFAULT_STREAM_SOFT_CAP,
   decideStreamAppend,
@@ -8,12 +8,7 @@ import {
   type StreamAppendDecision,
 } from './slack-blocks.js';
 
-export type SlackDmToolExecution = {
-  tool_name: string;
-  parameters: Record<string, unknown>;
-  result: string;
-  normalized_result?: ToolResultPresentation;
-};
+export type SlackDmToolExecution = ToolExecution;
 
 export type SlackDmStreamChunk =
   | { type: 'plan_update'; title: string }
@@ -464,12 +459,7 @@ export function reduceSlackDmStreamEvent(
     const toolState: SlackDmStreamState = {
       ...state,
       activeToolTaskIds,
-      toolExecutions: [...state.toolExecutions, {
-        tool_name: event.tool_name,
-        parameters: {},
-        result: event.result,
-        ...(event.normalized_result && { normalized_result: event.normalized_result }),
-      }],
+      toolExecutions: [...state.toolExecutions, event.execution],
     };
     if (toolState.delivery.tag !== 'open') return { state: toolState, effects: [] };
     return scheduleAsyncEffect(

--- a/server/src/addie/stream-tool-checkpoints.ts
+++ b/server/src/addie/stream-tool-checkpoints.ts
@@ -1,0 +1,83 @@
+import type { CreateMessageInput } from './thread-service.js';
+import type {
+  ToolExecution,
+  ToolExecutionPolicy,
+} from './model-providers/tool-orchestration.js';
+
+export interface StoredToolCall {
+  name: string;
+  input: unknown;
+  result: unknown;
+  duration_ms?: number;
+  is_error?: boolean;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => (
+    `${JSON.stringify(key)}:${canonicalJson(record[key])}`
+  )).join(',')}}`;
+}
+
+function replayKey(toolName: string, input: unknown): string {
+  return `${toolName}\0${canonicalJson(input)}`;
+}
+
+export function storedToolCall(execution: ToolExecution): StoredToolCall {
+  return {
+    name: execution.tool_name,
+    input: execution.parameters,
+    result: execution.result,
+    duration_ms: execution.duration_ms,
+    is_error: execution.is_error,
+  };
+}
+
+/**
+ * Build one hidden assistant row containing exactly one completed tool-use /
+ * tool-result pair. The row is intentionally marked interrupted: a later
+ * completed assistant response supersedes it, while an interrupted turn can
+ * reconstruct the pair without retaining partial prose.
+ */
+export function buildToolResultCheckpoint(input: {
+  threadId: string;
+  execution: ToolExecution;
+  requestedModel: string;
+  clientRequestId?: string;
+}): CreateMessageInput {
+  return {
+    thread_id: input.threadId,
+    role: 'assistant',
+    content: '',
+    tools_used: [input.execution.tool_name],
+    tool_calls: [storedToolCall(input.execution)],
+    model: input.requestedModel,
+    model_execution: {
+      source: 'local',
+      requested_provider: 'anthropic',
+      requested_model: input.requestedModel,
+      reason: 'stream_interrupted',
+    },
+    delivery_status: 'interrupted',
+    ...(input.clientRequestId && { client_request_id: input.clientRequestId }),
+  };
+}
+
+/**
+ * Prevent an interrupted-turn retry from dispatching an exact tool call whose
+ * result is already present in model history. Non-matching calls still pass
+ * through the caller's existing policy (or are allowed when no policy exists).
+ */
+export function blockCheckpointedToolReplays(
+  checkpoints: readonly StoredToolCall[],
+  delegate?: ToolExecutionPolicy,
+): ToolExecutionPolicy | undefined {
+  if (checkpoints.length === 0) return delegate;
+  const completed = new Set(checkpoints.map((call) => replayKey(call.name, call.input)));
+  return async (request) => {
+    if (completed.has(replayKey(request.toolName, request.input))) return { allowed: false };
+    return delegate ? delegate(request) : { allowed: true };
+  };
+}

--- a/server/src/addie/stream-tool-checkpoints.ts
+++ b/server/src/addie/stream-tool-checkpoints.ts
@@ -75,7 +75,15 @@ export function blockCheckpointedToolReplays(
   delegate?: ToolExecutionPolicy,
 ): ToolExecutionPolicy | undefined {
   if (checkpoints.length === 0) return delegate;
-  const completed = new Set(checkpoints.map((call) => replayKey(call.name, call.input)));
+  // A failed tool result is useful model context, but it is not an irreversible
+  // action receipt. Let the normal policy decide whether a later attempt may
+  // retry it.
+  const completed = new Set(
+    checkpoints
+      .filter((call) => call.is_error !== true)
+      .map((call) => replayKey(call.name, call.input)),
+  );
+  if (completed.size === 0) return delegate;
   return async (request) => {
     if (completed.has(replayKey(request.toolName, request.input))) return { allowed: false };
     return delegate ? delegate(request) : { allowed: true };

--- a/server/src/addie/thread-utils.ts
+++ b/server/src/addie/thread-utils.ts
@@ -84,6 +84,7 @@ export interface StoredConversationMessage {
     result: unknown;
     is_error?: boolean;
   }> | null;
+  delivery_status?: 'completed' | 'interrupted';
 }
 
 export interface AuthorizedConversationEntry {
@@ -103,29 +104,64 @@ export function buildAuthorizedConversationHistory(
   maxMessages: number,
 ): AuthorizedConversationEntry[] {
   const authorized: AuthorizedConversationEntry[] = [];
-  let includeAssistantResponse = false;
+  let activeUser: AuthorizedConversationEntry | null = null;
+  let activeAssistants: StoredConversationMessage[] = [];
 
-  for (const message of messages) {
-    if (message.role === 'user') {
-      includeAssistantResponse = message.user_id === currentUserId;
-      if (!includeAssistantResponse) continue;
-      authorized.push({
-        user: message.user_display_name || 'User',
-        text: message.content_sanitized || message.content,
-      });
-      continue;
-    }
-
-    if (message.role === 'assistant' && includeAssistantResponse) {
+  const flush = () => {
+    if (!activeUser) return;
+    authorized.push(activeUser);
+    const completed = activeAssistants.filter((message) => message.delivery_status !== 'interrupted');
+    const selected = completed.length > 0
+      ? completed
+      : activeAssistants.filter((message) => (message.tool_calls?.length ?? 0) > 0);
+    for (const message of selected) {
       authorized.push({
         user: 'Addie',
         text: message.content_sanitized || message.content,
         toolCalls: message.tool_calls ?? undefined,
       });
     }
+  };
+
+  for (const message of messages) {
+    if (message.role === 'user') {
+      flush();
+      activeAssistants = [];
+      activeUser = message.user_id === currentUserId
+        ? {
+            user: message.user_display_name || 'User',
+            text: message.content_sanitized || message.content,
+          }
+        : null;
+      continue;
+    }
+
+    if (message.role === 'assistant' && activeUser) activeAssistants.push(message);
   }
+  flush();
 
   return authorized.slice(-maxMessages);
+}
+
+/** Exact completed receipts from the latest authorized turn with no final response. */
+export function unresolvedToolCheckpointsForLatestTurn(
+  messages: StoredConversationMessage[],
+  currentUserId: string,
+): NonNullable<StoredConversationMessage['tool_calls']> {
+  let owned = false;
+  let hasCompletedAssistant = false;
+  let checkpoints: NonNullable<StoredConversationMessage['tool_calls']> = [];
+  for (const message of messages) {
+    if (message.role === 'user') {
+      owned = message.user_id === currentUserId;
+      hasCompletedAssistant = false;
+      checkpoints = [];
+    } else if (message.role === 'assistant' && owned) {
+      if (message.delivery_status !== 'interrupted') hasCompletedAssistant = true;
+      else if (message.tool_calls) checkpoints.push(...message.tool_calls);
+    }
+  }
+  return hasCompletedAssistant ? [] : checkpoints;
 }
 
 /** Encode Slack-editable channel metadata as explicitly untrusted data. */

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -30,6 +30,11 @@ import {
   type SponsoredIntelligenceContextKind,
 } from "../addie/slack-tool-selection.js";
 import { classifyLocalModelExecution } from "../addie/model-providers/model-provider.js";
+import {
+  blockCheckpointedToolReplays,
+  buildToolResultCheckpoint,
+  type StoredToolCall,
+} from "../addie/stream-tool-checkpoints.js";
 import { sanitizeSpeakerName } from "../addie/prompts.js";
 import { resolveUserTierFromDb } from "../addie/claude-cost-tracker.js";
 import {
@@ -1718,6 +1723,15 @@ export function createAddieChatRouter(options?: {
 
       // Get conversation history
       const threadMessages = await threadService.getThreadMessages(thread.thread_id, { limit: 100 });
+      const retryCheckpointToolCalls: StoredToolCall[] = retryRequested
+        ? threadMessages
+            .filter((message) => (
+              message.role === 'assistant'
+              && message.delivery_status === 'interrupted'
+              && message.client_request_id === clientRequestId
+            ))
+            .flatMap((message) => message.tool_calls ?? [])
+        : [];
 
       // Save user message
       if (!existingUserMessage) {
@@ -1819,6 +1833,9 @@ export function createAddieChatRouter(options?: {
         : null;
       const { processOptions, effectiveModel } = tieredAccess;
       const requestTools = routedWebTools?.requestTools ?? tieredAccess.requestTools;
+      const replayPolicy = blockCheckpointedToolReplays(
+        retryCheckpointToolCalls,
+      );
       requestedModelForAttempt = effectiveModel;
       const preTurnCertification = userId && certificationModuleContext.moduleId
         ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
@@ -1870,6 +1887,7 @@ export function createAddieChatRouter(options?: {
         currentSpeakerName: displayName || undefined,
         inputAttachments: attachments,
         ...(options?.evaluationMode ? { executionMode: 'evaluation' as const } : {}),
+        ...(replayPolicy ? { toolExecutionPolicy: replayPolicy } : {}),
         ...(streamAuthedScope
           ? { costScope: {
               ...streamAuthedScope,
@@ -1889,6 +1907,12 @@ export function createAddieChatRouter(options?: {
           toolsUsed.push(event.tool_name);
           sendEvent("tool_start", { tool_name: event.tool_name });
         } else if (event.type === 'tool_end') {
+          await threadService.addMessage(buildToolResultCheckpoint({
+            threadId: thread.thread_id,
+            execution: event.execution,
+            requestedModel: effectiveModel,
+            clientRequestId: clientRequestId || undefined,
+          }));
           sendEvent("tool_end", { tool_name: event.tool_name, is_error: event.is_error });
         } else if (event.type === 'retry') {
           sendEvent("retry", {
@@ -1913,14 +1937,6 @@ export function createAddieChatRouter(options?: {
             thread_id: thread.thread_id,
             role: 'assistant',
             content: 'Reply interrupted before completion. The learner can safely retry this turn.',
-            tools_used: event.tool_executions.map(execution => execution.tool_name),
-            tool_calls: event.tool_executions.map(execution => ({
-              name: execution.tool_name,
-              input: execution.parameters,
-              result: execution.result,
-              duration_ms: execution.duration_ms,
-              is_error: execution.is_error,
-            })),
             model: effectiveModel,
             model_execution: {
               source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'stream_interrupted',
@@ -2075,6 +2091,7 @@ export function createAddieChatRouter(options?: {
               input: exec.parameters,
               result: exec.result,
               duration_ms: exec.duration_ms,
+              is_error: exec.is_error,
             }))
           : undefined,
         model: effectiveModel,
@@ -2251,14 +2268,6 @@ export function createAddieChatRouter(options?: {
             thread_id: claimedTurn.threadId,
             role: 'assistant',
             content: 'Reply interrupted before completion. The learner can safely retry this turn.',
-            tools_used: terminalResponse?.tool_executions?.map(execution => execution.tool_name),
-            tool_calls: terminalResponse?.tool_executions?.map(execution => ({
-              name: execution.tool_name,
-              input: execution.parameters,
-              result: execution.result,
-              duration_ms: execution.duration_ms,
-              is_error: execution.is_error,
-            })),
             flagged: true,
             flag_reason: 'stream_interrupted: route_error',
             model_execution: {

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -323,6 +323,7 @@ export type WebChatRequestThreadService = Pick<ReturnType<typeof getThreadServic
   | 'getMessagesByClientRequestId'
   | 'claimClientTurn'
   | 'renewClientTurnLease'
+  | 'setClientTurnStatus'
 >;
 
 export interface RoutedWebTools {
@@ -1907,12 +1908,42 @@ export function createAddieChatRouter(options?: {
           toolsUsed.push(event.tool_name);
           sendEvent("tool_start", { tool_name: event.tool_name });
         } else if (event.type === 'tool_end') {
-          await threadService.addMessage(buildToolResultCheckpoint({
-            threadId: thread.thread_id,
-            execution: event.execution,
-            requestedModel: effectiveModel,
-            clientRequestId: clientRequestId || undefined,
-          }));
+          try {
+            await threadService.addMessage(buildToolResultCheckpoint({
+              threadId: thread.thread_id,
+              execution: event.execution,
+              requestedModel: effectiveModel,
+              clientRequestId: clientRequestId || undefined,
+            }));
+          } catch (checkpointError) {
+            logger.error(
+              { checkpointError, threadId: thread.thread_id, toolName: event.tool_name },
+              'Addie Chat Stream: Tool result checkpoint failed — stopping stream before further actions',
+            );
+            if (claimedTurn) {
+              try {
+                await threadService.setClientTurnStatus(
+                  claimedTurn.threadId,
+                  claimedTurn.clientRequestId,
+                  claimedTurn.leaseId,
+                  'completed',
+                );
+              } catch (statusError) {
+                logger.error(
+                  { statusError },
+                  'Addie Chat Stream: Failed to close unsafe-to-retry chat turn',
+                );
+              }
+              claimedTurn = null;
+            }
+            sendEvent('stream_error', {
+              error: 'An action completed, but its result could not be safely saved. Review the action before trying again.',
+              reason: 'checkpoint_persistence_failed',
+              recoverable: false,
+            });
+            res.end();
+            return;
+          }
           sendEvent("tool_end", { tool_name: event.tool_name, is_error: event.is_error });
         } else if (event.type === 'retry') {
           sendEvent("retry", {

--- a/server/tests/manual/fixed-trace-incident-eval.ts
+++ b/server/tests/manual/fixed-trace-incident-eval.ts
@@ -79,6 +79,7 @@ async function evaluateWebDelivery(): Promise<{
     getMessagesByClientRequestId: async () => [],
     claimClientTurn: async () => ({ state: 'claimed', leaseId: 'fixed-trace-web-lease' }),
     renewClientTurnLease: async () => true,
+    setClientTurnStatus: async () => true,
   };
   const prepareRequest = async (message: string): Promise<PreparedRequest> => ({
     messageToProcess: message,

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -807,6 +807,62 @@ describe('Addie chat conversation object authorization', () => {
     expect(assistantWrites[2]).not.toHaveProperty('tool_calls');
   });
 
+  it('stops before another tool and makes the turn non-retryable when checkpoint storage fails', async () => {
+    const execution = {
+      tool_name: 'schedule_meeting',
+      parameters: { title: 'Review' },
+      result: 'Meeting scheduled',
+      is_error: false,
+      duration_ms: 12,
+      sequence: 1,
+    };
+    let advancedPastCompletedTool = false;
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.addMessage.mockImplementation(async (message: { role: string; content?: string }) => {
+      if (message.role === 'assistant' && message.content === '') {
+        throw new Error('checkpoint database unavailable');
+      }
+      return {
+        ...message,
+        message_id: message.role === 'assistant' ? 'message_assistant' : 'message_user',
+      };
+    });
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield { type: 'tool_start', tool_name: execution.tool_name, parameters: execution.parameters };
+      yield {
+        type: 'tool_end', tool_name: execution.tool_name, result: execution.result,
+        is_error: false, execution,
+      };
+      advancedPastCompletedTool = true;
+      yield { type: 'tool_start', tool_name: 'send_follow_up', parameters: {} };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Schedule and follow up',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('checkpoint_persistence_failed');
+    expect(response.text).toContain('"recoverable":false');
+    expect(advancedPastCompletedTool).toBe(false);
+    expect(mocks.setClientTurnStatus).toHaveBeenCalledWith(
+      'thread_attacker',
+      'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+      'lease-1',
+      'completed',
+    );
+  });
+
   it('wires checkpointed calls into the retry execution guard', async () => {
     const clientRequestId = 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68';
     const checkpoint = {

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -730,6 +730,133 @@ describe('Addie chat conversation object authorization', () => {
     }));
   });
 
+  it('checkpoints each completed tool before a later stream error', async () => {
+    const firstExecution = {
+      tool_name: 'schedule_meeting',
+      parameters: { title: 'Review' },
+      result: 'Meeting scheduled',
+      is_error: false,
+      duration_ms: 12,
+      sequence: 1,
+    };
+    const secondExecution = {
+      tool_name: 'list_upcoming_meetings',
+      parameters: {},
+      result: 'One meeting',
+      is_error: false,
+      duration_ms: 8,
+      sequence: 2,
+    };
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.processMessageStream.mockImplementation(async function* () {
+      yield { type: 'tool_start', tool_name: firstExecution.tool_name, parameters: firstExecution.parameters };
+      yield {
+        type: 'tool_end', tool_name: firstExecution.tool_name, result: firstExecution.result,
+        is_error: false, execution: firstExecution,
+      };
+      yield { type: 'tool_start', tool_name: secondExecution.tool_name, parameters: secondExecution.parameters };
+      yield {
+        type: 'tool_end', tool_name: secondExecution.tool_name, result: secondExecution.result,
+        is_error: false, execution: secondExecution,
+      };
+      yield {
+        type: 'stream_error',
+        reason: 'Connection broke mid-reply',
+        deltasBeforeError: 1,
+        tool_executions: [firstExecution, secondExecution],
+        certification_reserve_used: false,
+      };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Schedule and summarize',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
+      });
+
+    expect(response.status).toBe(200);
+    const assistantWrites = mocks.addMessage.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.role === 'assistant');
+    expect(assistantWrites).toHaveLength(3);
+    expect(assistantWrites.slice(0, 2)).toEqual([
+      expect.objectContaining({
+        content: '',
+        delivery_status: 'interrupted',
+        tool_calls: [expect.objectContaining({ name: 'schedule_meeting', input: { title: 'Review' } })],
+      }),
+      expect.objectContaining({
+        content: '',
+        delivery_status: 'interrupted',
+        tool_calls: [expect.objectContaining({ name: 'list_upcoming_meetings', input: {} })],
+      }),
+    ]);
+    expect(assistantWrites[2]).toEqual(expect.objectContaining({
+      delivery_status: 'interrupted',
+      client_turn_lease_id: 'lease-1',
+      finalize_client_turn_status: 'interrupted',
+    }));
+    expect(assistantWrites[2]).not.toHaveProperty('tool_calls');
+  });
+
+  it('wires checkpointed calls into the retry execution guard', async () => {
+    const clientRequestId = 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68';
+    const checkpoint = {
+      name: 'schedule_meeting',
+      input: { title: 'Review' },
+      result: 'Meeting scheduled',
+      is_error: false,
+    };
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker',
+      channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      user_type: 'workos',
+      user_id: 'user_attacker',
+    });
+    mocks.getMessagesByClientRequestId.mockResolvedValue([{
+      message_id: 'message_user', role: 'user', content: 'Schedule a review', delivery_status: 'completed',
+    }]);
+    mocks.getThreadMessages.mockResolvedValue([
+      {
+        message_id: 'message_user', role: 'user', content: 'Schedule a review',
+        client_request_id: clientRequestId, delivery_status: 'completed',
+      },
+      {
+        message_id: 'checkpoint', role: 'assistant', content: '', tool_calls: [checkpoint],
+        client_request_id: clientRequestId, delivery_status: 'interrupted',
+      },
+    ]);
+    let replayDecision: unknown;
+    mocks.processMessageStream.mockImplementation(async function* (...args: unknown[]) {
+      const options = args[3] as { toolExecutionPolicy: (request: unknown) => Promise<unknown> };
+      replayDecision = await options.toolExecutionPolicy({
+        toolName: 'schedule_meeting', input: { title: 'Review' }, executionMode: 'production',
+      });
+      yield { type: 'done', response: successfulModelResponse('Already scheduled.') };
+    });
+
+    const response = await request(mountChatRouter())
+      .post('/stream')
+      .send({
+        message: 'Schedule a review',
+        conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        client_request_id: clientRequestId,
+        retry: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(replayDecision).toEqual({ allowed: false });
+  });
+
   it('gives every active certification learning thread the expanded reserve', async () => {
     const conversationId = '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489';
     mocks.memberContext = {

--- a/server/tests/unit/addie/slack-dm-stream.test.ts
+++ b/server/tests/unit/addie/slack-dm-stream.test.ts
@@ -354,11 +354,18 @@ describe('Slack DM stream tool metadata', () => {
     }, CONFIG, io);
     state = await interpretSlackDmStreamEvent(state, {
       type: 'tool_end', tool_name: 'lookup', result: 'ok', is_error: false,
+      execution: {
+        tool_name: 'lookup', parameters: { query: 'second' }, result: 'ok',
+        is_error: false, duration_ms: 12, sequence: 2,
+      },
     }, CONFIG, io);
 
     expect(state.toolsUsed).toEqual(['lookup', 'lookup']);
     expect(state.activeToolTaskIds).toEqual(['lookup_1']);
-    expect(state.toolExecutions).toEqual([{ tool_name: 'lookup', parameters: {}, result: 'ok' }]);
+    expect(state.toolExecutions).toEqual([{
+      tool_name: 'lookup', parameters: { query: 'second' }, result: 'ok',
+      is_error: false, duration_ms: 12, sequence: 2,
+    }]);
     const appendPayloads = calls.filter(call => call.kind === 'append').map(call => call.value);
     expect(appendPayloads[0]).toMatchObject({ chunks: [
       { type: 'plan_update', title: 'Addie is working' },
@@ -379,13 +386,20 @@ describe('Slack DM stream tool metadata', () => {
     }, CONFIG);
     const end = reduceSlackDmStreamEvent(start.state, {
       type: 'tool_end', tool_name: 'late_tool', result: 'late result', is_error: true,
+      execution: {
+        tool_name: 'late_tool', parameters: {}, result: 'late result',
+        is_error: true, duration_ms: 8, sequence: 1,
+      },
     }, CONFIG);
 
     expect(start.effects).toEqual([]);
     expect(end.effects).toEqual([]);
     expect(end.state.toolsUsed).toEqual(['late_tool']);
     expect(end.state.toolExecutions).toEqual([
-      { tool_name: 'late_tool', parameters: {}, result: 'late result' },
+      {
+        tool_name: 'late_tool', parameters: {}, result: 'late result',
+        is_error: true, duration_ms: 8, sequence: 1,
+      },
     ]);
   });
 });

--- a/server/tests/unit/addie/stream-tool-checkpoints.test.ts
+++ b/server/tests/unit/addie/stream-tool-checkpoints.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  blockCheckpointedToolReplays,
+  buildToolResultCheckpoint,
+} from '../../../src/addie/stream-tool-checkpoints.js';
+
+const execution = {
+  tool_name: 'schedule_meeting',
+  parameters: { title: 'Review', attendees: ['a@example.test'] },
+  result: 'Meeting scheduled',
+  is_error: false,
+  duration_ms: 25,
+  sequence: 1,
+} as const;
+
+describe('stream tool checkpoints', () => {
+  it('stores one complete tool-use/result pair without partial assistant prose', () => {
+    expect(buildToolResultCheckpoint({
+      threadId: 'thread-1',
+      execution,
+      requestedModel: 'claude-sonnet-5',
+      clientRequestId: 'request-1',
+    })).toEqual({
+      thread_id: 'thread-1',
+      role: 'assistant',
+      content: '',
+      tools_used: ['schedule_meeting'],
+      tool_calls: [{
+        name: 'schedule_meeting',
+        input: execution.parameters,
+        result: 'Meeting scheduled',
+        duration_ms: 25,
+        is_error: false,
+      }],
+      model: 'claude-sonnet-5',
+      model_execution: {
+        source: 'local',
+        requested_provider: 'anthropic',
+        requested_model: 'claude-sonnet-5',
+        reason: 'stream_interrupted',
+      },
+      client_request_id: 'request-1',
+      delivery_status: 'interrupted',
+    });
+  });
+
+  it('blocks only exact completed calls and preserves the existing policy', async () => {
+    const delegate = vi.fn().mockReturnValue({ allowed: true });
+    const policy = blockCheckpointedToolReplays([{
+      name: 'schedule_meeting',
+      input: { attendees: ['a@example.test'], title: 'Review' },
+      result: 'Meeting scheduled',
+    }], delegate)!;
+
+    await expect(policy({
+      toolName: 'schedule_meeting',
+      input: { title: 'Review', attendees: ['a@example.test'] },
+      executionMode: 'production',
+    })).resolves.toEqual({ allowed: false });
+    expect(delegate).not.toHaveBeenCalled();
+
+    const changed = {
+      toolName: 'schedule_meeting',
+      input: { title: 'Different review', attendees: ['a@example.test'] },
+      executionMode: 'production' as const,
+    };
+    await expect(policy(changed)).resolves.toEqual({ allowed: true });
+    expect(delegate).toHaveBeenCalledWith(changed);
+  });
+});

--- a/server/tests/unit/addie/stream-tool-checkpoints.test.ts
+++ b/server/tests/unit/addie/stream-tool-checkpoints.test.ts
@@ -67,4 +67,22 @@ describe('stream tool checkpoints', () => {
     await expect(policy(changed)).resolves.toEqual({ allowed: true });
     expect(delegate).toHaveBeenCalledWith(changed);
   });
+
+  it('leaves failed checkpointed calls retryable through the existing policy', async () => {
+    const delegate = vi.fn().mockReturnValue({ allowed: true });
+    const policy = blockCheckpointedToolReplays([{
+      name: 'schedule_meeting',
+      input: execution.parameters,
+      result: 'Calendar provider unavailable',
+      is_error: true,
+    }], delegate)!;
+    const request = {
+      toolName: 'schedule_meeting',
+      input: execution.parameters,
+      executionMode: 'production' as const,
+    };
+
+    expect(await policy(request)).toEqual({ allowed: true });
+    expect(delegate).toHaveBeenCalledWith(request);
+  });
 });

--- a/server/tests/unit/thread-utils.test.ts
+++ b/server/tests/unit/thread-utils.test.ts
@@ -7,6 +7,7 @@ import {
   buildThreadSummaryForRouter,
   buildUntrustedSlackHistoryContext,
   buildAuthorizedConversationHistory,
+  unresolvedToolCheckpointsForLatestTurn,
   buildUntrustedSlackChannelMetadataContext,
   isValidWorkingGroupSlug,
 } from '../../src/addie/thread-utils.js';
@@ -62,6 +63,41 @@ describe('Slack authority boundaries', () => {
       { user: 'Brian', text: 'show my status' },
       { user: 'Addie', text: 'Here is your status', toolCalls: undefined },
     ]);
+  });
+
+  it('keeps interrupted tool checkpoints only until a final assistant response exists', () => {
+    const checkpoint = {
+      name: 'schedule_meeting', input: { title: 'Review' }, result: 'scheduled', is_error: false,
+    };
+    const interrupted = [
+      { role: 'user', user_id: BRIAN, user_display_name: 'Brian', content: 'schedule and summarize' },
+      { role: 'assistant', content: '', delivery_status: 'interrupted' as const, tool_calls: [checkpoint] },
+      { role: 'assistant', content: '', delivery_status: 'interrupted' as const, tool_calls: [{
+        name: 'list_meetings', input: {}, result: 'one meeting', is_error: false,
+      }] },
+    ];
+
+    expect(buildAuthorizedConversationHistory(interrupted, BRIAN, 20)).toEqual([
+      { user: 'Brian', text: 'schedule and summarize' },
+      { user: 'Addie', text: '', toolCalls: [checkpoint] },
+      { user: 'Addie', text: '', toolCalls: [{
+        name: 'list_meetings', input: {}, result: 'one meeting', is_error: false,
+      }] },
+    ]);
+    expect(unresolvedToolCheckpointsForLatestTurn(interrupted, BRIAN)).toEqual([
+      checkpoint,
+      { name: 'list_meetings', input: {}, result: 'one meeting', is_error: false },
+    ]);
+
+    const completed = [...interrupted, {
+      role: 'assistant', content: 'Scheduled and summarized.', delivery_status: 'completed' as const,
+      tool_calls: [checkpoint],
+    }];
+    expect(buildAuthorizedConversationHistory(completed, BRIAN, 20)).toEqual([
+      { user: 'Brian', text: 'schedule and summarize' },
+      { user: 'Addie', text: 'Scheduled and summarized.', toolCalls: [checkpoint] },
+    ]);
+    expect(unresolvedToolCheckpointsForLatestTurn(completed, BRIAN)).toEqual([]);
   });
 
   it('marks channel-controlled metadata as untrusted data', () => {


### PR DESCRIPTION
## Summary

- persist each completed streaming tool-use/result pair atomically before requesting the next provider event
- keep partial natural-language output out of checkpoint rows and retain exact tool parameters, result, error state, duration, and sequence
- expose unresolved Slack checkpoints as valid structured tool history, while completed assistant responses supersede hidden checkpoints
- carry web checkpoints through idempotent ask-again turns and block exact completed tool calls from executing again
- stop the Slack stream before further actions if checkpoint persistence itself fails

Closes #6471. Parent: #4797.

## Verification

- focused streaming, retry, history, truncation, and replay tests (189 passed)
- `npm run test:addie-fixed-traces` (43 passed)
- `npm run typecheck`
- full pre-commit gate (560 files; 8,154 passed, 32 skipped)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
