### PR TITLE
fix(admin): preserve corporate credential primacy

### DIFF
--- a/server/src/db/user-merge-db.ts
+++ b/server/src/db/user-merge-db.ts
@@ -120,6 +120,8 @@ export interface MergeUsersOptions {
    * already is_primary=TRUE in normal mergeUsers callers.
    */
   ensurePrimaryFlag?: boolean;
+  /** Additional server-derived context retained with the transactional merge audit. */
+  auditContext?: Record<string, unknown>;
 }
 
 /**
@@ -877,6 +879,7 @@ export async function mergeUsers(
           primary_user_id: primaryUserId,
           secondary_user_id: secondaryUserId,
           merged_at: summary.merged_at,
+          ...(options.auditContext ? { audit_context: options.auditContext } : {}),
           tables_affected: summary.tables_merged
             .filter(t => t.rows_moved > 0 || t.rows_skipped_duplicate > 0)
             .map(t => t.table_name),

--- a/server/src/routes/admin/users.ts
+++ b/server/src/routes/admin/users.ts
@@ -22,12 +22,38 @@ import { backfillOrganizationMemberships, backfillUsers, backfillOrganizationDom
 import { sendSlackInviteEmail, hasSlackInviteBeenSent } from '../../notifications/email.js';
 import { getWorkos } from '../../auth/workos-client.js';
 import { mergeUsers } from '../../db/user-merge-db.js';
+import { resolveMembershipTier, type MembershipTierRow } from '../../db/organization-db.js';
 import {
   buildCountryMembersCsv,
   type CountryMemberExportRow,
 } from './country-members-export.js';
 
 const logger = createLogger('admin-users-routes');
+
+type CredentialOrganizationMembership = MembershipTierRow & {
+  workos_organization_id: string;
+  subscription_canceled_at: Date | null;
+};
+
+function resolveEntitledMemberships(rows: CredentialOrganizationMembership[]) {
+  return rows.flatMap((row) => {
+    const membershipTier = resolveMembershipTier(row);
+    return membershipTier
+      ? [{
+          workos_organization_id: row.workos_organization_id,
+          membership_tier: membershipTier,
+        }]
+      : [];
+  });
+}
+
+function isCorporateMembershipTier(tier: string): boolean {
+  return tier.startsWith('company_');
+}
+
+function isIndividualMembershipTier(tier: string): boolean {
+  return tier.startsWith('individual_');
+}
 
 /**
  * Linear-time plausibility check for an email-shaped string. Avoids the
@@ -1020,6 +1046,7 @@ export function createAdminUsersRouter(): Router {
   router.post('/:userId/credentials', ...requireGlobalAdmin, async (req, res) => {
     const adminEmail = req.user!.email;
     const adminUserId = req.user!.id;
+    const adminAuthCredentialId = req.user!.authWorkosUserId ?? req.user!.id;
     const existingUserId = req.params.userId;
     const credId = (req.body?.workos_user_id as string | undefined)?.trim();
 
@@ -1083,6 +1110,53 @@ export function createAdminUsersRouter(): Router {
       }
     }
 
+    // Do not let a corporate membership become an entitlement of an
+    // individual-tier identity merely because an operator confirmed a
+    // credential merge. The safe, supported direction for this shape is to
+    // keep the corporate credential canonical and bind the personal one to
+    // it. This check deliberately runs even when consolidate=true: that flag
+    // acknowledges an ordinary destructive merge; it is not a tier override.
+    const [credentialMemberships, hostMemberships] = await Promise.all([
+      pool.query<CredentialOrganizationMembership>(
+        `SELECT o.workos_organization_id, o.membership_tier,
+                o.subscription_price_lookup_key, o.subscription_status,
+                o.subscription_amount, o.subscription_interval, o.is_personal,
+                o.subscription_canceled_at
+           FROM organization_memberships om
+           JOIN organizations o
+             ON o.workos_organization_id = om.workos_organization_id
+          WHERE om.workos_user_id = $1
+            AND o.subscription_canceled_at IS NULL
+          ORDER BY o.workos_organization_id`,
+        [credId]
+      ),
+      pool.query<CredentialOrganizationMembership>(
+        `SELECT o.workos_organization_id, o.membership_tier,
+                o.subscription_price_lookup_key, o.subscription_status,
+                o.subscription_amount, o.subscription_interval, o.is_personal,
+                o.subscription_canceled_at
+           FROM organization_memberships om
+           JOIN organizations o
+             ON o.workos_organization_id = om.workos_organization_id
+          WHERE om.workos_user_id = $1
+            AND o.subscription_canceled_at IS NULL
+          ORDER BY o.workos_organization_id`,
+        [existingUserId]
+      ),
+    ]);
+    const corporateMemberships = resolveEntitledMemberships(credentialMemberships.rows)
+      .filter((membership) => isCorporateMembershipTier(membership.membership_tier));
+    const personalMemberships = resolveEntitledMemberships(hostMemberships.rows)
+      .filter((membership) => isIndividualMembershipTier(membership.membership_tier));
+    if (corporateMemberships.length > 0 && personalMemberships.length > 0) {
+      return res.status(409).json({
+        error: 'corporate_membership_personal_host_conflict',
+        message: 'Cannot bind a corporate-tier credential onto an individual-tier account. Start from the corporate account and bind the personal credential so the corporate account remains canonical.',
+        corporate_memberships: corporateMemberships,
+        personal_memberships: personalMemberships,
+      });
+    }
+
     // Foot-gun gate: refuse silent consolidation. If credId has any app-state
     // attached (org membership, points, certification work, working-group
     // membership), binding will MOVE it onto the host — that's a real account
@@ -1117,12 +1191,25 @@ export function createAdminUsersRouter(): Router {
       }
     }
 
+    if (consolidateConfirmed && req.adminAccessMechanism === 'static_admin_api_key') {
+      return res.status(403).json({
+        error: 'identity_bearing_admin_required',
+        message: 'Destructive consolidation must be confirmed by an identity-bearing SSO admin session; the static admin API key cannot provide individual actor attribution.',
+      });
+    }
+
     // mergeUsers moves any app-state from credId to existingUserId, rebinds
     // credId's identity_workos_users row to existingUserId's identity as
     // is_primary = FALSE, and drops the orphan identity. Throws if either
     // user lacks an identity binding.
     try {
-      await mergeUsers(existingUserId, credId, adminUserId);
+      await mergeUsers(existingUserId, credId, adminUserId, {
+        auditContext: {
+          acting_workos_user_id: adminAuthCredentialId,
+          admin_access_mechanism: req.adminAccessMechanism ?? null,
+          consolidation_confirmed: consolidateConfirmed,
+        },
+      });
     } catch (err) {
       logger.error({ err, existingUserId, credId }, 'Admin link-credential: mergeUsers failed');
       return res.status(500).json({ error: 'Failed to bind credential' });
@@ -1396,6 +1483,33 @@ export function createAdminUsersRouter(): Router {
       });
     }
 
+    // A corporate credential must remain canonical once it carries an
+    // entitled corporate membership. Otherwise an operator could safely bind
+    // a personal credential onto it, then promote that credential and move
+    // the corporate membership onto the personal account.
+    const currentMembershipRows = await pool.query<CredentialOrganizationMembership>(
+      `SELECT o.workos_organization_id, o.membership_tier,
+              o.subscription_price_lookup_key, o.subscription_status,
+              o.subscription_amount, o.subscription_interval, o.is_personal,
+              o.subscription_canceled_at
+         FROM organization_memberships om
+         JOIN organizations o
+           ON o.workos_organization_id = om.workos_organization_id
+        WHERE om.workos_user_id = $1
+          AND o.subscription_canceled_at IS NULL
+        ORDER BY o.workos_organization_id`,
+      [currentPrimaryId],
+    );
+    const corporateMemberships = resolveEntitledMemberships(currentMembershipRows.rows)
+      .filter((membership) => isCorporateMembershipTier(membership.membership_tier));
+    if (corporateMemberships.length > 0) {
+      return res.status(409).json({
+        error: 'corporate_membership_primary_required',
+        message: 'Cannot promote another credential while the current primary holds an entitled corporate membership. Keep the corporate credential canonical.',
+        corporate_memberships: corporateMemberships,
+      });
+    }
+
     // Foot-gun gate: promote runs the same consolidation as link-credential.
     // Memberships whose partner key the incoming credential already holds are
     // DELETED by it — the outgoing row's role, seat, upstream membership id,
@@ -1417,12 +1531,26 @@ export function createAdminUsersRouter(): Router {
       }
     }
 
+    if (req.body?.consolidate === true && req.adminAccessMechanism === 'static_admin_api_key') {
+      return res.status(403).json({
+        error: 'identity_bearing_admin_required',
+        message: 'Destructive consolidation must be confirmed by an identity-bearing SSO admin session; the static admin API key cannot provide individual actor attribution.',
+      });
+    }
+
     // Run mergeUsers with ensurePrimaryFlag so the data move, the secondary
     // rebind, AND the new primary's is_primary=TRUE flip all happen in one
     // transaction. This closes the window where the identity has zero
     // primaries.
     try {
-      await mergeUsers(newPrimaryId, currentPrimaryId, adminUserId, { ensurePrimaryFlag: true });
+      await mergeUsers(newPrimaryId, currentPrimaryId, adminUserId, {
+        ensurePrimaryFlag: true,
+        auditContext: {
+          acting_workos_user_id: adminAuthCredentialId,
+          admin_access_mechanism: req.adminAccessMechanism ?? null,
+          consolidation_confirmed: req.body?.consolidate === true,
+        },
+      });
     } catch (err) {
       logger.error(
         { err, userId, newPrimaryId, currentPrimaryId },

--- a/server/tests/integration/admin-link-unlink-credential.test.ts
+++ b/server/tests/integration/admin-link-unlink-credential.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import type { Pool } from 'pg';
+import { readFileSync } from 'node:fs';
 
 vi.hoisted(() => {
   process.env.WORKOS_API_KEY ??= 'sk_test_mock_key';
@@ -28,8 +29,10 @@ vi.mock('../../src/auth/workos-client.js', () => {
 
 vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
   const mockedRequireAuth = (req: any, _res: any, next: any) => {
+    req.adminAccessMechanism = req.headers['x-test-admin-access-mechanism'] || undefined;
     req.user = {
       id: 'user_test_admin_link',
+      authWorkosUserId: 'user_test_admin_link_credential',
       email: 'admin@test.local',
       emailVerified: true,
       createdAt: new Date().toISOString(),
@@ -99,6 +102,24 @@ describe('admin link / unlink credential', () => {
   }
 
   describe('POST /credentials (bind existing)', () => {
+    it('keeps the declared global-admin and people-UI confirmation contracts', () => {
+      const routeSource = readFileSync(
+        new URL('../../src/routes/admin/users.ts', import.meta.url),
+        'utf8',
+      );
+      const bindRoute = routeSource.match(
+        /router\.post\('\/:userId\/credentials', \.\.\.requireGlobalAdmin, async \(req, res\) => \{[\s\S]*?\n  \}\);/
+      )?.[0];
+      expect(bindRoute).toContain('...requireGlobalAdmin');
+
+      const peopleUi = readFileSync(
+        new URL('../../public/admin-people.html', import.meta.url),
+        'utf8',
+      );
+      expect(peopleUi).toContain('data.consolidate_confirmation_required');
+      expect(peopleUi).toContain('JSON.stringify({ workos_user_id: trimmed, consolidate: true })');
+    });
+
     it('binds an existing WorkOS user (already in local users) under host\'s identity', async () => {
       // Insert the target locally so the trigger creates its singleton identity
       await pool.query(
@@ -244,6 +265,17 @@ describe('admin link / unlink credential', () => {
         expect(refused.body.consolidate_confirmation_required).toBe(true);
         expect(refused.body.message).toMatch(/consolidate/i);
 
+        // A static global-admin key has no person-level principal, so it may
+        // observe the preflight but cannot acknowledge a destructive merge.
+        await request(app)
+          .post(`/api/admin/users/${HOST_USER_ID}/credentials`)
+          .set('X-Test-Admin-Access-Mechanism', 'static_admin_api_key')
+          .send({ workos_user_id: TARGET_USER_ID, consolidate: true })
+          .expect(403)
+          .expect(({ body }) => {
+            expect(body.error).toBe('identity_bearing_admin_required');
+          });
+
         // Same call with consolidate: true succeeds and moves the membership
         await request(app)
           .post(`/api/admin/users/${HOST_USER_ID}/credentials`)
@@ -256,9 +288,113 @@ describe('admin link / unlink credential', () => {
         );
         expect(moved.rows).toHaveLength(1);
         expect(moved.rows[0].workos_user_id).toBe(HOST_USER_ID);
+
+        // The destructive, server-confirmed consolidation is attributed to
+        // the authenticated global admin by mergeUsers' audit record.
+        const audit = await pool.query<{ workos_user_id: string; details: any }>(
+          `SELECT workos_user_id, details
+             FROM registry_audit_log
+            WHERE action = 'merge_user' AND resource_id = $1
+            ORDER BY created_at DESC LIMIT 1`,
+          [TARGET_USER_ID],
+        );
+        expect(audit.rows).toHaveLength(1);
+        expect(audit.rows[0].workos_user_id).toBe('user_test_admin_link');
+        expect(audit.rows[0].details).toMatchObject({
+          primary_user_id: HOST_USER_ID,
+          secondary_user_id: TARGET_USER_ID,
+          audit_context: {
+            acting_workos_user_id: 'user_test_admin_link_credential',
+            consolidation_confirmed: true,
+          },
+        });
       } finally {
         await pool.query(`DELETE FROM organization_memberships WHERE workos_organization_id = $1`, [orgId]);
         await pool.query(`DELETE FROM organizations WHERE workos_organization_id = $1`, [orgId]);
+      }
+    });
+
+    it('blocks a corporate-tier credential from being absorbed by an individual-tier host', async () => {
+      await pool.query(
+        `INSERT INTO users (workos_user_id, email, first_name, last_name, email_verified,
+                            workos_created_at, workos_updated_at, created_at, updated_at)
+         VALUES ($1, 'corporate@test.example', 'Corporate', 'User', true, NOW(), NOW(), NOW(), NOW())`,
+        [TARGET_USER_ID],
+      );
+      const personalOrgId = 'org_test_link_personal_tier';
+      const corporateOrgId = 'org_test_link_corporate_tier';
+      await pool.query(
+        `INSERT INTO organizations
+           (workos_organization_id, name, is_personal, membership_tier, subscription_status, created_at, updated_at)
+         VALUES
+           ($1, 'Personal test workspace', true, 'individual_professional', 'active', NOW(), NOW()),
+           ($2, 'Corporate test workspace', false, NULL, 'active', NOW(), NOW())`,
+        [personalOrgId, corporateOrgId],
+      );
+      await pool.query(
+        `UPDATE organizations
+            SET subscription_price_lookup_key = 'aao_membership_member'
+          WHERE workos_organization_id = $1`,
+        [corporateOrgId],
+      );
+      await pool.query(
+        `INSERT INTO organization_memberships
+           (workos_user_id, workos_organization_id, email, role, created_at, updated_at)
+         VALUES
+           ($1, $2, 'host@test.example', 'member', NOW(), NOW()),
+           ($3, $4, 'corporate@test.example', 'member', NOW(), NOW())`,
+        [HOST_USER_ID, personalOrgId, TARGET_USER_ID, corporateOrgId],
+      );
+
+      try {
+        for (const body of [
+          { workos_user_id: TARGET_USER_ID },
+          { workos_user_id: TARGET_USER_ID, consolidate: true },
+        ]) {
+          const response = await request(app)
+            .post(`/api/admin/users/${HOST_USER_ID}/credentials`)
+            .send(body)
+            .expect(409);
+          expect(response.body).toMatchObject({
+            error: 'corporate_membership_personal_host_conflict',
+            corporate_memberships: [{
+              workos_organization_id: corporateOrgId,
+              membership_tier: 'company_icl',
+            }],
+            personal_memberships: [{
+              workos_organization_id: personalOrgId,
+              membership_tier: 'individual_professional',
+            }],
+          });
+        }
+
+        const [membership, bindings] = await Promise.all([
+          pool.query(
+            `SELECT workos_user_id FROM organization_memberships
+              WHERE workos_organization_id = $1`,
+            [corporateOrgId],
+          ),
+          pool.query<{ identity_id: string }>(
+            `SELECT identity_id FROM identity_workos_users
+              WHERE workos_user_id IN ($1, $2)
+              ORDER BY workos_user_id`,
+            [HOST_USER_ID, TARGET_USER_ID],
+          ),
+        ]);
+        expect(membership.rows).toEqual([{ workos_user_id: TARGET_USER_ID }]);
+        expect(bindings.rows).toHaveLength(2);
+        expect(bindings.rows[0].identity_id).not.toBe(bindings.rows[1].identity_id);
+      } finally {
+        await pool.query(
+          `DELETE FROM organization_memberships
+            WHERE workos_organization_id IN ($1, $2)`,
+          [personalOrgId, corporateOrgId],
+        );
+        await pool.query(
+          `DELETE FROM organizations
+            WHERE workos_organization_id IN ($1, $2)`,
+          [personalOrgId, corporateOrgId],
+        );
       }
     });
   });

--- a/server/tests/integration/admin-promote-credential.test.ts
+++ b/server/tests/integration/admin-promote-credential.test.ts
@@ -26,8 +26,10 @@ vi.mock('../../src/auth/workos-client.js', () => {
 
 vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
   const mockedRequireAuth = (req: any, _res: any, next: any) => {
+    req.adminAccessMechanism = req.headers['x-test-admin-access-mechanism'] || undefined;
     req.user = {
       id: 'user_test_admin_promote',
+      authWorkosUserId: 'user_test_admin_promote_credential',
       email: 'admin@test.local',
       emailVerified: true,
       createdAt: new Date().toISOString(),
@@ -246,12 +248,78 @@ describe('admin promote credential to primary', () => {
     expect(bindings.rows.find(r => r.workos_user_id === TARGET_USER_ID)?.is_primary).toBe(true);
   });
 
+  it('requires an identity-bearing admin to confirm destructive promotion', async () => {
+    await setupOverlappingPair();
+
+    const response = await request(app)
+      .post(`/api/admin/users/${HOST_USER_ID}/credentials/${TARGET_USER_ID}/promote`)
+      .set('X-Test-Admin-Access-Mechanism', 'static_admin_api_key')
+      .send({ consolidate: true })
+      .expect(403);
+    expect(response.body.error).toBe('identity_bearing_admin_required');
+  });
+
   it('promotes without confirmation when the memberships do not overlap', async () => {
     await setupBoundPair();
 
     await request(app)
       .post(`/api/admin/users/${HOST_USER_ID}/credentials/${TARGET_USER_ID}/promote`)
       .expect(200);
+  });
+
+  it('blocks promotion away from a corporate primary after a personal credential was bound', async () => {
+    await pool.query(
+      `UPDATE organizations
+          SET is_personal = false, membership_tier = 'company_standard', subscription_status = 'active'
+        WHERE workos_organization_id = $1`,
+      [HOST_ORG_ID],
+    );
+    await pool.query(
+      `UPDATE organizations
+          SET is_personal = true, membership_tier = 'individual_professional', subscription_status = 'active'
+        WHERE workos_organization_id = $1`,
+      [TARGET_ORG_ID],
+    );
+    await pool.query(
+      `INSERT INTO organization_memberships (workos_user_id, workos_organization_id, email, role, created_at, updated_at)
+       VALUES ($1, $2, 'host@test.example', 'member', NOW(), NOW()),
+              ($3, $4, 'target@test.example', 'member', NOW(), NOW())`,
+      [HOST_USER_ID, HOST_ORG_ID, TARGET_USER_ID, TARGET_ORG_ID],
+    );
+
+    // This is the supported direction: the corporate credential remains
+    // primary when the personal credential is bound.
+    await request(app)
+      .post(`/api/admin/users/${HOST_USER_ID}/credentials`)
+      .send({ workos_user_id: TARGET_USER_ID, consolidate: true })
+      .expect(201);
+
+    const response = await request(app)
+      .post(`/api/admin/users/${HOST_USER_ID}/credentials/${TARGET_USER_ID}/promote`)
+      .expect(409);
+    expect(response.body).toMatchObject({
+      error: 'corporate_membership_primary_required',
+      corporate_memberships: [{
+        workos_organization_id: HOST_ORG_ID,
+        membership_tier: 'company_standard',
+      }],
+    });
+
+    const [corporateMembership, bindings] = await Promise.all([
+      pool.query(
+        `SELECT workos_user_id FROM organization_memberships
+          WHERE workos_organization_id = $1`,
+        [HOST_ORG_ID],
+      ),
+      pool.query<{ workos_user_id: string; is_primary: boolean }>(
+        `SELECT workos_user_id, is_primary FROM identity_workos_users
+          WHERE workos_user_id IN ($1, $2)`,
+        [HOST_USER_ID, TARGET_USER_ID],
+      ),
+    ]);
+    expect(corporateMembership.rows).toEqual([{ workos_user_id: HOST_USER_ID }]);
+    expect(bindings.rows.find((row) => row.workos_user_id === HOST_USER_ID)?.is_primary).toBe(true);
+    expect(bindings.rows.find((row) => row.workos_user_id === TARGET_USER_ID)?.is_primary).toBe(false);
   });
 
   it('writes a promote_credential_to_primary audit row', async () => {


### PR DESCRIPTION
## Summary
- block consolidating an entitled corporate credential into an individual-tier host, using canonical effective-tier resolution
- prevent the reverse promotion path from making an individual credential primary over an entitled corporate account
- require an identity-bearing global-admin session for destructive confirmed consolidations and attach the actor and acknowledgement to merge audit metadata

## Verification
- exercised synthetic personal-host/corporate-account admin flows: initial confirmation gate, explicit consolidation, credential bindings, membership state, and audit attribution
- ran focused route tests, global-admin authorization tests, typecheck, diff/scope checks, and the repository precommit hook

## Security
- no generic force override or client-only acknowledgement was added
- static admin API keys cannot perform destructive confirmed consolidation because they lack individual actor attribution

Related to #7214. No production identities or live WorkOS data were accessed or mutated.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d30e7f4c-47ae-45f3-80c2-e9dd71199827)
