### PR TITLE
Define Addie stream retry ownership

### DIFF
--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1913,10 +1913,19 @@ export class AddieClaudeClient {
   }
 
   /**
-   * Process a message with streaming - yields events as they occur
+   * Process a message as a stream of delivery events.
    *
-   * Note: Tool use temporarily pauses text streaming while the tool executes,
-   * then resumes with the response. The final 'done' event includes the complete response.
+   * Provider attempts are buffered here and may be retried only before that
+   * attempt exposes model content/tool events or executes a requested tool
+   * (a retry-status event may still describe the discarded attempt).
+   * Once a prior iteration has emitted text or a tool receipt, a later terminal
+   * provider failure becomes `stream_error`; this method never restarts the
+   * logical turn. Delivery adapters persist that boundary and own any explicit
+   * user-triggered continuation. These phases cannot use the one-shot
+   * `withRetry` helper because it has no event/tool visibility.
+   *
+   * Tool use pauses delivery while the tool executes, then resumes with its
+   * result. The final `done` event includes the complete response.
    *
    * @param userMessage - The user's message
    * @param threadContext - Optional thread history
@@ -2102,10 +2111,12 @@ export class AddieClaudeClient {
         let currentResponse: ModelResponse | null = null;
         let reusedEmptyResponse = false;
 
-        // Retry loop for streaming API calls (handles overloaded_error).
-        // Logical-turn buffering means no model output is exposed and no
-        // custom tool executes until a complete response is assembled, so a
-        // failed sample is safe to discard and retry even after deltas arrive.
+        // Provider-attempt retry (the pre-first-content/tool-event phase).
+        // Logical response buffering means no model output from this attempt is
+        // exposed and none of its requested tools executes until the response
+        // is complete.
+        // A failed sample is therefore safe to discard even after provider
+        // deltas arrive. This loop never restarts the surrounding logical turn.
         const maxStreamRetries = isExactlyOnceExecution(options) ? 0 : 3;
         let streamRetryCount = 0;
         let streamSucceeded = false;

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,13 +58,13 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "57cc16b025506e09d03855d62dd7daea976e28fc48fe170be4baa9975b336848",
+    "server/src/addie/claude-client.ts": "e2feb54728a277be9683c06ee603296bab200b084737fa1b016ce1d8c5f2b72e",
     "server/src/addie/prompts.ts": "f091b8d7dd9c3b09b9630d858370c4dff00260e05bdbf0fb2c94b9bb9ae958fa",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "050ffcc96af1af737c594cbc773b37483641f4d756d09a252c8aec569b9d3119",
-    "server/src/routes/addie-chat.ts": "f07553c08ee2bae8ccb0163e2dc6c352b7ca282bea0a3d528243fca06ac4a8fd",
+    "server/src/routes/addie-chat.ts": "64b53f955e3454f33cd3242723072f278410a0938499765f2a3f82d297682924",
     "server/src/routes/tavus.ts": "3f7f598555ee52090eb2a26ac0bf1dea5e1fe345ea8e57764b60879d7b96cfec",
     "server/src/addie/email-conversation-handler.ts": "091feb8569d9d254351c2c37b11747e34d3e5f6777bc362e5de750c05568a4a5",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -1652,8 +1652,12 @@ export function createAddieChatRouter(options?: {
         });
       }
 
-      // The message uniqueness constraint prevents duplicate storage; this
-      // lease prevents duplicate model/tool execution while a turn is active.
+      // User-triggered ask-again is owned here, separately from provider-attempt
+      // retry and terminal stream-error handling. The message constraint avoids
+      // duplicate storage; the lease serializes the turn; and, on an interrupted
+      // retry, persisted tool checkpoints below reconstruct results and block
+      // exact successful-call replay. Never restart a turn merely because the
+      // transport disconnected.
       if (!completedAssistantMessage && clientRequestId) {
         const claim = await threadService.claimClientTurn(
           thread.thread_id,

--- a/server/src/utils/anthropic-retry.ts
+++ b/server/src/utils/anthropic-retry.ts
@@ -1,8 +1,11 @@
 /**
- * Retry utilities for Anthropic API calls
+ * Retry utilities for one-shot Anthropic API calls.
  *
- * Handles transient errors like overloaded_error (529) and connection errors
- * with exponential backoff.
+ * This module deliberately does not expose a streaming retry wrapper. Addie
+ * owns provider-stream attempt buffering in `claude-client.ts`, while delivery
+ * adapters own interrupted-turn persistence and explicit user continuation.
+ * A generic async-generator wrapper cannot know whether a yielded value or
+ * tool action made restarting the generator unsafe.
  */
 
 import { APIError, APIConnectionError } from '@anthropic-ai/sdk';
@@ -185,7 +188,13 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Execute an async function with retry on transient errors
+ * Execute one promise-returning provider request with retry on transient errors.
+ *
+ * The callback must describe a request that is safe to submit again before it
+ * resolves. It must not expose partial output or perform an irreversible tool
+ * action. Streaming calls use Addie's buffered retry loop instead, because it
+ * can distinguish an unexposed provider attempt from an interrupted logical
+ * turn and cannot be safely merged into this helper.
  *
  * @param fn - The async function to execute
  * @param config - Retry configuration
@@ -259,94 +268,6 @@ export async function withRetry<T>(
       operation: operationName,
     },
     'Anthropic API: All retry attempts exhausted'
-  );
-
-  throw new RetriesExhaustedError(lastError, totalAttempts);
-}
-
-/**
- * Execute a streaming async generator with retry on transient errors
- *
- * Note: This retries the entire stream from the beginning if an error occurs.
- * For streaming APIs, errors typically happen during iteration, so we need
- * to restart the whole stream on retry.
- *
- * @param fn - Factory function that creates the async generator
- * @param config - Retry configuration
- * @param operationName - Name for logging purposes
- * @returns An async generator that yields from the function
- */
-export async function* withStreamRetry<T>(
-  fn: () => AsyncGenerator<T>,
-  config?: RetryConfig,
-  operationName?: string
-): AsyncGenerator<T> {
-  const finalConfig = { ...DEFAULT_CONFIG, ...config };
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= finalConfig.maxRetries + 1; attempt++) {
-    try {
-      const generator = fn();
-      for await (const item of generator) {
-        yield item;
-      }
-      // Successfully completed
-      return;
-    } catch (error) {
-      lastError = error;
-
-      // Don't retry if we've exhausted attempts
-      if (attempt > finalConfig.maxRetries) {
-        break;
-      }
-
-      // Don't retry non-retryable errors
-      if (!isRetryableError(error)) {
-        throw error;
-      }
-
-      const delayMs = calculateDelay(attempt, finalConfig);
-      const retryAfterSeconds = getProviderRetryAfterSeconds(error);
-      const providerDelayMs = retryAfterSeconds === undefined ? 0 : retryAfterSeconds * 1000;
-      if (providerDelayMs > finalConfig.maxDelayMs) {
-        logger.warn(
-          {
-            attempt,
-            maxRetries: finalConfig.maxRetries,
-            retryAfterSeconds,
-            operation: operationName,
-          },
-          'Anthropic API Stream: Retry-After exceeds request retry budget; deferring recovery',
-        );
-        throw new RetriesExhaustedError(error, attempt);
-      }
-      const scheduledDelayMs = Math.max(delayMs, providerDelayMs);
-
-      logger.warn(
-        {
-          attempt,
-          maxRetries: finalConfig.maxRetries,
-          delayMs: Math.round(scheduledDelayMs),
-          retryAfterSeconds,
-          error: error instanceof Error ? error.message : String(error),
-          operation: operationName,
-        },
-        `Anthropic API Stream: Retryable error, waiting before retry ${attempt}/${finalConfig.maxRetries}`
-      );
-
-      await sleep(scheduledDelayMs);
-    }
-  }
-
-  // All retries exhausted
-  const totalAttempts = finalConfig.maxRetries + 1;
-  logger.error(
-    {
-      totalAttempts,
-      error: lastError instanceof Error ? lastError.message : String(lastError),
-      operation: operationName,
-    },
-    'Anthropic API Stream: All retry attempts exhausted'
   );
 
   throw new RetriesExhaustedError(lastError, totalAttempts);

--- a/server/tests/unit/claude-client-stream-error.test.ts
+++ b/server/tests/unit/claude-client-stream-error.test.ts
@@ -8,11 +8,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  * the unprocessed partial text. Consumers can render a recovery banner and
  * drop the partial assistant turn from conversation history.
  *
- * The "no retry after content yielded" guard in claude-client.ts is
- * load-bearing: Anthropic streaming has no resumption token and the
- * prompt cache only dedupes input, so a retried request would sample a
- * fresh output and we'd be stitching two unrelated streams. The event
- * gives the consumer the signal needed to do the discard cleanly.
+ * Provider deltas remain buffered and may be retried before any event or tool
+ * from that attempt is exposed. After a prior logical-turn iteration has
+ * emitted an event or completed a tool, Anthropic has no resumption token, so
+ * the client emits `stream_error` instead of restarting the turn. The event
+ * gives the delivery owner the signal needed to persist and discard cleanly.
  */
 
 // Two stream stubs covering both realistic mid-stream failure shapes.
@@ -58,6 +58,7 @@ function makeApiErrorStub(MockedAPIError: { new (msg: string): Error & { status?
 
 // Selects which stub the mocked SDK returns. Mutated per-test below.
 let streamStubFactory: () => ReturnType<typeof makeKeywordErrorStub> = makeKeywordErrorStub;
+let sdkStreamCalls = 0;
 
 vi.mock('@anthropic-ai/sdk', () => {
   class MockAPIError extends Error {
@@ -72,13 +73,19 @@ vi.mock('@anthropic-ai/sdk', () => {
     default: class {
       beta = {
         messages: {
-          stream: vi.fn(() => streamStubFactory()),
+          stream: vi.fn(() => {
+            sdkStreamCalls++;
+            return streamStubFactory();
+          }),
           create: vi.fn(),
         },
       };
       messages = {
         create: vi.fn(),
-        stream: vi.fn(() => streamStubFactory()),
+        stream: vi.fn(() => {
+          sdkStreamCalls++;
+          return streamStubFactory();
+        }),
       };
     },
     APIError: MockAPIError,
@@ -97,6 +104,7 @@ beforeEach(() => {
   __setCostTrackerStore(__createInMemoryCostStore());
   // Default stub: keyword-only Error. Per-test overrides flip to APIError.
   streamStubFactory = makeKeywordErrorStub;
+  sdkStreamCalls = 0;
   vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: () => void) => {
     callback();
     return 0;
@@ -133,6 +141,7 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
     expect(evt.deltasBeforeError).toBe(1);
     expect(evt.tool_executions).toEqual([]);
     expect(evt.certification_reserve_used).toBe(false);
+    expect(sdkStreamCalls).toBe(4);
 
     // The recoverable terminal event is emitted exactly once. It carries the
     // completed tool receipts, so consumers do not need a second error event.
@@ -187,6 +196,37 @@ describe('processMessageStream — mid-stream upstream failure (#4797)', () => {
     expect(streamErrorEvents).toHaveLength(1);
     const evt = streamErrorEvents[0] as Extract<StreamEvent, { type: 'stream_error' }>;
     expect(evt.deltasBeforeError).toBe(1);
+  });
+
+  it('does not retry a non-retryable provider stream failure', async () => {
+    const sdkModule = await import('@anthropic-ai/sdk');
+    const MockedAPIError = (sdkModule as unknown as {
+      APIError: new (msg: string) => Error & { status?: number; error?: unknown };
+    }).APIError;
+    streamStubFactory = () => ({
+      async *[Symbol.asyncIterator]() {
+        const error = new MockedAPIError('Invalid request');
+        error.status = 400;
+        error.error = { type: 'invalid_request_error', message: 'Invalid request' };
+        throw error;
+      },
+      finalMessage: vi.fn().mockResolvedValue(null),
+    }) as unknown as ReturnType<typeof makeKeywordErrorStub>;
+    const client = new AddieClaudeClient('sk-fake-unused', 'claude-sonnet-4-6');
+    const events: StreamEvent[] = [];
+
+    for await (const event of client.processMessageStream(
+      'invalid request',
+      undefined,
+      undefined,
+      { costScope: { userId: 'test-user-non-retryable', tier: 'member_paid' }, maxIterations: 1 },
+    )) {
+      events.push(event);
+    }
+
+    expect(sdkStreamCalls).toBe(1);
+    expect(events.filter((event) => event.type === 'retry')).toHaveLength(0);
+    expect(events.filter((event) => event.type === 'stream_error')).toHaveLength(1);
   });
 
   it('surfaces provider recovery copy when the local circuit opens after buffered deltas', async () => {

--- a/tests/utils/anthropic-retry.test.ts
+++ b/tests/utils/anthropic-retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { APIError, APIConnectionError } from '@anthropic-ai/sdk';
-import { isRetryableError, withRetry, withStreamRetry, RetriesExhaustedError, isRetriesExhaustedError } from '../../server/src/utils/anthropic-retry.js';
+import { isRetryableError, withRetry, RetriesExhaustedError, isRetriesExhaustedError } from '../../server/src/utils/anthropic-retry.js';
 
 describe('anthropic-retry utilities', () => {
   describe('isRetryableError', () => {
@@ -249,85 +249,4 @@ describe('anthropic-retry utilities', () => {
     });
   });
 
-  describe('withStreamRetry', () => {
-    // Helper to create an async generator from an array
-    async function* arrayToGenerator<T>(items: T[]): AsyncGenerator<T> {
-      for (const item of items) {
-        yield item;
-      }
-    }
-
-    // Helper to collect all items from an async generator
-    async function collectGenerator<T>(gen: AsyncGenerator<T>): Promise<T[]> {
-      const items: T[] = [];
-      for await (const item of gen) {
-        items.push(item);
-      }
-      return items;
-    }
-
-    it('yields all items on successful first attempt', async () => {
-      const items = ['a', 'b', 'c'];
-      const fn = vi.fn(() => arrayToGenerator(items));
-
-      const result = await collectGenerator(withStreamRetry(fn));
-
-      expect(result).toEqual(items);
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it('retries on retryable errors and succeeds', async () => {
-      vi.useRealTimers();
-
-      let callCount = 0;
-      const fn = vi.fn(async function* () {
-        callCount++;
-        if (callCount === 1) {
-          throw new APIConnectionError({ message: 'Connection failed' });
-        }
-        yield 'success';
-      });
-
-      const result = await collectGenerator(
-        withStreamRetry(fn, { maxRetries: 2, initialDelayMs: 10, jitter: false })
-      );
-
-      expect(result).toEqual(['success']);
-      expect(fn).toHaveBeenCalledTimes(2);
-    });
-
-    it('throws non-retryable errors immediately', async () => {
-      const fn = vi.fn(async function* () {
-        throw new APIError(400, { type: 'error' }, 'Bad request', new Headers());
-      });
-
-      await expect(
-        collectGenerator(withStreamRetry(fn, { maxRetries: 3, initialDelayMs: 10, jitter: false }))
-      ).rejects.toThrow('400'); // APIError message format includes status code
-
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it('throws RetriesExhaustedError when retries exhausted', async () => {
-      vi.useRealTimers();
-
-      const fn = vi.fn(async function* () {
-        throw new APIError(500, { type: 'server_error' }, 'Server Error', new Headers());
-      });
-
-      try {
-        await collectGenerator(
-          withStreamRetry(fn, { maxRetries: 2, initialDelayMs: 10, jitter: false })
-        );
-        expect.unreachable('Should have thrown');
-      } catch (error) {
-        expect(isRetriesExhaustedError(error)).toBe(true);
-        if (isRetriesExhaustedError(error)) {
-          expect(error.attempts).toBe(3); // 1 initial + 2 retries
-        }
-      }
-
-      expect(fn).toHaveBeenCalledTimes(3);
-    });
-  });
 });


### PR DESCRIPTION
Closes #6472

## Summary
- remove the unused generic `withStreamRetry` helper that could restart a generator after observable output or tool actions
- document distinct ownership for one-shot provider retries, buffered pre-content stream attempts, terminal mid-stream failure, and explicit user ask-again recovery
- move retryable, exhausted, and non-retryable stream coverage onto the live `processMessageStream` implementation

## Validation
- full pre-commit: 8,167 passed, 32 skipped
- `npm run typecheck`
- 57 focused retry/stream/web tests
- `npm run test:addie-fixed-traces` (43/43)
- `npm run test:addie-tools`

No changeset: platform-only retry implementation and documentation; no protocol release surface.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99de5011-77ab-4298-8f57-543bd65b801e)
