### PR TITLE
fix(compliance): skip SI steps for non-SI agents

### DIFF
--- a/.changeset/fix-deterministic-si-gate.md
+++ b/.changeset/fix-deterministic-si-gate.md
@@ -1,0 +1,7 @@
+---
+"adcontextprotocol": patch
+---
+
+Gate the deterministic SI session follow-up steps on `si_initiate_session` so
+agents outside the sponsored intelligence domain cascade-skip the phase instead
+of receiving a false `si_send_message` failure. Reported in adcp-client#2827.

--- a/static/compliance/source/universal/deterministic-testing.yaml
+++ b/static/compliance/source/universal/deterministic-testing.yaml
@@ -1107,9 +1107,12 @@ phases:
             path: "context.correlation_id"
             value: "deterministic_testing--initiate_session"
             description: "Context correlation_id returned unchanged"
+      # Keep both follow-up steps gated on the phase's anchor tool. Older
+      # runners that miss phase-level capability gates still cascade-skip them
+      # when si_initiate_session is unavailable.
       - id: force_session_terminated
         title: 'Force session timeout'
-        requires_tool: comply_test_controller
+        requires_tool: si_initiate_session
         narrative: |
           Use the controller to force the session into terminated state with
           termination_reason: session_timeout.
@@ -1146,7 +1149,7 @@ phases:
             description: "Context correlation_id returned unchanged"
       - id: verify_terminated_session
         title: 'Verify messaging fails on terminated session'
-        requires_tool: comply_test_controller
+        requires_tool: si_initiate_session
         narrative: |
           Attempt to send a message on the terminated session. The agent must
           reject with SESSION_TERMINATED — per si-send-message-response.json,


### PR DESCRIPTION
## Summary

- gate deterministic SI session follow-up steps on the phase anchor tool
- cascade-skip the SI flow for agents outside the sponsored intelligence domain on older runners
- add a patch changeset for the corrected compliance applicability behavior

Fixes adcontextprotocol/adcp-client#2827.

## Testing

- `npm run build:compliance -- --check`
- `npm run test:sdk-runner-capability-gates`
- `npm run test:storyboard-sample-request-schema`
- `npm run test:storyboard-scoping`
- pre-commit suite: 560 files, 8,159 passed, 32 skipped
- pre-push current-source storyboard matrix: all seven tenants meet floors
- pre-push AdCP 3.0.26 compatibility matrix: all seven tenants meet floors
- changeset protocol-scope check

## Risk and follow-up

Low risk: this only narrows SI-session step applicability for agents that do not expose `si_initiate_session`. The published compliance bundle and deployed runner must refresh after merge for the downstream false failure to clear.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/974c0b49-4043-4738-8d4b-03a66dcb98af)
