### PR TITLE
fix(ops): harden production incident paths

### DIFF
--- a/server/src/addie/jobs/scheduler.ts
+++ b/server/src/addie/jobs/scheduler.ts
@@ -79,6 +79,47 @@ interface RunningJob {
   lastRunAt: Date | null;
   lastDurationMs: number | null;
   lastError: string | null;
+  lastMemoryProfile: JobMemoryProfile | null;
+}
+
+export interface JobMemorySnapshot {
+  rssMb: number;
+  heapUsedMb: number;
+  heapTotalMb: number;
+  externalMb: number;
+}
+
+export interface JobMemoryProfile {
+  before: JobMemorySnapshot;
+  after: JobMemorySnapshot;
+  delta: JobMemorySnapshot;
+}
+
+function memorySnapshot(): JobMemorySnapshot {
+  const memory = process.memoryUsage();
+  const toMb = (bytes: number) => Math.round(bytes / 1024 / 1024);
+  return {
+    rssMb: toMb(memory.rss),
+    heapUsedMb: toMb(memory.heapUsed),
+    heapTotalMb: toMb(memory.heapTotal),
+    externalMb: toMb(memory.external),
+  };
+}
+
+function memoryProfile(
+  before: JobMemorySnapshot,
+  after: JobMemorySnapshot,
+): JobMemoryProfile {
+  return {
+    before,
+    after,
+    delta: {
+      rssMb: after.rssMb - before.rssMb,
+      heapUsedMb: after.heapUsedMb - before.heapUsedMb,
+      heapTotalMb: after.heapTotalMb - before.heapTotalMb,
+      externalMb: after.externalMb - before.externalMb,
+    },
+  };
 }
 
 /**
@@ -92,6 +133,7 @@ export interface JobStatus {
   lastRunAt: string | null;
   lastDurationMs: number | null;
   lastError: string | null;
+  lastMemoryProfile: JobMemoryProfile | null;
   consecutiveFailures: number;
   businessHours?: BusinessHoursConstraint;
 }
@@ -216,6 +258,7 @@ export class JobScheduler {
       lastRunAt: null,
       lastDurationMs: null,
       lastError: null,
+      lastMemoryProfile: null,
     };
 
     const runJob = async () => {
@@ -236,6 +279,7 @@ export class JobScheduler {
       job.executing = true;
       await this.acquireSlot();
       const startTime = Date.now();
+      const memoryBefore = memorySnapshot();
       try {
         const result = await config.runner(config.options ?? ({} as never));
 
@@ -270,10 +314,23 @@ export class JobScheduler {
           });
         }
       } finally {
-        this.releaseSlot();
+        const durationMs = Date.now() - startTime;
+        const profile = memoryProfile(memoryBefore, memorySnapshot());
+        job.lastMemoryProfile = profile;
         job.executing = false;
         job.lastRunAt = new Date();
-        job.lastDurationMs = Date.now() - startTime;
+        job.lastDurationMs = durationMs;
+        logger.info(
+          {
+            jobName: name,
+            durationMs,
+            memory: profile,
+            activeJobs: this.activeJobs,
+            queuedJobs: this.waitQueue.length,
+          },
+          'Scheduled job memory profile',
+        );
+        this.releaseSlot();
       }
     };
 
@@ -374,6 +431,7 @@ export class JobScheduler {
         lastRunAt: job?.lastRunAt?.toISOString() ?? null,
         lastDurationMs: job?.lastDurationMs ?? null,
         lastError: job?.lastError ?? null,
+        lastMemoryProfile: job?.lastMemoryProfile ?? null,
         consecutiveFailures: this.consecutiveFailures.get(name) ?? 0,
         businessHours: config.businessHours,
       });

--- a/server/src/addie/model-providers/tool-orchestration.ts
+++ b/server/src/addie/model-providers/tool-orchestration.ts
@@ -607,7 +607,10 @@ export function createAddieToolExecutor(
         executionMode: options.executionMode,
       };
       if (operationalExecution) {
-        logger.error(invariantContext, invariantMessage);
+        // notifyToolError below owns the operator notification. Logging this
+        // at error as well causes the logger hook to emit a duplicate system
+        // alert for the same rejected call.
+        logger.warn(invariantContext, invariantMessage);
       } else {
         logger.debug(invariantContext, invariantMessage);
       }

--- a/server/src/audit/integrity/invariants/workos-verified-domains-mirrored.ts
+++ b/server/src/audit/integrity/invariants/workos-verified-domains-mirrored.ts
@@ -90,6 +90,43 @@ export const workosVerifiedDomainsMirroredInvariant: Invariant = {
           }
 
           if (row.workos_organization_id !== org.workos_organization_id) {
+            let localOwnerAlsoVerified = false;
+            try {
+              const localOwner = await workos.organizations.getOrganization(row.workos_organization_id);
+              localOwnerAlsoVerified = localOwner.domains.some((candidate) =>
+                candidate.domain.toLowerCase() === domain
+                && (String(candidate.state) === 'verified' || String(candidate.state) === 'legacy_verified'));
+            } catch (err) {
+              logger.warn(
+                { err, orgId: row.workos_organization_id, domain },
+                'workos-verified-domains-mirrored: local domain owner lookup failed',
+              );
+            }
+
+            if (localOwnerAlsoVerified) {
+              violations.push({
+                invariant: 'workos-verified-domains-mirrored',
+                severity: 'warning',
+                subject_type: 'domain',
+                subject_id: domain,
+                message:
+                  `WorkOS says ${domain} is verified for both "${org.name}" (${org.workos_organization_id}) ` +
+                  `and "${row.org_name ?? 'unknown'}" (${row.workos_organization_id}).`,
+                details: {
+                  domain,
+                  workos_organization_id: org.workos_organization_id,
+                  organization_name: org.name,
+                  local_workos_organization_id: row.workos_organization_id,
+                  local_organization_name: row.org_name,
+                  local_verified: row.verified,
+                  duplicate_verified_workos_ownership: true,
+                },
+                remediation_hint:
+                  'Resolve the duplicate WorkOS organizations and choose a canonical owner before reconciling local domain ownership.',
+              });
+              continue;
+            }
+
             violations.push({
               invariant: 'workos-verified-domains-mirrored',
               severity: 'critical',

--- a/server/src/db/migrations/579_user_deletion_foreign_keys.sql
+++ b/server/src/db/migrations/579_user_deletion_foreign_keys.sql
@@ -1,0 +1,84 @@
+-- WorkOS user.deleted must be able to remove the local user row even when the
+-- account has accumulated community, certification, portrait, or review data.
+--
+-- User-owned records follow the account and are deleted. Nullable attribution
+-- fields are cleared. Append-only accreditation/admin audit records retain the
+-- opaque WorkOS ID but deliberately stop enforcing a live users-row reference.
+
+ALTER TABLE connections
+  DROP CONSTRAINT IF EXISTS connections_requester_user_id_fkey,
+  ADD CONSTRAINT connections_requester_user_id_fkey
+    FOREIGN KEY (requester_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE,
+  DROP CONSTRAINT IF EXISTS connections_recipient_user_id_fkey,
+  ADD CONSTRAINT connections_recipient_user_id_fkey
+    FOREIGN KEY (recipient_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE community_points
+  DROP CONSTRAINT IF EXISTS community_points_workos_user_id_fkey,
+  ADD CONSTRAINT community_points_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE user_badges
+  DROP CONSTRAINT IF EXISTS user_badges_workos_user_id_fkey,
+  ADD CONSTRAINT user_badges_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE learner_progress
+  DROP CONSTRAINT IF EXISTS learner_progress_workos_user_id_fkey,
+  ADD CONSTRAINT learner_progress_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE certification_attempts
+  DROP CONSTRAINT IF EXISTS certification_attempts_workos_user_id_fkey,
+  ADD CONSTRAINT certification_attempts_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE user_credentials
+  DROP CONSTRAINT IF EXISTS user_credentials_workos_user_id_fkey,
+  ADD CONSTRAINT user_credentials_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE teaching_checkpoints
+  DROP CONSTRAINT IF EXISTS teaching_checkpoints_workos_user_id_fkey,
+  ADD CONSTRAINT teaching_checkpoints_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE certification_learner_feedback
+  DROP CONSTRAINT IF EXISTS certification_learner_feedback_workos_user_id_fkey,
+  ADD CONSTRAINT certification_learner_feedback_workos_user_id_fkey
+    FOREIGN KEY (workos_user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+ALTER TABLE member_portraits
+  DROP CONSTRAINT IF EXISTS member_portraits_user_id_fkey,
+  ADD CONSTRAINT member_portraits_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(workos_user_id) ON DELETE CASCADE;
+
+-- These rows are retained for accreditation/admin audit history. Their opaque
+-- user identifier remains useful after the corresponding local account is gone.
+ALTER TABLE learner_protocol_updates
+  DROP CONSTRAINT IF EXISTS learner_protocol_updates_workos_user_id_fkey,
+  DROP CONSTRAINT IF EXISTS learner_protocol_updates_attempt_id_fkey,
+  ADD CONSTRAINT learner_protocol_updates_attempt_id_fkey
+    FOREIGN KEY (attempt_id) REFERENCES certification_attempts(id) ON DELETE SET NULL;
+
+ALTER TABLE admin_module_completions
+  DROP CONSTRAINT IF EXISTS admin_module_completions_workos_user_id_fkey,
+  DROP CONSTRAINT IF EXISTS admin_module_completions_teaching_checkpoint_id_fkey,
+  ADD CONSTRAINT admin_module_completions_teaching_checkpoint_id_fkey
+    FOREIGN KEY (teaching_checkpoint_id) REFERENCES teaching_checkpoints(id) ON DELETE SET NULL,
+  DROP CONSTRAINT IF EXISTS admin_module_completions_learner_progress_id_fkey,
+  ADD CONSTRAINT admin_module_completions_learner_progress_id_fkey
+    FOREIGN KEY (learner_progress_id) REFERENCES learner_progress(id) ON DELETE SET NULL;
+
+ALTER TABLE admin_credential_reissue_events
+  DROP CONSTRAINT IF EXISTS admin_credential_reissue_events_workos_user_id_fkey;
+
+ALTER TABLE flagged_conversations
+  DROP CONSTRAINT IF EXISTS flagged_conversations_reviewed_by_fkey,
+  ADD CONSTRAINT flagged_conversations_reviewed_by_fkey
+    FOREIGN KEY (reviewed_by) REFERENCES users(workos_user_id) ON DELETE SET NULL;
+
+ALTER TABLE known_media_contacts
+  DROP CONSTRAINT IF EXISTS known_media_contacts_added_by_fkey,
+  ADD CONSTRAINT known_media_contacts_added_by_fkey
+    FOREIGN KEY (added_by) REFERENCES users(workos_user_id) ON DELETE SET NULL;

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -36,6 +36,7 @@ import {
   discoverAuthorizationServerMetadata,
   discoverOAuthProtectedResourceMetadata,
 } from '@modelcontextprotocol/sdk/client/auth.js';
+import { OAuthError as McpOAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import {
   checkResourceAllowed,
   resourceUrlFromServerUrl,
@@ -116,6 +117,11 @@ function sanitizeErrorMessage(error: unknown): string {
   return String(error)
     .slice(0, 200)
     .replace(/[<>]/g, '');
+}
+
+/** OAuth failures returned by an agent's authorization server are not app faults. */
+export function isAgentSideOAuthError(error: unknown): error is OAuthError | McpOAuthError {
+  return error instanceof OAuthError || error instanceof McpOAuthError;
 }
 
 function getCallbackUrl(req: Request): string {
@@ -337,8 +343,9 @@ export function createAgentOAuthRouter(): Router {
       // `warn` to keep the pino → posthog hook from paging #aao-errors.
       // Same convention as the `AuthenticationRequiredError` branch in
       // server/src/http.ts and the slack-client expected-error sites.
-      if (error instanceof OAuthError) {
-        logger.warn({ error, code: error.code }, 'OAuth flow start failed (agent-side)');
+      if (isAgentSideOAuthError(error)) {
+        const code = error instanceof OAuthError ? error.code : error.errorCode;
+        logger.warn({ error, code }, 'OAuth flow start failed (agent-side)');
       } else {
         logger.error({ error }, 'Failed to start OAuth flow');
       }

--- a/server/src/training-agent/seller-managed-control-jobs.ts
+++ b/server/src/training-agent/seller-managed-control-jobs.ts
@@ -7,7 +7,7 @@ import {
   type TaskRegistry,
   type TaskRegistryScope,
 } from '@adcp/sdk/server';
-import { query } from '../db/client.js';
+import { isDatabaseInitialized, query } from '../db/client.js';
 import { decrypt, deriveKey, encrypt } from '../db/encryption.js';
 import { createLogger } from '../logger.js';
 
@@ -836,15 +836,30 @@ export class SellerManagedControlJobCoordinator {
       ? new PostgresSellerManagedControlJobStore()
       : new InMemorySellerManagedControlJobStore(),
     private readonly notify: NotifyJob = async () => {},
+    private readonly isDatabaseReady: () => boolean = isDatabaseInitialized,
   ) {}
 
   start(): void {
-    void this.runAvailable().catch(err => logger.error({ err }, 'Initial seller-control reconciliation failed'));
+    this.reconcile('Initial seller-control reconciliation failed');
     if (process.env.NODE_ENV !== 'production' || this.timer) return;
     this.timer = setInterval(() => {
-      void this.runAvailable().catch(err => logger.error({ err }, 'Seller-control reconciliation failed'));
+      this.reconcile('Seller-control reconciliation failed');
     }, RECONCILE_INTERVAL_MS);
     this.timer.unref();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  private reconcile(errorMessage: string): void {
+    if (this.store instanceof PostgresSellerManagedControlJobStore && !this.isDatabaseReady()) {
+      logger.debug('Deferring seller-control reconciliation until database initialization');
+      return;
+    }
+    void this.runAvailable().catch(err => logger.error({ err }, errorMessage));
   }
 
   async enqueue(input: SellerManagedControlJobInput): Promise<SellerManagedControlJob> {

--- a/server/tests/integration/workos-user-deleted-primary.test.ts
+++ b/server/tests/integration/workos-user-deleted-primary.test.ts
@@ -173,5 +173,36 @@ describe('user.deleted: promote secondary before CASCADE (#3718)', () => {
     expect(survivors.rows[0].workos_user_id).toBe(secondary);
     expect(survivors.rows[0].is_primary).toBe(true);
   });
-});
 
+  it('deletes an account with accumulated community data', async () => {
+    const userId = await insertUser('community', 'community@test.example');
+    await pool.query(
+      `INSERT INTO community_points (workos_user_id, action, points)
+       VALUES ($1, 'test_activity', 1)`,
+      [userId],
+    );
+
+    await expect(
+      pool.query(`DELETE FROM users WHERE workos_user_id = $1`, [userId]),
+    ).resolves.toMatchObject({ rowCount: 1 });
+
+    const points = await pool.query(
+      `SELECT 1 FROM community_points WHERE workos_user_id = $1`,
+      [userId],
+    );
+    expect(points.rows).toHaveLength(0);
+  });
+
+  it('has no restrictive foreign keys pointing directly at users', async () => {
+    const restrictive = await pool.query<{ table_name: string; constraint_name: string }>(
+      `SELECT conrelid::regclass::text AS table_name, conname AS constraint_name
+         FROM pg_constraint
+        WHERE contype = 'f'
+          AND confrelid = 'users'::regclass
+          AND confdeltype IN ('a', 'r')
+        ORDER BY conrelid::regclass::text, conname`,
+    );
+
+    expect(restrictive.rows).toEqual([]);
+  });
+});

--- a/server/tests/unit/agent-oauth-membership-guard.test.ts
+++ b/server/tests/unit/agent-oauth-membership-guard.test.ts
@@ -33,6 +33,15 @@ const mcpAuthMocks = vi.hoisted(() => ({
   discoverAuthorizationServerMetadata: vi.fn(),
   discoverOAuthProtectedResourceMetadata: vi.fn(),
 }));
+const mcpServerAuthMocks = vi.hoisted(() => {
+  class OAuthError extends Error {
+    static errorCode = 'server_error';
+    get errorCode() {
+      return (this.constructor as typeof OAuthError).errorCode;
+    }
+  }
+  return { OAuthError };
+});
 const agentContextDbMocks = vi.hoisted(() => ({
   instance: {
     getById: vi.fn(),
@@ -72,6 +81,10 @@ vi.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
   discoverOAuthProtectedResourceMetadata: mcpAuthMocks.discoverOAuthProtectedResourceMetadata,
 }));
 
+vi.mock('@modelcontextprotocol/sdk/server/auth/errors.js', () => ({
+  OAuthError: mcpServerAuthMocks.OAuthError,
+}));
+
 vi.mock('../../src/auth/workos-client.js', () => ({
   getWorkos: () => ({
     userManagement: {
@@ -106,6 +119,7 @@ import {
   buildDurableOAuthScopeHint,
   createAgentOAuthRouter,
   createMembershipGuardedPendingFlowStore,
+  isAgentSideOAuthError,
 } from '../../src/routes/agent-oauth.js';
 import { oauthSafeFetch } from '../../src/utils/oauth-safe-fetch.js';
 
@@ -376,6 +390,12 @@ describe('agent OAuth safe fetch injection', () => {
 });
 
 describe('buildDurableOAuthScopeHint', () => {
+  it('recognizes OAuth failures from both SDK error families as agent-side', () => {
+    expect(isAgentSideOAuthError(new sdkMocks.OAuthError())).toBe(true);
+    expect(isAgentSideOAuthError(new mcpServerAuthMocks.OAuthError('registration failed'))).toBe(true);
+    expect(isAgentSideOAuthError(new Error('database unavailable'))).toBe(false);
+  });
+
   it('preserves advertised scopes and appends offline_access', () => {
     expect(buildDurableOAuthScopeHint(['openid', 'profile', 'email'])).toBe('openid profile email offline_access');
   });

--- a/server/tests/unit/integrity/invariants.test.ts
+++ b/server/tests/unit/integrity/invariants.test.ts
@@ -158,6 +158,10 @@ describe('workos-verified-domains-mirrored', () => {
       id: 'org_spanglish',
       name: 'Spanglish Movies',
       domains: [{ domain: 'spanglishmovies.com', state: 'verified' }],
+    }).mockResolvedValueOnce({
+      id: 'org_personal',
+      name: 'Gustavo Workspace',
+      domains: [],
     });
 
     const result = await workosVerifiedDomainsMirroredInvariant.check(makeCtx());
@@ -165,6 +169,43 @@ describe('workos-verified-domains-mirrored', () => {
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0].message).toContain('local row belongs');
     expect(result.violations[0].details?.local_workos_organization_id).toBe('org_personal');
+  });
+
+  it('warns instead of recommending an unsafe transfer when WorkOS verifies both orgs', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({
+        rows: [{ workos_organization_id: 'org_acme_primary', name: 'Acme Primary' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          domain: 'acme.test',
+          workos_organization_id: 'org_acme_duplicate',
+          org_name: 'Acme Duplicate',
+          verified: true,
+          is_primary: true,
+        }],
+      });
+    mockWorkosGetOrganization
+      .mockResolvedValueOnce({
+        id: 'org_acme_primary',
+        name: 'Acme Primary',
+        domains: [{ domain: 'acme.test', state: 'verified' }],
+      })
+      .mockResolvedValueOnce({
+        id: 'org_acme_duplicate',
+        name: 'Acme Duplicate',
+        domains: [{ domain: 'acme.test', state: 'legacy_verified' }],
+      });
+
+    const result = await workosVerifiedDomainsMirroredInvariant.check(makeCtx());
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      severity: 'warning',
+      subject_id: 'acme.test',
+      details: { duplicate_verified_workos_ownership: true },
+    });
+    expect(result.violations[0].remediation_hint).toContain('canonical owner');
   });
 });
 

--- a/server/tests/unit/job-scheduler.test.ts
+++ b/server/tests/unit/job-scheduler.test.ts
@@ -174,4 +174,53 @@ describe('JobScheduler', () => {
 
     scheduler.stopAll();
   });
+
+  it('records and logs the memory delta for each completed job', async () => {
+    vi.useFakeTimers();
+    const memorySpy = vi.spyOn(process, 'memoryUsage')
+      .mockReturnValueOnce({
+        rss: 100 * 1024 * 1024,
+        heapTotal: 60 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 0,
+      })
+      .mockReturnValueOnce({
+        rss: 112 * 1024 * 1024,
+        heapTotal: 66 * 1024 * 1024,
+        heapUsed: 47 * 1024 * 1024,
+        external: 7 * 1024 * 1024,
+        arrayBuffers: 0,
+      });
+
+    const scheduler = new JobScheduler();
+    scheduler.register({
+      name: 'profiled-job',
+      description: 'Profiled job',
+      interval: { value: 1, unit: 'hours' },
+      initialDelay: { value: 1, unit: 'seconds' },
+      runner: async () => undefined,
+    });
+
+    scheduler.start('profiled-job');
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(scheduler.getStatus()[0].lastMemoryProfile).toEqual({
+      before: { rssMb: 100, heapUsedMb: 40, heapTotalMb: 60, externalMb: 5 },
+      after: { rssMb: 112, heapUsedMb: 47, heapTotalMb: 66, externalMb: 7 },
+      delta: { rssMb: 12, heapUsedMb: 7, heapTotalMb: 6, externalMb: 2 },
+    });
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobName: 'profiled-job',
+        memory: expect.objectContaining({
+          delta: expect.objectContaining({ rssMb: 12, heapUsedMb: 7 }),
+        }),
+      }),
+      'Scheduled job memory profile',
+    );
+
+    memorySpy.mockRestore();
+    scheduler.stopAll();
+  });
 });

--- a/server/tests/unit/seller-managed-control-jobs.test.ts
+++ b/server/tests/unit/seller-managed-control-jobs.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createInMemoryTaskRegistry } from '@adcp/sdk/server';
 import {
   InMemorySellerManagedControlJobStore,
+  PostgresSellerManagedControlJobStore,
   SellerManagedControlJobCoordinator,
   rebindCachedSdkReplay,
   withSellerManagedIdempotencyReplay,
@@ -24,6 +25,11 @@ const INPUT = {
 };
 const TASK_SCOPE = { accountId: INPUT.accountId, ownerScope: INPUT.ownerScope };
 
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
 async function registerTask(taskRegistry: ReturnType<typeof createInMemoryTaskRegistry>): Promise<void> {
   await taskRegistry.create({
     tool: 'control_media_buy',
@@ -34,6 +40,30 @@ async function registerTask(taskRegistry: ReturnType<typeof createInMemoryTaskRe
 }
 
 describe('seller-managed control durable jobs', () => {
+  it('defers Postgres reconciliation until the database is initialized', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('NODE_ENV', 'production');
+    let databaseReady = false;
+    const store = new PostgresSellerManagedControlJobStore();
+    const claim = vi.spyOn(store, 'claim').mockResolvedValue(null);
+    const coordinator = new SellerManagedControlJobCoordinator(
+      createInMemoryTaskRegistry(),
+      async () => ({}),
+      store,
+      async () => {},
+      () => databaseReady,
+    );
+
+    coordinator.start();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(claim).not.toHaveBeenCalled();
+
+    databaseReady = true;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(claim).toHaveBeenCalledOnce();
+    coordinator.stop();
+  });
+
   it('replays the same orphaned task for the same caller idempotency key', async () => {
     const store = new InMemorySellerManagedControlJobStore();
     const first = await store.enqueue(INPUT);


### PR DESCRIPTION
## Summary

- make WorkOS user deletion resilient across accumulated user-owned and audit data
- prevent duplicate operational alerts for expected tool/OAuth failures and defer seller-control reconciliation until the database is ready
- add per-job memory profiles and treat duplicate verified WorkOS ownership as a warning requiring canonical ownership

## Production remediation completed

- verified the worker resize to 8 GB and healthy checks
- reconciled three guarded Stripe metadata conflicts; post-check: 1,039 scanned, 0 missing, 0 conflicts, 0 errors
- reconciled six unambiguous WorkOS domain mismatches and merged five verified duplicate org pairs into their member/billing canonical orgs
- final WorkOS scan: 2,177 orgs, 706 verified domains, 0 mismatches, 0 ambiguous claims

## Validation

- `npm run typecheck`
- `npm run test:migrations`
- focused unit: 85 passed
- focused integration: 6 passed
- pre-push storyboards: signals 52 clean / 86 passed; sales 152 / 730; governance 56 / 161; creative 58 / 209

The broad server-unit run reproduced three pre-existing Addie router expectation failures. After a 60-second external-repository clone timeout it also produced four native-auth timing failures; no changed-path test failed.