### PR TITLE
fix(addie): count rejected replay tool calls

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -480,6 +480,7 @@ export async function runFixedTraceCase(
       flagged: true,
       route: null,
       tools: [],
+      rejectedToolCalls: [],
     };
   }
 
@@ -500,6 +501,7 @@ export async function runFixedTraceCase(
       flagged: false,
       route,
       tools: [],
+      rejectedToolCalls: [],
     };
   }
 
@@ -541,6 +543,7 @@ export async function runFixedTraceCase(
       flagged: true,
       route,
       tools: [],
+      rejectedToolCalls: [],
     };
   }
 
@@ -586,6 +589,7 @@ export async function runFixedTraceCase(
       flagged: result.localReplacementReason !== null || terminalStatus !== 'complete',
       route,
       tools: result.tools.map(({ sequence: _sequence, ...tool }) => tool),
+      rejectedToolCalls: [],
     };
   } catch (error) {
     if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
@@ -616,6 +620,7 @@ export async function runFixedTraceCase(
       flagged: true,
       route,
       tools: checkpoint?.tools.map(({ sequence: _sequence, ...tool }) => tool) ?? [],
+      rejectedToolCalls: checkpoint ? [...checkpoint.rejectedToolCalls] : [],
     };
   } finally {
     clearTimeout(timeout);

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -129,6 +129,17 @@ export interface FixedTraceToolObservation {
   simulated: boolean;
 }
 
+/**
+ * A custom-tool call rejected by the fixed-trace boundary before execution.
+ * Inputs are deliberately omitted: the synthetic fixture surface makes the
+ * tool name sufficient to diagnose selection behavior without recording
+ * additional untrusted candidate output.
+ */
+export interface FixedTraceRejectedToolCall {
+  name: string;
+  reason: FixedTraceBoundaryReason;
+}
+
 export interface FixedTraceModelStageMetadata {
   source: 'provider' | 'local' | 'not_run';
   dispatched: boolean;
@@ -182,6 +193,8 @@ export interface FixedTraceObservation {
   flagged: boolean;
   route: { action: RouterAction; toolSets: string[] } | null;
   tools: FixedTraceToolObservation[];
+  /** Rejected pre-execution calls; completed receipts remain in `tools`. */
+  rejectedToolCalls: FixedTraceRejectedToolCall[];
 }
 
 function scalarInputValues(value: unknown, path = '$'): Array<{ path: string; value: string }> {
@@ -1240,6 +1253,10 @@ export function gradeFixedTrace(
   if (!routingPass) failures.push('routing_mismatch');
 
   const observedToolNames = observation.tools.map((tool) => tool.name);
+  // A rejected call has not executed, so it must not affect mutation-safety
+  // accounting. It is nevertheless candidate tool-selection evidence: a
+  // tool-loop boundary must not be reported as a perfect selection result.
+  const rejectedToolSelectionPass = observation.rejectedToolCalls.length === 0;
   const toolEvidencePass = observation.tools.every(toolEvidenceValid);
   const inputConstraintFailures = toolInputConstraintFailures(trace, observation.tools);
   const toolInputConstraintPass = inputConstraintFailures.length === 0;
@@ -1249,6 +1266,7 @@ export function gradeFixedTrace(
   const requiredTools = new Set(trace.expectation.requiredTools);
   const forbiddenTools = new Set(trace.expectation.forbiddenTools);
   const toolSelectionPass = [...requiredTools].every((name) => observedToolNames.includes(name))
+    && rejectedToolSelectionPass
     && toolEvidencePass
     && toolInputConstraintPass
     && new Set(observedToolNames).size === observedToolNames.length

--- a/server/src/addie/eval/fixed-trace-tool-loop.ts
+++ b/server/src/addie/eval/fixed-trace-tool-loop.ts
@@ -23,6 +23,7 @@ import { enforceFailedLookupEvidenceBoundary } from '../failed-lookup-evidence.j
 import type {
   FixedTraceBoundaryReason,
   FixedTraceCase,
+  FixedTraceRejectedToolCall,
   FixedTraceToolFixture,
   FixedTraceToolObservation,
 } from './fixed-trace-suite.js';
@@ -37,6 +38,7 @@ export type FixedTraceToolLoopReason = FixedTraceBoundaryReason;
 export interface FixedTraceToolLoopCheckpoint {
   usage: ModelUsage;
   tools: ReadonlyArray<FixedTraceToolExecution>;
+  rejectedToolCalls: ReadonlyArray<FixedTraceRejectedToolCall>;
 }
 
 export class FixedTraceToolLoopBoundaryError extends Error {
@@ -138,6 +140,13 @@ function safeIterationLimit(trace: FixedTraceCase, requested?: number): number {
   return limit;
 }
 
+function rejectedToolCalls(
+  reason: FixedTraceToolLoopReason,
+  calls: ReadonlyArray<{ name: string }>,
+): ReadonlyArray<FixedTraceRejectedToolCall> {
+  return Object.freeze(calls.map((call) => Object.freeze({ name: call.name, reason })));
+}
+
 /**
  * Execute one synthetic trace through the normalized provider boundary.
  *
@@ -190,10 +199,14 @@ export async function executeFixedTraceToolLoop(
   const seenCallIds = new Set<string>();
   const seenToolNames = new Set<string>();
   const modelLoop = new ModelTurnLoopState(iterationLimit);
-  const boundary = (reason: FixedTraceToolLoopReason): FixedTraceToolLoopBoundaryError => (
+  const boundary = (
+    reason: FixedTraceToolLoopReason,
+    calls: ReadonlyArray<{ name: string }> = [],
+  ): FixedTraceToolLoopBoundaryError => (
     new FixedTraceToolLoopBoundaryError(reason, {
       usage: modelLoop.usage,
       tools: Object.freeze([...executions]),
+      rejectedToolCalls: rejectedToolCalls(reason, calls),
     })
   );
 
@@ -244,7 +257,7 @@ export async function executeFixedTraceToolLoop(
     }
 
     if (executions.length + turn.toolCalls.length > trace.toolFixtures.length) {
-      throw boundary('tool_call_limit_exceeded');
+      throw boundary('tool_call_limit_exceeded', turn.toolCalls);
     }
     const calls = turn.toolCalls.map((call) => deepFreeze(structuredClone(call)));
     const batchCallIds = new Set<string>();
@@ -256,12 +269,12 @@ export async function executeFixedTraceToolLoop(
         || batchCallIds.has(call.id)
         || batchToolNames.has(call.name)
       ) {
-        throw boundary('duplicate_tool_call');
+        throw boundary('duplicate_tool_call', calls);
       }
       const entry = registered.get(call.name);
-      if (!entry) throw boundary('unknown_tool_call');
+      if (!entry) throw boundary('unknown_tool_call', calls);
       if (!entry.validate(call.input)) {
-        throw boundary('tool_input_invalid');
+        throw boundary('tool_input_invalid', calls);
       }
       batchCallIds.add(call.id);
       batchToolNames.add(call.name);

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -465,6 +465,7 @@ describe('fixed trace artifact runner', () => {
       terminalStatus: 'malformed',
       boundaryReason: 'duplicate_tool_call',
       flagged: true,
+      rejectedToolCalls: [{ name: 'create_working_group_post', reason: 'duplicate_tool_call' }],
       tools: [
         {
           name: 'list_working_groups',
@@ -484,6 +485,14 @@ describe('fixed trace artifact runner', () => {
       usage: { inputTokens: 30, outputTokens: 15 },
       estimatedCostUsd: 0.000105,
       pricingSource: 'Synthetic test pricing.',
+    });
+    expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({
+      deterministicPass: false,
+      toolSelectionPass: false,
+      // The duplicate mutation was rejected before execution, so the
+      // selection failure must not be misreported as an executed mutation.
+      mutationSafetyPass: true,
+      failures: expect.arrayContaining(['tool_selection_mismatch']),
     });
   });
 
@@ -703,6 +712,7 @@ describe('fixed trace artifact runner', () => {
       terminalStage: 'generation',
       terminalStatus: 'malformed',
       boundaryReason: 'unknown_tool_call',
+      rejectedToolCalls: [{ name: 'unknown_tool', reason: 'unknown_tool_call' }],
       metadata: {
         generation: {
           source: 'local',

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -135,6 +135,7 @@ function passingObservation(trace: FixedTraceCase): FixedTraceObservation {
         simulated: true,
       };
     }),
+    rejectedToolCalls: [],
   };
 }
 

--- a/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
+++ b/server/tests/unit/addie/fixed-trace-tool-loop.test.ts
@@ -311,6 +311,7 @@ describe('executeFixedTraceToolLoop', () => {
       checkpoint: {
         usage: { inputTokens: 10, outputTokens: 5 },
         tools: [],
+        rejectedToolCalls: [{ name: 'search_docs', reason: 'tool_input_invalid' }],
       },
     });
     expect(create).toHaveBeenCalledOnce();
@@ -355,6 +356,10 @@ describe('executeFixedTraceToolLoop', () => {
       checkpoint: {
         usage: { inputTokens: 10, outputTokens: 5 },
         tools: [],
+        rejectedToolCalls: [
+          { name: 'confirm_send_invoice', reason: 'duplicate_tool_call' },
+          { name: 'confirm_send_invoice', reason: 'duplicate_tool_call' },
+        ],
       },
     });
     expect(create).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Record fixed-trace custom-tool calls rejected before execution by name and boundary reason, without retaining raw inputs.
- Make rejected calls fail deterministic tool-selection scoring while leaving mutation safety tied only to executed receipts.
- Preserve cumulative usage and completed simulated receipts at every boundary.

Relates to #6846.

## Verification

- `npm run typecheck`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-suite.test.ts server/tests/unit/addie/fixed-trace-tool-loop.test.ts server/tests/unit/addie/fixed-trace-runner.test.ts` (66 passed)
- `npm run test:addie-fixed-traces` (43 passed)
- `npm run test:addie-tools`
- `npm run build`
- `git diff --check`

The repository-wide pre-commit server-unit suite was started automatically and ran for its 600-second wrapper limit before being terminated by that timeout, without an assertion failure reported.

No model calls, live replay, canary activation, threshold/configuration changes, production routing, secrets, or environment settings were changed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5bbd6ef1-0982-4890-85b5-dbc41f22f119)
