### PR TITLE
fix(admin): include location in membership export

### DIFF
--- a/server/src/db/working-group-db.ts
+++ b/server/src/db/working-group-db.ts
@@ -1708,6 +1708,8 @@ export class WorkingGroupDatabase {
     user_email: string;
     user_name: string;
     user_org_name: string;
+    city: string | null;
+    country: string | null;
     working_group_id: string;
     working_group_name: string;
     working_group_slug: string;
@@ -1719,6 +1721,8 @@ export class WorkingGroupDatabase {
       user_email: string;
       user_name: string;
       user_org_name: string;
+      city: string | null;
+      country: string | null;
       working_group_id: string;
       working_group_name: string;
       working_group_slug: string;
@@ -1730,6 +1734,8 @@ export class WorkingGroupDatabase {
          wgm.user_email,
          wgm.user_name,
          wgm.user_org_name,
+         u.city,
+         u.country,
          wg.id AS working_group_id,
          wg.name AS working_group_name,
          wg.slug AS working_group_slug,
@@ -1737,6 +1743,7 @@ export class WorkingGroupDatabase {
          wgm.joined_at
        FROM working_group_memberships wgm
        INNER JOIN working_groups wg ON wgm.working_group_id = wg.id
+       LEFT JOIN users u ON u.workos_user_id = wgm.workos_user_id
        WHERE wgm.status = 'active' AND wg.status = 'active'
        ORDER BY wgm.user_name, wg.display_order, wg.name`
     );

--- a/server/src/routes/admin/country-members-export.ts
+++ b/server/src/routes/admin/country-members-export.ts
@@ -10,7 +10,7 @@ export interface CountryMemberExportRow {
   organization_names: string[];
 }
 
-function csvCell(value: unknown): string {
+export function csvCell(value: unknown): string {
   const text = value == null ? '' : String(value);
   // Country exports are commonly opened in spreadsheet applications. Prevent
   // user-controlled names and organization values from becoming formulas.

--- a/server/src/routes/admin/users.ts
+++ b/server/src/routes/admin/users.ts
@@ -27,6 +27,7 @@ import {
   buildCountryMembersCsv,
   type CountryMemberExportRow,
 } from './country-members-export.js';
+import { buildWorkingGroupMembershipsCsv } from './working-group-memberships-export.js';
 
 const logger = createLogger('admin-users-routes');
 
@@ -516,15 +517,12 @@ export function createAdminUsersRouter(): Router {
       const wgDb = new WorkingGroupDatabase();
       const memberships = await wgDb.getAllMemberships();
 
+      res.setHeader('Cache-Control', 'private, no-store');
+
       // Check if CSV export is requested
       const format = req.query.format;
       if (format === 'csv') {
-        const csv = [
-          'User Name,Email,Organization,Working Group,Joined At',
-          ...memberships.map(m =>
-            `"${m.user_name || ''}","${m.user_email || ''}","${m.user_org_name || ''}","${m.working_group_name}","${m.joined_at ? new Date(m.joined_at).toISOString().split('T')[0] : ''}"`
-          ),
-        ].join('\n');
+        const csv = buildWorkingGroupMembershipsCsv(memberships);
 
         res.setHeader('Content-Type', 'text/csv');
         res.setHeader('Content-Disposition', 'attachment; filename="working-group-memberships.csv"');

--- a/server/src/routes/admin/working-group-memberships-export.ts
+++ b/server/src/routes/admin/working-group-memberships-export.ts
@@ -1,0 +1,38 @@
+import { csvCell } from './country-members-export.js';
+
+export interface WorkingGroupMembershipExportRow {
+  user_name: string | null;
+  user_email: string | null;
+  user_org_name: string | null;
+  city: string | null;
+  country: string | null;
+  working_group_name: string;
+  joined_at: Date | string | null;
+}
+
+export function buildWorkingGroupMembershipsCsv(
+  memberships: WorkingGroupMembershipExportRow[],
+): string {
+  const header = [
+    'User Name',
+    'Email',
+    'Organization',
+    'City',
+    'Country',
+    'Working Group',
+    'Joined At',
+  ];
+  const lines = memberships.map((membership) => [
+    membership.user_name,
+    membership.user_email,
+    membership.user_org_name,
+    membership.city,
+    membership.country,
+    membership.working_group_name,
+    membership.joined_at
+      ? new Date(membership.joined_at).toISOString().split('T')[0]
+      : '',
+  ].map(csvCell).join(','));
+
+  return [header.map(csvCell).join(','), ...lines].join('\n');
+}

--- a/server/tests/unit/admin-working-group-memberships-export.test.ts
+++ b/server/tests/unit/admin-working-group-memberships-export.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkingGroupMembershipsCsv } from '../../src/routes/admin/working-group-memberships-export.js';
+
+describe('working group memberships export', () => {
+  it('includes location and safely encodes user-controlled CSV values', () => {
+    const csv = buildWorkingGroupMembershipsCsv([{
+      user_id: 'user_test',
+      user_email: 'jane@example.com',
+      user_name: 'Jane O"Connor, Jr.',
+      user_org_name: '+SUM(1,1)',
+      city: 'New\nYork',
+      country: '=HYPERLINK("https://example.com")',
+      working_group_id: 'wg_test',
+      working_group_name: 'Events, North America',
+      working_group_slug: 'events-north-america',
+      is_private: false,
+      joined_at: new Date('2026-08-01T12:30:00.000Z'),
+    }]);
+
+    expect(csv).toContain('"City","Country"');
+    expect(csv).toContain('"Jane O""Connor, Jr."');
+    expect(csv).toContain('"\'+SUM(1,1)"');
+    expect(csv).toContain('"New\nYork"');
+    expect(csv).toContain('"\'=HYPERLINK(""https://example.com"")"');
+    expect(csv).toContain('"Events, North America"');
+    expect(csv).toContain('"2026-08-01"');
+  });
+
+  it('renders unknown locations as blank cells', () => {
+    const csv = buildWorkingGroupMembershipsCsv([{
+      user_id: 'user_without_location',
+      user_email: 'no-location@example.com',
+      user_name: 'No Location',
+      user_org_name: 'Example Org',
+      city: null,
+      country: null,
+      working_group_id: 'wg_test',
+      working_group_name: 'Events',
+      working_group_slug: 'events',
+      is_private: false,
+      joined_at: new Date('2026-08-01T12:30:00.000Z'),
+    }]);
+
+    expect(csv.split('\n')[1]).toContain('"Example Org","","","Events"');
+  });
+});


### PR DESCRIPTION
## Summary
- join existing user city and country data into working-group membership exports
- add City and Country columns while preserving blank values for unknown locations
- safely encode CSV cells and disable caching for the location-bearing admin response

Closes #7274

## Testing
- `npx vitest run --config server/vitest.config.ts tests/unit/admin-working-group-memberships-export.test.ts tests/unit/admin-country-members-export.test.ts`
- `npm run typecheck`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`
- precommit root unit phase: 68 files / 1,054 tests passed

The full local server-unit phase also reproduced four unrelated current-base failures in `billing-admin-tenant-boundary.test.ts` and `authorization-epoch-session.test.ts`; GitHub CI is the merge gate.

## Risk
- Low: global-admin-only export; no schema migration or protocol surface change.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d134ab7b-6a97-4db7-ab6a-5fd6356bfdea)
