### PR TITLE
docs(release): align the AdCP 3.2 RC.1 story

### DIFF
--- a/.changeset/clear-taxis-report.md
+++ b/.changeset/clear-taxis-report.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Align the AdCP 3.2 release story, SDK compatibility guidance, and Reliable Reporting reference docs with the published RC.1 checkpoint.

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/schema.json",
   "name": "AdCP - Ad Context Protocol",
   "banner": {
-    "content": "AdCP 3.2 preview is available — [see what's new and try the proposal lifecycle →](/3.2)",
+    "content": "AdCP 3.2 release candidate adds Reliable Reporting to the compact lifecycle — [open the current signed release →](https://github.com/adcontextprotocol/adcp/releases/tag/v3.2.0-rc.1)",
     "dismissible": true
   },
   "description": "AdCP (Ad Context Protocol) is the open standard for agentic advertising. It defines how AI agents buy media, generate creatives, activate audiences, and enforce governance across platforms. Current stable documentation index: https://docs.adcontextprotocol.org/llms-current.md.",

--- a/docs/building/by-layer/L3/error-handling.mdx
+++ b/docs/building/by-layer/L3/error-handling.mdx
@@ -125,7 +125,7 @@ AdCP exposes errors in two distinct places, and implementers need to populate th
 
 ### Error Object Fields
 
-These fields are defined by the [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) schema. `buyer_reason` is part of the 3.2 beta schema and is not present in the released 3.1 bundle.
+These fields are defined by the [`error.json`](https://adcontextprotocol.org/schemas/v3/core/error.json) schema. `buyer_reason` is part of the 3.2 release-candidate schema and is not present in the released 3.1 bundle.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -155,7 +155,7 @@ Use `buyer_reason` when the top-level error is too coarse for a buyer agent to r
 }
 ```
 
-{/* The buyer-reason creative codes are published in the 3.2 beta bundle. */}
+{/* The buyer-reason creative codes are published in the 3.2 release-candidate bundle. */}
 `buyer_reason.code` reuses the comprehensive standard vocabulary in [`error-code.json`](https://adcontextprotocol.org/schemas/v3/enums/error-code.json), including request, authorization, account, policy, governance, commercial, inventory, and creative failure classes. [`CREATIVE_SIZE_MISMATCH`](/docs/building/verification/compliance-catalog#error-code-creative-size-mismatch), [`CREATIVE_MISSING_CLICK_URL`](/docs/building/verification/compliance-catalog#error-code-creative-missing-click-url), and [`CREATIVE_VALIDATION_FAILED_GENERIC`](/docs/building/verification/compliance-catalog#error-code-creative-validation-failed-generic) cover the motivating creative-validation gaps. The wire field remains an open string: receivers MUST accept unknown codes, use `buyer_reason.message` for human-facing context, and route recovery from the enclosing `error.recovery`. Seller-specific extensions MUST follow the standard `X_{VENDOR}_{CODE}` naming rule. This permits later codes and platform-specific extensions without making older receivers reject the error object.
 
 `buyer_reason.message` MUST be buyer-safe. It MUST NOT contain vendor identifiers, ad-server type names, internal object names, internal IDs, stack traces, or other producer-private implementation details. Producers compose it from buyer-visible request and catalog data; they do not copy raw downstream error text. Buyer clients may display the message, but MUST treat it as untrusted producer text and MUST NOT use the free text for control flow.

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -23,21 +23,28 @@ For the layered model behind this — what each layer contains and what an SDK a
 
 What "shipped" means at each layer is the [L0–L3 checklist](/docs/building/cross-cutting/sdk-stack#what-an-sdk-at-each-layer-should-provide).
 
-*Last updated: 2026-09-03.*
+*Last updated: 2026-09-05.*
 
 | SDK | Current package | 3.2 RC support | L0 | L1 | L2 | L3 |
 |---|---|---|:-:|:-:|:-:|:-:|
 | **`@adcp/sdk`** (TypeScript) | `14.0.0-beta.31` | Exact `3.2.0-rc.0` support | ✅ | ✅ | ✅ | ✅ |
 | **`adcp`** (Python) | `8.0.0b13` | Exact `3.2.0-rc.0` schemas and types; higher-level helpers remain partial | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| **`adcp/v3`** (Go) | `v3.0.0` | Pending exact 3.2 support | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| **`adcp/v3`** (Go) | `v3.2.0` | Partial 3.2 support; generated schemas remain pinned to `3.2.0-beta.9` | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
 
 Legend: ✅ shipped · ⚠️ partial / role-dependent · ❌ not yet covered. The L0–L3 columns describe the current package, not a 3.2 support claim.
 
 <Warning>
-**3.2 packages are prereleases.** TypeScript beta.31 and Python beta.13 support
-the exact RC.0 protocol checkpoint.
-Neither implies compatibility with a later checkpoint. Go has not published an exact
-3.2 support statement yet. See the [3.2 prerelease program](/docs/reference/3-2-beta).
+**No SDK currently embeds RC.1.** TypeScript beta.31 and Python beta.13 support
+the exact RC.0 protocol checkpoint; neither implies compatibility with RC.1.
+Go SDK `v3.2.0` adds 3.2 proposal and signing support, but its generated
+protocol types remain on beta.9. An
+[RC.1 update is in review](https://github.com/adcontextprotocol/adcp-go/pull/493),
+but it is not supported until a package is published. See the
+[3.2 prerelease program](/docs/reference/3-2-beta).
+
+Use the signed RC.1 bundle directly for raw-wire validation or code generation.
+The install and CLI examples below deliberately remain pinned to RC.0 until an
+SDK publishes an explicit RC.1 support statement.
 </Warning>
 
 The TypeScript SDK currently provides the broadest L0–L3 surface. Python is a
@@ -138,13 +145,17 @@ result = await client.get_products(
 ## Go
 
 ```bash
-go get github.com/adcontextprotocol/adcp-go/adcp/v3@v3.0.0
+go get github.com/adcontextprotocol/adcp-go/adcp/v3@v3.2.0
 ```
 
 The Go SDK's `adcp/v3` module provides typed tool registration, response
-builders, signing, and a compliance test controller. Types are generated from
-canonical AdCP schemas. The `/v3` suffix is required by Go semantic import
-versioning.
+builders, signing, a compliance test controller, and partial 3.2 proposal
+support. Its `v3.2.0` generated types are pinned to protocol `3.2.0-beta.9`, so
+use TypeScript or Python for exact RC.0 schemas, and use the signed protocol
+bundle directly for exact RC.1 schemas. The
+[RC.1 regeneration PR](https://github.com/adcontextprotocol/adcp-go/pull/493)
+is work in progress, not a released support claim. The `/v3` suffix is required
+by Go semantic import versioning.
 
 | Component | Import |
 |-----------|--------|

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -9,10 +9,14 @@ description: "AdCP is an open agentic advertising standard. Follow Alex's team f
 <img src="/images/walkthrough/adcp-01-fragmentation.png" alt="Alex stands arms crossed in a war room of mismatched screens and tangled cables, surveying the chaos — her team hunched over laptops in the background" style={{ width: '100%', borderRadius: '12px', marginBottom: '2rem' }} />
 
 <Info>
-AdCP 3.2 is in beta. It adds an explicit proposal-to-operation lifecycle and
-an experimental authenticated-principal connection layer. See
+AdCP 3.2 is in release candidate. RC.1 is the current signed protocol bundle;
+it combines the proposal-to-operation lifecycle, an experimental
+authenticated-principal connection layer, and experimental Reliable Reporting
+1.0. No SDK embeds RC.1 yet. Use its signed assets for raw-wire and code-generation
+testing, or retain RC.0 for the currently matched TypeScript and Python SDKs.
+See
 [what's new in 3.2](/docs/reference/whats-new-in-3-2) and the
-[beta program](/docs/reference/3-2-beta) before testing.
+[prerelease program](/docs/reference/3-2-beta) before testing.
 </Info>
 
 Alex runs media operations at Pinnacle Agency. Her team buys across six channels — CTV, display, audio, social, retail media, and digital out-of-home. Each channel has its own buying methods, its own terminology, its own way of handling creatives, targeting, and reporting. IOs for some. APIs for others. DSPs for programmatic. Dashboards for everything.

--- a/docs/learning/foundations/a2b-testing-your-first-agent.mdx
+++ b/docs/learning/foundations/a2b-testing-your-first-agent.mdx
@@ -77,7 +77,7 @@ so first-time learners can focus on the four-call lifecycle. The same public
 seller also supports compact 3.2 targeting-aware discovery. After this module,
 use the [buyer briefs supplement](/docs/learning/supplements/buyer-briefs-and-get-products)
 to practice `list_products`, `request_proposals`, and effective targeting
-readback with the pinned beta wire and SDK.
+readback with the pinned `3.2-rc.0` wire and matched SDK prerelease.
 </Note>
 
 ```bash

--- a/docs/media-buy/reporting-core-implementation-guide.mdx
+++ b/docs/media-buy/reporting-core-implementation-guide.mdx
@@ -232,23 +232,27 @@ digest is intentionally retained).
   explicit zero-row publication.
 - The **reporting-core fixture test** is the tier boundary stated as code —
   copy its Core capability block and offering as your starting fixtures.
-- Buyers verify you the same way their SDKs do: webhook or not, they poll
+- Buyers verify the contract the same way with or without webhooks: they poll
   `get_reporting_status` and reconcile obligations against what they
   received.
 
-The reporting lab requires a negotiated AdCP 3.2 release that supports
-Reliable Reporting 1.0 (planned for the next RC.1 wire bundle); the deployed
-training agent otherwise serves its RC.0/default surface, where these
-experimental reporting fields are unavailable. Put the same negotiated version
-on every `sync_accounts`, controller, and `get_reporting_status` request.
+Reliable Reporting 1.0 is published in the RC.1 wire bundle. The public
+training agent still serves its RC.0/default surface, where the RC.1 reporting
+fields are unavailable, so the reporting lab is not live there yet. In any
+RC.1-capable environment, put the same negotiated version on every
+`sync_accounts`, controller, and `get_reporting_status` request.
 
-In the public sales sandbox, call `comply_test_controller` with
+Once the public sales sandbox advertises `"3.2-rc.1"`, call
+`comply_test_controller` with
 `scenario: "reporting_core_lifecycle_probe"` and `operation: "prepare"`. Use
 the returned account and stable identifiers in a `get_reporting_status`
 `periods` read. Then run `advance_time` with `target_health: "delayed"`, read
 the summary, run `publish_zero_row`, and read the periods view again. The
 [controller reference](/docs/building/by-layer/L3/comply-test-controller#reporting_core_lifecycle_probe)
 contains the exact request shapes.
+
+Until then, run those shapes against your own RC.1-capable local or staging
+implementation; do not send RC.1-only fields to the RC.0 training route.
 
 ## The ladder above Core
 

--- a/docs/media-buy/task-reference/get_media_buy_delivery.mdx
+++ b/docs/media-buy/task-reference/get_media_buy_delivery.mdx
@@ -8,12 +8,11 @@ testable: true
 
 Retrieve comprehensive delivery metrics and performance data for media buy reporting.
 
-{/* The released task endpoint remains /schemas/v3. RC1-only exact-revision
-    fields below are unreleased source in static/schemas/source/media-buy/
-    get-media-buy-delivery-{request,response}.json. */}
-**Request schema:** [`get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-request.json)
+{/* Exact RC.1 is pinned because the stable /schemas/v3 surface does not include
+    the release-candidate exact-revision contract. */}
+**Request schema:** [`get-media-buy-delivery-request.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/get-media-buy-delivery-request.json)
 
-**Response schema:** [`get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json)
+**Response schema:** [`get-media-buy-delivery-response.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/get-media-buy-delivery-response.json)
 
 **Response Time**: ~60 seconds (reporting query)
 
@@ -24,7 +23,7 @@ Retrieve comprehensive delivery metrics and performance data for media buy repor
 ## Exact Reliable Reporting revision read
 
 Reliable Reporting adds the mutually exclusive `reporting_revision_id` selector
-in the next RC schema. It returns the immutable content for exactly that revision,
+in RC.1. It returns the immutable content for exactly that revision,
 not a newly calculated date-range result. The response carries the full
 `reporting_revision` metadata, authoritative `reporting_rows`, and
 `reporting_revision_binding` with the same revision ID, row count, control totals,
@@ -120,7 +119,7 @@ Returns delivery data as per-media-buy rows:
 | `by_package` | Package-level breakdowns with delivery_status, paused state, and pacing_index |
 | `daily_breakdown` | Day-by-day delivery for single-currency rows. Omitted for legacy/external mixed-currency buys because daily rows have no package currency grain. |
 
-See [schema](https://adcontextprotocol.org/schemas/v3/media-buy/get-media-buy-delivery-response.json) for the released field list. RC1-only exact-revision fields are documented in the unreleased source noted above.
+See the pinned [RC.1 schema](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/get-media-buy-delivery-response.json) for the released field list, including exact-revision reads.
 
 ### Final vs provisional numbers
 

--- a/docs/media-buy/task-reference/get_reporting_status.mdx
+++ b/docs/media-buy/task-reference/get_reporting_status.mdx
@@ -5,8 +5,8 @@ description: "Check Reliable Reporting health, enumerate expected periods and re
 ---
 
 <Warning>
-**Reliable Reporting 1.0 / RC1 additions — unreleased source contract.** This
-task is experimental. Sellers implementing it declare
+**Reliable Reporting 1.0 is published in RC.1 and remains experimental.**
+Sellers implementing it declare
 `media_buy.reporting_delivery` in `get_adcp_capabilities.experimental_features`.
 </Warning>
 
@@ -16,23 +16,22 @@ usable. It does not replace [`get_media_buy_delivery`](/docs/media-buy/task-refe
 as the reporting-data API.
 
 <Note>
-The schema links below describe the published RC0 baseline. Fields and behavior
-explicitly labeled **Reliable Reporting 1.0 / RC1** below are unreleased source
-contract and will publish with RC1. RC0 does not support `changes_after`,
-`adjustment_receipts`, receipt replacement semantics, or any other RC1-only
+The schema links below pin the published RC.1 contract. RC.0 does not support `changes_after`,
+`adjustment_receipts`, receipt replacement semantics, or any other RC.1-only
 addition.
 </Note>
 
-**Request schema:** [`get-reporting-status-request.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.0/media-buy/get-reporting-status-request.json)
+{/* The stable /schemas/v3 alias does not expose this RC.1-only task yet. */}
+**Request schema:** [`get-reporting-status-request.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/get-reporting-status-request.json)
 
-**Response schema:** [`get-reporting-status-response.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.0/media-buy/get-reporting-status-response.json)
+**Response schema:** [`get-reporting-status-response.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/get-reporting-status-response.json)
 
 <Note>
-**Reliable Reporting 1.0 / RC1 additions:** incremental `changes_after` repair and
+**Reliable Reporting 1.0 / RC.1 additions:** incremental `changes_after` repair and
 its checkpoint, post-official `adjustments[]` and `adjustment_receipts[]`, and their
-correction/reconciliation semantics below are unreleased. RC0 already supports the
+correction/reconciliation semantics below are published in RC.1. RC.0 supports the
 `summary`, `periods`, and `revision` views, retained revisions, materializations,
-`receipts[]`, and cursor pagination; do not infer the RC1 additions from that baseline.
+`receipts[]`, and cursor pagination; do not infer the RC.1 additions from that baseline.
 </Note>
 
 ## Views
@@ -42,8 +41,8 @@ Every request explicitly selects one response shape:
 | View | Use |
 | --- | --- |
 | `summary` | Answer “where is my reporting?” for an account, media-buy, and time scope. |
-| `periods` | Enumerate a flat cursor-paginated ledger of obligations, retained revisions, **RC1** post-official adjustments and adjustment receipts, materialization attempts, and consumer receipts. Use **RC1** `changes_after` for incremental repair. |
-| `revision` | Resolve one exact `reporting_revision_id` and a cursor-paginated page of its **RC1** adjustments and adjustment receipts, materializations, and receipts. |
+| `periods` | Enumerate a flat cursor-paginated ledger of obligations, retained revisions, **RC.1** post-official adjustments and adjustment receipts, materialization attempts, and consumer receipts. Use **RC.1** `changes_after` for incremental repair. |
+| `revision` | Resolve one exact `reporting_revision_id` and a cursor-paginated page of its **RC.1** adjustments and adjustment receipts, materializations, and receipts. |
 
 SDKs may default a convenience `status()` call to `summary`; the wire request remains
 explicit so adding a filter never silently changes the response type.

--- a/docs/media-buy/task-reference/sync_reporting_receipts.mdx
+++ b/docs/media-buy/task-reference/sync_reporting_receipts.mdx
@@ -5,8 +5,8 @@ description: "Record authenticated consumer reconciliation results for Reliable 
 ---
 
 <Warning>
-**Reliable Reporting 1.0 / RC1 additions — unreleased source contract.** This
-task is experimental and belongs to the optional **Reconciled Billing tier**: only sellers advertising
+**Reliable Reporting 1.0 is published in RC.1 and remains experimental.** This
+task belongs to the optional **Reconciled Billing tier**: only sellers advertising
 `media_buy.reporting_delivery.reconciled_billing: true` implement it, and its
 presence is declared through `receipt_task`. Core-tier sellers never implement
 receipts. Sellers implementing it declare `media_buy.reporting_delivery` in
@@ -25,7 +25,7 @@ it is not invoice/price/fee approval, a dispute waiver, posting authorization, o
 payment due. `rejected` means an evidence discrepancy only. An external billing system
 MAY retain `reporting_revision_id` as supporting evidence.
 
-**Reliable Reporting 1.0 / RC1 addition:** If the source is corrected, the seller
+**Reliable Reporting 1.0 / RC.1 addition:** If the source is corrected, the seller
 publishes a separate accounting-only reporting adjustment into a period
 derived from its pinned billing calendar and correction policy; that metadata does not
 authorize reopening books or altering invoices. The consumer recomputes the adjustment's
@@ -39,22 +39,21 @@ records matching reporting evidence; that billing system still decides whether a
 invoice action is appropriate.
 
 <Note>
-The schema links below describe the published RC0 baseline. Fields and behavior
-explicitly labeled **Reliable Reporting 1.0 / RC1** below are unreleased source
-contract and will publish with RC1. RC0 does not support `changes_after`,
-`adjustment_receipts`, receipt replacement semantics, or any other RC1-only
+The schema links below pin the published RC.1 contract. RC.0 does not support `changes_after`,
+`adjustment_receipts`, receipt replacement semantics, or any other RC.1-only
 addition.
 </Note>
 
-**Request schema:** [`sync-reporting-receipts-request.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.0/media-buy/sync-reporting-receipts-request.json)
+{/* The stable /schemas/v3 alias does not expose this RC.1-only task yet. */}
+**Request schema:** [`sync-reporting-receipts-request.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/sync-reporting-receipts-request.json)
 
-**Response schema:** [`sync-reporting-receipts-response.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.0/media-buy/sync-reporting-receipts-response.json)
+**Response schema:** [`sync-reporting-receipts-response.json`](https://adcontextprotocol.org/schemas/3.2.0-rc.1/media-buy/sync-reporting-receipts-response.json)
 
 <Note>
-**Reliable Reporting 1.0 / RC1 additions:** `adjustment_receipts[]`, post-official
+**Reliable Reporting 1.0 / RC.1 additions:** `adjustment_receipts[]`, post-official
 adjustment reconciliation, and receipt replacement/supersession and append-only-history
-semantics below are unreleased. RC0 already supports the batched revision
-materialization `receipts[]` form; it must not be read as supporting these RC1 additions.
+semantics below are published in RC.1. RC.0 supports the batched revision
+materialization `receipts[]` form; it must not be read as supporting these RC.1 additions.
 </Note>
 
 ```json
@@ -93,7 +92,7 @@ governance consumer. The seller accepts a receipt only for that principal's
 account-bound obligation and materialization. Unknown, unauthorized, cross-account,
 and cross-caller identifiers return indistinguishable failures.
 
-**Reliable Reporting 1.0 / RC1 reconciliation semantics:** reconciliation is immediately due once the revision and verified materialization are
+**Reliable Reporting 1.0 / RC.1 reconciliation semantics:** reconciliation is immediately due once the revision and verified materialization are
 readable; Reliable Reporting does not define a separate receipt SLA. A missing current
 revision receipt produces `action_required` / `RECEIPT_REQUIRED`; a missing adjustment
 receipt produces `ADJUSTMENT_RECEIPT_REQUIRED`, both assigned to the consumer. A current
@@ -111,7 +110,7 @@ totals. Its selected verification profile adds one of:
 - `canonical_digest`: the digest of canonical logical content, required for billing.
 
 If evidence differs, consumers submit `status: rejected` with stable rejection codes.
-**Reliable Reporting 1.0 / RC1 replacement semantics:**
+**Reliable Reporting 1.0 / RC.1 replacement semantics:**
 A receipt records exactly one materialization evidence attempt. Materializations are
 attempts within one current authenticated-consumer + obligation + revision replacement
 chain, not independently reconciled materialization chains. A receipt ID is immutable. Exact retries are unchanged; reuse with different content

--- a/docs/reference/3-2-beta.mdx
+++ b/docs/reference/3-2-beta.mdx
@@ -15,8 +15,18 @@ change 3.2 surfaces before GA.
 </Warning>
 
 The 3.2 prerelease cycle started with a protocol-first beta checkpoint.
-RC.0 is the current protocol checkpoint. TypeScript SDK `14.0.0-beta.31` and
-Python SDK `8.0.0b13` consume the signed RC.0 bundle:
+RC.1 is the current signed protocol checkpoint. No SDK embeds it yet.
+TypeScript SDK `14.0.0-beta.31` and Python SDK `8.0.0b13` remain exact RC.0
+pairings:
+
+<Info>
+**RC.1 separates protocol-first and SDK-backed testing.** Use its signed bundle
+for raw-wire validation and code generation. Continue using RC.0 for the
+currently matched TypeScript and Python SDKs. A
+[Go RC.1 update is in review](https://github.com/adcontextprotocol/adcp-go/pull/493),
+but it is not usable until a package is published with an explicit support
+statement.
+</Info>
 
 | Checkpoint | Purpose | Who should test |
 |---|---|---|
@@ -32,31 +42,32 @@ Python SDK `8.0.0b13` consume the signed RC.0 bundle:
 | `3.2.0-beta.9` | Previous protocol checkpoint for the draft account change feed, inventory-list receipts, inventory delivery identity, seller policy and change rights, and broader conformance coverage | Pinned adopters comparing beta.9 and beta.10 behavior |
 | `3.2.0-beta.10` | Previous protocol checkpoint for managed reporting delivery, authenticated principals, audio VAST and DOOH support, programmed channel collections, committed collection selection, and expanded conformance coverage | Pinned adopters comparing beta.10 and beta.11 behavior |
 | `3.2.0-beta.11` | Previous protocol checkpoint | Pinned adopters comparing beta.11 and RC.0 behavior |
-| `3.2.0-rc.0` | Current protocol checkpoint | SDK-backed, raw-wire, code-generation, and integration testing |
-| SDK wave | `@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed `3.2.0-rc.0`; Go remains pending | TypeScript and Python adopters, Go maintainers, and early integration teams |
+| `3.2.0-rc.0` | Previous protocol checkpoint | SDK-backed integration testing with an exact RC.0 package pairing |
+| `3.2.0-rc.1` | Current protocol checkpoint for Reliable Reporting 1.0 and reporting-semantics hardening | Raw-wire, signed-artifact, code-generation, and SDK implementation testing |
+| Current SDK wave | `@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed `3.2.0-rc.0`; Go `adcp/v3@v3.2.0` remains pinned to protocol beta.9 | RC.0 SDK-backed testing while RC.1 SDK work proceeds |
 
 Earlier betas remain useful as pinned implementation checkpoints. For
-SDK-backed testing of the current checkpoint, pair TypeScript SDK beta.31 or
-Python SDK beta.13 with protocol RC.0. TypeScript SDK beta.29 and Python SDK
-beta.12 remain historical pairings for beta.11. Do not combine a newer wire pin
-with an SDK generated from an older bundle unless the SDK maintainer documents
-forward compatibility.
+SDK-backed testing, pair TypeScript SDK beta.31 or Python SDK beta.13 with
+protocol RC.0. TypeScript SDK beta.29 and Python SDK beta.12 remain historical
+pairings for beta.11. No current SDK pairing is RC.1 evidence. Do not combine a
+newer wire pin with an SDK generated from an older bundle unless the SDK
+maintainer documents forward compatibility.
 
 ## Know which version string to use
 
 The artifact version, wire pin, and documentation selector are related but not
 interchangeable:
 
-| Surface | beta.0 | beta.1 | beta.2 | beta.3 | beta.4 | beta.5 | beta.6 | beta.7 | beta.8 | beta.9 | beta.10 | beta.11 | RC.0 |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Protocol artifact | `3.2.0-beta.0` | `3.2.0-beta.1` | `3.2.0-beta.2` | `3.2.0-beta.3` | `3.2.0-beta.4` | `3.2.0-beta.5` | `3.2.0-beta.6` | `3.2.0-beta.7` | `3.2.0-beta.8` | `3.2.0-beta.9` | `3.2.0-beta.10` | `3.2.0-beta.11` | `3.2.0-rc.0` |
-| Git tag | `v3.2.0-beta.0` | `v3.2.0-beta.1` | `v3.2.0-beta.2` | `v3.2.0-beta.3` | `v3.2.0-beta.4` | `v3.2.0-beta.5` | `v3.2.0-beta.6` | `v3.2.0-beta.7` | `v3.2.0-beta.8` | `v3.2.0-beta.9` | `v3.2.0-beta.10` | `v3.2.0-beta.11` | `v3.2.0-rc.0` |
-| `adcp_version` wire pin | `"3.2-beta.0"` | `"3.2-beta.1"` | `"3.2-beta.2"` | `"3.2-beta.3"` | `"3.2-beta.4"` | `"3.2-beta.5"` | `"3.2-beta.6"` | `"3.2-beta.7"` | `"3.2-beta.8"` | `"3.2-beta.9"` | `"3.2-beta.10"` | `"3.2-beta.11"` | `"3.2-rc.0"` |
-| Documentation selector | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-rc` |
+| Surface | beta.0 | beta.1 | beta.2 | beta.3 | beta.4 | beta.5 | beta.6 | beta.7 | beta.8 | beta.9 | beta.10 | beta.11 | RC.0 | RC.1 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Protocol artifact | `3.2.0-beta.0` | `3.2.0-beta.1` | `3.2.0-beta.2` | `3.2.0-beta.3` | `3.2.0-beta.4` | `3.2.0-beta.5` | `3.2.0-beta.6` | `3.2.0-beta.7` | `3.2.0-beta.8` | `3.2.0-beta.9` | `3.2.0-beta.10` | `3.2.0-beta.11` | `3.2.0-rc.0` | `3.2.0-rc.1` |
+| Git tag | `v3.2.0-beta.0` | `v3.2.0-beta.1` | `v3.2.0-beta.2` | `v3.2.0-beta.3` | `v3.2.0-beta.4` | `v3.2.0-beta.5` | `v3.2.0-beta.6` | `v3.2.0-beta.7` | `v3.2.0-beta.8` | `v3.2.0-beta.9` | `v3.2.0-beta.10` | `v3.2.0-beta.11` | `v3.2.0-rc.0` | `v3.2.0-rc.1` |
+| `adcp_version` wire pin | `"3.2-beta.0"` | `"3.2-beta.1"` | `"3.2-beta.2"` | `"3.2-beta.3"` | `"3.2-beta.4"` | `"3.2-beta.5"` | `"3.2-beta.6"` | `"3.2-beta.7"` | `"3.2-beta.8"` | `"3.2-beta.9"` | `"3.2-beta.10"` | `"3.2-beta.11"` | `"3.2-rc.0"` | `"3.2-rc.1"` |
+| Documentation selector | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-beta` | `3.2-rc` | `3.2-rc` |
 
 Only send a prerelease wire pin to a peer that advertises that exact value in
 `get_adcp_capabilities.adcp.supported_versions`. Prerelease pins are exact: a
-buyer pinned to `"3.2-rc.0"` must not silently negotiate to another prerelease,
+buyer pinned to `"3.2-rc.1"` must not silently negotiate to another prerelease,
 and a stable `"3.2"` pin must not silently negotiate to a prerelease.
 
 ## Use matched SDK prereleases
@@ -79,19 +90,26 @@ Python `adcp==8.0.0b13` carries RC.0 schemas and generated types. Its
 higher-level caller/server helpers remain role-dependent, so consult the SDK
 matrix before treating schema parity as complete L1–L3 coverage.
 
-## Use the RC.0 artifact directly
+Go `adcp/v3@v3.2.0` includes 3.2 proposal APIs and signing additions, but its
+generated schemas remain pinned to protocol `3.2.0-beta.9`. It is not an exact
+RC.0 or RC.1 pairing; use it only for the documented partial surface. The
+[RC.1 Go update](https://github.com/adcontextprotocol/adcp-go/pull/493) is in
+review, but it is not supported until a package is published with an explicit
+protocol-version statement.
 
-Download the signed RC.0 protocol bundle rather
+## Use the RC.1 artifact directly
+
+Download the signed RC.1 protocol bundle rather
 than copying schemas from `main` or from the moving `/schemas/latest/` path:
 
 ```bash
-curl -fLO https://adcontextprotocol.org/protocol/3.2.0-rc.0.tgz
-curl -fLO https://adcontextprotocol.org/protocol/3.2.0-rc.0.tgz.sha256
-shasum -a 256 -c 3.2.0-rc.0.tgz.sha256
-tar -xzf 3.2.0-rc.0.tgz
+curl -fLO https://adcontextprotocol.org/protocol/3.2.0-rc.1.tgz
+curl -fLO https://adcontextprotocol.org/protocol/3.2.0-rc.1.tgz.sha256
+shasum -a 256 -c 3.2.0-rc.1.tgz.sha256
+tar -xzf 3.2.0-rc.1.tgz
 ```
 
-The extracted `adcp-3.2.0-rc.0/` directory contains:
+The extracted `adcp-3.2.0-rc.1/` directory contains:
 
 - `manifest.json` — release version, bundle contents, skills, and file count;
 - `schemas/` — source-shaped and bundled request/response schemas, including
@@ -109,13 +127,13 @@ Useful direct-artifact tests are:
 1. Generate or refresh types from the pinned bundled schemas.
 2. Validate representative requests and responses for the roles you implement.
 3. Compare your advertised tools with `schemas/manifest.json`.
-4. Exercise raw MCP or A2A calls with `adcp_version: "3.2-rc.0"` against a
+4. Exercise raw MCP or A2A calls with `adcp_version: "3.2-rc.1"` against a
    staging peer that advertises the same pin.
 5. Run the compliance assets with a source-compatible runner if you maintain
    one. Do not weaken production authentication to accommodate a prerelease runner.
 
 <Note>
-**No 3.2 verification badge is currently issued for RC.0.** Treat it as an
+**No 3.2 verification badge is currently issued for a prerelease.** Treat RC.1 as an
 implementation input, not a certification target.
 </Note>
 
@@ -142,15 +160,16 @@ SDK implementation bugs in the SDK's own repository. Accepted protocol fixes
 receive a changeset and ship in a later prerelease; published prereleases are never rebuilt
 in place.
 
-## Current RC.0 checkpoint
+## Current RC.1 checkpoint
 
-Protocol beta.1 through beta.11 and RC.0 are published. TypeScript SDK beta.31
-and Python SDK beta.13 embed the exact RC.0 bundle. Before treating
-a test result as RC.0 protocol evidence, confirm that:
+Protocol beta.1 through beta.11, RC.0, and RC.1 are published. No SDK embeds
+RC.1 yet; TypeScript SDK beta.31 and Python SDK beta.13 embed RC.0. Before
+treating a test result as RC.1 protocol evidence, confirm that:
 
-- the test uses the signed RC.0 artifact directly;
-- both peers advertise `"3.2-rc.0"` before calls use that pin;
-- the integration scenarios below run against RC.0 and retain the exact
+- the test uses the signed RC.1 artifact directly rather than an older SDK's
+  generated schemas;
+- both peers advertise `"3.2-rc.1"` before calls use that pin;
+- the integration scenarios below run against RC.1 and retain the exact
   bundle version;
 - copy/paste installation and validation commands have been executed as
   published;
@@ -253,7 +272,8 @@ Include this information in a prerelease issue:
 - schema path or JSON Pointer involved;
 - expected and actual behavior;
 - minimal redacted payload and validation error;
-- whether the problem blocks RC.0 interoperability.
+- whether the problem blocks RC.1 interoperability or only an older SDK-backed
+  checkpoint.
 
 Never include credentials, signed URLs, bearer tokens, private keys, or live
 customer payloads.

--- a/docs/reference/migration/3-1-to-3-2.mdx
+++ b/docs/reference/migration/3-1-to-3-2.mdx
@@ -8,11 +8,12 @@ description: "Role-based migration checklist for adopting the AdCP 3.2 release c
 # Migrating from 3.1 to 3.2
 
 <Warning>
-**3.2 is in release candidate.** RC.0 is the current protocol checkpoint. TypeScript
-`@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed RC.0 exactly.
-Python higher-level helpers remain partial, and Go exact
-support remains pending. Keep production traffic pinned to `"3.1"` while
-validating 3.2 in staging.
+**3.2 is in release candidate.** RC.1 is the current signed protocol
+checkpoint and has no matched SDK yet. TypeScript
+`@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed RC.0 exactly;
+Python higher-level helpers remain partial. Go `adcp/v3@v3.2.0` remains
+generated from protocol beta.9. Keep production traffic pinned to `"3.1"`
+while validating an exact 3.2 checkpoint in staging.
 </Warning>
 
 3.2 is a minor release over 3.1. Existing integrations do not need to adopt the
@@ -47,21 +48,21 @@ surfaces by hand.
 | Step | Who | Action |
 |---|---|---|
 | 1 | Everyone | Keep production on `"3.1"`; choose an exact 3.2 prerelease artifact for staging. |
-| 2 | SDK and codegen maintainers | Generate from the signed `3.2.0-rc.0` protocol tarball, not `main` or `/schemas/latest/`. |
+| 2 | SDK and codegen maintainers | Generate from the signed `3.2.0-rc.1` protocol tarball, not `main` or `/schemas/latest/`. |
 | 3 | Sellers and agents | Advertise the exact prerelease in `adcp.supported_versions` and echo the release actually served. |
-| 4 | Buyers | Send `adcp_version: "3.2-rc.0"` only after exact capability discovery; never silently move between prerelease pins. |
+| 4 | Buyers | Send `adcp_version: "3.2-rc.1"` only after exact capability discovery; never silently move between prerelease pins. |
 | 5 | Media-buy implementations | Move create/update success handling completely to `media_buy_status`. |
 | 6 | Signing implementations | Require `content-digest` coverage and migrate request `Signature` and `Content-Digest` binary values to RFC 8941 padded Base64. |
 | 7 | Creative implementations | Adopt canonical format capability/product discovery and isolate legacy projection at compatibility boundaries. |
-| 8 | Compliance operators | Test RC.0 from its signed assets or pair `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13` with exact RC.0. Retain the exact package and wire versions. |
+| 8 | Compliance operators | Test RC.1 from its signed assets. For SDK-backed RC.0 testing, pair `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13` with exact RC.0. Retain the exact package and wire versions. |
 | 9 | Delivery-reporting implementations | Emit and consume currency at media-buy or package grain, move qualified outcomes to `by_package[].metric_values`, and stop producing new `aggregated_totals`. |
 
 ## Required to claim 3.2 behavior
 
 ### Serve and echo the exact release
 
-During prerelease, version matching is exact. A seller serving RC.0 advertises
-`"3.2-rc.0"`. Do not advertise stable `"3.2"` before GA, silently negotiate
+During prerelease, version matching is exact. A seller serving RC.1 advertises
+`"3.2-rc.1"`. Do not advertise stable `"3.2"` before GA, silently negotiate
 between prerelease pins, or treat a major-only declaration as evidence of 3.2
 support.
 
@@ -221,8 +222,8 @@ See [Cross-role governance enforcement](/docs/reference/migration/cross-role-gov
 | Creative agent | Canonical supported-format capabilities, operation selection, and explicit compatibility handling for legacy named formats. |
 | Signals or measurement agent | Exact prerelease pin and only the attestation, targeting, or feedback capabilities actually implemented. |
 | Governance provider/service | Exact prerelease pin, `governance.campaign` experimental declaration, and the complete cross-role authorization migration. |
-| SDK maintainer | Signed RC.0 bundle ingestion, generated-type/validator tests, exact support matrix entry, and protocol feedback destined for the next prerelease. |
-| Compliance operator | Matching RC.0 assets and SDK support end to end; no 3.2 badge from a prerelease checkpoint. |
+| SDK maintainer | Signed RC.1 bundle ingestion, generated-type/validator tests, exact support matrix entry, and protocol feedback destined for the next prerelease. |
+| Compliance operator | Matching assets and wire pin end to end; no 3.2 badge from a prerelease checkpoint. RC.1 has no matched SDK yet. |
 
 ## Rollback
 

--- a/docs/reference/migration/index.mdx
+++ b/docs/reference/migration/index.mdx
@@ -14,7 +14,7 @@ This page covers every breaking change when upgrading from AdCP 2.x to 3.0, with
 </Info>
 
 <Info>
-**Preparing for 3.2?** Start with the [3.1 to 3.2 migration guide](/docs/reference/migration/3-1-to-3-2). During beta, also read the [3.2 beta program](/docs/reference/3-2-beta) for the protocol-first beta.0, initial SDK wave, beta.1 protocol convergence, and exact beta.1 SDK refresh.
+**Preparing for 3.2?** Start with the [3.1 to 3.2 migration guide](/docs/reference/migration/3-1-to-3-2). For the signed RC.1 artifact, exact wire pins, RC.0-matched SDKs, and feedback guidance, read the [3.2 prerelease program](/docs/reference/3-2-beta).
 </Info>
 
 <Warning>

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -11,7 +11,7 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 
 ## Version 3.2.0
 
-**Status:** Release-candidate cycle — minor release targeting the 3.2.0 milestone. Beta.0 was the protocol-first cut used as the canonical input for SDK work. RC.0 is the current protocol checkpoint. TypeScript `@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed RC.0 exactly. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
+**Status:** Release-candidate cycle — minor release targeting the 3.2.0 milestone. RC.1 is the current signed protocol checkpoint. It completes the experimental Reliable Reporting 1.0 contract and hardens delivery, reach, and vendor-metric semantics. No SDK embeds RC.1 yet. TypeScript `@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed RC.0 exactly. Go `adcp/v3@v3.2.0` includes partial 3.2 proposal and signing support but its generated schemas remain pinned to beta.9. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
 
 ### Prerelease checkpoints
 
@@ -29,7 +29,8 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 | `3.2.0-beta.9` | Add the draft account change feed, product-scoped inventory-list receipts, authority-discriminated inventory delivery identity, seller policy and change-right contracts, and broader conformance coverage | Previous protocol checkpoint; remains available for pinned prerelease adopters |
 | `3.2.0-beta.10` | Add managed reporting delivery, authenticated principals, audio VAST and DOOH support, programmed channel collections, committed collection selection, and expanded conformance coverage | Previous protocol checkpoint with exact TypeScript support in `@adcp/sdk@14.0.0-beta.28` and exact Python schema/type support in `adcp==8.0.0b11` |
 | `3.2.0-beta.11` | Add `get_principal` to the MCP media-buy role profile and align the public training agent with the latest beta bundle | Previous protocol checkpoint with exact TypeScript support in `@adcp/sdk@14.0.0-beta.29` and exact Python schema/type support in `adcp==8.0.0b12` |
-| `3.2.0-rc.0` | Publish the first 3.2 release candidate after beta integration fixes and expand reporting lifecycle conformance | Current protocol checkpoint with exact TypeScript support in `@adcp/sdk@14.0.0-beta.31` and exact Python schema/type support in `adcp==8.0.0b13` |
+| `3.2.0-rc.0` | Publish the first 3.2 release candidate after beta integration fixes and expand reporting lifecycle conformance | Previous checkpoint with exact TypeScript support in `@adcp/sdk@14.0.0-beta.31` and exact Python schema/type support in `adcp==8.0.0b13` |
+| `3.2.0-rc.1` | Complete the experimental Reliable Reporting 1.0 contract and harden delivery currency, aggregate reach, vendor-metric identity, and integration behavior | Current signed protocol checkpoint; no matched SDK release yet |
 
 Each prerelease is immutable. The `3.2-rc` documentation selector advances to the latest release candidate; the `3.2-beta` selector remains frozen at beta.11. Pinned protocol, schema, compliance, and documentation artifacts remain available. See the [3.2 prerelease program](/docs/reference/3-2-beta).
 
@@ -42,6 +43,7 @@ Each prerelease is immutable. The `3.2-rc` documentation selector advances to th
 - **Creative:** canonical capability discovery, image pixel density and rendition sets, localization, async preview opt-in, audio loudness, VAST 4.3 and validation levels, accessibility detail, and synthetic depiction provenance.
 - **Security and evidence:** required body binding for 3.2 request-signing profiles, OAuth discovery grading, portable attestations, rights and signal evidence, signed brand-response verification, and safer secured asset access.
 - **Operations and measurement:** capability/account change notifications, snapshot-and-log repair, demographic and spot delivery, metric accountability, deterministic filters, fixture resolution, and capability-selected runtime projections.
+- **Reliable Reporting:** a separately discovered, versioned experimental three-tier contract for expected-period obligations, immutable official revisions, managed materializations, authenticated receipts, correction ledgers, and repairable status. RC.1 completes Reliable Reporting 1.0.
 - **Experimental surfaces:** cross-role campaign governance revisions and Trusted Match authentication, routing, attribution, and creative-data cleanup under their existing experimental declarations.
 
 ### Adopter action
@@ -52,8 +54,8 @@ Each prerelease is immutable. The `3.2-rc` documentation selector advances to th
 | A seller or service | Advertise and echo the exact prerelease served, emit canonical status/retry shapes, and declare only capabilities actually implemented. |
 | A signing implementation | Require `content-digest` coverage for every signed request body on a 3.2 signing endpoint. |
 | A creative implementation | Prefer canonical capability and product format discovery; isolate named-format conversion at compatibility boundaries. |
-| An SDK maintainer | Generate from the current signed RC.0 tarball, publish an exact support statement, and route accepted protocol corrections into a later prerelease. |
-| A compliance operator | Test RC.0 from its signed assets or with `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13`. Retain the exact package and wire versions and do not issue a 3.2 badge from a prerelease checkpoint. |
+| An SDK maintainer | Generate from the current signed RC.1 tarball, publish an exact support statement, and route accepted protocol corrections into a later prerelease. |
+| A compliance operator | Test RC.1 from its signed assets. For SDK-backed RC.0 testing, use `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13`. Go `adcp/v3@v3.2.0` remains generated from beta.9. Retain exact package and wire versions and do not issue a 3.2 badge from a prerelease checkpoint. |
 
 ### Required 3.2 migrations
 

--- a/docs/reference/versioning.mdx
+++ b/docs/reference/versioning.mdx
@@ -250,13 +250,14 @@ The v2 sunset is the documented exception to this commitment: v2 predates this p
 |---------|--------|
 | **3.0** | April 2026 — GA release |
 | **3.1** | Late June 2026 |
-| **3.2** | Beta cycle begins August 2026; GA targeted for late September 2026 |
+| **3.2** | RC.1 published September 2026; GA targeted for late September 2026 |
 | **4.0** | Early 2027 — next major, accumulated breaking changes |
 
-The 3.2 cycle publishes a protocol-first beta.0 before its SDK wave. Beta.1
-incorporates that integration feedback, then becomes SDK-backed only after SDKs
-ingest the exact beta.1 bundle and publish matching evidence. See the
-[3.2 beta program](/docs/reference/3-2-beta).
+The 3.2 cycle began with a protocol-first beta before SDK convergence. RC.1 is
+now the current signed protocol checkpoint; no SDK embeds it yet. TypeScript
+SDK beta.31 and Python SDK beta.13 remain exact RC.0 pairings, while a Go RC.1
+update is in review. See the
+[3.2 prerelease program](/docs/reference/3-2-beta).
 
 Further 3.x releases are scheduled based on implementation feedback and working group priorities, with at least 8 weeks between stable releases. Planned scope for each release is tracked on the [GitHub milestones page](https://github.com/adcontextprotocol/adcp/milestones) — open issues on the `3.1.0` and `3.2.0` milestones reflect current candidate work, not fixed commitments.
 

--- a/docs/reference/versions.mdx
+++ b/docs/reference/versions.mdx
@@ -13,7 +13,7 @@ description: "Every published AdCP version, its status, and its end-of-life date
 
 | Status | Versions | Wire pin | What it means |
 |---|---|---|---|
-| **Release candidate** | 3.2 (current prerelease: `rc.0`) | `"3.2-rc.0"` | Development and staging only. RC.0 is the current protocol checkpoint; TypeScript SDK beta.31 and Python SDK beta.13 embed it exactly. Follow the [3.2 prerelease program](/docs/reference/3-2-beta). |
+| **Release candidate** | 3.2 (current prerelease: `rc.1`) | `"3.2-rc.1"` | Development and staging only. RC.1 is the current signed protocol checkpoint and has no matched SDK yet. TypeScript SDK beta.31 and Python SDK beta.13 embed RC.0; Go SDK 3.2.0 remains generated from beta.9. Follow the [3.2 prerelease program](/docs/reference/3-2-beta). |
 | **Active** | 3.1 (current stable: 3.1.20) | `"3.1"` | Current production minor release. See [What's New in AdCP 3.1](/docs/reference/whats-new-in-3-1) for the feature set. |
 | **Maintained** | 3.0 (current stable: 3.0.26) | `"3.0"` | Supported previous minor for existing production integrations. Receives compatibility and security patches. |
 | **End of life** | 2.0.0, 2.1.0, 2.5.0–2.5.3 | — | No patches. Migrate to 3.0. See [v2 sunset](/docs/reference/v2-sunset). |
@@ -45,7 +45,8 @@ Supported patches don't change the wire contract. Upgrading within 3.0.x is alwa
 
 | Version | Released | Notes |
 |---|---|---|
-| **3.2.0-rc.0** | 2026-09-03 | Current protocol checkpoint and first 3.2 release candidate. TypeScript SDK beta.31 and Python SDK beta.13 embed it exactly; use `"3.2-rc.0"` only with peers that explicitly advertise it. |
+| **3.2.0-rc.1** | 2026-09-05 | Current protocol checkpoint. Completes the experimental Reliable Reporting 1.0 contract and hardens delivery, reach, and vendor-metric semantics. No SDK embeds it yet; use `"3.2-rc.1"` only with peers that explicitly advertise it. |
+| 3.2.0-rc.0 | 2026-09-03 | First 3.2 release candidate. TypeScript SDK beta.31 and Python SDK beta.13 embed it exactly; Go SDK 3.2.0 remains generated from beta.9. |
 | 3.2.0-beta.11 | 2026-09-03 | Previous protocol checkpoint. Adds `get_principal` to the MCP media-buy role profile alongside `sync_principal`, and aligns training-agent and compliance guidance with the beta.10 bundle. TypeScript SDK beta.29 and Python SDK beta.12 embed it exactly. |
 | 3.2.0-beta.10 | 2026-09-01 | Previous protocol checkpoint. Adds managed reporting delivery, authenticated principals, audio VAST and DOOH support, programmed channel collections, and committed collection selection. TypeScript SDK beta.28 and Python SDK beta.11 embed it. |
 | 3.2.0-beta.9 | 2026-08-28 | Previous protocol checkpoint. Adds the draft account change feed, product-scoped inventory-list receipts, authority-discriminated inventory delivery identity, seller policy and change-right contracts, and broader conformance coverage. |
@@ -97,8 +98,8 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 | If you are… | Use |
 |---|---|
 | Building a new production integration today | **3.1**. Pin `"3.1"` on the wire. |
-| Implementing or testing 3.2 without an SDK | Use the signed **3.2 RC.0** artifacts with raw-wire or code-generation workflows. Follow the [prerelease program](/docs/reference/3-2-beta). |
-| Running an SDK-backed 3.2 integration test | Use `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13` with exact wire pin `"3.2-rc.0"`; use Go only after its support matrix row names an exact checkpoint. |
+| Implementing or testing 3.2 without an SDK | Use the signed **3.2 RC.1** artifacts with raw-wire or code-generation workflows. Follow the [prerelease program](/docs/reference/3-2-beta). |
+| Running an SDK-backed 3.2 integration test | No SDK embeds RC.1 yet. Use `@adcp/sdk@14.0.0-beta.31` or Python `adcp==8.0.0b13` only with exact RC.0 wire pin `"3.2-rc.0"`. Go `adcp/v3@v3.2.0` remains generated from beta.9. |
 | Running an existing 3.0 integration | Stay on **3.0** while you migrate, or move to **3.1** when your SDK and validation are ready. |
 | Running a 2.5.x integration | Upgrade now — out of support. Start with the [migration guide](/docs/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |

--- a/docs/reference/whats-new-in-3-2.mdx
+++ b/docs/reference/whats-new-in-3-2.mdx
@@ -8,11 +8,21 @@ description: "AdCP 3.2 turns a media-buy conversation into an explicit lifecycle
 # What's new in AdCP 3.2
 
 <Warning>
-**3.2 is in release candidate.** RC.0 is the current protocol checkpoint. TypeScript
-`@adcp/sdk@14.0.0-beta.31` and Python `adcp==8.0.0b13` embed RC.0. Python
-higher-level helpers remain partial, and Go exact support is
-still pending. See the [3.2 prerelease program](/docs/reference/3-2-beta) before testing.
+**3.2 is in release candidate.** RC.1 is the current signed protocol
+checkpoint. No SDK embeds it yet. TypeScript `@adcp/sdk@14.0.0-beta.31` and
+Python `adcp==8.0.0b13` embed RC.0; Python higher-level helpers remain partial.
+Go `adcp/v3@v3.2.0` has partial 3.2 support but remains pinned to protocol
+beta.9. Use RC.1 for raw-wire or code-generation testing, and do not combine it
+with an older SDK unless that SDK documents forward compatibility. See the
+[3.2 prerelease program](/docs/reference/3-2-beta).
 </Warning>
+
+<Info>
+**New in RC.1:** Reliable Reporting 1.0 becomes a named, version-discovered
+experimental capability, with stronger delivery, reach, vendor-metric, and
+reconciliation semantics. The public training seller and current SDK wave
+remain on RC.0 until they publish explicit RC.1 support.
+</Info>
 
 AdCP 3.2 turns a media-buy conversation into a commercial lifecycle that
 software can safely operate. A buyer can move from a brief to seller-authored
@@ -23,7 +33,8 @@ kind of change is happening.
 That is the release's central upgrade: conversational on the outside,
 explicit and accountable on the inside. Targeting and creative capabilities
 are discoverable, commercial terms are immutable and digestible, retries are
-safe, and operational changes no longer rewrite the agreement they came from.
+safe, operational changes no longer rewrite the agreement they came from, and
+expected reports cannot silently disappear.
 
 Existing 3.1 integrations can remain pinned to `"3.1"`. The broad 3.x
 `get_products`, `create_media_buy`, and `update_media_buy` facades remain
@@ -32,7 +43,7 @@ tools after capability discovery.
 
 <CardGroup cols={3}>
   <Card
-    title="Try the lifecycle"
+    title="Try the proposal flow"
     icon="messages"
     href="https://agenticadvertising.org/chat?prompt=Run%20a%20live%20AdCP%203.2%20proposal%20demo%20against%20the%20constrained-seller%20training%20profile.%20Show%20me%20the%20alternatives%20and%20stop%20before%20refining."
   >
@@ -40,13 +51,82 @@ tools after capability discovery.
     required.
   </Card>
   <Card title="Build it" icon="code" href="/docs/building/by-layer/L4/choose-your-sdk">
-    Choose an SDK that explicitly embeds the current 3.2 protocol checkpoint.
+    Choose an SDK-backed RC.0 path or use the signed RC.1 bundle directly.
   </Card>
   <Card title="Adopt it" icon="route" href="/docs/reference/migration/3-1-to-3-2">
     Add compact lifecycle tools incrementally while keeping 3.1 integrations
     pinned and working.
   </Card>
 </CardGroup>
+
+## What 3.2 means for you
+
+| If you are… | The practical change | Start here |
+|---|---|---|
+| A media buyer or operator | A brief can become a seller-authored proposal, a negotiated hold, an accepted buy, and a controlled campaign without losing which terms were agreed. | [Try the live lifecycle](https://agenticadvertising.org/chat?prompt=Run%20a%20live%20AdCP%203.2%20proposal%20demo%20against%20the%20constrained-seller%20training%20profile.%20Show%20me%20the%20alternatives%20and%20stop%20before%20refining.) |
+| A developer or platform team | Seven capability-gated tools replace overloaded modes, with immutable proposal state, revision checks, exact version negotiation, and MCP validation-schema pairs that are 76–95% smaller for comparable operations. | [Choose an SDK](/docs/building/by-layer/L4/choose-your-sdk) |
+| An existing 3.1 adopter | There is no forced migration deadline: keep production pinned to `"3.1"`, add compact tools incrementally, and validate an exact release candidate in staging. | [Follow the migration guide](/docs/reference/migration/3-1-to-3-2) |
+
+## 3.1 to 3.2 by the numbers
+
+3.1 made the 3.x foundation safer to operate: release pinning, canonical
+creative formats, distributed brand trust, wholesale-feed repair, webhook
+observability, idempotency, and capability-gated compliance. 3.2 builds the
+commercial lifecycle on that foundation: explicit proposals, holds,
+acceptance, controls, targeting resolution, principal configuration, and
+reporting reconciliation.
+
+| Published surface | 3.1.0 | 3.2.0-rc.1 | Change |
+|---|---:|---:|---:|
+| Source JSON Schema files | 648 | 979 | +331 (+51%) |
+| Manifested tools | 64 | 77 | +13 net (+20%) |
+| Compliance YAML files | 137 | 215 | +78 (+57%) |
+| Source documentation pages | 327 | 367 | +40 (+12%) |
+
+The schema count reflects named request, response, async, and reusable schemas
+for code generation; it is a surface-area measure, not a claim that every file
+represents a separate adopter feature. The tool delta is 14 additions and one
+retired experimental tool. Seven of the additions are the compact media-buy
+lifecycle itself.
+
+The larger corpus produces a smaller per-operation MCP validation footprint. The
+compact tools no longer pull every legacy mode, inline creative, and provenance
+branch into each operation. Comparing the published, self-contained 3.1 bundled
+request-plus-response schemas with the generic RC.1 MCP media-buy pairs under
+`mcp/2026-07-28/media-buy/`:
+
+| Comparable operation | 3.1 compatibility pair | 3.2 RC.1 compact pair | Reduction |
+|---|---:|---:|---:|
+| Proposal planning | 3,021,309 bytes (`get_products`) | 734,563 bytes (`request_proposals`) | 75.7% |
+| Direct purchase | 2,782,428 bytes (`create_media_buy`) | 508,751 bytes (`buy_products`) | 81.7% |
+| Proposal acceptance | 2,782,428 bytes (`create_media_buy`) | 328,309 bytes (`accept_proposal`) | 88.2% |
+| Operational control | 4,369,798 bytes (`update_media_buy`) | 204,300 bytes (`control_media_buy`) | 95.3% |
+
+These are UTF-8 JSON Schema artifact sizes, not typical transaction-body sizes
+or a latency benchmark. The 3.2 model-context profile presents input-only
+schemas; response schemas remain available to SDKs and validators.
+
+There are two useful lenses on features and hardening:
+
+- **Published impact:** the cumulative 3.2 prerelease changelog contains 245
+  entries: 137 under **Minor Changes** (56%) and 108 under **Patch Changes**
+  (44%). Those release labels describe compatibility impact, not engineering
+  effort, so they are not a pure feature-versus-hardening classification.
+- **Repository engineering:** the 917 PRs represented between the 3.1.0 and
+  RC.1 tags classify by conventional title as 188 feature/spec PRs (21%), 455
+  fix/test/refactor/performance/compliance PRs (50%), 207 docs/release/CI/dependency
+  PRs (23%), and 67 untyped PRs (7%). That is about 2.4 hardening PRs for every
+  feature PR. This broader lens includes the reference implementation, training,
+  website, and member application as well as protocol work.
+
+The published 3.2 ledger contains entries from 225 merged PRs by 12 human
+authors, plus four direct commits.
+Using the milestone's current membership, 145 of the 146 issues opened by the
+RC.1 cutoff were already closed at the cut. Across release-ledger PR authors
+and milestone issue authors, at least 23 people contributed directly; reviews,
+comments, working-group discussion, and SDK-repository contributions make the
+real participation count higher. Counts describe merged units, not effort or
+lines of code.
 
 ## The 3.2 feature set
 
@@ -87,6 +167,32 @@ identity. A client can add proposal exploration before it adds purchasing.
 Cross-agent transfer of a committed hold is deliberately not implied: the
 agent that accepts a proposal must be able to authenticate its buyer binding,
 resolve the immutable snapshot, and consume its inventory hold atomically.
+
+### Reliable Reporting makes missing data visible
+
+Reliable Reporting 1.0 treats reporting as an accountable ledger rather than
+an optional export. A buyer can determine which reporting periods should
+exist, whether each obligation is waiting, healthy, delayed, or requires
+action, and whether an official revision is present—even when the correct
+report contains zero rows. Missing obligations cannot disappear from the
+seller's own denominator.
+
+The model has three explicitly discovered tiers:
+
+- **Core** adds schedule-derived obligations, immutable revisions, health, and
+  `get_reporting_status` over reporting transports the seller already offers;
+- **Managed Delivery** binds durable file, dataset-share, or warehouse
+  materializations to exact revisions, destinations, retention, and access;
+- **Reconciled Billing** adds authenticated consumer receipts, canonical
+  content agreement, and explicit post-official adjustments without claiming
+  to create or settle invoices.
+
+RC.0 introduced the reporting-status baseline. RC.1 makes Reliable Reporting
+a named, version-discovered experimental capability and adds source-timezone
+schedules, checkpointed repair for missed or out-of-order events, immutable
+billing-purpose evidence, adjustment and receipt reconciliation, and
+evidence-scoped reliability statistics. RC.1 has no matched SDK pairing yet. See
+[Implementing Reliable Reporting Core](/docs/media-buy/reporting-core-implementation-guide).
 
 ### A durable connection for authenticated principals
 
@@ -217,6 +323,12 @@ Creative agents advertise stable capability IDs and supported operations;
 products expose accepted `format_options[]`; build and transformer calls select
 those capabilities directly.
 
+For a generative campaign, that creates one traceable path from brief and
+format selection through build, pre-flight preview, assignment, live delivery,
+and post-flight replay. Keep the chosen capability, format, creative and
+variant IDs, and provenance together so the asset audited after delivery is
+the asset that was previewed before launch.
+
 3.2 also adds image pixel-density and rendition-set semantics, creative
 localization, optional async preview, audio loudness constraints, VAST-tagged
 audio delivery through the `audio_vast` canonical, VAST 4.3 and validation
@@ -295,6 +407,7 @@ does not turn every schema addition into an implementation claim. The current
 | Portable attestations and audience evidence | Versioned `attestations`, `rights-attestations`, `governance-runtime-attestations`, and `audience-evidence` vector suites | Deterministic trust, binding, revocation, cache-reuse, and requirement-mode coverage. These library fixtures do not claim a live issuer/resolver network or replace an agent storyboard. |
 | Timezone and operational controls | Account-timezone and budget-cap-timezone storyboard families, plus deterministic media-buy read filters | End-to-end for the declared reference-agent routes. |
 | OAuth and cache isolation | `oauth_setup` and wholesale product/signal cache-scope isolation storyboards | Protocol and transport behavior are exercised independently of any one commercial workflow. |
+| Reliable Reporting 1.0 | `reporting_core_declaration`, `reporting_core`, `reliable_reporting_managed_delivery`, and `reliable_reporting_reconciled_billing` cover the named capability and its three tiers | Published in RC.1. The public training seller remains on RC.0 until it advertises and serves the newer exact pin. |
 | Experimental governance and Trusted Match | Property-list webhook signing and publisher-authentication rejection storyboards | Partial reference evidence only; experimental declarations and exact-version pinning remain mandatory. |
 | Advanced delivery reporting | `advanced_delivery_reporting` covers metric narrowing, `time_based_views`, canonical `by_format` rows, limits, truncation disclosure, and applied-sort echoes across discovery, purchase, simulation, and delivery | End-to-end on the reference sales tenant for the declared product capabilities. Expanded channel-specific OOH/audio metrics remain separate coverage work. |
 | Audience activation | `audience_activation_discovery` covers the experimental feature gate, catalog-wide method union, per-product declarations, vendor-constrained matching, OR and wildcard semantics, and exclusion of undeclared products | Discovery is end-to-end on the reference sales tenant. External dataset or distributed-segment binding remains an account-setup integration until the external-source runtime extension lands; the storyboard does not imply that runtime exists. |
@@ -308,13 +421,14 @@ for the remaining runner and coverage gaps.
 
 | If you are… | Review before advertising 3.2 |
 |---|---|
-| Any seller or service | Advertise `"3.2-rc.0"` only when serving that exact prerelease, echo it on responses, and keep 3.1 traffic on its negotiated contract. |
+| Any seller or service | Advertise `"3.2-rc.1"` only when serving that exact prerelease, echo it on responses, and keep 3.1 traffic on its negotiated contract. |
 | A buyer | Gate compact tools and optional targeting on capabilities; do not infer 3.2 support from a major-only declaration. |
 | A media-buy implementer | Use `media_buy_status` on create/update success payloads; root `status` is the task-envelope state. |
+| A reporting implementer | Treat Reliable Reporting as a separately discovered, versioned experimental capability. Do not infer RC.1 fields from RC.0 or from legacy delivery reporting. |
 | A signing implementation | Require `content-digest` coverage for every signed body on a 3.2 signing endpoint. |
 | A creative implementation | Prefer canonical capability and product format discovery; retain legacy conversion only at a proven compatibility boundary. |
-| An SDK maintainer | Generate from the signed RC.0 tarball, name the exact supported bundle, and feed accepted protocol corrections into the next prerelease. |
-| A compliance operator | Test RC.0 from its signed assets or an SDK that explicitly lists RC.0, such as TypeScript SDK 14 beta.31 or Python SDK 8 beta.13; retain end-to-end integration evidence and do not issue a 3.2 badge from a prerelease. |
+| An SDK maintainer | Generate from the signed RC.1 tarball, name the exact supported bundle, and feed accepted protocol corrections into the next prerelease. |
+| A compliance operator | Test RC.1 directly from its signed assets. For SDK-backed RC.0 testing, use an SDK that explicitly lists RC.0, such as TypeScript SDK 14 beta.31 or Python SDK 8 beta.13. Do not treat any of those packages as RC.1 evidence; retain exact versions end to end and do not issue a 3.2 badge from a prerelease. |
 
 ## Start here
 

--- a/scripts/update-release-docs-nav.mjs
+++ b/scripts/update-release-docs-nav.mjs
@@ -15,6 +15,7 @@ const DIST_DOCS_PREFIX_RE = /^dist\/docs\/[^/]+\//;
 const DIST_DOCS_ABSOLUTE_PREFIX_RE = /^\/dist\/docs\/[^/]+\//;
 const PRERELEASE_DOCS_LABEL_RE = /^(\d+)\.(\d+)-([0-9A-Za-z]+)$/;
 const PRERELEASE_BANNER_VERSION_RE = /AdCP (\d+)\.(\d+) ([0-9A-Za-z]+)\.\d+/g;
+const OFFICIAL_PRERELEASE_RELEASE_URL_RE = /https:\/\/github\.com\/adcontextprotocol\/adcp\/releases\/tag\/v\d+\.\d+\.\d+-(?:beta|rc)\.\d+/g;
 const VERSION_LINE_RE = /^(\d+\.\d+)/;
 const RELEASE_STORY_ALIASES = new Set([
   '/3.2',
@@ -216,8 +217,11 @@ function updatePrereleaseBanner(config, releaseVersion, majorMinor) {
   const snapshotPathPattern = new RegExp(
     `/dist/docs/[^/]+/reference/${slug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
   );
+  const officialReleaseUrl = `https://github.com/adcontextprotocol/adcp/releases/tag/v${releaseVersion}`;
+  const hasOfficialReleaseUrl = OFFICIAL_PRERELEASE_RELEASE_URL_RE.test(content);
+  OFFICIAL_PRERELEASE_RELEASE_URL_RE.lastIndex = 0;
 
-  if (!content.includes(sourcePath) && !snapshotPathPattern.test(content)) {
+  if (!content.includes(sourcePath) && !snapshotPathPattern.test(content) && !hasOfficialReleaseUrl) {
     return false;
   }
 
@@ -225,6 +229,7 @@ function updatePrereleaseBanner(config, releaseVersion, majorMinor) {
   config.banner.content = content
     .replace(sourcePath, destination)
     .replace(snapshotPathPattern, destination)
+    .replace(OFFICIAL_PRERELEASE_RELEASE_URL_RE, officialReleaseUrl)
     .replace(
       PRERELEASE_BANNER_VERSION_RE,
       (version, bannerMajor, bannerMinor, bannerPrerelease) =>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -32,14 +32,14 @@
 </head>
 <body data-nav-theme="dark">
 
-<!-- 3.2 preview announcement strip (dismissible) -->
-<div id="aao-announcement" style="display:none;background:var(--color-brand);color:var(--color-text-on-dark);padding:10px 20px;text-align:center;font-size:14px;line-height:1.4;position:relative;">
-  <strong>AdCP 3.2 preview is ready to try</strong> &mdash; <a href="https://docs.adcontextprotocol.org/3.2" style="color:var(--color-text-on-dark);text-decoration:underline;">explore the proposal lifecycle &rarr;</a>
-  <button onclick="document.getElementById('aao-announcement').style.display='none';document.cookie='aao_announce_32_dismissed=1;path=/;max-age=2592000';" aria-label="Dismiss announcement" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--color-text-on-dark);font-size:18px;cursor:pointer;padding:0 6px;line-height:1;">&times;</button>
+<!-- 3.2 release-candidate announcement strip (dismissible) -->
+<div id="adcp-announcement" style="display:none;background:var(--color-brand);color:var(--color-text-on-dark);padding:10px 20px;text-align:center;font-size:14px;line-height:1.4;position:relative;">
+  <strong>AdCP 3.2 release candidate adds Reliable Reporting to the compact lifecycle</strong> &mdash; <a href="https://github.com/adcontextprotocol/adcp/releases/tag/v3.2.0-rc.1" style="color:var(--color-text-on-dark);text-decoration:underline;">open the current signed release &rarr;</a>
+  <button onclick="document.getElementById('adcp-announcement').style.display='none';document.cookie='adcp_announce_32_rc1_dismissed=1;path=/;max-age=2592000';" aria-label="Dismiss announcement" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--color-text-on-dark);font-size:18px;cursor:pointer;padding:0 6px;line-height:1;">&times;</button>
 </div>
 <script>
-  if (!document.cookie.split(';').some(c => c.trim().startsWith('aao_announce_32_dismissed='))) {
-    document.getElementById('aao-announcement').style.display = 'block';
+  if (!document.cookie.split(';').some(c => c.trim().startsWith('adcp_announce_32_rc1_dismissed='))) {
+    document.getElementById('adcp-announcement').style.display = 'block';
   }
 </script>
 

--- a/server/src/db/migrations/580_curriculum_3_2_rc_wording.sql
+++ b/server/src/db/migrations/580_curriculum_3_2_rc_wording.sql
@@ -1,0 +1,21 @@
+-- Keep the stored S1 sandbox guidance aligned with the training seller's
+-- matched immutable checkpoint. Migration 550 introduced the exercise during
+-- beta; deployed databases need an explicit follow-up rather than an edit to
+-- that historical migration.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM certification_modules WHERE id = 'S1') THEN
+    RAISE EXCEPTION 'Module S1 not found';
+  END IF;
+
+  UPDATE certification_modules
+  SET exercise_definitions = replace(
+    exercise_definitions::text,
+    'On the exact 3.2 beta wire,',
+    'On the exact AdCP 3.2-rc.0 wire,'
+  )::jsonb
+  WHERE id = 'S1'
+    AND exercise_definitions::text LIKE '%On the exact 3.2 beta wire,%';
+END;
+$$;

--- a/tests/docs-nav-validation.test.cjs
+++ b/tests/docs-nav-validation.test.cjs
@@ -290,9 +290,19 @@ test('prerelease banner links directly or through a public alias to the current 
   const overviewPage = collectPages(previewVersion.groups).find(page =>
     page.endsWith(`/reference/whats-new-in-${major}-${minor}`)
   );
+  const previewBuilds = new Set(
+    collectPages(previewVersion.groups)
+      .map(page => /^dist\/docs\/([^/]+)\//.exec(page)?.[1])
+      .filter(Boolean)
+  );
+  const [previewBuild] = previewBuilds;
+  const officialReleaseUrl = previewBuilds.size === 1
+    ? `https://github.com/adcontextprotocol/adcp/releases/tag/v${previewBuild}`
+    : null;
   const allowedDestinations = new Set([
     landingPage ? `/${landingPage}` : null,
-    overviewPage ? `/${overviewPage}` : null
+    overviewPage ? `/${overviewPage}` : null,
+    officialReleaseUrl
   ]);
   const resolvedDestination = bannerRedirect?.destination || bannerLink;
   if (!allowedDestinations.has(resolvedDestination)) {
@@ -300,7 +310,7 @@ test('prerelease banner links directly or through a public alias to the current 
       `Prerelease banner must resolve to the current story; found ${bannerLink || 'no link'}`
     );
   }
-  if (new RegExp(`AdCP ${major}\\.${minor} (?:beta|rc)\\.\\d+`).test(bannerContent)) {
+  if (new RegExp(`AdCP ${major}\\.${minor} (?:beta|rc)\\.\\d+`, 'i').test(bannerContent)) {
     throw new Error('Prerelease banner must not freeze a moving prerelease ordinal in its copy');
   }
 });

--- a/tests/update-release-docs-nav.test.cjs
+++ b/tests/update-release-docs-nav.test.cjs
@@ -255,6 +255,19 @@ function sampleConfig() {
     );
   });
 
+  test('retargets an official prerelease release URL to the new checkpoint', () => {
+    const config = sampleConfig();
+    config.banner.content =
+      'AdCP 3.1 release candidate is available — [start testing →](https://github.com/adcontextprotocol/adcp/releases/tag/v3.1.0-rc.4)';
+
+    updateDocsConfig(config, '3.1.0-rc.5', '3.1-rc');
+
+    assert.equal(
+      config.banner.content,
+      'AdCP 3.1 release candidate is available — [start testing →](https://github.com/adcontextprotocol/adcp/releases/tag/v3.1.0-rc.5)'
+    );
+  });
+
   test('does not convert live docs paths when updating the existing default version', () => {
     const config = sampleConfig();
     config.navigation.versions[0].groups[0].pages.push('dist/docs/3.0.0/old');


### PR DESCRIPTION
## Summary

- align the public 3.2 story, banners, migration guidance, and training copy with the published `3.2.0-rc.1` checkpoint
- elevate experimental Reliable Reporting 1.0 and quantify both the 3.1-to-3.2 release growth and the 76–95% smaller comparable MCP validation-schema pairs
- state exact SDK boundaries: TypeScript/Python at RC.0, Go `v3.2.0` at beta.9-generated partial support, and the Go RC.1 refresh still in review
- keep immutable release snapshots untouched while linking the moving banner to the official signed release and teaching release tooling to retarget that URL

## Validation

- expert product, docs, and release-metrics reviews
- `npm run test:docs-nav`
- `npm run test:release-docs-nav`
- `npm run test:owned-links`
- `npm run test:migrations`
- `npm run lint:schema-links`
- pre-commit unit, server-unit, and typecheck suite (with Conductor's dev-auth bypass variables removed)
- `git diff --check`

## Notes

- The immutable `3.2.0-rc.1` docs snapshot predates this publication copy, so it is not rewritten. The banner points to the official GitHub release; these source-doc corrections will be present in the next generated snapshot.
- Go RC.1 work: https://github.com/adcontextprotocol/adcp-go/pull/493

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/52318a35-a244-4d84-8320-6b997e5cfe5e)
