### PR TITLE
docs(release): reflect merged Go RC.1 update

### DIFF
--- a/.changeset/fresh-plums-approve.md
+++ b/.changeset/fresh-plums-approve.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update the 3.2 SDK guidance after the Go RC.1 regeneration merged and its package release entered review.

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -37,9 +37,10 @@ Legend: ✅ shipped · ⚠️ partial / role-dependent · ❌ not yet covered. T
 **No SDK currently embeds RC.1.** TypeScript beta.31 and Python beta.13 support
 the exact RC.0 protocol checkpoint; neither implies compatibility with RC.1.
 Go SDK `v3.2.0` adds 3.2 proposal and signing support, but its generated
-protocol types remain on beta.9. An
-[RC.1 update is in review](https://github.com/adcontextprotocol/adcp-go/pull/493),
-but it is not supported until a package is published. See the
+protocol types remain on beta.9. The
+[RC.1 update has merged](https://github.com/adcontextprotocol/adcp-go/pull/493),
+and [release PR #494](https://github.com/adcontextprotocol/adcp-go/pull/494)
+is preparing `adcp/v3.2.1`; it is not supported until that package is published. See the
 [3.2 prerelease program](/docs/reference/3-2-beta).
 
 Use the signed RC.1 bundle directly for raw-wire validation or code generation.
@@ -153,9 +154,10 @@ builders, signing, a compliance test controller, and partial 3.2 proposal
 support. Its `v3.2.0` generated types are pinned to protocol `3.2.0-beta.9`, so
 use TypeScript or Python for exact RC.0 schemas, and use the signed protocol
 bundle directly for exact RC.1 schemas. The
-[RC.1 regeneration PR](https://github.com/adcontextprotocol/adcp-go/pull/493)
-is work in progress, not a released support claim. The `/v3` suffix is required
-by Go semantic import versioning.
+[RC.1 regeneration has merged](https://github.com/adcontextprotocol/adcp-go/pull/493),
+and [release PR #494](https://github.com/adcontextprotocol/adcp-go/pull/494)
+is preparing `adcp/v3.2.1`, but that prospective version is not a released
+support claim. The `/v3` suffix is required by Go semantic import versioning.
 
 | Component | Import |
 |-----------|--------|

--- a/docs/reference/3-2-beta.mdx
+++ b/docs/reference/3-2-beta.mdx
@@ -22,10 +22,11 @@ pairings:
 <Info>
 **RC.1 separates protocol-first and SDK-backed testing.** Use its signed bundle
 for raw-wire validation and code generation. Continue using RC.0 for the
-currently matched TypeScript and Python SDKs. A
-[Go RC.1 update is in review](https://github.com/adcontextprotocol/adcp-go/pull/493),
-but it is not usable until a package is published with an explicit support
-statement.
+currently matched TypeScript and Python SDKs. The
+[Go RC.1 update has merged](https://github.com/adcontextprotocol/adcp-go/pull/493),
+and [release PR #494](https://github.com/adcontextprotocol/adcp-go/pull/494)
+is preparing `adcp/v3.2.1`, but it is not usable until that package is published
+with an explicit support statement.
 </Info>
 
 | Checkpoint | Purpose | Who should test |
@@ -93,9 +94,10 @@ matrix before treating schema parity as complete L1–L3 coverage.
 Go `adcp/v3@v3.2.0` includes 3.2 proposal APIs and signing additions, but its
 generated schemas remain pinned to protocol `3.2.0-beta.9`. It is not an exact
 RC.0 or RC.1 pairing; use it only for the documented partial surface. The
-[RC.1 Go update](https://github.com/adcontextprotocol/adcp-go/pull/493) is in
-review, but it is not supported until a package is published with an explicit
-protocol-version statement.
+[RC.1 Go update has merged](https://github.com/adcontextprotocol/adcp-go/pull/493),
+and [release PR #494](https://github.com/adcontextprotocol/adcp-go/pull/494)
+is preparing `adcp/v3.2.1`, but it is not supported until that package is
+published with an explicit protocol-version statement.
 
 ## Use the RC.1 artifact directly
 

--- a/docs/reference/versioning.mdx
+++ b/docs/reference/versioning.mdx
@@ -256,7 +256,7 @@ The v2 sunset is the documented exception to this commitment: v2 predates this p
 The 3.2 cycle began with a protocol-first beta before SDK convergence. RC.1 is
 now the current signed protocol checkpoint; no SDK embeds it yet. TypeScript
 SDK beta.31 and Python SDK beta.13 remain exact RC.0 pairings, while a Go RC.1
-update is in review. See the
+update has merged and its `adcp/v3.2.1` release PR is open. See the
 [3.2 prerelease program](/docs/reference/3-2-beta).
 
 Further 3.x releases are scheduled based on implementation feedback and working group priorities, with at least 8 weeks between stable releases. Planned scope for each release is tracked on the [GitHub milestones page](https://github.com/adcontextprotocol/adcp/milestones) — open issues on the `3.1.0` and `3.2.0` milestones reflect current candidate work, not fixed commitments.


### PR DESCRIPTION
## Summary

- update the 3.2 SDK guidance after the Go RC.1 regeneration merged
- point readers to the open release PR preparing `adcp/v3.2.1`
- retain the critical boundary that no RC.1 Go package is published yet

## Validation

- `npm run test:docs-nav`
- `npm run lint:schema-links`
- `npm run test:owned-links`
- pre-commit root/server unit and typecheck suite
- `git diff --check`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/52318a35-a244-4d84-8320-6b997e5cfe5e)
