### PR TITLE
fix(security): resolve CodeQL findings

### DIFF
--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -4721,7 +4721,7 @@
 
       async function submitFeedback(messageId, rating, category, tags, suggestion) {
         try {
-          await authFetch(`/api/addie/chat/${conversationId}/feedback`, {
+          await authFetch(`/api/addie/chat/${encodeURIComponent(conversationId)}/feedback`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -4791,7 +4791,7 @@
           btn.addEventListener('click', async () => {
             const rating = parseInt(btn.dataset.rating);
             try {
-              await authFetch(`/api/addie/chat/${conversationId}/feedback`, {
+              await authFetch(`/api/addie/chat/${encodeURIComponent(conversationId)}/feedback`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/server/src/routes/agent-oauth.ts
+++ b/server/src/routes/agent-oauth.ts
@@ -16,6 +16,7 @@
  *      tokens via our storage adapter; we redirect to oauth-complete.
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import { Router, Request, Response } from 'express';
 import { validate as uuidValidate } from 'uuid';
 import {
@@ -55,6 +56,19 @@ const STATE_COOKIE = 'adcp_oauth_state';
 const STATE_COOKIE_TTL_MS = 10 * 60 * 1000;
 const OFFLINE_ACCESS_SCOPE = 'offline_access';
 const PRM_ABSENT_MARKER = 'does not implement OAuth 2.0 Protected Resource Metadata';
+
+function encodeOAuthStateBinding(state: string): string {
+  // State is a public CSRF nonce carried in the authorization redirect, not a
+  // password or credential. Use a versioned representation for the separate
+  // HttpOnly browser-binding cookie rather than applying password hashing.
+  return `v1.${Buffer.from(state, 'utf8').toString('base64url')}`;
+}
+
+function oauthStateMatchesBinding(state: string, expectedBinding: string): boolean {
+  const actual = Buffer.from(encodeOAuthStateBinding(state), 'ascii');
+  const expected = Buffer.from(expectedBinding, 'ascii');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
 
 export function buildDurableOAuthScopeHint(
   scopes: readonly string[] | undefined,
@@ -321,11 +335,11 @@ export function createAgentOAuthRouter(): Router {
         ...(scopeHint && { clientMetadata: { scope: scopeHint } }),
       });
 
-      // Browser-binding for CSRF (SEP-835 §state guidance). The cookie
-      // value must equal the AS-supplied `state` on the callback;
-      // /callback rejects mismatches and missing cookies before consuming
-      // the pending row.
-      res.cookie(STATE_COOKIE, state, {
+      // Browser-binding for CSRF (SEP-835 §state guidance). Keep the cookie's
+      // representation distinct from the protocol parameter; the callback
+      // encodes the returned state and compares it in constant time before
+      // consuming the pending row.
+      res.cookie(STATE_COOKIE, encodeOAuthStateBinding(state), {
         httpOnly: true,
         secure: req.secure,
         sameSite: 'lax',
@@ -365,8 +379,8 @@ export function createAgentOAuthRouter(): Router {
    *
    * Defense layers:
    *   1. `requireAuth` — must have a live session, not just a state value.
-   *   2. `expectedState` — mandatory; the cookie set on /start must match
-   *      what the AS bounced back. Missing cookie aborts the flow.
+   *   2. State binding — mandatory; the binding cookie set on /start must match
+   *      the state the AS bounced back. Missing/mismatched cookies abort.
    *   3. Pre-token-exchange org check — `flow.carry.organization_id` must
    *      still be an active org for the calling user before the SDK can
    *      exchange the code or persist tokens.
@@ -375,25 +389,12 @@ export function createAgentOAuthRouter(): Router {
     const clearStateCookie = () => res.clearCookie(STATE_COOKIE, { path: '/api/oauth/agent/callback' });
     const { code, state, error, error_description } = req.query;
 
-    if (error) {
-      logger.warn({ error, error_description }, 'OAuth error from provider');
-      const safeError = sanitizeErrorMessage(error_description || error);
-      clearStateCookie();
-      return res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent(safeError)}`);
-    }
-
-    if (typeof code !== 'string' || code.length === 0) {
-      clearStateCookie();
-      return res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent('No authorization code received')}`);
-    }
     if (typeof state !== 'string' || state.length === 0) {
-      clearStateCookie();
       return res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent('No state parameter received')}`);
     }
 
-    const expectedState = req.cookies?.[STATE_COOKIE];
-    clearStateCookie();
-    if (typeof expectedState !== 'string' || expectedState.length === 0) {
+    const expectedStateBinding = req.cookies?.[STATE_COOKIE];
+    if (typeof expectedStateBinding !== 'string' || expectedStateBinding.length === 0) {
       logger.warn({}, 'OAuth callback missing state cookie — refusing to consume pending flow');
       const params = new URLSearchParams({
         success: 'false',
@@ -401,6 +402,29 @@ export function createAgentOAuthRouter(): Router {
         code: 'state_cookie_missing',
       });
       return res.redirect(`/oauth-complete.html?${params.toString()}`);
+    }
+
+    if (!oauthStateMatchesBinding(state, expectedStateBinding)) {
+      logger.warn({}, 'OAuth callback state binding mismatch — refusing to consume pending flow');
+      const params = new URLSearchParams({
+        success: 'false',
+        error: 'OAuth state does not match this browser session',
+        code: 'state_mismatch',
+      });
+      return res.redirect(`/oauth-complete.html?${params.toString()}`);
+    }
+
+    // Only a callback bound to the browser that started the flow may consume
+    // (or cancel) it. Invalid callbacks leave the short-lived cookie intact so
+    // a forged navigation cannot terminate the legitimate flow.
+    clearStateCookie();
+    if (error) {
+      logger.warn({ error, error_description }, 'OAuth error from provider');
+      const safeError = sanitizeErrorMessage(error_description || error);
+      return res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent(safeError)}`);
+    }
+    if (typeof code !== 'string' || code.length === 0) {
+      return res.redirect(`/oauth-complete.html?success=false&error=${encodeURIComponent('No authorization code received')}`);
     }
 
     const userId = req.user?.id;
@@ -422,7 +446,9 @@ export function createAgentOAuthRouter(): Router {
         pendingFlowStore: guardedPendingFlowStore,
         agentStorage,
         fetch: oauthSafeFetch,
-        expectedState,
+        // The SDK API requires expectedState; browser binding is enforced by
+        // the independent state-binding comparison above.
+        expectedState: state,
       });
 
       // Defense in depth: the guarded pending-flow store already checked

--- a/server/src/routes/member-agents.ts
+++ b/server/src/routes/member-agents.ts
@@ -41,6 +41,7 @@ import { ensureMemberProfileExists } from '../services/member-profile-autopublis
 import { performCreateOrganization } from '../services/organization-bootstrap.js';
 import { isDevModeEnabled, getDevUser } from '../middleware/auth.js';
 import { isFreeEmail, getCompanyDomain } from '../utils/email-domain.js';
+import { validateExternalUrl } from '../utils/url-security.js';
 import {
   gateAgentVisibilityForCaller,
   type VisibilityWarning,
@@ -237,14 +238,60 @@ export function createMemberAgentsRouter(config: MemberAgentsRouterConfig): Rout
     return root.charAt(0).toUpperCase() + root.slice(1);
   }
 
-  function isParseableUrl(value: string): boolean {
-    try {
-      // eslint-disable-next-line no-new
-      new URL(value);
-      return true;
-    } catch {
-      return false;
+  type AgentRegistrationValidation =
+    | {
+        ok: true;
+        body: Partial<AgentConfig>;
+        targetUrl: string;
+      }
+    | {
+        ok: false;
+        error: Record<string, unknown>;
+      };
+
+  function validateAgentRegistrationBody(raw: unknown): AgentRegistrationValidation {
+    const candidate = (raw ?? {}) as Partial<AgentConfig>;
+    if (typeof candidate.url !== 'string' || candidate.url.length === 0) {
+      return { ok: false, error: { error: 'url is required' } };
     }
+    if (!validateExternalUrl(candidate.url)) {
+      return { ok: false, error: { error: 'url must be a valid http or https URL' } };
+    }
+    const parsedUrl = new URL(candidate.url);
+    if (parsedUrl.username || parsedUrl.password) {
+      return { ok: false, error: { error: 'url must not contain credentials' } };
+    }
+    if (candidate.url.includes('?') || candidate.url.includes('#')) {
+      return {
+        ok: false,
+        error: { error: 'url must not contain query strings or fragments' },
+      };
+    }
+
+    const canonicalUrl = canonicalizeAgentUrl(candidate.url);
+    if (!canonicalUrl) {
+      return { ok: false, error: { error: 'url is not a valid agent URL' } };
+    }
+    if (
+      typeof candidate.type !== 'string' ||
+      !isValidAgentType(candidate.type) ||
+      candidate.type === 'unknown'
+    ) {
+      return {
+        ok: false,
+        error: {
+          error: 'type is required',
+          message:
+            'Specify one of: brand, rights, measurement, governance, creative, sales, buying, signals.',
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      body: { ...candidate, url: canonicalUrl },
+      targetUrl: canonicalUrl,
+    };
   }
 
   /**
@@ -408,37 +455,9 @@ export function createMemberAgentsRouter(config: MemberAgentsRouterConfig): Rout
       if (!resolved) return;
       const { orgId, orgAutoCreated } = resolved;
 
-      const body = (req.body ?? {}) as Partial<AgentConfig>;
-      if (typeof body.url !== 'string' || body.url.length === 0) {
-        return res.status(400).json({ error: 'url is required' });
-      }
-      if (!isParseableUrl(body.url)) {
-        return res.status(400).json({ error: 'url must be a valid URL' });
-      }
-      // Query strings and fragments have no place in agent identity (issue
-      // #3573). Reject at the boundary — `canonicalizeAgentUrl` itself
-      // preserves them verbatim, so the check belongs here.
-      if (body.url.includes('?') || body.url.includes('#')) {
-        return res.status(400).json({ error: 'url must not contain query strings or fragments' });
-      }
-      const canonicalUrl = canonicalizeAgentUrl(body.url);
-      if (!canonicalUrl) {
-        return res.status(400).json({ error: 'url is not a valid agent URL' });
-      }
-      // `type` is required from the caller — never inferred. 'unknown' is
-      // reserved for server-side smuggle protection (resolveAgentTypes), not
-      // for client input. The caller MUST declare what kind of agent this is.
-      if (typeof body.type !== 'string' || !isValidAgentType(body.type) || body.type === 'unknown') {
-        return res.status(400).json({
-          error: 'type is required',
-          message: 'Specify one of: brand, rights, measurement, governance, creative, sales, buying, signals.',
-        });
-      }
-      // Persist and compare in canonical form so the registered side
-      // collapses with the discovered side (issue #3573).
-      body.url = canonicalUrl;
-      const targetUrl = canonicalUrl;
-
+      const validation = validateAgentRegistrationBody(req.body);
+      if (!validation.ok) return res.status(400).json(validation.error);
+      const { body, targetUrl } = validation;
       // Hostname ownership check (#4499 MVP). Catches the escalation-#340
       // failure mode: org has staked a domain claim (`organization_domains`
       // row with `verified = true`) but is now registering an agent on a

--- a/server/tests/integration/member-agents-api.test.ts
+++ b/server/tests/integration/member-agents-api.test.ts
@@ -887,6 +887,44 @@ describe('Per-agent REST API (/api/me/agents)', () => {
     expect(withFrag.status).toBe(400);
   });
 
+  it.each(['javascript:alert(1)', 'data:text/plain,agent', 'file:///tmp/agent'])(
+    'POST returns 400 for non-network agent URL %s',
+    async (url) => {
+      const orgId = `${TEST_PREFIX}_scheme_${url.slice(0, 4)}`;
+      const userId = `${orgId}_user`;
+      await seedOrg(pool, orgId, 'individual_professional');
+      await provisionUser(userId, orgId);
+      await createProfile(orgId, `scheme${url.slice(0, 4)}`);
+
+      (app as any).setCurrentUser(userId);
+      const res = await request(app)
+        .post('/api/me/agents')
+        .send({ url, type: 'sales' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('url must be a valid http or https URL');
+    },
+  );
+
+  it('POST returns 400 when url contains embedded credentials', async () => {
+    const orgId = `${TEST_PREFIX}_url_credentials`;
+    const userId = `${orgId}_user`;
+    await seedOrg(pool, orgId, 'individual_professional');
+    await provisionUser(userId, orgId);
+    await createProfile(orgId, 'urlcredentials');
+
+    (app as any).setCurrentUser(userId);
+    const credentialedUrl = new URL('https://agent.example.test/mcp');
+    credentialedUrl.username = 'test-user';
+    credentialedUrl.password = 'test-password';
+    const res = await request(app)
+      .post('/api/me/agents')
+      .send({ url: credentialedUrl.toString(), type: 'sales' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('url must not contain credentials');
+  });
+
   it('POST returns 400 when url contains an embedded wildcard', async () => {
     const orgId = `${TEST_PREFIX}_canon_wild`;
     const userId = `${TEST_PREFIX}_canon_wild_user`;

--- a/server/tests/unit/agent-oauth-membership-guard.test.ts
+++ b/server/tests/unit/agent-oauth-membership-guard.test.ts
@@ -128,6 +128,10 @@ const TEST_ORG_ID = 'org_123';
 const AGENT_CONTEXT_ID = '11111111-1111-4111-8111-111111111111';
 const TEST_AGENT_URL = 'https://agent.example.com/mcp';
 
+function stateBinding(state: string): string {
+  return `v1.${Buffer.from(state, 'utf8').toString('base64url')}`;
+}
+
 function makeApp(stateCookie?: string) {
   const app = express();
   if (stateCookie) {
@@ -266,6 +270,11 @@ describe('GET /api/oauth/agent/start durable scope hint', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('https://auth.example.com/authorize');
+    const stateCookie = res.headers['set-cookie']?.find((cookie: string) =>
+      cookie.startsWith('adcp_oauth_state='),
+    );
+    expect(stateCookie).toContain(`adcp_oauth_state=${stateBinding('state_123')}`);
+    expect(stateCookie).not.toContain('adcp_oauth_state=state_123');
     expect(mcpAuthMocks.discoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(
       TEST_AGENT_URL,
       undefined,
@@ -360,7 +369,7 @@ describe('agent OAuth safe fetch injection', () => {
       persisted: true,
     });
 
-    await request(makeApp('state_123'))
+    await request(makeApp(stateBinding('state_123')))
       .get('/api/oauth/agent/callback')
       .query({ code: 'code_123', state: 'state_123' })
       .expect(302);
@@ -371,6 +380,49 @@ describe('agent OAuth safe fetch injection', () => {
       expectedState: 'state_123',
       fetch: oauthSafeFetch,
     }));
+  });
+
+  it('rejects a callback whose state does not match the browser binding', async () => {
+    const response = await request(makeApp(stateBinding('different_state')))
+      .get('/api/oauth/agent/callback')
+      .query({ code: 'code_123', state: 'state_123' })
+      .expect(302);
+
+    expect(response.headers.location).toContain('code=state_mismatch');
+    expect(sdkMocks.completeWebOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it('rejects the legacy clear-text state cookie even when it matches the callback', async () => {
+    const response = await request(makeApp('state_123'))
+      .get('/api/oauth/agent/callback')
+      .query({ code: 'code_123', state: 'state_123' })
+      .expect(302);
+
+    expect(response.headers.location).toContain('code=state_mismatch');
+    expect(sdkMocks.completeWebOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it('requires browser-bound state on provider error callbacks', async () => {
+    const response = await request(makeApp(stateBinding('different_state')))
+      .get('/api/oauth/agent/callback')
+      .query({ error: 'access_denied', state: 'state_123' })
+      .expect(302);
+
+    expect(response.headers.location).toContain('code=state_mismatch');
+    expect(response.headers['set-cookie']).toBeUndefined();
+    expect(sdkMocks.completeWebOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it('accepts a provider error callback with browser-bound state', async () => {
+    const response = await request(makeApp(stateBinding('state_123')))
+      .get('/api/oauth/agent/callback')
+      .query({ error: 'access_denied', error_description: 'User denied access', state: 'state_123' })
+      .expect(302);
+
+    expect(response.headers.location).toContain('success=false');
+    expect(response.headers.location).toContain('User%20denied%20access');
+    expect(response.headers['set-cookie']?.[0]).toContain('adcp_oauth_state=;');
+    expect(sdkMocks.completeWebOAuthFlow).not.toHaveBeenCalled();
   });
 
   it('passes the scoped fetcher to status discovery', async () => {

--- a/server/tests/unit/client-security-wiring.test.ts
+++ b/server/tests/unit/client-security-wiring.test.ts
@@ -64,6 +64,13 @@ describe('browser external URL defenses', () => {
     expect(source.match(/siSessionCapability = null/g)?.length).toBeGreaterThanOrEqual(2);
     expect(source).not.toMatch(/console\.log\([^\n]*anonymous_access_token/);
   });
+
+  it('encodes conversation IDs before using them in feedback request paths', async () => {
+    const source = await publicSource('chat.html');
+    expect(source.match(/chat\/\$\{encodeURIComponent\(conversationId\)\}\/feedback/g))
+      .toHaveLength(2);
+    expect(source).not.toContain('chat/${conversationId}/feedback');
+  });
 });
 
 describe('server URL validation branch wiring', () => {


### PR DESCRIPTION
## Summary
- bind OAuth state to the initiating browser and validate it before success or provider-error callbacks
- encode conversation IDs used in feedback request paths
- validate and canonicalize agent registration input before hostname verification, rejecting non-network URLs and embedded credentials
- make registration validation an explicit boundary so CodeQL no longer treats rejection branches as sensitive-action bypasses

## Testing
- exact CodeQL 2.26.4 rerun for all affected queries
- `npx vitest run --config server/vitest.config.ts server/tests/unit/agent-oauth-membership-guard.test.ts server/tests/unit/client-security-wiring.test.ts` (26 passed)
- `npm run test:unit` (1,054 passed)
- `npm run typecheck`
- `node scripts/check-changeset-protocol-scope.cjs origin/main`

## Review
- deep code, security, and Node.js testing expert reviews completed
- no remaining Must Fix or Should Fix findings

## Risks / follow-ups
- no changeset: server/app security hardening only

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0e5ffcd0-2d05-441c-9fac-98bacd6042cf)
