### PR TITLE
feat(addie): add fixed-trace hybrid architecture arm

### DIFF
--- a/server/src/addie/eval/fixed-trace-architecture.ts
+++ b/server/src/addie/eval/fixed-trace-architecture.ts
@@ -24,7 +24,7 @@ export const FIXED_TRACE_ARCHITECTURE_ARMS = Object.freeze({
   }),
   deterministic_policy_llm_fallback_hybrid: Object.freeze({
     id: 'deterministic_policy_llm_fallback_hybrid',
-    routeSource: 'production_quick_match_with_llm_fallback',
+    routeSource: 'reviewed_safe_subset_of_production_quick_match_with_unchanged_llm_fallback',
     rolloutEligible: false,
     diagnosticOnly: true,
   }),
@@ -45,10 +45,26 @@ export type FixedTraceArchitectureArmProvenance =
  * quick-match policy.  It can only terminate no-tool surface outcomes; every
  * routed/tool-bearing decision retains the incumbent strict LLM router.
  */
-export const FIXED_TRACE_HYBRID_POLICY_VERSION = 'fixed-trace-hybrid-quick-match-v1';
+export const FIXED_TRACE_HYBRID_POLICY_VERSION = 'fixed-trace-hybrid-safe-subset-v2';
+export const FIXED_TRACE_HYBRID_SAFETY_GATE_VERSION = 'exact-harmless-terminal-admission-v1';
+
+export class FixedTraceHybridAdmissionSnapshotError extends Error {
+  readonly code = 'invalid_hybrid_admission_snapshot';
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'FixedTraceHybridAdmissionSnapshotError';
+  }
+}
 
 export interface FixedTraceHybridPolicy {
   version: string;
+  /** The reviewed fail-closed admission gate, bound into cohort provenance. */
+  safetyGateVersion: typeof FIXED_TRACE_HYBRID_SAFETY_GATE_VERSION;
+  safetyGateStatus: 'reviewed_safe_subset';
+  /** This arm never claims to run the full production substring matcher. */
+  localAdmissionSource: 'reviewed_safe_subset_of_production_quick_match';
+  fallbackSource: 'unchanged_incumbent_two_stage_llm_router';
   /** A subset of production quick-match terminal actions, never `respond`. */
   localTerminalActions: readonly ('ignore' | 'react')[];
   /** Admin state is never an admission signal for a local outcome. */
@@ -67,6 +83,8 @@ export interface FixedTraceHybridDecision {
     | 'thread_context_requires_router'
     | 'admin_requires_router'
     | 'channel_privacy_not_captured'
+    | 'unsafe_or_ambiguous_message'
+    | 'quick_match_exception'
     | 'tool_or_mutation_capability_requires_router'
     | 'policy_disallows_terminal_action';
   plan: ExecutionPlan | null;
@@ -74,6 +92,10 @@ export interface FixedTraceHybridDecision {
 
 const DEFAULT_FIXED_TRACE_HYBRID_POLICY: FixedTraceHybridPolicy = Object.freeze({
   version: FIXED_TRACE_HYBRID_POLICY_VERSION,
+  safetyGateVersion: FIXED_TRACE_HYBRID_SAFETY_GATE_VERSION,
+  safetyGateStatus: 'reviewed_safe_subset',
+  localAdmissionSource: 'reviewed_safe_subset_of_production_quick_match',
+  fallbackSource: 'unchanged_incumbent_two_stage_llm_router',
   localTerminalActions: Object.freeze(['ignore', 'react'] as const),
   requireNonAdmin: true,
   requirePrivateChannelForChannelOutcome: true,
@@ -93,10 +115,146 @@ export function validateFixedTraceHybridPolicy(policy: FixedTraceHybridPolicy): 
     || policy.localTerminalActions.length === 0
     || policy.localTerminalActions.some((action) => action !== 'ignore' && action !== 'react')
     || new Set(policy.localTerminalActions).size !== policy.localTerminalActions.length
+    || policy.safetyGateVersion !== FIXED_TRACE_HYBRID_SAFETY_GATE_VERSION
+    || policy.safetyGateStatus !== 'reviewed_safe_subset'
+    || policy.localAdmissionSource !== 'reviewed_safe_subset_of_production_quick_match'
+    || policy.fallbackSource !== 'unchanged_incumbent_two_stage_llm_router'
     || policy.requireNonAdmin !== true
     || policy.requirePrivateChannelForChannelOutcome !== true
     || policy.fallbackRouter !== 'two_stage_llm_router'
   ) throw new Error('Fixed trace hybrid policy is invalid');
+}
+
+type HybridAdmissionSnapshot = Readonly<{
+  message: string;
+  source: FixedTraceCase['request']['source'];
+  isAdmin: boolean;
+  isThread: boolean;
+  channelPrivacy?: 'private' | 'public';
+}>;
+
+type HybridQuickMatcher = (context: Readonly<{
+  message: string;
+  source: 'dm' | 'channel';
+  isThread: boolean;
+  isAAOAdmin: boolean;
+}>) => ExecutionPlan | null;
+
+function ownDataProperty(source: unknown, name: string, owner = 'input'): unknown {
+  try {
+    if (typeof source !== 'object' || source === null) {
+      throw new FixedTraceHybridAdmissionSnapshotError(`Hybrid admission ${owner} must be an object`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(source, name);
+    if (!descriptor || !('value' in descriptor)) {
+      throw new FixedTraceHybridAdmissionSnapshotError(`Hybrid admission ${owner}.${name} must be an own data property`);
+    }
+    return descriptor.value;
+  } catch (error) {
+    if (error instanceof FixedTraceHybridAdmissionSnapshotError) throw error;
+    throw new FixedTraceHybridAdmissionSnapshotError(`Hybrid admission ${owner}.${name} could not be snapshotted`, { cause: error });
+  }
+}
+
+/**
+ * This reads request facts once from data descriptors and detaches them before
+ * any matcher can execute. Proxies/accessors therefore abort before router or
+ * provider dispatch rather than participating in routing.
+ */
+function snapshotHybridAdmissionInput(input: unknown): HybridAdmissionSnapshot {
+  const message = ownDataProperty(input, 'message');
+  const source = ownDataProperty(input, 'source');
+  const isAdmin = ownDataProperty(input, 'isAdmin');
+  const isThread = ownDataProperty(input, 'isThread');
+  let channelPrivacy: unknown;
+  try {
+    const descriptor = typeof input === 'object' && input !== null
+      ? Object.getOwnPropertyDescriptor(input, 'channelPrivacy')
+      : undefined;
+    if (descriptor && !('value' in descriptor)) {
+      throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission input.channelPrivacy must be an own data property');
+    }
+    channelPrivacy = descriptor?.value;
+  } catch (error) {
+    if (error instanceof FixedTraceHybridAdmissionSnapshotError) throw error;
+    throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission input.channelPrivacy could not be snapshotted', { cause: error });
+  }
+  if (
+    typeof message !== 'string'
+    || (source !== 'dm' && source !== 'channel')
+    || typeof isAdmin !== 'boolean'
+    || typeof isThread !== 'boolean'
+    || (channelPrivacy !== undefined && channelPrivacy !== 'private' && channelPrivacy !== 'public')
+  ) throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission input has invalid request facts');
+  return Object.freeze({ message, source, isAdmin, isThread, ...(channelPrivacy === undefined ? {} : { channelPrivacy }) });
+}
+
+function snapshotHybridPolicy(input: unknown): FixedTraceHybridPolicy {
+  const policy = ownDataProperty(input, 'policy');
+  const localTerminalActions = ownDataProperty(policy, 'localTerminalActions', 'policy');
+  if (!Array.isArray(localTerminalActions)) {
+    throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission policy.localTerminalActions must be an array');
+  }
+  const actionLength = ownDataProperty(localTerminalActions, 'length', 'policy.localTerminalActions');
+  if (typeof actionLength !== 'number' || !Number.isSafeInteger(actionLength) || actionLength < 0 || actionLength > 2) {
+    throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission policy.localTerminalActions has invalid length');
+  }
+  const actions = Array.from({ length: actionLength }, (_, index) => (
+    ownDataProperty(localTerminalActions, String(index), 'policy.localTerminalActions')
+  ));
+  const snapshot = Object.freeze({
+    version: ownDataProperty(policy, 'version', 'policy'),
+    safetyGateVersion: ownDataProperty(policy, 'safetyGateVersion', 'policy'),
+    safetyGateStatus: ownDataProperty(policy, 'safetyGateStatus', 'policy'),
+    localAdmissionSource: ownDataProperty(policy, 'localAdmissionSource', 'policy'),
+    fallbackSource: ownDataProperty(policy, 'fallbackSource', 'policy'),
+    localTerminalActions: Object.freeze(actions),
+    requireNonAdmin: ownDataProperty(policy, 'requireNonAdmin', 'policy'),
+    requirePrivateChannelForChannelOutcome: ownDataProperty(policy, 'requirePrivateChannelForChannelOutcome', 'policy'),
+    fallbackRouter: ownDataProperty(policy, 'fallbackRouter', 'policy'),
+  }) as FixedTraceHybridPolicy;
+  try {
+    validateFixedTraceHybridPolicy(snapshot);
+  } catch (error) {
+    throw new FixedTraceHybridAdmissionSnapshotError('Hybrid admission policy is invalid', { cause: error });
+  }
+  return snapshot;
+}
+
+type SafeTerminalForm = Readonly<{ action: 'ignore' | 'react'; emoji?: string }>;
+
+const SAFE_IGNORE_FORMS = new Set([
+  'ok', 'okay', 'k', 'got it', 'cool', 'nice', 'lol', 'haha', 'sounds good',
+  'will do', 'on it', 'done', 'working on it',
+]);
+const SAFE_REACT_FORMS = new Map<string, string>([
+  ['hi', 'wave'], ['hello', 'wave'], ['hey', 'wave'], ['good morning', 'wave'],
+  ['good afternoon', 'wave'], ['howdy', 'wave'], ['thanks', 'heart'], ['thank you', 'heart'],
+]);
+const UNSAFE_OR_AMBIGUOUS_LANGUAGE = /\b(?:no|not|never|don't|do\s+not|delete|remove|ship|send|invoice|billing|payment|account|admin|tool|generate|create|update|change|cancel|refund|user)\b/i;
+const UNSAFE_DELIMITER_OR_QUOTE = /["'`;,:|/\\]/;
+const CONTROL_OR_LINE_SEPARATOR = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/;
+
+/**
+ * Reviewed evaluator-only subset of production quick-match. It deliberately
+ * accepts only fully consumed exact harmless forms after bounded normalization;
+ * production's wider substring matcher remains unchanged and is not evidence.
+ */
+function safeTerminalForm(snapshot: HybridAdmissionSnapshot): SafeTerminalForm | null {
+  if (Buffer.byteLength(snapshot.message, 'utf8') > 128) return null;
+  if (CONTROL_OR_LINE_SEPARATOR.test(snapshot.message) || UNSAFE_DELIMITER_OR_QUOTE.test(snapshot.message)) return null;
+  const normalized = snapshot.message
+    .normalize('NFKC')
+    .toLowerCase()
+    .trim()
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"');
+  if (!normalized || UNSAFE_OR_AMBIGUOUS_LANGUAGE.test(normalized)) return null;
+  if (SAFE_IGNORE_FORMS.has(normalized) || (normalized.endsWith('.') && SAFE_IGNORE_FORMS.has(normalized.slice(0, -1)))) {
+    return Object.freeze({ action: 'ignore' });
+  }
+  const emoji = SAFE_REACT_FORMS.get(normalized);
+  return emoji ? Object.freeze({ action: 'react', emoji }) : null;
 }
 
 /**
@@ -112,27 +270,71 @@ export function decideFixedTraceHybridRoute(input: {
   isThread: boolean;
   channelPrivacy?: 'private' | 'public';
   policy: FixedTraceHybridPolicy;
+  /** Internal test seam; production uses the unchanged quick-match function. */
+  quickMatcher?: HybridQuickMatcher;
 }): FixedTraceHybridDecision {
-  validateFixedTraceHybridPolicy(input.policy);
-  if (input.isAdmin) return { mode: 'llm_router_fallback', reason: 'admin_requires_router', plan: null };
-  if (input.isThread) return { mode: 'llm_router_fallback', reason: 'thread_context_requires_router', plan: null };
-  if (input.source === 'channel' && input.channelPrivacy !== 'private') {
+  const snapshot = snapshotHybridAdmissionInput(input);
+  // Request facts are snapshotted before policy validation or matcher code.
+  // A hostile request accessor therefore cannot run after a dispatch boundary.
+  const policy = snapshotHybridPolicy(input);
+  if (snapshot.isAdmin) return { mode: 'llm_router_fallback', reason: 'admin_requires_router', plan: null };
+  if (snapshot.isThread) return { mode: 'llm_router_fallback', reason: 'thread_context_requires_router', plan: null };
+  if (snapshot.source === 'channel' && snapshot.channelPrivacy !== 'private') {
     return { mode: 'llm_router_fallback', reason: 'channel_privacy_not_captured', plan: null };
   }
-  const plan = quickMatchRoutingContext({
-    message: input.message,
-    source: input.source,
-    isThread: input.isThread,
-    isAAOAdmin: input.isAdmin,
-  });
-  if (!plan) return { mode: 'llm_router_fallback', reason: 'no_production_quick_match', plan: null };
-  if (plan.action === 'respond') {
+  const safeForm = safeTerminalForm(snapshot);
+  if (!safeForm) return { mode: 'llm_router_fallback', reason: 'unsafe_or_ambiguous_message', plan: null };
+  let matcher: HybridQuickMatcher;
+  try {
+    const suppliedMatcher = Object.getOwnPropertyDescriptor(input, 'quickMatcher');
+    if (suppliedMatcher && !('value' in suppliedMatcher)) throw new Error('quickMatcher accessor');
+    if (suppliedMatcher?.value !== undefined && typeof suppliedMatcher.value !== 'function') {
+      throw new Error('quickMatcher is not a function');
+    }
+    matcher = suppliedMatcher?.value ?? quickMatchRoutingContext;
+  } catch {
+    return { mode: 'llm_router_fallback', reason: 'quick_match_exception', plan: null };
+  }
+  let matchedAction: 'ignore' | 'react' | 'respond' | null;
+  let matchedEmoji: string | undefined;
+  try {
+    const plan = matcher(Object.freeze({
+      message: snapshot.message,
+      source: snapshot.source,
+      isThread: snapshot.isThread,
+      isAAOAdmin: snapshot.isAdmin,
+    }));
+    matchedAction = plan?.action ?? null;
+    matchedEmoji = plan?.action === 'react' ? plan.emoji : undefined;
+  } catch {
+    return { mode: 'llm_router_fallback', reason: 'quick_match_exception', plan: null };
+  }
+  if (!matchedAction) return { mode: 'llm_router_fallback', reason: 'no_production_quick_match', plan: null };
+  if (matchedAction === 'respond') {
     return { mode: 'llm_router_fallback', reason: 'tool_or_mutation_capability_requires_router', plan: null };
   }
-  if (!input.policy.localTerminalActions.includes(plan.action)) {
+  if (matchedAction !== safeForm.action || !policy.localTerminalActions.includes(matchedAction)) {
     return { mode: 'llm_router_fallback', reason: 'policy_disallows_terminal_action', plan: null };
   }
-  return { mode: 'local_terminal', reason: 'production_quick_match_terminal', plan };
+  if (matchedAction === 'react' && matchedEmoji !== safeForm.emoji) {
+    return { mode: 'llm_router_fallback', reason: 'policy_disallows_terminal_action', plan: null };
+  }
+  return {
+    mode: 'local_terminal',
+    reason: 'production_quick_match_terminal',
+    plan: safeForm.action === 'react'
+      ? Object.freeze({
+          action: 'react' as const,
+          emoji: safeForm.emoji!,
+          reason: 'Reviewed exact harmless terminal form',
+          decision_method: 'quick_match' as const,
+        })
+      : Object.freeze({
+          action: 'ignore' as const,
+          reason: 'Reviewed exact harmless terminal form',
+          decision_method: 'quick_match' as const,
+        }),
+  };
 }
 
 export function fixedTraceArchitectureArm(

--- a/server/src/addie/eval/fixed-trace-architecture.ts
+++ b/server/src/addie/eval/fixed-trace-architecture.ts
@@ -1,4 +1,5 @@
 import type { AddieTool } from '../types.js';
+import { quickMatchRoutingContext, type ExecutionPlan } from '../router.js';
 import type { FixedTraceCase } from './fixed-trace-suite.js';
 
 /**
@@ -13,22 +14,126 @@ export const FIXED_TRACE_ARCHITECTURE_ARMS = Object.freeze({
     // Architectural capability is distinct from authenticated evaluation
     // evidence; this foundation is diagnostic-only.
     rolloutEligible: false,
+    diagnosticOnly: true,
   }),
   direct_generation: Object.freeze({
     id: 'direct_generation',
     routeSource: 'deployable_surface_policy',
     rolloutEligible: false,
+    diagnosticOnly: true,
+  }),
+  deterministic_policy_llm_fallback_hybrid: Object.freeze({
+    id: 'deterministic_policy_llm_fallback_hybrid',
+    routeSource: 'production_quick_match_with_llm_fallback',
+    rolloutEligible: false,
+    diagnosticOnly: true,
   }),
   oracle_route_diagnostic: Object.freeze({
     id: 'oracle_route_diagnostic',
     routeSource: 'fixture_oracle',
     rolloutEligible: false,
+    diagnosticOnly: true,
   }),
 } as const);
 
 export type FixedTraceArchitectureArmId = keyof typeof FIXED_TRACE_ARCHITECTURE_ARMS;
 export type FixedTraceArchitectureArmProvenance =
   (typeof FIXED_TRACE_ARCHITECTURE_ARMS)[FixedTraceArchitectureArmId];
+
+/**
+ * The diagnostic hybrid is intentionally a strict subset of production's
+ * quick-match policy.  It can only terminate no-tool surface outcomes; every
+ * routed/tool-bearing decision retains the incumbent strict LLM router.
+ */
+export const FIXED_TRACE_HYBRID_POLICY_VERSION = 'fixed-trace-hybrid-quick-match-v1';
+
+export interface FixedTraceHybridPolicy {
+  version: string;
+  /** A subset of production quick-match terminal actions, never `respond`. */
+  localTerminalActions: readonly ('ignore' | 'react')[];
+  /** Admin state is never an admission signal for a local outcome. */
+  requireNonAdmin: true;
+  /** Channel outcomes require a captured private-channel fact. */
+  requirePrivateChannelForChannelOutcome: true;
+  /** All non-local outcomes use the incumbent strict router stage. */
+  fallbackRouter: 'two_stage_llm_router';
+}
+
+export interface FixedTraceHybridDecision {
+  mode: 'local_terminal' | 'llm_router_fallback';
+  reason:
+    | 'production_quick_match_terminal'
+    | 'no_production_quick_match'
+    | 'thread_context_requires_router'
+    | 'admin_requires_router'
+    | 'channel_privacy_not_captured'
+    | 'tool_or_mutation_capability_requires_router'
+    | 'policy_disallows_terminal_action';
+  plan: ExecutionPlan | null;
+}
+
+const DEFAULT_FIXED_TRACE_HYBRID_POLICY: FixedTraceHybridPolicy = Object.freeze({
+  version: FIXED_TRACE_HYBRID_POLICY_VERSION,
+  localTerminalActions: Object.freeze(['ignore', 'react'] as const),
+  requireNonAdmin: true,
+  requirePrivateChannelForChannelOutcome: true,
+  fallbackRouter: 'two_stage_llm_router',
+});
+
+export function fixedTraceHybridPolicy(
+  policy: FixedTraceHybridPolicy | undefined = undefined,
+): FixedTraceHybridPolicy {
+  return policy ?? DEFAULT_FIXED_TRACE_HYBRID_POLICY;
+}
+
+export function validateFixedTraceHybridPolicy(policy: FixedTraceHybridPolicy): void {
+  if (!policy.version.trim()) throw new Error('Fixed trace hybrid policy version is required');
+  if (
+    !Array.isArray(policy.localTerminalActions)
+    || policy.localTerminalActions.length === 0
+    || policy.localTerminalActions.some((action) => action !== 'ignore' && action !== 'react')
+    || new Set(policy.localTerminalActions).size !== policy.localTerminalActions.length
+    || policy.requireNonAdmin !== true
+    || policy.requirePrivateChannelForChannelOutcome !== true
+    || policy.fallbackRouter !== 'two_stage_llm_router'
+  ) throw new Error('Fixed trace hybrid policy is invalid');
+}
+
+/**
+ * Make a deterministic hybrid decision from production quick-match behavior
+ * and request/surface facts only.  Do not pass a trace object to this helper:
+ * its routing, expectation, fixture, result, rubric, and grade fields are
+ * deliberately outside the admission boundary.
+ */
+export function decideFixedTraceHybridRoute(input: {
+  message: string;
+  source: FixedTraceCase['request']['source'];
+  isAdmin: boolean;
+  isThread: boolean;
+  channelPrivacy?: 'private' | 'public';
+  policy: FixedTraceHybridPolicy;
+}): FixedTraceHybridDecision {
+  validateFixedTraceHybridPolicy(input.policy);
+  if (input.isAdmin) return { mode: 'llm_router_fallback', reason: 'admin_requires_router', plan: null };
+  if (input.isThread) return { mode: 'llm_router_fallback', reason: 'thread_context_requires_router', plan: null };
+  if (input.source === 'channel' && input.channelPrivacy !== 'private') {
+    return { mode: 'llm_router_fallback', reason: 'channel_privacy_not_captured', plan: null };
+  }
+  const plan = quickMatchRoutingContext({
+    message: input.message,
+    source: input.source,
+    isThread: input.isThread,
+    isAAOAdmin: input.isAdmin,
+  });
+  if (!plan) return { mode: 'llm_router_fallback', reason: 'no_production_quick_match', plan: null };
+  if (plan.action === 'respond') {
+    return { mode: 'llm_router_fallback', reason: 'tool_or_mutation_capability_requires_router', plan: null };
+  }
+  if (!input.policy.localTerminalActions.includes(plan.action)) {
+    return { mode: 'llm_router_fallback', reason: 'policy_disallows_terminal_action', plan: null };
+  }
+  return { mode: 'local_terminal', reason: 'production_quick_match_terminal', plan };
+}
 
 export function fixedTraceArchitectureArm(
   arm: FixedTraceArchitectureArmId = 'two_stage_llm_router',
@@ -50,7 +155,7 @@ export interface FixedTraceToolUniverseProvenance {
     | 'fixture_local_routed_replay'
     | 'authorized_definition_handler_intersection_not_captured'
     | 'fixture_oracle';
-  intentNarrowing: 'llm_router' | 'not_applied' | 'fixture_oracle';
+  intentNarrowing: 'llm_router' | 'production_quick_match_or_llm_router' | 'not_applied' | 'fixture_oracle';
   bounded: boolean;
   deployable: boolean;
   toolNames: readonly string[] | null;
@@ -96,6 +201,15 @@ export function fixedTraceToolUniverseProvenance(
     return Object.freeze({
       source: 'fixture_oracle',
       intentNarrowing: 'fixture_oracle',
+      bounded: true,
+      deployable: false,
+      toolNames: null,
+    });
+  }
+  if (arm === 'deterministic_policy_llm_fallback_hybrid') {
+    return Object.freeze({
+      source: 'fixture_local_routed_replay',
+      intentNarrowing: 'production_quick_match_or_llm_router',
       bounded: true,
       deployable: false,
       toolNames: null,

--- a/server/src/addie/eval/fixed-trace-diagnostic-cli.ts
+++ b/server/src/addie/eval/fixed-trace-diagnostic-cli.ts
@@ -1,12 +1,13 @@
 export interface FixedTraceDiagnosticCliArguments {
   providers?: string;
   architectureArm?: string;
+  suite?: string;
   softMaxUsd?: string;
   output?: string;
   validateOnly: boolean;
 }
 
-const NAMES = new Set(['providers', 'architecture-arm', 'soft-max-usd', 'output', 'validate-only']);
+const NAMES = new Set(['providers', 'architecture-arm', 'suite', 'soft-max-usd', 'output', 'validate-only']);
 
 /** Strict, side-effect-free parser for the diagnostic-only manual evaluator. */
 export function parseFixedTraceDiagnosticCliArguments(values: readonly string[]): FixedTraceDiagnosticCliArguments {
@@ -29,6 +30,7 @@ export function parseFixedTraceDiagnosticCliArguments(values: readonly string[])
   return {
     providers: typeof seen.get('providers') === 'string' ? seen.get('providers') as string : undefined,
     architectureArm: typeof seen.get('architecture-arm') === 'string' ? seen.get('architecture-arm') as string : undefined,
+    suite: typeof seen.get('suite') === 'string' ? seen.get('suite') as string : undefined,
     softMaxUsd: typeof seen.get('soft-max-usd') === 'string' ? seen.get('soft-max-usd') as string : undefined,
     output: typeof seen.get('output') === 'string' ? seen.get('output') as string : undefined,
     validateOnly: seen.get('validate-only') === true || seen.get('validate-only') === 'true',

--- a/server/src/addie/eval/fixed-trace-diagnostic-run.ts
+++ b/server/src/addie/eval/fixed-trace-diagnostic-run.ts
@@ -467,6 +467,8 @@ function sameArtifactRunMetadata(left: FixedTraceRunMetadata, right: FixedTraceR
     && left.architectureArm.id === right.architectureArm.id
     && left.architectureArm.routeSource === right.architectureArm.routeSource
     && left.architectureArm.rolloutEligible === right.architectureArm.rolloutEligible
+    && left.architectureArm.diagnosticOnly === right.architectureArm.diagnosticOnly
+    && JSON.stringify(left.hybridPolicy) === JSON.stringify(right.hybridPolicy)
     && left.executionEnvelope.source === right.executionEnvelope.source
     && left.executionEnvelope.deployable === right.executionEnvelope.deployable;
 }
@@ -578,6 +580,7 @@ export async function runFixedTraceDiagnosticArtifact(
       run.observations[0]?.metadata.architectureConfigSha256 ?? null,
     ])),
     architectureArm: fixedTraceArchitectureArm(commonMetadata.architectureArm.id),
+    hybridPolicy: commonMetadata.hybridPolicy,
     toolUniverse: fixedTraceToolUniverseProvenance(commonMetadata.architectureArm.id),
     executionEnvelope: fixedTraceExecutionEnvelopeProvenance(commonMetadata.architectureArm.id),
     requestedProviders: plans.map((plan) => plan.name),

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -44,10 +44,14 @@ import {
 } from './fixed-trace-budget.js';
 import {
   admitFixedTraceDirectArm,
+  decideFixedTraceHybridRoute,
   fixedTraceArchitectureArm,
   fixedTraceExecutionEnvelopeProvenance,
+  fixedTraceHybridPolicy,
   fixedTraceToolUniverseProvenance,
+  validateFixedTraceHybridPolicy,
   type FixedTraceArchitectureArmId,
+  type FixedTraceHybridPolicy,
   type FixedTraceToolDefinitionProvenance,
 } from './fixed-trace-architecture.js';
 import {
@@ -96,6 +100,8 @@ export interface FixedTraceRunnerConfig {
   toolDefinitionProvenance?: FixedTraceToolDefinitionProvenance;
   /** Defaults to the existing two-stage LLM-router architecture. */
   architectureArm?: FixedTraceArchitectureArmId;
+  /** Required only by the diagnostic hybrid; default policy is versioned. */
+  hybridPolicy?: FixedTraceHybridPolicy;
   /** One-based repetition identifier; runs are never silently pooled. */
   repetition?: number;
   router: FixedTraceProviderStageConfig;
@@ -165,13 +171,13 @@ function assertTraceSuiteIdentity(config: FixedTraceRunnerConfig): void {
 }
 
 function assertFixtureDefinitionUniverse(config: FixedTraceRunnerConfig): void {
-  // Routed/oracle replay registers only trace fixtures. A wider definition
+  // Routed/hybrid/oracle replay registers only trace fixtures. A wider definition
   // list would make the declared config differ from executable inputs. Direct
   // remains intentionally exempt: its deployable request-derived universe has
   // not yet been captured by this diagnostic foundation.
   if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
   if (!Array.isArray(config.toolDefinitions)) {
-    throw new Error('Fixed trace routed/oracle definitions must exactly match configured suite fixtures');
+    throw new Error('Fixed trace routed/hybrid/oracle definitions must exactly match configured suite fixtures');
   }
   const fixtureNames = new Set(config.traceSuite.flatMap((trace) => trace.toolFixtures.map((fixture) => fixture.name)));
   const definitionNames = config.toolDefinitions.map((definition) => definition.name);
@@ -179,12 +185,12 @@ function assertFixtureDefinitionUniverse(config: FixedTraceRunnerConfig): void {
     definitionNames.length !== fixtureNames.size
     || new Set(definitionNames).size !== definitionNames.length
     || definitionNames.some((name) => !fixtureNames.has(name))
-  ) throw new Error('Fixed trace routed/oracle definitions must exactly match configured suite fixtures');
+  ) throw new Error('Fixed trace routed/hybrid/oracle definitions must exactly match configured suite fixtures');
 }
 
 function assertFixtureRegistrations(config: FixedTraceRunnerConfig): void {
   // Direct is admission-only: it must not derive a fake executable universe
-  // from fixture-local definitions. Routed and oracle replay use this exact
+  // from fixture-local definitions. Routed, hybrid, and oracle replay use this exact
   // registration primitive at generation time, so validate it before router
   // dispatch as well.
   if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
@@ -243,6 +249,11 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
   }
   if (config.injectProviderDegradation !== undefined && typeof config.injectProviderDegradation !== 'boolean') {
     throw new Error('Fixed trace runner injectProviderDegradation must be boolean when supplied');
+  }
+  if (config.architectureArm === 'deterministic_policy_llm_fallback_hybrid') {
+    validateFixedTraceHybridPolicy(fixedTraceHybridPolicy(config.hybridPolicy));
+  } else if (config.hybridPolicy !== undefined) {
+    throw new Error('Fixed trace hybrid policy is only valid for the hybrid architecture arm');
   }
 }
 
@@ -621,6 +632,9 @@ export function fixedTraceArchitectureConfigSha256(
     toolSchemaSha256,
     toolDefinitionProvenance: config.toolDefinitionProvenance ?? 'fixture_local',
     architectureArm: arm,
+    hybridPolicy: arm.id === 'deterministic_policy_llm_fallback_hybrid'
+      ? fixedTraceHybridPolicy(config.hybridPolicy)
+      : null,
     toolUniverse: fixedTraceToolUniverseProvenance(arm.id),
     executionEnvelope: fixedTraceExecutionEnvelopeProvenance(arm.id),
     routerControl: cohortStageControl(config.router),
@@ -701,6 +715,9 @@ function baseMetadata(
     providerDegradationInjectionEnabled: config.injectProviderDegradation !== false,
     repetition: config.repetition ?? 1,
     architectureArm,
+    hybridPolicy: architectureArm.id === 'deterministic_policy_llm_fallback_hybrid'
+      ? fixedTraceHybridPolicy(config.hybridPolicy)
+      : null,
     toolUniverse: {
       ...fixedTraceToolUniverseProvenance(architectureArm.id),
       // Routed/oracle fixture surfaces are exact replay inputs. Direct has no
@@ -933,6 +950,16 @@ export async function runFixedTraceCase(
     // incomplete deployable fixture surface is not evidence.
     return directAdmissionMetadata(executionConfig, toolSchemaSha256, executionTrace);
   }
+  const hybridDecision = architectureArm.id === 'deterministic_policy_llm_fallback_hybrid'
+    ? decideFixedTraceHybridRoute({
+        message: executionTrace.request.message,
+        source: executionTrace.request.source,
+        isAdmin: executionTrace.request.isAdmin,
+        isThread: (executionTrace.request.threadContext?.length ?? 0) > 0,
+        channelPrivacy: executionTrace.request.channelPrivacy,
+        policy: fixedTraceHybridPolicy(executionConfig.hybridPolicy),
+      })
+    : null;
   const routed = architectureArm.id === 'oracle_route_diagnostic'
     ? {
         request: null,
@@ -942,6 +969,15 @@ export async function runFixedTraceCase(
         status: null,
         metadata: notRunStageMetadata(executionTrace),
       }
+    : hybridDecision?.mode === 'local_terminal'
+      ? {
+          request: null,
+          response: null,
+          plan: hybridDecision.plan,
+          output: '',
+          status: null,
+          metadata: notRunStageMetadata(executionTrace),
+        }
     : await executeRouter(executionTrace, executionConfig.router, assertBeforeDispatch);
   const generationNotRun = notRunStageMetadata(executionTrace);
   if (!routed.plan || routed.status) {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -1255,6 +1255,58 @@ export function fixedTraceSuiteSha256(
 }
 
 /**
+ * Deliberately separate from the legacy 32-case canonical corpus. This small,
+ * evaluator-owned synthetic suite exercises only the reviewed local terminal
+ * subset; it is the minimum planner binding required before hybrid outcomes
+ * can even be described as covered. It remains diagnostic-only.
+ */
+export const FIXED_TRACE_HYBRID_EVALUATOR_SUITE_VERSION = 'addie-fixed-trace-hybrid-evaluator-v1' as const;
+export const FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS = 3 as const;
+
+const HYBRID_EVALUATOR_BASE_TRACE = FIXED_TRACE_SUITE.find((trace) => trace.id === 'knowledge-task-model');
+if (!HYBRID_EVALUATOR_BASE_TRACE) throw new Error('Fixed trace hybrid evaluator base trace is missing');
+
+export const FIXED_TRACE_HYBRID_EVALUATOR_SUITE: ReadonlyArray<FixedTraceCase> = deepFreeze([
+  {
+    ...HYBRID_EVALUATOR_BASE_TRACE,
+    id: 'hybrid-evaluator-ignore-ok',
+    request: { source: 'dm', message: 'ok', nowUtc: NOW, isAdmin: false },
+    routing: { action: 'ignore', toolSets: [] },
+    toolFixtures: [],
+    expectation: {
+      terminalStatuses: ['ignored'], requiredTools: [], allowedTools: [], forbiddenTools: [], mutationAuthorization: 'none',
+    },
+    answerRubric: [],
+  },
+  {
+    ...HYBRID_EVALUATOR_BASE_TRACE,
+    id: 'hybrid-evaluator-react-hi',
+    request: { source: 'channel', channelPrivacy: 'private', message: 'hi', nowUtc: NOW, isAdmin: false },
+    routing: { action: 'react', toolSets: [] },
+    toolFixtures: [],
+    expectation: {
+      terminalStatuses: ['reacted'], requiredTools: [], allowedTools: [], forbiddenTools: [], mutationAuthorization: 'none',
+    },
+    answerRubric: [],
+  },
+  {
+    ...HYBRID_EVALUATOR_BASE_TRACE,
+    id: 'hybrid-evaluator-react-thanks',
+    request: { source: 'channel', channelPrivacy: 'private', message: 'thanks', nowUtc: NOW, isAdmin: false },
+    routing: { action: 'react', toolSets: [] },
+    toolFixtures: [],
+    expectation: {
+      terminalStatuses: ['reacted'], requiredTools: [], allowedTools: [], forbiddenTools: [], mutationAuthorization: 'none',
+    },
+    answerRubric: [],
+  },
+]);
+
+export function fixedTraceHybridEvaluatorSuiteSha256(): string {
+  return fixedTraceSuiteSha256(FIXED_TRACE_HYBRID_EVALUATOR_SUITE);
+}
+
+/**
  * Deterministic internal-consistency payload for a candidate cohort. It
  * deliberately excludes returned provider identity, usage, latency, and
  * trace-local effective limits, which are per-call outcomes. It is not an
@@ -1889,6 +1941,15 @@ export interface FixedTraceSummary {
   terminalStatusCounts: Record<FixedTraceTerminalStatus, number>;
   latencyP95Ms: number | null;
   totalEstimatedCostUsd: number | null;
+  /** Null outside the hybrid arm; otherwise an explicit evidence-coverage blocker. */
+  hybridCoverage: {
+    suiteVersion: typeof FIXED_TRACE_HYBRID_EVALUATOR_SUITE_VERSION;
+    plannerBound: boolean;
+    localAdmissionCount: number;
+    minimumLocalAdmissions: typeof FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS;
+    sufficient: boolean;
+    blocker: 'hybrid_evaluator_suite_not_bound' | 'hybrid_local_admission_coverage_below_minimum' | null;
+  } | null;
   comparisonEligible: boolean;
 }
 
@@ -2010,6 +2071,27 @@ export function summarizeFixedTraceRun(
   const cohortToolNames = runContract.architectureArm.id === 'direct_generation'
     ? null
     : [...new Set(observations.flatMap((observation) => observation.metadata.toolUniverse.toolNames ?? []))].sort();
+  const localAdmissionCount = observations.filter((observation) => (
+    observation.terminalStage === 'surface'
+    && (observation.terminalStatus === 'ignored' || observation.terminalStatus === 'reacted')
+    && observation.metadata.router.source === 'not_run'
+  )).length;
+  const hybridPlannerBound = runContract.architectureArm.id === 'deterministic_policy_llm_fallback_hybrid'
+    && suppliedSuiteSha256 === fixedTraceHybridEvaluatorSuiteSha256();
+  const hybridCoverage = runContract.architectureArm.id === 'deterministic_policy_llm_fallback_hybrid'
+    ? {
+        suiteVersion: FIXED_TRACE_HYBRID_EVALUATOR_SUITE_VERSION,
+        plannerBound: hybridPlannerBound,
+        localAdmissionCount,
+        minimumLocalAdmissions: FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS,
+        sufficient: hybridPlannerBound && localAdmissionCount >= FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS,
+        blocker: !hybridPlannerBound
+          ? 'hybrid_evaluator_suite_not_bound' as const
+          : localAdmissionCount < FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS
+            ? 'hybrid_local_admission_coverage_below_minimum' as const
+            : null,
+      }
+    : null;
   return {
     grades,
     summary: {
@@ -2047,6 +2129,7 @@ export function summarizeFixedTraceRun(
       terminalStatusCounts,
       latencyP95Ms: sortedLatency.length === 0 ? null : sortedLatency[p95Index],
       totalEstimatedCostUsd,
+      hybridCoverage,
       // Raw observations and summaries are serializable. Until the follow-up
       // evaluator-owned coordinator can authenticate the run context and
       // ledger, this replay is diagnostic evidence only.

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
   fixedTraceArchitectureArm,
+  validateFixedTraceHybridPolicy,
 } from './fixed-trace-architecture.js';
 import {
   fixedTraceEstimatedCostUsd,
@@ -22,6 +23,7 @@ import type {
   FixedTraceArchitectureArmProvenance,
   FixedTraceDirectArmAdmission,
   FixedTraceExecutionEnvelopeProvenance,
+  FixedTraceHybridPolicy,
   FixedTraceToolDefinitionProvenance,
   FixedTraceToolUniverseProvenance,
 } from './fixed-trace-architecture.js';
@@ -109,6 +111,8 @@ export interface FixedTraceCase {
     message: string;
     nowUtc: string;
     isAdmin: boolean;
+    /** Required for a local channel outcome; absent facts fail safe to routing. */
+    channelPrivacy?: 'private' | 'public';
     threadContext?: ReadonlyArray<{ user: 'member' | 'addie'; text: string }>;
   };
   routing: {
@@ -271,6 +275,8 @@ export interface FixedTraceRunMetadata {
   repetition: number;
   /** Immutable architecture-arm cohort provenance. */
   architectureArm: FixedTraceArchitectureArmProvenance;
+  /** Candidate controls for the hybrid arm; included in the cohort fingerprint. */
+  hybridPolicy: FixedTraceHybridPolicy | null;
   /** How this arm obtained its visible tool universe. */
   toolUniverse: FixedTraceToolUniverseProvenance;
   /** Provenance for confirmation, idempotency, and mutation safety policy. */
@@ -1262,6 +1268,7 @@ export function fixedTraceArchitectureConfigPayload(metadata: Pick<
   | 'toolSchemaSha256'
   | 'toolDefinitionProvenance'
   | 'architectureArm'
+  | 'hybridPolicy'
   | 'toolUniverse'
   | 'executionEnvelope'
   | 'routerControl'
@@ -1283,6 +1290,7 @@ export function fixedTraceArchitectureConfigPayload(metadata: Pick<
       schemaSha256: metadata.toolSchemaSha256,
     },
     architectureArm: metadata.architectureArm,
+    hybridPolicy: metadata.hybridPolicy,
     toolUniverse: cohortToolUniverse,
     executionEnvelope: metadata.executionEnvelope,
     routerControl: metadata.routerControl,
@@ -1529,15 +1537,26 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   const caseControl = trace.caseControl ?? null;
   if (!sameCaseControl(caseControl, metadata.caseControl)) failures.push('case_control_mismatch');
   const arm = metadata.architectureArm;
-  if (!arm || !['two_stage_llm_router', 'direct_generation', 'oracle_route_diagnostic'].includes(arm.id)) {
+  if (!arm || !['two_stage_llm_router', 'direct_generation', 'deterministic_policy_llm_fallback_hybrid', 'oracle_route_diagnostic'].includes(arm.id)) {
     failures.push('architecture_arm_invalid');
   } else {
     const canonicalArm = fixedTraceArchitectureArm(arm.id);
     if (
       arm.routeSource !== canonicalArm.routeSource
       || arm.rolloutEligible !== canonicalArm.rolloutEligible
+      || arm.diagnosticOnly !== canonicalArm.diagnosticOnly
     ) failures.push('architecture_arm_invalid');
   }
+  if (arm?.id === 'deterministic_policy_llm_fallback_hybrid') {
+    if (metadata.hybridPolicy === null) failures.push('hybrid_policy_missing');
+    else {
+      try {
+        validateFixedTraceHybridPolicy(metadata.hybridPolicy);
+      } catch {
+        failures.push('hybrid_policy_invalid');
+      }
+    }
+  } else if (metadata.hybridPolicy !== null) failures.push('hybrid_policy_unexpected');
   if (arm?.id === 'direct_generation') {
     if (metadata.directArmAdmission === null) {
       failures.push('direct_arm_admission_missing');
@@ -1554,6 +1573,11 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   }
   const toolUniverse = metadata.toolUniverse;
   if (!toolUniverse || !['fixture_local_routed_replay', 'authorized_definition_handler_intersection_not_captured', 'fixture_oracle'].includes(toolUniverse.source)) {
+    failures.push('tool_universe_provenance_invalid');
+  } else if (
+    arm?.id === 'deterministic_policy_llm_fallback_hybrid'
+    && (toolUniverse.source !== 'fixture_local_routed_replay' || toolUniverse.intentNarrowing !== 'production_quick_match_or_llm_router' || !toolUniverse.bounded || toolUniverse.deployable)
+  ) {
     failures.push('tool_universe_provenance_invalid');
   } else if (
     arm?.id === 'two_stage_llm_router'
@@ -1579,6 +1603,11 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   }
   const executionEnvelope = metadata.executionEnvelope;
   if (!executionEnvelope || !['fixture_expectation', 'request_thread_facts_not_captured', 'fixture_oracle'].includes(executionEnvelope.source)) {
+    failures.push('execution_envelope_provenance_invalid');
+  } else if (
+    arm?.id === 'deterministic_policy_llm_fallback_hybrid'
+    && (executionEnvelope.source !== 'fixture_expectation' || executionEnvelope.deployable)
+  ) {
     failures.push('execution_envelope_provenance_invalid');
   } else if (
     arm?.id === 'two_stage_llm_router'
@@ -1903,6 +1932,8 @@ export function assertFixedTraceRunContract(
       || candidate.architectureArm.id !== runContract.architectureArm.id
       || candidate.architectureArm.routeSource !== runContract.architectureArm.routeSource
       || candidate.architectureArm.rolloutEligible !== runContract.architectureArm.rolloutEligible
+      || candidate.architectureArm.diagnosticOnly !== runContract.architectureArm.diagnosticOnly
+      || canonicalJson(candidate.hybridPolicy) !== canonicalJson(runContract.hybridPolicy)
       || candidate.toolUniverse.source !== runContract.toolUniverse.source
       || candidate.toolUniverse.intentNarrowing !== runContract.toolUniverse.intentNarrowing
       || candidate.toolUniverse.bounded !== runContract.toolUniverse.bounded
@@ -2004,7 +2035,7 @@ export function summarizeFixedTraceRun(
       complete,
       deterministicPassRate: ratio(grades.filter((grade) => grade.deterministicPass).length),
       answerPassRate: answerGrades.length === 0 ? null : ratio(answerGrades.filter((grade) => grade.answerPass).length, answerGrades.length),
-      routingPassRate: runContract.architectureArm.id === 'two_stage_llm_router'
+      routingPassRate: ['two_stage_llm_router', 'deterministic_policy_llm_fallback_hybrid'].includes(runContract.architectureArm.id)
         ? ratio(grades.filter((grade) => grade.routingPass === true).length)
         : null,
       toolSelectionPassRate: ratio(grades.filter((grade) => grade.toolSelectionPass).length),

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -1450,6 +1450,16 @@ export class AddieRouter {
    * Returns null if no quick match, meaning the full router should run.
    */
   quickMatch(ctx: RoutingContext): ExecutionPlan | null {
+    return quickMatchRoutingContext(ctx);
+  }
+}
+
+/**
+ * Production's deterministic pre-router policy.  Keep this separate from
+ * `AddieRouter` so diagnostic callers can reuse the exact policy without
+ * constructing a provider-backed router or widening their capability surface.
+ */
+export function quickMatchRoutingContext(ctx: RoutingContext): ExecutionPlan | null {
     const startTime = Date.now();
     // Normalize smart quotes (Slack converts ' to \u2018/\u2019 and " to \u201C/\u201D)
     const text = ctx.message
@@ -1565,6 +1575,5 @@ export class AddieRouter {
     }
 
     // No quick match - need full router
-    return null;
-  }
+  return null;
 }

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -41,7 +41,10 @@ import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from '../../src/addie/eval/fixed
 import { parseFixedTraceDiagnosticCliArguments } from '../../src/addie/eval/fixed-trace-diagnostic-cli.js';
 import { reserveFixedTraceDiagnosticOutput } from '../../src/addie/eval/fixed-trace-diagnostic-output.js';
 import { canonicalFixedTraceToolDefinitions } from '../../src/addie/eval/fixed-trace-tools.js';
-import { type FixedTraceArchitectureArmId } from '../../src/addie/eval/fixed-trace-architecture.js';
+import {
+  fixedTraceHybridPolicy,
+  type FixedTraceArchitectureArmId,
+} from '../../src/addie/eval/fixed-trace-architecture.js';
 import {
   FIXED_TRACE_SUITE,
   fixedTraceSuiteSha256,
@@ -271,7 +274,7 @@ if (new Set(providerNames).size !== providerNames.length || providerNames.length
   throw new Error('--providers must contain one or more unique providers');
 }
 const architectureArm = (argument('architecture-arm') ?? 'two_stage_llm_router') as FixedTraceArchitectureArmId;
-if (!(architectureArm in { two_stage_llm_router: true, direct_generation: true, oracle_route_diagnostic: true })) {
+if (!(architectureArm in { two_stage_llm_router: true, direct_generation: true, deterministic_policy_llm_fallback_hybrid: true, oracle_route_diagnostic: true })) {
   throw new Error('Unknown --architecture-arm value');
 }
 const softMaxUsd = Number(argument('soft-max-usd'));
@@ -325,6 +328,9 @@ const artifact = await runFixedTraceDiagnosticArtifact({
     toolDefinitions,
     toolDefinitionProvenance: 'fixture_local',
     architectureArm,
+    ...(architectureArm === 'deterministic_policy_llm_fallback_hybrid'
+      ? { hybridPolicy: fixedTraceHybridPolicy() }
+      : {}),
   },
   budget,
   outputReservation,

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -11,7 +11,9 @@
  * before intent narrowing, but this harness neither captures that intersection
  * nor bounds it independently; fixture-local schemas must not stand in for it.
  * `oracle_route_diagnostic` may execute generation with fixture routing.
- * Every arm is diagnostic-only in this foundation: independent judging,
+ * The hybrid-only `--suite=hybrid-evaluator` binds the separately reviewed
+ * local-admission corpus without altering the legacy 32 traces. Every arm is
+ * diagnostic-only in this foundation: independent judging,
  * comparison, and rollout are blocked until an evaluator-owned run-context
  * and raw-ledger coordinator can authenticate serialized artifacts.
  *
@@ -47,6 +49,7 @@ import {
 } from '../../src/addie/eval/fixed-trace-architecture.js';
 import {
   FIXED_TRACE_SUITE,
+  FIXED_TRACE_HYBRID_EVALUATOR_SUITE,
   fixedTraceSuiteSha256,
   type FixedTracePricing,
 } from '../../src/addie/eval/fixed-trace-suite.js';
@@ -117,7 +120,7 @@ const PRICING = {
 const cliArguments = parseFixedTraceDiagnosticCliArguments(process.argv.slice(2));
 
 function argument(name: string): string | undefined {
-  return cliArguments[{ providers: 'providers', 'architecture-arm': 'architectureArm', 'soft-max-usd': 'softMaxUsd', output: 'output' }[name] as keyof typeof cliArguments] as string | undefined;
+  return cliArguments[{ providers: 'providers', 'architecture-arm': 'architectureArm', suite: 'suite', 'soft-max-usd': 'softMaxUsd', output: 'output' }[name] as keyof typeof cliArguments] as string | undefined;
 }
 
 function sha256(value: string): string {
@@ -277,6 +280,14 @@ const architectureArm = (argument('architecture-arm') ?? 'two_stage_llm_router')
 if (!(architectureArm in { two_stage_llm_router: true, direct_generation: true, deterministic_policy_llm_fallback_hybrid: true, oracle_route_diagnostic: true })) {
   throw new Error('Unknown --architecture-arm value');
 }
+const suiteName = argument('suite') ?? 'canonical';
+if (suiteName !== 'canonical' && suiteName !== 'hybrid-evaluator') throw new Error('Unknown --suite value');
+if (suiteName === 'hybrid-evaluator' && architectureArm !== 'deterministic_policy_llm_fallback_hybrid') {
+  throw new Error('--suite=hybrid-evaluator requires --architecture-arm=deterministic_policy_llm_fallback_hybrid');
+}
+const traceSuite = suiteName === 'hybrid-evaluator'
+  ? FIXED_TRACE_HYBRID_EVALUATOR_SUITE
+  : FIXED_TRACE_SUITE;
 const softMaxUsd = Number(argument('soft-max-usd'));
 if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
   throw new Error('--soft-max-usd is required and must be positive');
@@ -291,6 +302,7 @@ if (cliArguments.validateOnly) {
     validated: {
       providers: providerNames,
       architectureArm,
+      suite: suiteName,
       softMaxUsd,
       outputPath,
     },
@@ -311,7 +323,7 @@ const promptConfigVersion = sha256(JSON.stringify({
   rules: loadRules(),
   responseStyle: loadResponseStyle(),
 }));
-const toolDefinitions = canonicalFixedTraceToolDefinitions();
+const toolDefinitions = canonicalFixedTraceToolDefinitions(traceSuite);
 const budget = new FixedTraceBudget(softMaxUsd);
 const plans = providerPlans(providerNames, budget);
 const runStartedAt = new Date().toISOString();
@@ -323,8 +335,8 @@ const artifact = await runFixedTraceDiagnosticArtifact({
     gitCommit,
     gitDirty,
     promptConfigVersion,
-    traceSuite: FIXED_TRACE_SUITE,
-    traceSuiteSha256: fixedTraceSuiteSha256(FIXED_TRACE_SUITE),
+    traceSuite,
+    traceSuiteSha256: fixedTraceSuiteSha256(traceSuite),
     toolDefinitions,
     toolDefinitionProvenance: 'fixture_local',
     architectureArm,
@@ -343,6 +355,7 @@ console.log(JSON.stringify({
   outputPath,
   runRootId,
   providers: providerNames,
+  suite: suiteName,
   comparisonEligible: artifact.comparisonEligible,
   rolloutPass: artifact.rolloutPass,
   budget: artifact.budget,

--- a/server/tests/unit/addie/fixed-trace-diagnostic-cli.test.ts
+++ b/server/tests/unit/addie/fixed-trace-diagnostic-cli.test.ts
@@ -7,13 +7,13 @@ import { parseFixedTraceDiagnosticCliArguments } from '../../../src/addie/eval/f
 describe('fixed-trace diagnostic CLI parser', () => {
   it('accepts only bounded dry-run forms', () => {
     expect(parseFixedTraceDiagnosticCliArguments(['--validate-only', '--providers=openai']))
-      .toEqual({ validateOnly: true, providers: 'openai', architectureArm: undefined, softMaxUsd: undefined, output: undefined });
+      .toEqual({ validateOnly: true, providers: 'openai', architectureArm: undefined, suite: undefined, softMaxUsd: undefined, output: undefined });
     expect(parseFixedTraceDiagnosticCliArguments(['--validate-only=true']).validateOnly).toBe(true);
   });
 
   it.each([
     ['--validate-only=false'], ['--validate-onl'], ['--providers=openai', '--providers=google'],
-    ['positional'], ['--judge-providers=openai'], ['--providers'],
+    ['positional'], ['--judge-providers=openai'], ['--providers'], ['--suite=unknown'],
   ])('rejects unsafe option input %j', (args) => {
     expect(() => parseFixedTraceDiagnosticCliArguments(args)).toThrow();
   });
@@ -29,8 +29,22 @@ describe('fixed-trace diagnostic CLI parser', () => {
     }).find((line) => line?.diagnosticOnly === true);
     expect(validated).toMatchObject({
       diagnosticOnly: true,
-      validated: { providers: ['openai'], architectureArm: 'direct_generation', softMaxUsd: 1, outputPath: output },
+      validated: { providers: ['openai'], architectureArm: 'direct_generation', suite: 'canonical', softMaxUsd: 1, outputPath: output },
     });
+    expect(existsSync(output)).toBe(false);
+  });
+
+  it('binds the reviewed hybrid evaluator suite only to the hybrid arm during validate-only planning', () => {
+    const output = resolve('/tmp/fixed-trace-diagnostic-cli-hybrid-suite-no-write.json');
+    const result = execFileSync('npx', [
+      'tsx', 'server/tests/manual/fixed-trace-provider-eval.ts', '--validate-only', '--providers=openai',
+      '--architecture-arm=deterministic_policy_llm_fallback_hybrid', '--suite=hybrid-evaluator', '--soft-max-usd=1', `--output=${output}`,
+    ], { cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, OPENAI_API_KEY: '' } });
+    expect(result).toContain('"suite":"hybrid-evaluator"');
+    expect(() => execFileSync('npx', [
+      'tsx', 'server/tests/manual/fixed-trace-provider-eval.ts', '--validate-only', '--providers=openai',
+      '--architecture-arm=two_stage_llm_router', '--suite=hybrid-evaluator', '--soft-max-usd=1', `--output=${output}`,
+    ], { cwd: process.cwd(), stdio: 'pipe' })).toThrow();
     expect(existsSync(output)).toBe(false);
   });
 

--- a/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
+++ b/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
 import { reserveFixedTraceDiagnosticOutput } from '../../../src/addie/eval/fixed-trace-diagnostic-output.js';
 import { canonicalFixedTraceToolDefinitions } from '../../../src/addie/eval/fixed-trace-tools.js';
+import { fixedTraceHybridPolicy } from '../../../src/addie/eval/fixed-trace-architecture.js';
 import type { FixedTraceProviderStageConfig } from '../../../src/addie/eval/fixed-trace-runner.js';
 import {
   FIXED_TRACE_SUITE,
@@ -289,7 +290,8 @@ describe('fixed-trace diagnostic output reservation', () => {
         traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]),
         toolDefinitions: [],
         toolDefinitionProvenance: 'fixture_local',
-        architectureArm: 'two_stage_llm_router',
+        architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+        hybridPolicy: fixedTraceHybridPolicy(),
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -307,6 +309,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       comparisonEligible: false,
       promotionEvidenceEligible: false,
       rolloutPass: false,
+      architectureArm: { id: 'deterministic_policy_llm_fallback_hybrid', diagnosticOnly: true },
+      hybridPolicy: fixedTraceHybridPolicy(),
       runs: [{
         provider: 'anthropic',
         summary: { complete: true, comparisonEligible: false },

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -26,7 +26,9 @@ import {
 } from '../../../src/addie/eval/fixed-trace-suite.js';
 import {
   admitFixedTraceDirectArm,
+  decideFixedTraceHybridRoute,
   deriveFixedTraceDirectToolUniverse,
+  fixedTraceHybridPolicy,
 } from '../../../src/addie/eval/fixed-trace-architecture.js';
 import { FAILED_LOOKUP_EVIDENCE_RESPONSE } from '../../../src/addie/failed-lookup-evidence.js';
 import { ADMIN_TOOLS } from '../../../src/addie/mcp/admin-tools.js';
@@ -393,6 +395,144 @@ function expandedFixtureTrace(id = 'expanded-fixture-tool'): FixedTraceCase {
 }
 
 describe('fixed trace artifact runner', () => {
+  it('uses production quick-match terminal behavior only from allowed request facts', () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const policy = fixedTraceHybridPolicy();
+    const decide = (candidate: FixedTraceCase) => decideFixedTraceHybridRoute({
+      message: candidate.request.message,
+      source: candidate.request.source,
+      isAdmin: candidate.request.isAdmin,
+      isThread: (candidate.request.threadContext?.length ?? 0) > 0,
+      channelPrivacy: candidate.request.channelPrivacy,
+      policy,
+    });
+    const obvious: FixedTraceCase = {
+      ...selectedTrace,
+      request: { source: 'dm', message: 'ok', isAdmin: false, nowUtc: selectedTrace.request.nowUtc },
+    };
+    const answerLeakingChanges: FixedTraceCase = {
+      ...obvious,
+      routing: { action: 'respond', toolSets: ['admin_events'] },
+      toolFixtures: [{ name: 'fixture_only', effect: 'mutation', resultStatus: 'ok', result: 'different fixture result' }],
+      expectation: {
+        ...obvious.expectation,
+        requiredTools: ['fixture_only'],
+        allowedTools: ['fixture_only'],
+        requiredTextAny: [['different expected answer']],
+      },
+      answerRubric: ['different grade label'],
+    };
+
+    expect(decide(answerLeakingChanges)).toMatchObject(decide(obvious));
+    expect(decide(obvious)).toMatchObject({
+      mode: 'local_terminal', reason: 'production_quick_match_terminal', plan: { action: 'ignore' },
+    });
+  });
+
+  it('runs obvious local outcomes without a router dispatch and routes ambiguous cases through the incumbent stages', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const localTrace: FixedTraceCase = {
+      ...selectedTrace,
+      request: { source: 'dm', message: 'ok', isAdmin: false, nowUtc: selectedTrace.request.nowUtc },
+    };
+    const localRouter = new ScriptedProvider([]);
+    const localGeneration = new ScriptedProvider([]);
+    const local = await runFixedTraceCase(localTrace, config(localRouter, localGeneration, {
+      traceSuite: [localTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+    expect(local).toMatchObject({ terminalStage: 'surface', terminalStatus: 'ignored', route: { action: 'ignore', toolSets: [] } });
+    expect(local.metadata.hybridPolicy).toEqual(fixedTraceHybridPolicy());
+    expect(localRouter.respondCalls).toHaveLength(0);
+    expect(localGeneration.respondCalls).toHaveLength(0);
+
+    const ambiguousTrace: FixedTraceCase = {
+      ...selectedTrace,
+      request: { source: 'dm', message: 'Explain AdCP authentication.', isAdmin: false, nowUtc: selectedTrace.request.nowUtc },
+    };
+    const ambiguousRouter = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const ambiguousGeneration = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    const ambiguous = await runFixedTraceCase(ambiguousTrace, config(ambiguousRouter, ambiguousGeneration, {
+      traceSuite: [ambiguousTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+    expect(ambiguous.terminalStage).toBe('generation');
+    expect(ambiguousRouter.respondCalls).toHaveLength(1);
+    expect(ambiguousGeneration.respondCalls).toHaveLength(1);
+  });
+
+  it('fails hybrid admission safe for tool-bearing, admin, thread, and unknown-privacy cases', () => {
+    const policy = fixedTraceHybridPolicy();
+    const decide = (input: Parameters<typeof decideFixedTraceHybridRoute>[0]) => decideFixedTraceHybridRoute({ ...input, policy });
+    expect(decide({ message: 'attendee list for the summit', source: 'dm', isAdmin: false, isThread: false }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'tool_or_mutation_capability_requires_router' });
+    expect(decide({ message: 'send the invoice to the member', source: 'dm', isAdmin: false, isThread: false }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'no_production_quick_match' });
+    expect(decide({ message: 'thanks', source: 'dm', isAdmin: true, isThread: false }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'admin_requires_router' });
+    expect(decide({ message: 'thanks', source: 'dm', isAdmin: false, isThread: true }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'thread_context_requires_router' });
+    expect(decide({ message: 'hello', source: 'channel', isAdmin: false, isThread: false, channelPrivacy: 'public' }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'channel_privacy_not_captured' });
+    expect(decide({ message: 'hello', source: 'channel', isAdmin: false, isThread: false }))
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'channel_privacy_not_captured' });
+  });
+
+  it('keeps routed tool definitions and generation execution identical after hybrid fallback', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const incumbentRouter = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const incumbentGeneration = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    await runFixedTraceCase(selectedTrace, config(incumbentRouter, incumbentGeneration, { traceSuite: [selectedTrace] }));
+
+    const hybridRouter = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const hybridGeneration = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    await runFixedTraceCase(selectedTrace, config(hybridRouter, hybridGeneration, {
+      traceSuite: [selectedTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+
+    expect(hybridRouter.respondCalls).toHaveLength(1);
+    expect(hybridGeneration.respondCalls).toEqual(incumbentGeneration.respondCalls);
+  });
+
+  it('binds hybrid policy and fallback-router controls into the frozen architecture identity', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const policy = fixedTraceHybridPolicy();
+    const hybrid = config(new ScriptedProvider([]), new ScriptedProvider([]), {
+      traceSuite: [selectedTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid', hybridPolicy: policy,
+    });
+    const incumbent = { ...hybrid, architectureArm: 'two_stage_llm_router' as const, hybridPolicy: undefined };
+    expect(fixedTraceArchitectureConfigSha256(hybrid)).not.toBe(fixedTraceArchitectureConfigSha256(incumbent));
+    expect(fixedTraceArchitectureConfigSha256({ ...hybrid, hybridPolicy: { ...policy, version: 'fixed-trace-hybrid-quick-match-v2' } }))
+      .not.toBe(fixedTraceArchitectureConfigSha256(hybrid));
+    expect(fixedTraceArchitectureConfigSha256({ ...hybrid, hybridPolicy: { ...policy, localTerminalActions: ['ignore'] } }))
+      .not.toBe(fixedTraceArchitectureConfigSha256(hybrid));
+    expect(fixedTraceArchitectureConfigSha256({ ...hybrid, router: { ...hybrid.router, timeoutMs: 20_000 } }))
+      .not.toBe(fixedTraceArchitectureConfigSha256(hybrid));
+
+    const invalidRouter = new ScriptedProvider([]);
+    await expect(runFixedTraceCase(selectedTrace, config(invalidRouter, new ScriptedProvider([]), {
+      traceSuite: [selectedTrace],
+      architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+      hybridPolicy: { ...policy, localTerminalActions: ['respond' as never] },
+    }))).rejects.toThrow('Fixed trace hybrid policy is invalid');
+    expect(invalidRouter.respondCalls).toHaveLength(0);
+  });
+
+  it('does not permit hybrid policy restamping after the first dispatch', async () => {
+    const firstTrace = trace('knowledge-task-model');
+    const secondTrace = { ...structuredClone(firstTrace), id: 'hybrid-second-trace' };
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const generation = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    const runConfig = config(router, generation, {
+      traceSuite: [firstTrace, secondTrace],
+      architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+      hybridPolicy: { ...fixedTraceHybridPolicy() },
+    });
+    await runFixedTraceCase(firstTrace, runConfig);
+    runConfig.hybridPolicy!.version = 'fixed-trace-hybrid-quick-match-v2';
+    await expect(runFixedTraceCase(secondTrace, runConfig))
+      .rejects.toThrow('Fixed trace runner execution identity changed after dispatch binding');
+    expect(router.respondCalls).toHaveLength(1);
+    expect(generation.respondCalls).toHaveLength(1);
+  });
   it('keeps an unapproved same-provider returned model unpriced for failure telemetry', async () => {
     const router = new ScriptedProvider([{ ...routeResponse('respond', ['knowledge']), model: 'other-anthropic-model' }]);
     const generation = new ScriptedProvider([
@@ -889,14 +1029,14 @@ describe('fixed trace artifact runner', () => {
       .toThrow('incomplete or duplicated');
   });
 
-  it('rejects unused fixture-local definitions for routed and oracle execution', async () => {
+  it('rejects unused fixture-local definitions for routed, hybrid, and oracle execution', async () => {
     const selectedTrace = trace('knowledge-task-model');
-    for (const architectureArm of ['two_stage_llm_router', 'oracle_route_diagnostic'] as const) {
+    for (const architectureArm of ['two_stage_llm_router', 'deterministic_policy_llm_fallback_hybrid', 'oracle_route_diagnostic'] as const) {
       const router = new ScriptedProvider([]);
       await expect(runFixedTraceCase(selectedTrace, config(router, new ScriptedProvider([]), {
         architectureArm,
         toolDefinitions: [...TOOL_DEFINITIONS, tool('out_of_suite_fixture_tool')],
-      }))).rejects.toThrow('routed/oracle definitions must exactly match configured suite fixtures');
+      }))).rejects.toThrow('routed/hybrid/oracle definitions must exactly match configured suite fixtures');
       expect(router.respondCalls).toHaveLength(0);
     }
   });
@@ -939,14 +1079,14 @@ describe('fixed trace artifact runner', () => {
     await expect(runFixedTraceCase(firstTrace, config(missingRouter, new ScriptedProvider([]), {
       traceSuite: expandedSuite,
       toolDefinitions: TOOL_DEFINITIONS,
-    }))).rejects.toThrow('routed/oracle definitions must exactly match configured suite fixtures');
+    }))).rejects.toThrow('routed/hybrid/oracle definitions must exactly match configured suite fixtures');
     expect(missingRouter.respondCalls).toHaveLength(0);
 
     const duplicateRouter = new ScriptedProvider([]);
     await expect(runFixedTraceCase(firstTrace, config(duplicateRouter, new ScriptedProvider([]), {
       traceSuite: expandedSuite,
       toolDefinitions: [...definitions, fixtureDefinition],
-    }))).rejects.toThrow('routed/oracle definitions must exactly match configured suite fixtures');
+    }))).rejects.toThrow('routed/hybrid/oracle definitions must exactly match configured suite fixtures');
     expect(duplicateRouter.respondCalls).toHaveLength(0);
 
     const staleRouter = new ScriptedProvider([]);
@@ -1139,6 +1279,14 @@ describe('fixed trace artifact runner', () => {
       toolDefinitions: [invalidDefinition],
     }))).rejects.toMatchObject({ reason: 'tool_schema_invalid' });
     expect(invalidSchemaRouter.respondCalls).toHaveLength(0);
+
+    const hybridInvalidSchemaRouter = new ScriptedProvider([]);
+    await expect(runFixedTraceCase(expandedTrace, config(hybridInvalidSchemaRouter, new ScriptedProvider([]), {
+      traceSuite: [expandedTrace],
+      toolDefinitions: [invalidDefinition],
+      architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }))).rejects.toMatchObject({ reason: 'tool_schema_invalid' });
+    expect(hybridInvalidSchemaRouter.respondCalls).toHaveLength(0);
 
     const duplicateFixtureTrace = structuredClone(trace('knowledge-task-model'));
     duplicateFixtureTrace.toolFixtures = [

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -423,7 +423,16 @@ describe('fixed trace artifact runner', () => {
       answerRubric: ['different grade label'],
     };
 
-    expect(decide(answerLeakingChanges)).toMatchObject(decide(obvious));
+    // `quickMatchRoutingContext` intentionally reports measured local latency.
+    // The routing decision must remain fixture-independent, but wall-clock
+    // timing is not part of that stable decision contract.
+    const withoutLatency = (decision: ReturnType<typeof decideFixedTraceHybridRoute>) => ({
+      ...decision,
+      plan: decision.plan === null
+        ? null
+        : (({ latency_ms: _latencyMs, ...plan }) => plan)(decision.plan),
+    });
+    expect(withoutLatency(decide(answerLeakingChanges))).toEqual(withoutLatency(decide(obvious)));
     expect(decide(obvious)).toMatchObject({
       mode: 'local_terminal', reason: 'production_quick_match_terminal', plan: { action: 'ignore' },
     });

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -18,6 +18,8 @@ import {
 } from '../../../src/addie/eval/fixed-trace-budget.js';
 import {
   FIXED_TRACE_SUITE,
+  FIXED_TRACE_HYBRID_EVALUATOR_SUITE,
+  FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS,
   fixedTraceSuiteSha256,
   gradeFixedTrace,
   mutationInputProvenanceFailures,
@@ -28,6 +30,7 @@ import {
   admitFixedTraceDirectArm,
   decideFixedTraceHybridRoute,
   deriveFixedTraceDirectToolUniverse,
+  FixedTraceHybridAdmissionSnapshotError,
   fixedTraceHybridPolicy,
 } from '../../../src/addie/eval/fixed-trace-architecture.js';
 import { FAILED_LOOKUP_EVIDENCE_RESPONSE } from '../../../src/addie/failed-lookup-evidence.js';
@@ -472,9 +475,9 @@ describe('fixed trace artifact runner', () => {
     const policy = fixedTraceHybridPolicy();
     const decide = (input: Parameters<typeof decideFixedTraceHybridRoute>[0]) => decideFixedTraceHybridRoute({ ...input, policy });
     expect(decide({ message: 'attendee list for the summit', source: 'dm', isAdmin: false, isThread: false }))
-      .toMatchObject({ mode: 'llm_router_fallback', reason: 'tool_or_mutation_capability_requires_router' });
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'unsafe_or_ambiguous_message' });
     expect(decide({ message: 'send the invoice to the member', source: 'dm', isAdmin: false, isThread: false }))
-      .toMatchObject({ mode: 'llm_router_fallback', reason: 'no_production_quick_match' });
+      .toMatchObject({ mode: 'llm_router_fallback', reason: 'unsafe_or_ambiguous_message' });
     expect(decide({ message: 'thanks', source: 'dm', isAdmin: true, isThread: false }))
       .toMatchObject({ mode: 'llm_router_fallback', reason: 'admin_requires_router' });
     expect(decide({ message: 'thanks', source: 'dm', isAdmin: false, isThread: true }))
@@ -485,8 +488,135 @@ describe('fixed trace artifact runner', () => {
       .toMatchObject({ mode: 'llm_router_fallback', reason: 'channel_privacy_not_captured' });
   });
 
-  it('keeps routed tool definitions and generation execution identical after hybrid fallback', async () => {
+  it('fails closed for exact and adjacent mutation, tool, delimiter, negation, and control-byte bypasses', () => {
+    const policy = fixedTraceHybridPolicy();
+    const decide = (message: string) => decideFixedTraceHybridRoute({
+      message, source: 'channel', isAdmin: false, isThread: false, channelPrivacy: 'private', policy,
+    });
+    for (const message of [
+      'ship invoice now',
+      'delete it thanks',
+      'hi; delete user',
+      'not hi delete it',
+      'hi\u2028delete user',
+      'hi\0delete user',
+    ]) {
+      expect(decide(message)).toMatchObject({ mode: 'llm_router_fallback', reason: 'unsafe_or_ambiguous_message' });
+    }
+    expect(decide('hi')).toMatchObject({ mode: 'local_terminal', plan: { action: 'react', emoji: 'wave' } });
+    expect(decide('thanks')).toMatchObject({ mode: 'local_terminal', plan: { action: 'react', emoji: 'heart' } });
+  });
+
+  it('snapshots request facts before matching, catches matcher failures, and never dispatches an unsafe local request', async () => {
+    const policy = fixedTraceHybridPolicy();
+    const throwingMatcher = decideFixedTraceHybridRoute({
+      message: 'ok', source: 'dm', isAdmin: false, isThread: false, policy,
+      quickMatcher: () => { throw new Error('matcher failure'); },
+    });
+    expect(throwingMatcher).toMatchObject({ mode: 'llm_router_fallback', reason: 'quick_match_exception', plan: null });
+
+    const mutableInput = {
+      message: 'ok', source: 'dm' as const, isAdmin: false, isThread: false, policy,
+      quickMatcher: (snapshot: Readonly<{ message: string; source: 'dm' | 'channel'; isThread: boolean; isAAOAdmin: boolean }>) => {
+        mutableInput.message = 'delete user';
+        expect(snapshot).toEqual({ message: 'ok', source: 'dm', isThread: false, isAAOAdmin: false });
+        expect(Object.isFrozen(snapshot)).toBe(true);
+        return { action: 'ignore' as const, reason: 'synthetic', decision_method: 'quick_match' as const };
+      },
+    };
+    expect(decideFixedTraceHybridRoute(mutableInput)).toMatchObject({ mode: 'local_terminal', plan: { action: 'ignore' } });
+
+    const getterInput = Object.defineProperties({}, {
+      message: { get: () => { throw new Error('untrusted getter'); }, enumerable: true },
+      source: { value: 'dm', enumerable: true },
+      isAdmin: { value: false, enumerable: true },
+      isThread: { value: false, enumerable: true },
+      policy: { value: policy, enumerable: true },
+    });
+    expect(() => decideFixedTraceHybridRoute(getterInput as Parameters<typeof decideFixedTraceHybridRoute>[0]))
+      .toThrow(FixedTraceHybridAdmissionSnapshotError);
+    const proxyInput = new Proxy({ message: 'ok', source: 'dm', isAdmin: false, isThread: false, policy }, {
+      getOwnPropertyDescriptor: () => { throw new Error('untrusted proxy'); },
+    });
+    expect(() => decideFixedTraceHybridRoute(proxyInput as Parameters<typeof decideFixedTraceHybridRoute>[0]))
+      .toThrow(FixedTraceHybridAdmissionSnapshotError);
+
     const selectedTrace = trace('knowledge-task-model');
+    const unsafeTrace: FixedTraceCase = {
+      ...selectedTrace,
+      request: { source: 'dm', message: 'hi delete it', isAdmin: false, nowUtc: selectedTrace.request.nowUtc },
+    };
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const generation = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    await runFixedTraceCase(unsafeTrace, config(router, generation, {
+      traceSuite: [unsafeTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+    expect(router.respondCalls).toHaveLength(1);
+    expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('marks legacy hybrid replay as uncovered and exercises reviewed local admission only with the separate evaluator suite', async () => {
+    const policy = fixedTraceHybridPolicy();
+    const canonicalDecisions = FIXED_TRACE_SUITE.map((candidate) => decideFixedTraceHybridRoute({
+      message: candidate.request.message,
+      source: candidate.request.source,
+      isAdmin: candidate.request.isAdmin,
+      isThread: (candidate.request.threadContext?.length ?? 0) > 0,
+      channelPrivacy: candidate.request.channelPrivacy,
+      policy,
+    }));
+    expect(canonicalDecisions).toHaveLength(32);
+    expect(canonicalDecisions.every((decision) => decision.mode === 'llm_router_fallback')).toBe(true);
+
+    const legacyTrace = trace('knowledge-task-model');
+    const legacyRouter = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const legacyGeneration = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
+    const legacyObservations = await runFixedTraceSuite(config(legacyRouter, legacyGeneration, {
+      traceSuite: [legacyTrace], architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+    expect(summarizeFixedTraceRun(legacyObservations, [legacyTrace]).summary.hybridCoverage).toMatchObject({
+      plannerBound: false, localAdmissionCount: 0, sufficient: false, blocker: 'hybrid_evaluator_suite_not_bound',
+    });
+
+    const localObservations = await runFixedTraceSuite(config(new ScriptedProvider([]), new ScriptedProvider([]), {
+      traceSuite: FIXED_TRACE_HYBRID_EVALUATOR_SUITE,
+      architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+    }));
+    const coverage = summarizeFixedTraceRun(localObservations, FIXED_TRACE_HYBRID_EVALUATOR_SUITE).summary.hybridCoverage;
+    expect(coverage).toMatchObject({
+      plannerBound: true,
+      localAdmissionCount: FIXED_TRACE_HYBRID_MINIMUM_LOCAL_ADMISSIONS,
+      sufficient: true,
+      blocker: null,
+    });
+
+    // A local terminal result whose router metadata is not `not_run` is not
+    // admissible local-coverage evidence. This keeps the evidence gate
+    // fail-closed even when a serialized observation is internally invalid.
+    const zeroLocalCoverage = localObservations.map((observation) => ({
+      ...observation,
+      metadata: {
+        ...observation.metadata,
+        router: { ...observation.metadata.router, source: 'local' as const },
+      },
+    }));
+    expect(summarizeFixedTraceRun(zeroLocalCoverage, FIXED_TRACE_HYBRID_EVALUATOR_SUITE).summary.hybridCoverage)
+      .toMatchObject({
+        plannerBound: true,
+        localAdmissionCount: 0,
+        sufficient: false,
+        blocker: 'hybrid_local_admission_coverage_below_minimum',
+      });
+  });
+
+  it('keeps routed tool definitions and generation execution identical after hybrid fallback', async () => {
+    const selectedTrace: FixedTraceCase = {
+      ...trace('knowledge-task-model'),
+      request: {
+        ...trace('knowledge-task-model').request,
+        threadContext: [{ user: 'member', text: 'Please continue with the protocol explanation.' }],
+      },
+    };
     const incumbentRouter = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
     const incumbentGeneration = new ScriptedProvider([response([{ type: 'text', text: 'Synthetic answer.' }])]);
     await runFixedTraceCase(selectedTrace, config(incumbentRouter, incumbentGeneration, { traceSuite: [selectedTrace] }));
@@ -498,6 +628,7 @@ describe('fixed trace artifact runner', () => {
     }));
 
     expect(hybridRouter.respondCalls).toHaveLength(1);
+    expect(hybridRouter.respondCalls).toEqual(incumbentRouter.respondCalls);
     expect(hybridGeneration.respondCalls).toEqual(incumbentGeneration.respondCalls);
   });
 

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -106,6 +106,7 @@ function metadata(overrides: Partial<FixedTraceRunMetadata> = {}): FixedTraceRun
     providerDegradationInjectionEnabled: true,
     repetition: 1,
     architectureArm: fixedTraceArchitectureArm(),
+    hybridPolicy: null,
     toolUniverse: fixedTraceToolUniverseProvenance(),
     executionEnvelope: fixedTraceExecutionEnvelopeProvenance(),
     directArmAdmission: null,


### PR DESCRIPTION
## Summary
- add a diagnostic-only production quick-match admission arm with incumbent LLM-router fallback
- bind hybrid policy and diagnostic status into fixed-trace provenance and artifact identity
- cover no-oracle admission, fail-safe boundaries, router fallback, and provenance persistence

## Validation
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-*.test.ts`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/direct-slack-tool-selection.test.ts server/tests/unit/addie/slack-tool-selection.test.ts server/tests/unit/addie/web-tool-selection.test.ts server/tests/unit/addie/tavus-tool-selection.test.ts server/tests/unit/addie/provider-router-eval.test.ts`
- `npm run test:addie-tools`
- `git diff --check origin/main...HEAD`

`npm run typecheck` remains blocked by unrelated pre-existing fields in `server/src/training-agent/reporting-reliability.ts`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a664b49e-9ccf-47ee-9488-ccf94bc6c4b9)
