### PR TITLE
fix(addie): require exact OpenAI response model identity

### DIFF
--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -306,7 +306,10 @@ export class OpenAIResponsesProvider implements ModelProvider {
       { maxRetries: 0, signal: options.signal },
     );
     const normalized = normalizeOpenAIResponse(response);
-    if (normalized.model !== request.model && !normalized.model.startsWith(`${request.model}-`)) {
+    // Returned model identity is a billing and trust boundary. This adapter has
+    // no reviewed, literal canonical-alias allowlist, so aliases and suffixes
+    // must not inherit the requested model's approval or pricing.
+    if (normalized.model !== request.model) {
       throw new UnexpectedModelIdentityError('openai', request.model, normalized.model);
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -151,8 +151,8 @@ describe('fixed trace provider budget', () => {
       .toThrow('cache read accounting is unavailable');
   });
 
-  it('closes shared admission rather than settling an unapproved returned model at requested rates', async () => {
-    const mismatched = { ...RESPONSE, model: 'other-openai-model' };
+  it('closes shared admission rather than settling an attacker-controlled returned model suffix at requested rates', async () => {
+    const mismatched = { ...RESPONSE, model: 'gpt-5.6-luna-attacker-controlled' };
     const delegate = new BudgetScriptedProvider([mismatched, RESPONSE]);
     const budget = new FixedTraceBudget(1);
     const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -148,8 +148,41 @@ describe('OpenAIResponsesProvider', () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create.mock.calls[0][1]).toEqual({ maxRetries: 0, signal: undefined });
     expect(beforeDispatch).toHaveBeenCalledTimes(1);
+    expect(normalized.model).toBe(OPENAI_ROUTER_MODEL);
     expect(normalized.finishReason).toBe('stop');
     expect(normalized.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 0 });
+  });
+
+  it.each([
+    'gpt-5.6-luna-attacker-controlled',
+    'gpt-5.6-luna-2026-01-01',
+    'gpt-5.6-luna-latest',
+    'gpt-5.6-terra',
+    'anthropic-gpt-5.6-luna',
+  ])('rejects the unapproved returned OpenAI model identity %s', async (model) => {
+    const provider = new OpenAIResponsesProvider('unused', {
+      responses: { create: vi.fn().mockResolvedValue(openAIResponse({ model })) },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(OPENAI_ROUTER_MODEL))))
+      .rejects.toMatchObject({
+        name: 'UnexpectedModelIdentityError',
+        provider: 'openai',
+        expectedModel: OPENAI_ROUTER_MODEL,
+        actualModel: model,
+      });
+  });
+
+  it.each([
+    { model: '', label: 'empty' },
+    { model: undefined, label: 'missing' },
+  ])('rejects a $label returned OpenAI model identity', async ({ model }) => {
+    const provider = new OpenAIResponsesProvider('unused', {
+      responses: { create: vi.fn().mockResolvedValue(openAIResponse({ model })) },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(OPENAI_ROUTER_MODEL))))
+      .rejects.toThrow(`Malformed OpenAI response model`);
   });
 
   it('projects custom tools and stateless function-call continuation exactly', () => {


### PR DESCRIPTION
## Summary
- require literal equality between requested and returned OpenAI Responses model identities
- reject suffixes, date aliases, latest aliases, cross-model names, and provider-like names
- prove an attacker-controlled suffix remains unpriced and closes fixed-trace admission

## Validation
- npx vitest run --config server/vitest.config.ts server/tests/unit/addie/model-provider-openai-google.test.ts server/tests/unit/addie/fixed-trace-budget.test.ts server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts server/tests/unit/addie/fixed-trace-judge.test.ts server/tests/unit/addie/fixed-trace-runner.test.ts server/tests/unit/addie/fixed-trace-suite.test.ts
- npm run typecheck
- git diff --check

No canonical OpenAI response alias is accepted: the reviewed OpenAI pricing profile is exact_model_identity_v1, and no literal returned-model alias allowlist/evidence exists in this repository.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/89bc2c01-43f9-445e-b82c-118d6a72c196)
