### PR TITLE
fix(addie): require exact OpenAI response model identity

### DIFF
--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -306,7 +306,10 @@ export class OpenAIResponsesProvider implements ModelProvider {
       { maxRetries: 0, signal: options.signal },
     );
     const normalized = normalizeOpenAIResponse(response);
-    if (normalized.model !== request.model && !normalized.model.startsWith(`${request.model}-`)) {
+    // Returned model identity is a billing and trust boundary. This adapter has
+    // no reviewed, literal canonical-alias allowlist, so aliases and suffixes
+    // must not inherit the requested model's approval or pricing.
+    if (normalized.model !== request.model) {
       throw new UnexpectedModelIdentityError('openai', request.model, normalized.model);
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -151,8 +151,8 @@ describe('fixed trace provider budget', () => {
       .toThrow('cache read accounting is unavailable');
   });
 
-  it('closes shared admission rather than settling an unapproved returned model at requested rates', async () => {
-    const mismatched = { ...RESPONSE, model: 'other-openai-model' };
+  it('closes shared admission rather than settling an attacker-controlled returned model suffix at requested rates', async () => {
+    const mismatched = { ...RESPONSE, model: 'gpt-5.6-luna-attacker-controlled' };
     const delegate = new BudgetScriptedProvider([mismatched, RESPONSE]);
     const budget = new FixedTraceBudget(1);
     const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -148,8 +148,41 @@ describe('OpenAIResponsesProvider', () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(create.mock.calls[0][1]).toEqual({ maxRetries: 0, signal: undefined });
     expect(beforeDispatch).toHaveBeenCalledTimes(1);
+    expect(normalized.model).toBe(OPENAI_ROUTER_MODEL);
     expect(normalized.finishReason).toBe('stop');
     expect(normalized.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 0 });
+  });
+
+  it.each([
+    'gpt-5.6-luna-attacker-controlled',
+    'gpt-5.6-luna-2026-01-01',
+    'gpt-5.6-luna-latest',
+    'gpt-5.6-terra',
+    'anthropic-gpt-5.6-luna',
+  ])('rejects the unapproved returned OpenAI model identity %s', async (model) => {
+    const provider = new OpenAIResponsesProvider('unused', {
+      responses: { create: vi.fn().mockResolvedValue(openAIResponse({ model })) },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(OPENAI_ROUTER_MODEL))))
+      .rejects.toMatchObject({
+        name: 'UnexpectedModelIdentityError',
+        provider: 'openai',
+        expectedModel: OPENAI_ROUTER_MODEL,
+        actualModel: model,
+      });
+  });
+
+  it.each([
+    { model: '', label: 'empty' },
+    { model: undefined, label: 'missing' },
+  ])('rejects a $label returned OpenAI model identity', async ({ model }) => {
+    const provider = new OpenAIResponsesProvider('unused', {
+      responses: { create: vi.fn().mockResolvedValue(openAIResponse({ model })) },
+    });
+
+    await expect(collectModelResponse(provider.respond(request(OPENAI_ROUTER_MODEL))))
+      .rejects.toThrow(`Malformed OpenAI response model`);
   });
 
   it('projects custom tools and stateless function-call continuation exactly', () => {


### PR DESCRIPTION
Require the returned OpenAI Responses model identity to exactly match the requested Luna model so suffixes and aliases cannot inherit approval or pricing.

Adds mocked regressions for attacker-controlled suffix, arbitrary date, latest, Terra, provider-like, empty, and missing identities; preserves the fixed-trace attacker-suffix budget closure.

Checks passed:
- targeted OpenAI provider + fixed-trace budget tests (49)
- `npm run test:addie-fixed-traces` (51)
- `npm run test:addie-tools`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Also attempted `npm run test:server-unit`; stopped at the 600s bound after unrelated failures in `billing-admin-tenant-boundary.test.ts` and `authorization-epoch-session.test.ts`.

## Historical OpenAI returned-model evidence

Historical development live-eval runs provide the requested wire-identity confirmation (these are not final quality evidence):

- `fixed-traces-v31-openai-2026-09-04.json` — SHA-256 `79921e214b2b949938aa01414c8f75c778e682a76bb3c866043d4e98e8f5ad42`: 63 requested-model Luna objects; 60 non-null returned identities, all exactly `gpt-5.6-luna`; 3 null failures.
- `fixed-traces-v31-openai-2026-09-05-boundary-fix.json` — SHA-256 `3809e0cab580ce1195242d0f997849abc486bf097eb2c7e40ac232a1e96a7def`: 63 requested-model Luna objects; 61 non-null returned identities, all exactly `gpt-5.6-luna`; 2 null failures.

Across both runs, there were zero non-null alternate or snapshot identities. Exact equality remains intentional: if provider behavior changes to return a snapshot, alias, suffix, or any other non-identical identity, this boundary fails closed rather than accepting an unreviewed model identity for observation or pricing.