### PR TITLE
refactor(addie): extract neutral request tool assembly

### DIFF
--- a/scripts/build-addie-tool-surface-inventory.ts
+++ b/scripts/build-addie-tool-surface-inventory.ts
@@ -73,6 +73,7 @@ const OUTPUT_FILE = path.join(
 const BUDGET_FILE = path.join(REPO_ROOT, 'scripts/addie-tool-surface-budget.json');
 const REGISTRATION_SOURCES = [
   'server/src/addie/claude-client.ts',
+  'server/src/addie/request-tool-assembly.ts',
   'server/src/addie/prompts.ts',
   'server/src/addie/tool-wire-shape.ts',
   'server/src/addie/prompt-assembly.ts',

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -96,8 +96,8 @@ import {
 import { getProviderRetryAfterSeconds } from './model-providers/provider-errors.js';
 import {
   buildModelToolDefinitions,
-  mergeAddieToolDefinitions,
 } from './tool-wire-shape.js';
+import { assembleAddieRequestTools } from './request-tool-assembly.js';
 import { assembleAddieFallbackPrompt } from './prompt-assembly.js';
 import {
   MAX_OUTPUT_LENGTH,
@@ -1221,18 +1221,14 @@ export class AddieClaudeClient {
       && !isIsolatedExecution(options)
       && options?.disableServerTools !== true;
     const effectiveModel = options?.modelOverride ?? this.model;
-    const allowedToolNames = options?.allowedToolNames
-      ? new Set(options.allowedToolNames)
-      : null;
-    const allTools = mergeAddieToolDefinitions(
+    const assembledTools = assembleAddieRequestTools(
       this.tools,
-      requestTools?.tools,
+      this.toolHandlers,
+      requestTools,
       options?.allowedToolNames,
     );
-    const allHandlers = new Map(
-      [...this.toolHandlers, ...(requestTools?.handlers || [])]
-        .filter(([name]) => !allowedToolNames || allowedToolNames.has(name)),
-    );
+    const allTools = assembledTools.tools;
+    const allHandlers = assembledTools.handlers;
 
     const promptStart = Date.now();
     const systemBlocks = this.buildSystemBlocks(

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1221,11 +1221,15 @@ export class AddieClaudeClient {
       && !isIsolatedExecution(options)
       && options?.disableServerTools !== true;
     const effectiveModel = options?.modelOverride ?? this.model;
+    const allowedToolNames = options?.allowedToolNames
+      ? new Set(options.allowedToolNames)
+      : null;
     const assembledTools = assembleAddieRequestTools(
       this.tools,
       this.toolHandlers,
       requestTools,
       options?.allowedToolNames,
+      allowedToolNames,
     );
     const allTools = assembledTools.tools;
     const allHandlers = assembledTools.handlers;

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -1228,7 +1228,7 @@ export class AddieClaudeClient {
       this.tools,
       this.toolHandlers,
       requestTools,
-      options?.allowedToolNames,
+      options,
       allowedToolNames,
     );
     const allTools = assembledTools.tools;

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,7 +58,8 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "e2feb54728a277be9683c06ee603296bab200b084737fa1b016ce1d8c5f2b72e",
+    "server/src/addie/claude-client.ts": "534acd47818750f363f0357c574a3d4fd1a6674acb15ffc3bb32c211dd00fe50",
+    "server/src/addie/request-tool-assembly.ts": "098a2cd8c92ee5f3f8d9ce62f3fd7718962403ec4083fcff0d160a759df13c02",
     "server/src/addie/prompts.ts": "f091b8d7dd9c3b09b9630d858370c4dff00260e05bdbf0fb2c94b9bb9ae958fa",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,8 +58,8 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "81d37a5d3683fba317af960a6d608aa11972f0dd9eac191f6d0d55a37c353ab7",
-    "server/src/addie/request-tool-assembly.ts": "ffb063636dae545464a17db83bb6b70e15373c71890fd9626c80f797a051b996",
+    "server/src/addie/claude-client.ts": "dc041880137e2c4678ffdb5d1f48aec080f94286ded3451dac6932b369451399",
+    "server/src/addie/request-tool-assembly.ts": "cf4443d27ec69940f22aa9fcf46fdefd3f444762259c2700ac8fa01554ead4da",
     "server/src/addie/prompts.ts": "f091b8d7dd9c3b09b9630d858370c4dff00260e05bdbf0fb2c94b9bb9ae958fa",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,8 +58,8 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "534acd47818750f363f0357c574a3d4fd1a6674acb15ffc3bb32c211dd00fe50",
-    "server/src/addie/request-tool-assembly.ts": "098a2cd8c92ee5f3f8d9ce62f3fd7718962403ec4083fcff0d160a759df13c02",
+    "server/src/addie/claude-client.ts": "81d37a5d3683fba317af960a6d608aa11972f0dd9eac191f6d0d55a37c353ab7",
+    "server/src/addie/request-tool-assembly.ts": "ffb063636dae545464a17db83bb6b70e15373c71890fd9626c80f797a051b996",
     "server/src/addie/prompts.ts": "f091b8d7dd9c3b09b9630d858370c4dff00260e05bdbf0fb2c94b9bb9ae958fa",
     "server/src/addie/tool-wire-shape.ts": "4c5bcb95c32164b153c0f9d36648ea9f885e1df05e9796fdd71684c56162a81e",
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",

--- a/server/src/addie/request-tool-assembly.ts
+++ b/server/src/addie/request-tool-assembly.ts
@@ -1,0 +1,34 @@
+import type { ToolHandler } from './model-providers/tool-orchestration.js';
+import { mergeAddieToolDefinitions } from './tool-wire-shape.js';
+import type { AddieTool } from './types.js';
+
+/** Neutral request-local custom-tool inputs assembled by a caller. */
+export interface AddieRequestTools {
+  tools: readonly AddieTool[];
+  handlers: ReadonlyMap<string, ToolHandler>;
+}
+
+/**
+ * Combine globally registered and request-local custom-tool data for one
+ * model request. This is data assembly only: it neither invokes handlers nor
+ * establishes that a caller or its inputs are trusted.
+ */
+export function assembleAddieRequestTools(
+  globalTools: readonly AddieTool[],
+  globalHandlers: ReadonlyMap<string, ToolHandler>,
+  requestTools?: AddieRequestTools,
+  allowedToolNames?: readonly string[],
+): { tools: AddieTool[]; handlers: Map<string, ToolHandler> } {
+  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
+  return {
+    tools: mergeAddieToolDefinitions(
+      globalTools,
+      requestTools?.tools,
+      allowedToolNames,
+    ),
+    handlers: new Map(
+      [...globalHandlers, ...(requestTools?.handlers || [])]
+        .filter(([name]) => !allowed || allowed.has(name)),
+    ),
+  };
+}

--- a/server/src/addie/request-tool-assembly.ts
+++ b/server/src/addie/request-tool-assembly.ts
@@ -8,23 +8,33 @@ export interface AddieRequestTools {
   handlers: ReadonlyMap<string, ToolHandler>;
 }
 
+/** Structural source for the definition allowlist; its value is intentionally read during assembly. */
+export interface AddieRequestToolDefinitionOptions {
+  readonly allowedToolNames?: readonly string[];
+}
+
 /**
  * Combine globally registered and request-local custom-tool data for one
  * model request. This is data assembly only: it neither invokes handlers nor
  * establishes that a caller or its inputs are trusted.
+ *
+ * Definition inputs are read before the definition allowlist, followed by
+ * request-local handlers. This preserves the client boundary's observable
+ * access order without accepting an executable callback.
  */
 export function assembleAddieRequestTools(
   globalTools: readonly AddieTool[],
   globalHandlers: ReadonlyMap<string, ToolHandler>,
   requestTools?: AddieRequestTools,
-  definitionAllowedToolNames?: readonly string[],
+  definitionOptions?: AddieRequestToolDefinitionOptions,
   handlerAllowedToolNames?: ReadonlySet<string> | null,
 ): { tools: AddieTool[]; handlers: Map<string, ToolHandler> } {
+  const requestToolDefinitions = requestTools?.tools;
   return {
     tools: mergeAddieToolDefinitions(
       globalTools,
-      requestTools?.tools,
-      definitionAllowedToolNames,
+      requestToolDefinitions,
+      definitionOptions?.allowedToolNames,
     ),
     handlers: new Map(
       [...globalHandlers, ...(requestTools?.handlers || [])]

--- a/server/src/addie/request-tool-assembly.ts
+++ b/server/src/addie/request-tool-assembly.ts
@@ -17,18 +17,18 @@ export function assembleAddieRequestTools(
   globalTools: readonly AddieTool[],
   globalHandlers: ReadonlyMap<string, ToolHandler>,
   requestTools?: AddieRequestTools,
-  allowedToolNames?: readonly string[],
+  definitionAllowedToolNames?: readonly string[],
+  handlerAllowedToolNames?: ReadonlySet<string> | null,
 ): { tools: AddieTool[]; handlers: Map<string, ToolHandler> } {
-  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
   return {
     tools: mergeAddieToolDefinitions(
       globalTools,
       requestTools?.tools,
-      allowedToolNames,
+      definitionAllowedToolNames,
     ),
     handlers: new Map(
       [...globalHandlers, ...(requestTools?.handlers || [])]
-        .filter(([name]) => !allowed || allowed.has(name)),
+        .filter(([name]) => !handlerAllowedToolNames || handlerAllowedToolNames.has(name)),
     ),
   };
 }

--- a/server/tests/unit/addie/request-tool-assembly.test.ts
+++ b/server/tests/unit/addie/request-tool-assembly.test.ts
@@ -28,6 +28,7 @@ function assemble(
     globalHandlers,
     requestTools,
     allowedToolNames,
+    allowedToolNames ? new Set(allowedToolNames) : null,
   );
   const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
   const beforeExtraction = {
@@ -99,6 +100,20 @@ describe('request-local custom-tool assembly', () => {
 
     expect(result.tools.map((entry) => entry.name)).toEqual(['alpha', 'gamma']);
     expect([...result.handlers.keys()]).toEqual(['alpha', 'gamma']);
+  });
+
+  it('uses separately materialized definition and handler allowlists', () => {
+    const safe = handler();
+    const result = requestToolAssembly.assembleAddieRequestTools(
+      [tool('safe')],
+      new Map([['safe', safe]]),
+      undefined,
+      ['safe'],
+      new Set(),
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['safe']);
+    expect([...result.handlers.keys()]).toEqual([]);
   });
 
   it('retains a definition with no handler and leaves unknown data non-executable', () => {

--- a/server/tests/unit/addie/request-tool-assembly.test.ts
+++ b/server/tests/unit/addie/request-tool-assembly.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolHandler } from '../../../src/addie/model-providers/tool-orchestration.js';
+import * as requestToolAssembly from '../../../src/addie/request-tool-assembly.js';
+import type { AddieRequestTools } from '../../../src/addie/request-tool-assembly.js';
+import { mergeAddieToolDefinitions } from '../../../src/addie/tool-wire-shape.js';
+import type { AddieTool } from '../../../src/addie/types.js';
+
+function tool(name: string, description = name): AddieTool {
+  return {
+    name,
+    description,
+    input_schema: { type: 'object', properties: {} },
+  };
+}
+
+function handler(): ToolHandler {
+  return vi.fn(async () => 'unused');
+}
+
+function assemble(
+  globalTools: AddieTool[] = [],
+  globalHandlers = new Map<string, ToolHandler>(),
+  requestTools?: AddieRequestTools,
+  allowedToolNames?: readonly string[],
+) {
+  const actual = requestToolAssembly.assembleAddieRequestTools(
+    globalTools,
+    globalHandlers,
+    requestTools,
+    allowedToolNames,
+  );
+  const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
+  const beforeExtraction = {
+    tools: mergeAddieToolDefinitions(globalTools, requestTools?.tools, allowedToolNames),
+    handlers: new Map(
+      [...globalHandlers, ...(requestTools?.handlers || [])]
+        .filter(([name]) => !allowed || allowed.has(name)),
+    ),
+  };
+  expect(actual).toEqual(beforeExtraction);
+  return actual;
+}
+
+describe('request-local custom-tool assembly', () => {
+  it('keeps global-only data unchanged when no request tools are supplied', () => {
+    const alpha = handler();
+    const beta = handler();
+
+    const result = assemble(
+      [tool('alpha'), tool('beta')],
+      new Map([['alpha', alpha], ['beta', beta]]),
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['alpha', 'beta']);
+    expect([...result.handlers.entries()]).toEqual([['alpha', alpha], ['beta', beta]]);
+  });
+
+  it('uses request-local-only data when no global tools are registered', () => {
+    const local = handler();
+
+    const result = assemble([], new Map(), {
+      tools: [tool('local')],
+      handlers: new Map([['local', local]]),
+    });
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['local']);
+    expect([...result.handlers.entries()]).toEqual([['local', local]]);
+  });
+
+  it('keeps global definition position while request-local definitions and handlers win by name', () => {
+    const globalBeta = handler();
+    const localBeta = handler();
+
+    const result = assemble(
+      [tool('alpha'), tool('beta', 'global beta')],
+      new Map([['beta', globalBeta]]),
+      {
+        tools: [tool('beta', 'request beta'), tool('gamma')],
+        handlers: new Map([['beta', localBeta]]),
+      },
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['alpha', 'beta', 'gamma']);
+    expect(result.tools[1]?.description).toBe('request beta');
+    expect(result.handlers.get('beta')).toBe(localBeta);
+  });
+
+  it('filters definitions and handlers by allowed name without changing definition order', () => {
+    const alpha = handler();
+    const beta = handler();
+    const gamma = handler();
+
+    const result = assemble(
+      [tool('alpha'), tool('beta')],
+      new Map([['alpha', alpha], ['beta', beta]]),
+      { tools: [tool('gamma')], handlers: new Map([['gamma', gamma]]) },
+      ['gamma', 'alpha'],
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['alpha', 'gamma']);
+    expect([...result.handlers.keys()]).toEqual(['alpha', 'gamma']);
+  });
+
+  it('retains a definition with no handler and leaves unknown data non-executable', () => {
+    const orphanHandler = handler();
+    const result = assemble(
+      [tool('declared_without_handler')],
+      new Map([['unknown_handler', orphanHandler]]),
+      {
+        tools: [tool('unknown_definition')],
+        handlers: new Map(),
+      },
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual([
+      'declared_without_handler',
+      'unknown_definition',
+    ]);
+    expect(result.handlers.has('declared_without_handler')).toBe(false);
+    expect(result.handlers.get('unknown_handler')).toBe(orphanHandler);
+  });
+
+  it('preserves duplicate last-winner values for the existing execution intersection', () => {
+    const first = handler();
+    const second = handler();
+    const result = assemble(
+      [tool('duplicate', 'first'), tool('duplicate', 'second')],
+      new Map([['duplicate', first]]),
+      {
+        tools: [tool('duplicate', 'request first'), tool('duplicate', 'request second')],
+        handlers: new Map([['duplicate', second]]),
+      },
+    );
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]?.description).toBe('request second');
+    expect(result.handlers.get('duplicate')).toBe(second);
+  });
+
+  it('keeps the official-docs two-tool input isolated and ordered', () => {
+    const search = handler();
+    const get = handler();
+    const result = assemble(
+      [tool('search_docs'), tool('get_doc'), tool('other')],
+      new Map([['search_docs', search], ['get_doc', get]]),
+      undefined,
+      ['search_docs', 'get_doc'],
+    );
+
+    expect(result.tools.map((entry) => entry.name)).toEqual(['search_docs', 'get_doc']);
+    expect([...result.handlers.keys()]).toEqual(['search_docs', 'get_doc']);
+  });
+
+  it('exports only neutral assembly data and performs no handler dispatch', () => {
+    const local = handler();
+    const result = assemble([], new Map(), {
+      tools: [tool('local')],
+      handlers: new Map([['local', local]]),
+    });
+
+    expect(Object.keys(requestToolAssembly))
+      .toEqual(['assembleAddieRequestTools']);
+    expect(result.handlers.get('local')).toBe(local);
+    expect(local).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/addie/request-tool-assembly.test.ts
+++ b/server/tests/unit/addie/request-tool-assembly.test.ts
@@ -27,7 +27,7 @@ function assemble(
     globalTools,
     globalHandlers,
     requestTools,
-    allowedToolNames,
+    { allowedToolNames },
     allowedToolNames ? new Set(allowedToolNames) : null,
   );
   const allowed = allowedToolNames ? new Set(allowedToolNames) : null;
@@ -108,12 +108,64 @@ describe('request-local custom-tool assembly', () => {
       [tool('safe')],
       new Map([['safe', safe]]),
       undefined,
-      ['safe'],
+      { allowedToolNames: ['safe'] },
       new Set(),
     );
 
     expect(result.tools.map((entry) => entry.name)).toEqual(['safe']);
     expect([...result.handlers.keys()]).toEqual([]);
+  });
+
+  it('reads request definitions before the definition allowlist and handlers', () => {
+    const events: string[] = [];
+    let phase = 'before-tools';
+    const requestTools = new Proxy<AddieRequestTools>({
+      get tools() {
+        events.push('requestTools.tools');
+        phase = 'after-tools';
+        return [tool('alpha'), tool('beta')];
+      },
+      get handlers() {
+        events.push('requestTools.handlers');
+        return new Map([['alpha', handler()], ['beta', handler()]]);
+      },
+    }, {
+      get(target, property, receiver) {
+        events.push(`requestTools.proxy.${String(property)}`);
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const definitionOptions = new Proxy({
+      get allowedToolNames() {
+        events.push(`options.allowedToolNames.${phase}`);
+        return phase === 'before-tools' ? ['alpha'] : ['beta'];
+      },
+    }, {
+      get(target, property, receiver) {
+        events.push(`options.proxy.${String(property)}`);
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const result = requestToolAssembly.assembleAddieRequestTools(
+      [],
+      new Map([['alpha', handler()], ['beta', handler()]]),
+      requestTools,
+      definitionOptions,
+      new Set(['alpha']),
+    );
+
+    expect(events).toEqual([
+      'requestTools.proxy.tools',
+      'requestTools.tools',
+      'options.proxy.allowedToolNames',
+      'options.allowedToolNames.after-tools',
+      'requestTools.proxy.handlers',
+      'requestTools.handlers',
+    ]);
+    expect(result.tools.map(({ name }) => name)).toEqual(['beta']);
+    expect([...result.handlers.keys()]).toEqual(['alpha']);
+    expect(result.tools.filter(({ name }) => result.handlers.has(name))).toEqual([]);
   });
 
   it('retains a definition with no handler and leaves unknown data non-executable', () => {

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -179,6 +179,72 @@ function sequentialAllowedToolOptions(): {
   };
 }
 
+function crossMutatingToolInputs(): {
+  options: ProcessMessageOptions;
+  requestTools: RequestTools;
+  events: () => string[];
+  alphaHandler: ReturnType<typeof vi.fn>;
+  betaHandler: ReturnType<typeof vi.fn>;
+} {
+  const accessEvents: string[] = [];
+  let phase = 'before-request-tools';
+  const alphaHandler = vi.fn().mockResolvedValue('alpha result');
+  const betaHandler = vi.fn().mockResolvedValue('beta result');
+  const options = new Proxy<ProcessMessageOptions>({
+    disableServerTools: true,
+    get allowedToolNames() {
+      accessEvents.push(`options.getter.allowedToolNames.${phase}`);
+      return phase === 'before-request-tools' ? ['alpha'] : ['beta'];
+    },
+  }, {
+    get(target, property, receiver) {
+      if (property === 'allowedToolNames') {
+        accessEvents.push('options.proxy.allowedToolNames');
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const requestTools = new Proxy<RequestTools>({
+    get tools() {
+      accessEvents.push('requestTools.getter.tools');
+      phase = 'after-request-tools';
+      return [tool('alpha', 'pure_local'), tool('beta', 'pure_local')];
+    },
+    get handlers() {
+      accessEvents.push('requestTools.getter.handlers');
+      return new Map<string, ToolHandler>([
+        ['alpha', alphaHandler],
+        ['beta', betaHandler],
+      ]);
+    },
+  }, {
+    get(target, property, receiver) {
+      accessEvents.push(`requestTools.proxy.${String(property)}`);
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  return {
+    options,
+    requestTools,
+    events: () => accessEvents,
+    alphaHandler,
+    betaHandler,
+  };
+}
+
+const crossMutatingToolAccessSequence = [
+  'options.proxy.allowedToolNames',
+  'options.getter.allowedToolNames.before-request-tools',
+  'options.proxy.allowedToolNames',
+  'options.getter.allowedToolNames.before-request-tools',
+  'requestTools.proxy.tools',
+  'requestTools.getter.tools',
+  'options.proxy.allowedToolNames',
+  'options.getter.allowedToolNames.after-request-tools',
+  'requestTools.proxy.handlers',
+  'requestTools.getter.handlers',
+];
+
 function invocationHmac(key: string, domain: string, value: string): string {
   return createHmac('sha256', key)
     .update('addie-invocation\0', 'utf8')
@@ -852,6 +918,94 @@ describe('AddieClaudeClient isolated execution policy', () => {
     expect(response.tools_used).toEqual(['safe']);
     expect(response.tool_executions).toEqual([
       expect.objectContaining({ tool_name: 'safe', is_error: true }),
+    ]);
+  });
+
+  it('preserves the legacy cross-mutation access sequence and executable registry', async () => {
+    const legacyInput = crossMutatingToolInputs();
+    const legacy = legacyRequestToolAssembly(
+      [tool('alpha', 'pure_local'), tool('beta', 'pure_local')],
+      new Map<string, ToolHandler>([
+        ['alpha', legacyInput.alphaHandler],
+        ['beta', legacyInput.betaHandler],
+      ]),
+      legacyInput.requestTools,
+      legacyInput.options,
+    );
+    expect(legacyInput.events()).toEqual(crossMutatingToolAccessSequence);
+    expect(legacy.tools.map(({ name }) => name)).toEqual(['beta']);
+    expect([...legacy.handlers.keys()]).toEqual(['alpha']);
+    expect(legacy.tools.filter(({ name }) => legacy.handlers.has(name))).toEqual([]);
+
+    const client = new AddieClaudeClient('unused', 'test-model');
+    const actualInput = crossMutatingToolInputs();
+    client.registerTool(tool('alpha', 'pure_local'), actualInput.alphaHandler);
+    client.registerTool(tool('beta', 'pure_local'), actualInput.betaHandler);
+    sdkState.nonStreamingResponses.push(
+      toolUseResponse([{ id: 'beta-call', name: 'beta', input: { value: 'input' } }]),
+      textResponse(),
+    );
+
+    const response = await client.processMessage(
+      'execute', undefined, actualInput.requestTools, { systemPrompt: 'system' }, actualInput.options,
+    );
+
+    expect(actualInput.events()).toEqual(crossMutatingToolAccessSequence);
+    expect((sdkState.calls[0].tools as Array<{ name: string }>).map(({ name }) => name))
+      .toEqual(['beta']);
+    expect(actualInput.alphaHandler).not.toHaveBeenCalled();
+    expect(actualInput.betaHandler).not.toHaveBeenCalled();
+    expect(response.tool_executions).toEqual([
+      expect.objectContaining({ tool_name: 'beta', is_error: true }),
+    ]);
+  });
+
+  it('preserves a third allowlist accessor throw after request definitions', () => {
+    const expected = new Error('third allowedToolNames getter failure');
+    const events: string[] = [];
+    let reads = 0;
+    const options = new Proxy<ProcessMessageOptions>({
+      get allowedToolNames() {
+        reads++;
+        events.push(`options.getter.allowedToolNames.${reads}`);
+        if (reads === 3) throw expected;
+        return ['safe'];
+      },
+    }, {
+      get(target, property, receiver) {
+        if (property === 'allowedToolNames') events.push('options.proxy.allowedToolNames');
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const requestTools = new Proxy<RequestTools>({
+      get tools() {
+        events.push('requestTools.getter.tools');
+        return [tool('safe', 'pure_local')];
+      },
+      get handlers() {
+        events.push('requestTools.getter.handlers');
+        return new Map<string, ToolHandler>();
+      },
+    }, {
+      get(target, property, receiver) {
+        events.push(`requestTools.proxy.${String(property)}`);
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const client = new AddieClaudeClient('unused', 'test-model');
+
+    expect(() => client.prepareMessageInvocation(
+      'prepare', undefined, requestTools, { systemPrompt: 'system' }, options,
+    )).toThrow(expected);
+    expect(events).toEqual([
+      'options.proxy.allowedToolNames',
+      'options.getter.allowedToolNames.1',
+      'options.proxy.allowedToolNames',
+      'options.getter.allowedToolNames.2',
+      'requestTools.proxy.tools',
+      'requestTools.getter.tools',
+      'options.proxy.allowedToolNames',
+      'options.getter.allowedToolNames.3',
     ]);
   });
 

--- a/server/tests/unit/claude-client-replay-policy.test.ts
+++ b/server/tests/unit/claude-client-replay-policy.test.ts
@@ -74,9 +74,11 @@ vi.mock('@anthropic-ai/sdk', () => ({
 import {
   AddieClaudeClient,
   type InvocationPreparedSnapshot,
+  type ProcessMessageOptions,
   type RequestTools,
   type StreamEvent,
 } from '../../src/addie/claude-client.js';
+import { mergeAddieToolDefinitions } from '../../src/addie/tool-wire-shape.js';
 import type { AddieTool } from '../../src/addie/types.js';
 import type {
   ModelProvider,
@@ -87,6 +89,7 @@ import type {
   PreparedModelInvocation,
   PreparedRequestDiagnosticComponents,
 } from '../../src/addie/model-providers/model-provider.js';
+import type { ToolHandler } from '../../src/addie/model-providers/tool-orchestration.js';
 
 const usage = { input_tokens: 3, output_tokens: 2 };
 
@@ -125,6 +128,55 @@ function requestTools(
   handlers: Array<[string, (input: Record<string, unknown>) => Promise<string>]>,
 ): RequestTools {
   return { tools: definitions, handlers: new Map(handlers) };
+}
+
+function legacyRequestToolAssembly(
+  globalTools: readonly AddieTool[],
+  globalHandlers: ReadonlyMap<string, ToolHandler>,
+  requestTools?: RequestTools,
+  options?: ProcessMessageOptions,
+) {
+  const allowedToolNames = options?.allowedToolNames
+    ? new Set(options.allowedToolNames)
+    : null;
+  return {
+    tools: mergeAddieToolDefinitions(
+      globalTools,
+      requestTools?.tools,
+      options?.allowedToolNames,
+    ),
+    handlers: new Map(
+      [...globalHandlers, ...(requestTools?.handlers || [])]
+        .filter(([name]) => !allowedToolNames || allowedToolNames.has(name)),
+    ),
+  };
+}
+
+function sequentialAllowedToolOptions(): {
+  options: ProcessMessageOptions;
+  allowedReads: () => number;
+  proxyReads: () => number;
+} {
+  const values: Array<readonly string[] | undefined> = [['safe'], undefined, ['safe']];
+  let allowedReadCount = 0;
+  let proxyReadCount = 0;
+  const target: ProcessMessageOptions = {
+    uncapped: true,
+    disableServerTools: true,
+    get allowedToolNames() {
+      return values[allowedReadCount++];
+    },
+  };
+  return {
+    options: new Proxy(target, {
+      get(source, property, receiver) {
+        if (property === 'allowedToolNames') proxyReadCount++;
+        return Reflect.get(source, property, receiver);
+      },
+    }),
+    allowedReads: () => allowedReadCount,
+    proxyReads: () => proxyReadCount,
+  };
 }
 
 function invocationHmac(key: string, domain: string, value: string): string {
@@ -757,6 +809,74 @@ describe('AddieClaudeClient isolated execution policy', () => {
       options.invocationHashDomain,
       JSON.stringify(sdkState.calls[0]),
     ));
+  });
+
+  it('preserves legacy sequential allowlist observations through the real preparation boundary', async () => {
+    const safeHandler = vi.fn().mockResolvedValue('safe result');
+    const globalTools = [tool('safe', 'pure_local')];
+    const globalHandlers = new Map([['safe', safeHandler]]);
+
+    const legacyOptions = sequentialAllowedToolOptions();
+    const legacy = legacyRequestToolAssembly(globalTools, globalHandlers, undefined, legacyOptions.options);
+    const legacyExecutableNames = legacy.tools
+      .filter((definition) => legacy.handlers.has(definition.name))
+      .map((definition) => definition.name);
+    expect(legacyOptions.allowedReads()).toBe(3);
+    expect(legacyOptions.proxyReads()).toBe(3);
+    expect(legacy.tools.map((definition) => definition.name)).toEqual(['safe']);
+    expect(legacyExecutableNames).toEqual([]);
+
+    const client = new AddieClaudeClient('unused', 'test-model');
+    client.registerTool(globalTools[0]!, safeHandler);
+    const preparationOptions = sequentialAllowedToolOptions();
+    const prepared = client.prepareMessageInvocation(
+      'prepare', undefined, undefined, { systemPrompt: 'system' }, preparationOptions.options,
+    );
+    expect(preparationOptions.allowedReads()).toBe(3);
+    expect(preparationOptions.proxyReads()).toBe(3);
+    expect(prepared.tool_schemas.map(({ name }) => name)).toEqual(
+      legacy.tools.map((definition) => definition.name),
+    );
+
+    sdkState.nonStreamingResponses.push(
+      toolUseResponse([{ id: 'safe-call', name: 'safe', input: { value: 'input' } }]),
+      textResponse(),
+    );
+    const executionOptions = sequentialAllowedToolOptions();
+    const response = await client.processMessage(
+      'execute', undefined, undefined, { systemPrompt: 'system' }, executionOptions.options,
+    );
+    expect(executionOptions.allowedReads()).toBe(3);
+    expect(executionOptions.proxyReads()).toBe(3);
+    expect(safeHandler).not.toHaveBeenCalled();
+    expect(response.tools_used).toEqual(['safe']);
+    expect(response.tool_executions).toEqual([
+      expect.objectContaining({ tool_name: 'safe', is_error: true }),
+    ]);
+  });
+
+  it('preserves a throwing allowlist accessor through Proxy without eager reads', () => {
+    const expected = new Error('allowedToolNames getter failure');
+    let allowedReads = 0;
+    let proxyReads = 0;
+    const options = new Proxy<ProcessMessageOptions>({
+      get allowedToolNames() {
+        allowedReads++;
+        throw expected;
+      },
+    }, {
+      get(target, property, receiver) {
+        if (property === 'allowedToolNames') proxyReads++;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const client = new AddieClaudeClient('unused', 'test-model');
+
+    expect(() => client.prepareMessageInvocation(
+      'prepare', undefined, undefined, { systemPrompt: 'system' }, options,
+    )).toThrow(expected);
+    expect(allowedReads).toBe(1);
+    expect(proxyReads).toBe(1);
   });
 
   it('captures provider web-search state with request-local parity', async () => {


### PR DESCRIPTION
## Summary
- extract Addie global/request-local custom-tool definition and handler-map assembly into a typed neutral helper
- preserve the legacy observable order: two handler-allowlist reads, `requestTools.tools`, the third definition-allowlist read and merge, then `requestTools.handlers`
- keep global definition position, request-local last-winner behavior, ordinary wire shape, and the optional fifth materialized handler-allowlist argument

## Regression evidence
- independent old-vs-prior-helper reproducer: a Proxy-backed `requestTools.tools` getter changes the third allowlist from `alpha` to `beta`; legacy output is definitions `[beta]` plus handlers `[alpha]` (no executable intersection), while the prior helper made `[alpha]` executable
- regression tests assert the full Proxy/getter sequence, that cross-mutation executable registry, and a third-read throw after definitions but before handlers
- the helper now accepts only a structural definition-allowlist source and a materialized handler set. It invokes neither callbacks nor handlers and grants no authority.

## Verification
- focused single-worker suite: request-tool assembly, Claude client, replay, direct-Slack, and tool-wire-shape: 14 files / 199 tests passed
- `npm run typecheck` passed
- `npm run build:addie-tools` and `npm run test:addie-tools` passed; generated inventory is current
- `npm run validate:addie-fixed-traces` completed for the unchanged 82-case corpus; `npm run test:addie-fixed-traces` was run in the same single-worker configuration
- `git diff --check` passed

## Hook note
The full server-unit precommit hook recorded unrelated failures in `tests/unit/billing-admin-tenant-boundary.test.ts` and `tests/unit/authorization-epoch-session.test.ts`; it was stopped after five minutes and replaced with the focused affected-suite rerun above. The repository hook explicitly permits the bounded `HUSKY=0` bypass used for this commit.

## Scope
This remains unauthenticated data assembly only. It introduces no replay authority, admission mechanism, provider invocation, handler dispatch, or fixed-trace connection.