### PR TITLE
fix(addie): enforce common fixed-trace tool universe

### DIFF
--- a/server/src/addie/direct-tool-universe.ts
+++ b/server/src/addie/direct-tool-universe.ts
@@ -134,7 +134,9 @@ export function createSyntheticDirectToolReceiptHandlers(
       toolName: tool.definition.name,
       definitionSha256: tool.definitionSha256,
       handlerProvenance: 'evaluator_simulated_receipt',
-      receiptHandlerIdentitySha256: sha256(`evaluator-receipt/${tool.definition.name}/${tool.definitionSha256}`),
+      // The receipt must repeat the exact handler identity included in the
+      // universe binding, not a parallel descriptive hash.
+      receiptHandlerIdentitySha256: tool.handlerIdentitySha256,
       definitionHandlerSha256: universe.definitionHandlerSha256,
     } satisfies SyntheticDirectToolReceipt),
   })));

--- a/server/src/addie/direct-tool-universe.ts
+++ b/server/src/addie/direct-tool-universe.ts
@@ -54,6 +54,19 @@ export interface SyntheticDirectToolReceipt {
   readonly definitionHandlerSha256: string;
 }
 
+/**
+ * A frozen evaluator-only receipt handler bound to one captured definition.
+ * A caller receives a fresh set for each environment, so it cannot alter a
+ * handler selected by another evaluation run.
+ */
+export interface SyntheticDirectToolReceiptHandler {
+  readonly definition: AddieTool;
+  readonly definitionSha256: string;
+  readonly handlerIdentitySha256: string;
+  readonly handlerProvenance: 'evaluator_simulated_receipt';
+  readonly handler: ToolHandler;
+}
+
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
   if (typeof value === 'number') {
@@ -110,15 +123,21 @@ function fixedTraceProductionDefinitions(): AddieTool[] {
  */
 export function createSyntheticDirectToolReceiptHandlers(
   universe: CapturedDirectToolUniverse,
-): Map<string, ToolHandler> {
-  return new Map(universe.tools.map((tool) => [tool.definition.name, async () => JSON.stringify({
-    kind: 'synthetic_direct_tool_receipt',
-    toolName: tool.definition.name,
+): readonly SyntheticDirectToolReceiptHandler[] {
+  return Object.freeze(universe.tools.map((tool) => Object.freeze({
+    definition: tool.definition,
     definitionSha256: tool.definitionSha256,
-    handlerProvenance: 'evaluator_simulated_receipt',
-    receiptHandlerIdentitySha256: sha256(`evaluator-receipt/${tool.definition.name}/${tool.definitionSha256}`),
-    definitionHandlerSha256: universe.definitionHandlerSha256,
-  } satisfies SyntheticDirectToolReceipt)]));
+    handlerIdentitySha256: tool.handlerIdentitySha256,
+    handlerProvenance: tool.handlerProvenance,
+    handler: async () => JSON.stringify({
+      kind: 'synthetic_direct_tool_receipt',
+      toolName: tool.definition.name,
+      definitionSha256: tool.definitionSha256,
+      handlerProvenance: 'evaluator_simulated_receipt',
+      receiptHandlerIdentitySha256: sha256(`evaluator-receipt/${tool.definition.name}/${tool.definitionSha256}`),
+      definitionHandlerSha256: universe.definitionHandlerSha256,
+    } satisfies SyntheticDirectToolReceipt),
+  })));
 }
 
 /**
@@ -165,7 +184,3 @@ function captureFixedTraceEvaluatorToolUniverse(): CapturedDirectToolUniverse {
  * with inert evaluator receipt handlers.
  */
 export const FIXED_TRACE_DIRECT_TOOL_UNIVERSE = captureFixedTraceEvaluatorToolUniverse();
-
-export const FIXED_TRACE_DIRECT_TOOL_HANDLERS = createSyntheticDirectToolReceiptHandlers(
-  FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
-);

--- a/server/src/addie/eval/fixed-trace-architecture.ts
+++ b/server/src/addie/eval/fixed-trace-architecture.ts
@@ -347,13 +347,124 @@ export function fixedTraceArchitectureArm(
 
 export type FixedTraceToolDefinitionProvenance =
   | 'fixture_local'
-  | 'evaluator_owned_production_definitions_simulated_receipts';
+  | 'evaluator_owned_production_definitions_simulated_receipts'
+  | 'evaluator_owned_common_tool_universe';
+
+/**
+ * Candidate-visible tools for an architecture comparison must come from this
+ * evaluator-owned contract, never from the trace's scored fixture fields.
+ *
+ * The current evaluator has a neutral, production-registry-derived descriptor
+ * set, but no authenticated definition/handler binding or shared execution
+ * envelope.  Keep that limitation in the artifact-shaped provenance instead
+ * of silently treating simulated receipts as production authority.
+ */
+export interface FixedTraceCommonToolUniverseProvenance {
+  source: 'evaluator_owned_common_tool_universe';
+  policy: 'shared_deterministic_surface_policy';
+  candidateVisibleToolNames: readonly string[];
+  candidateVisibleToolNamesSha256: string;
+  candidateVisibleToolSchemaSha256: string;
+  definitionHandlerSha256: string;
+  admission: 'blocked_missing_authenticated_definition_handler_intersection';
+  missingPrerequisites: readonly [
+    'authenticated_definition_handler_intersection',
+    'shared_request_thread_execution_envelope',
+  ];
+}
+
+export interface FixedTraceCommonToolUniverseAdmission {
+  admitted: false;
+  provenance: FixedTraceCommonToolUniverseProvenance;
+  reasons: readonly (
+    | 'common_tool_universe_provenance_missing_or_unknown'
+    | 'authenticated_definition_handler_intersection_not_captured'
+    | 'shared_request_thread_execution_envelope_not_captured'
+    | 'evaluator_simulated_receipt_handlers'
+  )[];
+}
+
+/** A fail-closed error that callers can retain as a JSON-safe audit record. */
+export class FixedTraceCommonToolUniverseAdmissionError extends Error {
+  constructor(readonly admission: FixedTraceCommonToolUniverseAdmission) {
+    super(`Fixed trace architecture comparison is not admitted: ${admission.reasons.join(', ')}`);
+    this.name = 'FixedTraceCommonToolUniverseAdmissionError';
+  }
+}
+
+/**
+ * Return the same detached neutral definitions for every candidate arm. This
+ * takes an arm only to make equality at the architecture boundary explicit;
+ * it deliberately never accepts a trace or fixture.
+ */
+export function fixedTraceCommonToolDefinitions(
+  _arm: FixedTraceArchitectureArmId,
+): readonly AddieTool[] {
+  return Object.freeze(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools.map((tool) => tool.definition));
+}
+
+export function fixedTraceCommonToolUniverseProvenance(
+  _arm: FixedTraceArchitectureArmId,
+): FixedTraceCommonToolUniverseProvenance {
+  return Object.freeze({
+    source: 'evaluator_owned_common_tool_universe',
+    policy: 'shared_deterministic_surface_policy',
+    candidateVisibleToolNames: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames,
+    candidateVisibleToolNamesSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256,
+    candidateVisibleToolSchemaSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256,
+    definitionHandlerSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256,
+    admission: 'blocked_missing_authenticated_definition_handler_intersection',
+    missingPrerequisites: Object.freeze([
+      'authenticated_definition_handler_intersection',
+      'shared_request_thread_execution_envelope',
+    ] as const),
+  });
+}
+
+/**
+ * Records the live-execution prerequisites which are unavailable to this
+ * evaluator. They block direct-arm admission; they do not grant authority to
+ * evaluator-only component simulations.
+ */
+export function admitFixedTraceCommonToolUniverse(
+  arm: Exclude<FixedTraceArchitectureArmId, 'oracle_route_diagnostic'>,
+  definitionProvenance: unknown,
+): FixedTraceCommonToolUniverseAdmission {
+  const provenance = fixedTraceCommonToolUniverseProvenance(arm);
+  const reasons: FixedTraceCommonToolUniverseAdmission['reasons'][number][] = [];
+  if (definitionProvenance !== 'evaluator_owned_common_tool_universe') {
+    reasons.push('common_tool_universe_provenance_missing_or_unknown');
+  }
+  reasons.push(
+    'authenticated_definition_handler_intersection_not_captured',
+    'shared_request_thread_execution_envelope_not_captured',
+    'evaluator_simulated_receipt_handlers',
+  );
+  return Object.freeze({ admitted: false, provenance, reasons: Object.freeze(reasons) });
+}
+
+/** Reject unknown provenance before a diagnostic candidate can dispatch. */
+export function assertFixedTraceCommonToolUniverseAdmission(
+  arm: Exclude<FixedTraceArchitectureArmId, 'oracle_route_diagnostic'>,
+  definitionProvenance: unknown,
+): FixedTraceCommonToolUniverseProvenance {
+  const admission = admitFixedTraceCommonToolUniverse(arm, definitionProvenance);
+  // The missing production binding blocks only live-handler authority (and
+  // therefore the direct arm). Component-only evaluator screens use inert,
+  // evaluator-owned receipts and must still reach the runner's normal
+  // execution-identity checks. Unknown provenance is never permitted there.
+  if (admission.reasons.includes('common_tool_universe_provenance_missing_or_unknown')) {
+    throw new FixedTraceCommonToolUniverseAdmissionError(admission);
+  }
+  return admission.provenance;
+}
 
 /** Records what selected the candidate's visible tools for diagnostic replay. */
 export interface FixedTraceToolUniverseProvenance {
   source:
     | 'fixture_local_routed_replay'
     | 'evaluator_owned_production_definitions_simulated_receipts'
+    | 'evaluator_owned_common_tool_universe'
     | 'fixture_oracle';
   intentNarrowing: 'llm_router' | 'production_quick_match_or_llm_router' | 'not_applied' | 'fixture_oracle';
   bounded: boolean;
@@ -362,6 +473,12 @@ export interface FixedTraceToolUniverseProvenance {
   toolNamesSha256?: string | null;
   toolSchemaSha256?: string | null;
   definitionHandlerSha256?: string | null;
+  /** Present only for the evaluator-owned common component universe. */
+  commonUniverseAdmission?: 'blocked_missing_authenticated_definition_handler_intersection';
+  commonUniverseMissingPrerequisites?: readonly (
+    | 'authenticated_definition_handler_intersection'
+    | 'shared_request_thread_execution_envelope'
+  )[];
 }
 
 export interface FixedTraceRequestThreadFactsProvenance {
@@ -430,7 +547,7 @@ export function fixedTraceRequestThreadFactsProvenance(
  * can reuse the production-equivalent executor.
  */
 export interface FixedTraceExecutionEnvelopeProvenance {
-  source: 'fixture_expectation' | 'request_thread_facts_not_captured' | 'evaluator_owned_shared_request_thread_envelope' | 'fixture_oracle';
+  source: 'fixture_expectation' | 'request_thread_facts_not_captured' | 'evaluator_owned_shared_request_thread_envelope' | 'evaluator_owned_synthetic_receipt_envelope' | 'fixture_oracle';
   deployable: boolean;
 }
 

--- a/server/src/addie/eval/fixed-trace-diagnostic-run.ts
+++ b/server/src/addie/eval/fixed-trace-diagnostic-run.ts
@@ -5,9 +5,8 @@ import {
   type FixedTraceProviderStageConfig,
 } from './fixed-trace-runner.js';
 import {
+  assertFixedTraceCommonToolUniverseAdmission,
   fixedTraceArchitectureArm,
-  fixedTraceExecutionEnvelopeProvenance,
-  fixedTraceToolUniverseProvenance,
 } from './fixed-trace-architecture.js';
 import {
   summarizeFixedTraceRun,
@@ -307,6 +306,13 @@ function requestedStageConfig(stage: FixedTraceProviderStageConfig): {
 export async function runFixedTraceDiagnosticCandidate(
   config: FixedTraceRunnerConfig,
 ) {
+  const arm = fixedTraceArchitectureArm(config.architectureArm);
+  // The legacy fixture-local runner remains a replay validator, not an
+  // architecture-comparison candidate. Do this before runner preflight so no
+  // provider prepare/dispatch or synthetic handler execution can occur.
+  if (arm.id !== 'oracle_route_diagnostic') {
+    assertFixedTraceCommonToolUniverseAdmission(arm.id, config.toolDefinitionProvenance);
+  }
   const observations = await runFixedTraceSuite(config);
   return {
     ...summarizeFixedTraceRun(observations, config.traceSuite),
@@ -469,6 +475,7 @@ function sameArtifactRunMetadata(left: FixedTraceRunMetadata, right: FixedTraceR
     && left.architectureArm.rolloutEligible === right.architectureArm.rolloutEligible
     && left.architectureArm.diagnosticOnly === right.architectureArm.diagnosticOnly
     && JSON.stringify(left.hybridPolicy) === JSON.stringify(right.hybridPolicy)
+    && JSON.stringify(left.toolUniverse) === JSON.stringify(right.toolUniverse)
     && left.executionEnvelope.source === right.executionEnvelope.source
     && left.executionEnvelope.deployable === right.executionEnvelope.deployable
     && JSON.stringify(left.requestThreadFacts) === JSON.stringify(right.requestThreadFacts);
@@ -488,6 +495,14 @@ export async function runFixedTraceDiagnosticArtifact(
   // by reference. In particular, do not acquire the one-way budget lease
   // until every planned suite has passed its no-dispatch preflight.
   const baseConfig = snapshotBaseConfig(options.baseConfig);
+  const baseArm = fixedTraceArchitectureArm(baseConfig.architectureArm);
+  if (baseArm.id !== 'oracle_route_diagnostic') {
+    // Reject absent or forged neutral-universe provenance before acquiring a
+    // budget lease or entering any runner/provider boundary. A valid neutral
+    // contract may continue to evaluator-only component simulation; direct
+    // admission remains separately fail-closed in the runner.
+    assertFixedTraceCommonToolUniverseAdmission(baseArm.id, baseConfig.toolDefinitionProvenance);
+  }
   const budgetLedger = options.budget;
   const requestedPlans = snapshotPlans(options.plans, budgetLedger);
   const runRootId = snapshotNonblank(options.runRootId, 'run root ID');
@@ -582,8 +597,8 @@ export async function runFixedTraceDiagnosticArtifact(
     ])),
     architectureArm: fixedTraceArchitectureArm(commonMetadata.architectureArm.id),
     hybridPolicy: commonMetadata.hybridPolicy,
-    toolUniverse: fixedTraceToolUniverseProvenance(commonMetadata.architectureArm.id),
-    executionEnvelope: fixedTraceExecutionEnvelopeProvenance(commonMetadata.architectureArm.id),
+    toolUniverse: commonMetadata.toolUniverse,
+    executionEnvelope: commonMetadata.executionEnvelope,
     requestThreadFacts: commonMetadata.requestThreadFacts,
     requestedProviders: plans.map((plan) => plan.name),
     requestedArchitectureArm: commonMetadata.architectureArm.id,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -33,7 +33,9 @@ import {
   executeFixedTraceToolLoop,
   FixedTraceToolLoopBoundaryError,
   MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS,
+  validateFixedTraceToolLoopEnvironment,
   validateFixedTraceToolLoopFixtures,
+  type FixedTraceEvaluatorToolEnvironment,
 } from './fixed-trace-tool-loop.js';
 import {
   FixedTraceBudgetAdmissionError,
@@ -42,11 +44,15 @@ import {
   fixedTraceResponsePricingPolicy,
   fixedTraceResponseUsesPricingPolicy,
 } from './fixed-trace-budget.js';
-import { FIXED_TRACE_DIRECT_TOOL_UNIVERSE } from '../direct-tool-universe.js';
+import {
+  FIXED_TRACE_DIRECT_TOOL_HANDLERS,
+  FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
+} from '../direct-tool-universe.js';
 import {
   admitFixedTraceDirectArm,
   decideFixedTraceHybridRoute,
   fixedTraceArchitectureArm,
+  fixedTraceCommonToolDefinitions,
   fixedTraceExecutionEnvelopeProvenance,
   fixedTraceHybridPolicy,
   fixedTraceRequestThreadFactsProvenance,
@@ -128,6 +134,32 @@ interface FixedTraceExecutionIdentity {
 const boundTraceExecutionIdentities = new WeakMap<FixedTraceRunnerConfig, FixedTraceExecutionIdentity>();
 const preflightedFixtureRegistrations = new WeakMap<FixedTraceRunnerConfig, string>();
 
+function usesCommonToolUniverse(config: FixedTraceRunnerConfig): boolean {
+  return config.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
+    && fixedTraceArchitectureArm(config.architectureArm).id !== 'oracle_route_diagnostic';
+}
+
+/**
+ * This is deliberately evaluator-owned and contains no production handlers.
+ * The direct-safe-fallback registry supplies only neutral definitions; every
+ * callable entry returns an inert synthetic receipt and mutations are refused.
+ */
+function fixedTraceCommonToolEnvironment(): FixedTraceEvaluatorToolEnvironment {
+  return Object.freeze({
+    tools: Object.freeze(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools.map((tool) => {
+    const handler = FIXED_TRACE_DIRECT_TOOL_HANDLERS.get(tool.definition.name);
+    if (!handler) throw new Error(`Missing evaluator receipt handler: ${tool.definition.name}`);
+    return Object.freeze({
+      definition: tool.definition,
+      handler,
+      effect: tool.definition.replaySafety === 'mutation' ? 'mutation' as const : 'read' as const,
+      resultStatus: 'ok' as const,
+    });
+    })),
+    authorize: ({ isMutation }: { toolName: string; toolCallId: string; isMutation: boolean }) => ({ allowed: !isMutation }),
+  });
+}
+
 /**
  * An evaluator-owned execution contract changed after its request snapshot was
  * made. This is neither a provider failure nor a scored terminal outcome.
@@ -177,6 +209,13 @@ function assertFixtureDefinitionUniverse(config: FixedTraceRunnerConfig): void {
   // list would make the declared config differ from executable inputs. Direct
   // has its own evaluator-owned request-fact universe below.
   if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
+  if (usesCommonToolUniverse(config)) {
+    validateFixedTraceToolLoopEnvironment(
+      fixedTraceCommonToolDefinitions(fixedTraceArchitectureArm(config.architectureArm).id),
+      fixedTraceCommonToolEnvironment(),
+    );
+    return;
+  }
   if (!Array.isArray(config.toolDefinitions)) {
     throw new Error('Fixed trace routed/hybrid/oracle definitions must exactly match configured suite fixtures');
   }
@@ -195,6 +234,7 @@ function assertFixtureRegistrations(config: FixedTraceRunnerConfig): void {
   // registration primitive at generation time, so validate it before router
   // dispatch as well.
   if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
+  if (usesCommonToolUniverse(config)) return;
   for (const trace of config.traceSuite) {
     validateFixedTraceToolLoopFixtures(trace, resolveTraceDefinitions(trace, config.toolDefinitions));
   }
@@ -223,6 +263,7 @@ function preflightFixtureRegistrations(
  * can never be created with a run contract that was invalid from the start.
  */
 function validateRunProvenance(config: FixedTraceRunnerConfig): void {
+  const architectureArm = fixedTraceArchitectureArm(config.architectureArm);
   if (typeof config.runId !== 'string' || config.runId.trim().length === 0) {
     throw new Error('Fixed trace runner runId must be nonblank');
   }
@@ -243,9 +284,15 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
   }
   if (
     config.toolDefinitionProvenance !== undefined
-    && !['fixture_local', 'evaluator_owned_production_definitions_simulated_receipts'].includes(config.toolDefinitionProvenance)
+    && !['fixture_local', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe'].includes(config.toolDefinitionProvenance)
   ) {
     throw new Error('Fixed trace runner toolDefinitionProvenance is invalid');
+  }
+  if (
+    architectureArm.id === 'oracle_route_diagnostic'
+    && config.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
+  ) {
+    throw new Error('Fixed trace fixture oracle cannot claim the common candidate tool universe');
   }
   if (config.injectProviderDegradation !== undefined && typeof config.injectProviderDegradation !== 'boolean') {
     throw new Error('Fixed trace runner injectProviderDegradation must be boolean when supplied');
@@ -258,7 +305,9 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
 }
 
 function runProvenanceSha256(config: FixedTraceRunnerConfig): string {
-  const toolDefinitionProvenance = fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
+  const toolDefinitionProvenance = usesCommonToolUniverse(config)
+    ? 'evaluator_owned_common_tool_universe'
+    : fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
     ? 'evaluator_owned_production_definitions_simulated_receipts'
     : config.toolDefinitionProvenance ?? 'fixture_local';
   return sha256({
@@ -617,7 +666,7 @@ export function fixedTraceToolSchemaSha256(
  * same suite-validated execution identity as routed replay.
  */
 function toolSchemaForConfig(config: FixedTraceRunnerConfig): string {
-  return fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
+  return usesCommonToolUniverse(config) || fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
     ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256
     : fixedTraceToolSchemaSha256(config.traceSuite, config.toolDefinitions);
 }
@@ -644,15 +693,35 @@ export function fixedTraceArchitectureConfigSha256(
     stageControlVersion: FIXED_TRACE_STAGE_CONTROL_VERSION,
     promptConfigVersion: config.promptConfigVersion,
     toolSchemaSha256,
-    toolDefinitionProvenance: arm.id === 'direct_generation'
+    toolDefinitionProvenance: usesCommonToolUniverse(config)
+      ? 'evaluator_owned_common_tool_universe'
+      : arm.id === 'direct_generation'
       ? 'evaluator_owned_production_definitions_simulated_receipts'
       : config.toolDefinitionProvenance ?? 'fixture_local',
     architectureArm: arm,
     hybridPolicy: arm.id === 'deterministic_policy_llm_fallback_hybrid'
       ? fixedTraceHybridPolicy(config.hybridPolicy)
       : null,
-    toolUniverse: fixedTraceToolUniverseProvenance(arm.id),
-    executionEnvelope: fixedTraceExecutionEnvelopeProvenance(arm.id),
+    toolUniverse: usesCommonToolUniverse(config)
+      ? {
+          source: 'evaluator_owned_common_tool_universe',
+          intentNarrowing: 'not_applied',
+          bounded: true,
+          deployable: false,
+          toolNames: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames,
+          toolNamesSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256,
+          toolSchemaSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256,
+          definitionHandlerSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256,
+          commonUniverseAdmission: 'blocked_missing_authenticated_definition_handler_intersection',
+          commonUniverseMissingPrerequisites: [
+            'authenticated_definition_handler_intersection',
+            'shared_request_thread_execution_envelope',
+          ],
+        }
+      : fixedTraceToolUniverseProvenance(arm.id),
+    executionEnvelope: usesCommonToolUniverse(config)
+      ? { source: 'evaluator_owned_synthetic_receipt_envelope', deployable: false }
+      : fixedTraceExecutionEnvelopeProvenance(arm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, arm.id),
     routerControl: cohortStageControl(config.router),
     generationControl: cohortStageControl(config.generation),
@@ -734,7 +803,9 @@ function baseMetadata(
     addieCodeVersion: CODE_VERSION,
     promptConfigVersion: config.promptConfigVersion,
     toolSchemaSha256,
-    toolDefinitionProvenance: architectureArm.id === 'direct_generation'
+    toolDefinitionProvenance: usesCommonToolUniverse(config)
+      ? 'evaluator_owned_common_tool_universe'
+      : architectureArm.id === 'direct_generation'
       ? 'evaluator_owned_production_definitions_simulated_receipts'
       : config.toolDefinitionProvenance ?? 'fixture_local',
     stageControlVersion: FIXED_TRACE_STAGE_CONTROL_VERSION,
@@ -745,13 +816,31 @@ function baseMetadata(
     hybridPolicy: architectureArm.id === 'deterministic_policy_llm_fallback_hybrid'
       ? fixedTraceHybridPolicy(config.hybridPolicy)
       : null,
-    toolUniverse: {
-      ...fixedTraceToolUniverseProvenance(architectureArm.id),
-      toolNames: architectureArm.id === 'direct_generation'
-        ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames
-        : [...trace.toolFixtures.map((fixture) => fixture.name)].sort(),
-    },
-    executionEnvelope: fixedTraceExecutionEnvelopeProvenance(architectureArm.id),
+    toolUniverse: usesCommonToolUniverse(config)
+      ? {
+          source: 'evaluator_owned_common_tool_universe',
+          intentNarrowing: 'not_applied',
+          bounded: true,
+          deployable: false,
+          toolNames: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames,
+          toolNamesSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256,
+          toolSchemaSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256,
+          definitionHandlerSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256,
+          commonUniverseAdmission: 'blocked_missing_authenticated_definition_handler_intersection',
+          commonUniverseMissingPrerequisites: [
+            'authenticated_definition_handler_intersection',
+            'shared_request_thread_execution_envelope',
+          ],
+        }
+      : {
+          ...fixedTraceToolUniverseProvenance(architectureArm.id),
+          toolNames: architectureArm.id === 'direct_generation'
+            ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames
+            : [...trace.toolFixtures.map((fixture) => fixture.name)].sort(),
+        },
+    executionEnvelope: usesCommonToolUniverse(config)
+      ? { source: 'evaluator_owned_synthetic_receipt_envelope', deployable: false }
+      : fixedTraceExecutionEnvelopeProvenance(architectureArm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, architectureArm.id),
     directArmAdmission: admission,
     caseControl: trace.caseControl ?? null,
@@ -1033,7 +1122,12 @@ export async function runFixedTraceCase(
     };
   }
 
-  const definitions = resolveTraceDefinitions(executionTrace, executionConfig.toolDefinitions);
+  // Only an explicitly provenance-bound comparison may use this evaluator
+  // universe. It has no trace input, so expected tool calls/selections cannot
+  // affect candidate-visible definitions.
+  const definitions = usesCommonToolUniverse(executionConfig)
+    ? fixedTraceCommonToolDefinitions(architectureArm.id)
+    : resolveTraceDefinitions(executionTrace, executionConfig.toolDefinitions);
   const generationRequest = buildFixedTraceGenerationRequest(
     executionTrace,
     routed.plan,
@@ -1086,6 +1180,9 @@ export async function runFixedTraceCase(
       executionTrace,
       definitions,
       {
+        ...(usesCommonToolUniverse(executionConfig)
+          ? { evaluatorToolEnvironment: fixedTraceCommonToolEnvironment() }
+          : {}),
         signal: controller.signal,
         maxIterations: generationConfig.maxIterations,
         beforePrepare: (request) => {

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -45,8 +45,8 @@ import {
   fixedTraceResponseUsesPricingPolicy,
 } from './fixed-trace-budget.js';
 import {
-  FIXED_TRACE_DIRECT_TOOL_HANDLERS,
   FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
+  createSyntheticDirectToolReceiptHandlers,
 } from '../direct-tool-universe.js';
 import {
   admitFixedTraceDirectArm,
@@ -144,19 +144,41 @@ function usesCommonToolUniverse(config: FixedTraceRunnerConfig): boolean {
  * The direct-safe-fallback registry supplies only neutral definitions; every
  * callable entry returns an inert synthetic receipt and mutations are refused.
  */
-function fixedTraceCommonToolEnvironment(): FixedTraceEvaluatorToolEnvironment {
+interface FixedTraceCommonToolEnvironmentBinding {
+  readonly environment: FixedTraceEvaluatorToolEnvironment;
+  readonly definitionHandlerSha256: string;
+}
+
+function fixedTraceCommonToolEnvironment(): FixedTraceCommonToolEnvironmentBinding {
+  const receiptHandlers = createSyntheticDirectToolReceiptHandlers(FIXED_TRACE_DIRECT_TOOL_UNIVERSE);
+  const handlersByName = new Map(receiptHandlers.map((handler) => [handler.definition.name, handler]));
+  const definitionHandlerSha256 = sha256(receiptHandlers.map((handler) => ({
+    name: handler.definition.name,
+    definitionSha256: handler.definitionSha256,
+    handlerIdentitySha256: handler.handlerIdentitySha256,
+    handlerProvenance: handler.handlerProvenance,
+  })));
+  if (
+    handlersByName.size !== receiptHandlers.length
+    || definitionHandlerSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256
+  ) throw new Error('Fixed trace evaluator receipt handlers do not match the captured common universe');
   return Object.freeze({
-    tools: Object.freeze(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools.map((tool) => {
-    const handler = FIXED_TRACE_DIRECT_TOOL_HANDLERS.get(tool.definition.name);
-    if (!handler) throw new Error(`Missing evaluator receipt handler: ${tool.definition.name}`);
-    return Object.freeze({
-      definition: tool.definition,
-      handler,
-      effect: tool.definition.replaySafety === 'mutation' ? 'mutation' as const : 'read' as const,
-      resultStatus: 'ok' as const,
-    });
-    })),
-    authorize: ({ isMutation }: { toolName: string; toolCallId: string; isMutation: boolean }) => ({ allowed: !isMutation }),
+    definitionHandlerSha256,
+    environment: Object.freeze({
+      tools: Object.freeze(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools.map((tool) => {
+        const handler = handlersByName.get(tool.definition.name);
+        if (!handler || handler.definition !== tool.definition || handler.definitionSha256 !== tool.definitionSha256) {
+          throw new Error(`Missing evaluator receipt handler: ${tool.definition.name}`);
+        }
+        return Object.freeze({
+          definition: tool.definition,
+          handler: handler.handler,
+          effect: tool.definition.replaySafety === 'mutation' ? 'mutation' as const : 'read' as const,
+          resultStatus: 'ok' as const,
+        });
+      })),
+      authorize: ({ isMutation }: { toolName: string; toolCallId: string; isMutation: boolean }) => ({ allowed: !isMutation }),
+    }),
   });
 }
 
@@ -210,10 +232,14 @@ function assertFixtureDefinitionUniverse(config: FixedTraceRunnerConfig): void {
   // has its own evaluator-owned request-fact universe below.
   if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
   if (usesCommonToolUniverse(config)) {
+    const environment = fixedTraceCommonToolEnvironment();
     validateFixedTraceToolLoopEnvironment(
       fixedTraceCommonToolDefinitions(fixedTraceArchitectureArm(config.architectureArm).id),
-      fixedTraceCommonToolEnvironment(),
+      environment.environment,
     );
+    if (environment.definitionHandlerSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256) {
+      throw new Error('Fixed trace common tool environment binding changed during preflight');
+    }
     return;
   }
   if (!Array.isArray(config.toolDefinitions)) {
@@ -1168,6 +1194,9 @@ export async function runFixedTraceCase(
   }
 
   let timedOut = false;
+  const evaluatorToolEnvironment = usesCommonToolUniverse(executionConfig)
+    ? fixedTraceCommonToolEnvironment()
+    : null;
   const controller = new AbortController();
   const timeout = setTimeout(() => {
     timedOut = true;
@@ -1181,7 +1210,7 @@ export async function runFixedTraceCase(
       definitions,
       {
         ...(usesCommonToolUniverse(executionConfig)
-          ? { evaluatorToolEnvironment: fixedTraceCommonToolEnvironment() }
+          ? { evaluatorToolEnvironment: evaluatorToolEnvironment!.environment }
           : {}),
         signal: controller.signal,
         maxIterations: generationConfig.maxIterations,

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -2788,9 +2788,9 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   const toolUniverse = metadata.toolUniverse;
   if (!toolUniverse || !['fixture_local_routed_replay', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe', 'fixture_oracle'].includes(toolUniverse.source)) {
     failures.push('tool_universe_provenance_invalid');
-  } else if (
-    metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
-    && (toolUniverse.source !== 'evaluator_owned_common_tool_universe' || toolUniverse.intentNarrowing !== 'not_applied' || !toolUniverse.bounded || toolUniverse.deployable
+  } else if (metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe') {
+    if (
+      toolUniverse.source !== 'evaluator_owned_common_tool_universe' || toolUniverse.intentNarrowing !== 'not_applied' || !toolUniverse.bounded || toolUniverse.deployable
       || toolUniverse.toolNamesSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256
       || toolUniverse.toolSchemaSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256
       || toolUniverse.definitionHandlerSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256
@@ -2798,9 +2798,8 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
       || canonicalJson(toolUniverse.commonUniverseMissingPrerequisites) !== canonicalJson([
         'authenticated_definition_handler_intersection',
         'shared_request_thread_execution_envelope',
-      ]))
-  ) {
-    failures.push('tool_universe_provenance_invalid');
+      ])
+    ) failures.push('tool_universe_provenance_invalid');
   } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
     && (toolUniverse.source !== 'fixture_local_routed_replay' || toolUniverse.intentNarrowing !== 'production_quick_match_or_llm_router' || !toolUniverse.bounded || toolUniverse.deployable)
@@ -2854,11 +2853,10 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   const executionEnvelope = metadata.executionEnvelope;
   if (!executionEnvelope || !['fixture_expectation', 'evaluator_owned_shared_request_thread_envelope', 'evaluator_owned_synthetic_receipt_envelope', 'fixture_oracle'].includes(executionEnvelope.source)) {
     failures.push('execution_envelope_provenance_invalid');
-  } else if (
-    metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
-    && (executionEnvelope.source !== 'evaluator_owned_synthetic_receipt_envelope' || executionEnvelope.deployable)
-  ) {
-    failures.push('execution_envelope_provenance_invalid');
+  } else if (metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe') {
+    if (executionEnvelope.source !== 'evaluator_owned_synthetic_receipt_envelope' || executionEnvelope.deployable) {
+      failures.push('execution_envelope_provenance_invalid');
+    }
   } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
     && (executionEnvelope.source !== 'fixture_expectation' || executionEnvelope.deployable)

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -2482,6 +2482,8 @@ export function fixedTraceArchitectureConfigPayload(metadata: Pick<
     toolNamesSha256: metadata.toolUniverse.toolNamesSha256 ?? null,
     toolSchemaSha256: metadata.toolUniverse.toolSchemaSha256 ?? null,
     definitionHandlerSha256: metadata.toolUniverse.definitionHandlerSha256 ?? null,
+    commonUniverseAdmission: metadata.toolUniverse.commonUniverseAdmission ?? null,
+    commonUniverseMissingPrerequisites: metadata.toolUniverse.commonUniverseMissingPrerequisites ?? null,
   };
   return {
     traceSuiteSha256: metadata.traceSuiteSha256,
@@ -2735,7 +2737,7 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   if (!metadata.promptConfigVersion.trim()) failures.push('prompt_config_version_missing');
   if (!Number.isSafeInteger(metadata.repetition) || metadata.repetition < 1) failures.push('repetition_invalid');
   if (metadata.stageControlVersion !== FIXED_TRACE_STAGE_CONTROL_VERSION) failures.push('stage_control_version_mismatch');
-  if (!['fixture_local', 'evaluator_owned_production_definitions_simulated_receipts'].includes(metadata.toolDefinitionProvenance)) {
+  if (!['fixture_local', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe'].includes(metadata.toolDefinitionProvenance)) {
     failures.push('tool_definition_provenance_invalid');
   }
   if (typeof metadata.providerDegradationInjectionEnabled !== 'boolean') failures.push('provider_degradation_policy_invalid');
@@ -2784,7 +2786,20 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
     failures.push('direct_arm_admission_unexpected');
   }
   const toolUniverse = metadata.toolUniverse;
-  if (!toolUniverse || !['fixture_local_routed_replay', 'evaluator_owned_production_definitions_simulated_receipts', 'fixture_oracle'].includes(toolUniverse.source)) {
+  if (!toolUniverse || !['fixture_local_routed_replay', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe', 'fixture_oracle'].includes(toolUniverse.source)) {
+    failures.push('tool_universe_provenance_invalid');
+  } else if (
+    metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
+    && (toolUniverse.source !== 'evaluator_owned_common_tool_universe' || toolUniverse.intentNarrowing !== 'not_applied' || !toolUniverse.bounded || toolUniverse.deployable
+      || toolUniverse.toolNamesSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256
+      || toolUniverse.toolSchemaSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256
+      || toolUniverse.definitionHandlerSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256
+      || toolUniverse.commonUniverseAdmission !== 'blocked_missing_authenticated_definition_handler_intersection'
+      || canonicalJson(toolUniverse.commonUniverseMissingPrerequisites) !== canonicalJson([
+        'authenticated_definition_handler_intersection',
+        'shared_request_thread_execution_envelope',
+      ]))
+  ) {
     failures.push('tool_universe_provenance_invalid');
   } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
@@ -2810,7 +2825,7 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
   ) {
     failures.push('tool_universe_provenance_invalid');
   }
-  const expectedToolNames = arm?.id === 'direct_generation'
+  const expectedToolNames = metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe' || arm?.id === 'direct_generation'
     ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames
     : [...trace.toolFixtures.map((fixture) => fixture.name)].sort();
   if (!sameToolUniverseNames(toolUniverse?.toolNames ?? null, expectedToolNames)) {
@@ -2837,7 +2852,12 @@ function metadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata
     failures.push('request_thread_facts_provenance_invalid');
   }
   const executionEnvelope = metadata.executionEnvelope;
-  if (!executionEnvelope || !['fixture_expectation', 'evaluator_owned_shared_request_thread_envelope', 'fixture_oracle'].includes(executionEnvelope.source)) {
+  if (!executionEnvelope || !['fixture_expectation', 'evaluator_owned_shared_request_thread_envelope', 'evaluator_owned_synthetic_receipt_envelope', 'fixture_oracle'].includes(executionEnvelope.source)) {
+    failures.push('execution_envelope_provenance_invalid');
+  } else if (
+    metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe'
+    && (executionEnvelope.source !== 'evaluator_owned_synthetic_receipt_envelope' || executionEnvelope.deployable)
+  ) {
     failures.push('execution_envelope_provenance_invalid');
   } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
@@ -3186,6 +3206,8 @@ export function assertFixedTraceRunContract(
       || candidate.toolUniverse.toolNamesSha256 !== runContract.toolUniverse.toolNamesSha256
       || candidate.toolUniverse.toolSchemaSha256 !== runContract.toolUniverse.toolSchemaSha256
       || candidate.toolUniverse.definitionHandlerSha256 !== runContract.toolUniverse.definitionHandlerSha256
+      || candidate.toolUniverse.commonUniverseAdmission !== runContract.toolUniverse.commonUniverseAdmission
+      || canonicalJson(candidate.toolUniverse.commonUniverseMissingPrerequisites ?? null) !== canonicalJson(runContract.toolUniverse.commonUniverseMissingPrerequisites ?? null)
       || candidate.executionEnvelope.source !== runContract.executionEnvelope.source
       || candidate.executionEnvelope.deployable !== runContract.executionEnvelope.deployable
       || canonicalJson(candidate.requestThreadFacts) !== canonicalJson(runContract.requestThreadFacts)
@@ -3306,6 +3328,8 @@ export function summarizeFixedTraceRun(
           toolNamesSha256: runContract.toolUniverse.toolNamesSha256 ?? null,
           toolSchemaSha256: runContract.toolUniverse.toolSchemaSha256 ?? null,
           definitionHandlerSha256: runContract.toolUniverse.definitionHandlerSha256 ?? null,
+          commonUniverseAdmission: runContract.toolUniverse.commonUniverseAdmission,
+          commonUniverseMissingPrerequisites: runContract.toolUniverse.commonUniverseMissingPrerequisites,
         },
         executionEnvelope: runContract.executionEnvelope,
         requestThreadFacts: runContract.requestThreadFacts,

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -42,6 +42,7 @@ import {
 import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from '../../src/addie/eval/fixed-trace-tool-loop.js';
 import { parseFixedTraceDiagnosticCliArguments } from '../../src/addie/eval/fixed-trace-diagnostic-cli.js';
 import { reserveFixedTraceDiagnosticOutput } from '../../src/addie/eval/fixed-trace-diagnostic-output.js';
+import { fixedTraceCommonToolDefinitions } from '../../src/addie/eval/fixed-trace-architecture.js';
 import { canonicalFixedTraceToolDefinitions } from '../../src/addie/eval/fixed-trace-tools.js';
 import {
   fixedTraceHybridPolicy,
@@ -323,7 +324,9 @@ const promptConfigVersion = sha256(JSON.stringify({
   rules: loadRules(),
   responseStyle: loadResponseStyle(),
 }));
-const toolDefinitions = canonicalFixedTraceToolDefinitions(traceSuite);
+const toolDefinitions = architectureArm === 'oracle_route_diagnostic'
+  ? canonicalFixedTraceToolDefinitions(traceSuite)
+  : fixedTraceCommonToolDefinitions(architectureArm);
 const budget = new FixedTraceBudget(softMaxUsd);
 const plans = providerPlans(providerNames, budget);
 const runStartedAt = new Date().toISOString();
@@ -338,7 +341,9 @@ const artifact = await runFixedTraceDiagnosticArtifact({
     traceSuite,
     traceSuiteSha256: fixedTraceSuiteSha256(traceSuite),
     toolDefinitions,
-    toolDefinitionProvenance: 'fixture_local',
+    toolDefinitionProvenance: architectureArm === 'oracle_route_diagnostic'
+      ? 'fixture_local'
+      : 'evaluator_owned_common_tool_universe',
     architectureArm,
     ...(architectureArm === 'deterministic_policy_llm_fallback_hybrid'
       ? { hybridPolicy: fixedTraceHybridPolicy() }

--- a/server/tests/unit/addie/direct-tool-universe.test.ts
+++ b/server/tests/unit/addie/direct-tool-universe.test.ts
@@ -44,9 +44,11 @@ describe('direct tool-universe evaluator descriptors', () => {
     // The only public handler constructor always makes evaluator receipts;
     // prototype/constructor spoofing and matching digests are non-authority.
     const handlers = createSyntheticDirectToolReceiptHandlers(copiedAndBrandedLooking);
-    expect([...handlers.keys()]).toEqual(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames);
+    expect(handlers.map((handler) => handler.definition.name)).toEqual(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames);
     const first = FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools[0]!;
-    expect(JSON.parse(await handlers.get(first.definition.name)!({ query: 'mock' }))).toMatchObject({
+    const firstHandler = handlers.find((handler) => handler.definition.name === first.definition.name);
+    expect(firstHandler).toBeDefined();
+    expect(JSON.parse(await firstHandler!.handler({ query: 'mock' }))).toMatchObject({
       kind: 'synthetic_direct_tool_receipt',
       handlerProvenance: 'evaluator_simulated_receipt',
       toolName: first.definition.name,

--- a/server/tests/unit/addie/direct-tool-universe.test.ts
+++ b/server/tests/unit/addie/direct-tool-universe.test.ts
@@ -52,6 +52,7 @@ describe('direct tool-universe evaluator descriptors', () => {
       kind: 'synthetic_direct_tool_receipt',
       handlerProvenance: 'evaluator_simulated_receipt',
       toolName: first.definition.name,
+      receiptHandlerIdentitySha256: first.handlerIdentitySha256,
     });
     expect(mockHandler).not.toHaveBeenCalled();
   });

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -6,7 +6,10 @@ import {
   fixedTraceCommonToolDefinitions,
   fixedTraceCommonToolUniverseProvenance,
 } from '../../../src/addie/eval/fixed-trace-architecture.js';
-import { FIXED_TRACE_DIRECT_TOOL_HANDLERS, FIXED_TRACE_DIRECT_TOOL_UNIVERSE } from '../../../src/addie/direct-tool-universe.js';
+import {
+  createSyntheticDirectToolReceiptHandlers,
+  FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
+} from '../../../src/addie/direct-tool-universe.js';
 import { runFixedTraceDiagnosticCandidate } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
 import { FIXED_TRACE_SUITE, fixedTraceSuiteSha256, type FixedTraceCase } from '../../../src/addie/eval/fixed-trace-suite.js';
 import type {
@@ -75,6 +78,7 @@ class ScriptedProvider implements ModelProvider {
     yield { type: 'response_start', provider: this.id, model: response.model, id: response.id };
     for (const [index, content] of response.content.entries()) {
       if (content.type === 'text') yield { type: 'text_delta', index, text: content.text };
+      else if (content.type === 'tool_call') yield { type: 'tool_call', index, call: content };
     }
     yield { type: 'response_complete', response };
   }
@@ -216,6 +220,43 @@ describe('fixed-trace common evaluator tool universe', () => {
       .toEqual(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames);
   });
 
+  it('does not consume a caller-mutated synthetic handler map or misstate its binding evidence', async () => {
+    const externalHandlerMap = new Map(createSyntheticDirectToolReceiptHandlers(
+      FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
+    ).map((handler) => [handler.definition.name, handler.handler]));
+    const replacement = vi.fn(async () => '{"attacker":"handler"}');
+    externalHandlerMap.set('search_docs', replacement);
+    const router = new ScriptedProvider([
+      scriptedResponse('router-response', JSON.stringify({
+        action: 'respond', tool_sets: [], confidence: 'high', requires_depth: false, reason: 'Synthetic route.',
+      })),
+    ]);
+    const generation = new ScriptedProvider([
+      {
+        provider: 'anthropic', model: 'claude-haiku-4-5', id: 'tool-call-response',
+        content: [{ type: 'tool_call', id: 'search-docs-probe', name: 'search_docs', input: { query: 'probe' } }],
+        finishReason: 'tool_calls', providerFinishReason: 'tool_calls', usage: { inputTokens: 10, outputTokens: 5 },
+      },
+      scriptedResponse('generation-response', 'Synthetic terminal response.'),
+    ]);
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'knowledge-task-model')!;
+    const runConfig = {
+      ...config(router, generation, [trace]),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe' as const,
+    };
+    runConfig.generation.maxIterations = 2;
+
+    const result = await runFixedTraceDiagnosticCandidate(runConfig);
+
+    expect(replacement).not.toHaveBeenCalled();
+    expect(generation.requests).toHaveLength(2);
+    expect(JSON.stringify(generation.requests[1])).toContain('synthetic_direct_tool_receipt');
+    expect(result.observations[0]!.metadata.toolUniverse).toMatchObject({
+      source: 'evaluator_owned_common_tool_universe',
+      definitionHandlerSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256,
+    });
+  });
+
   it.each([undefined, 'fixture_local', 'forged'])(
     'fails closed with typed provenance for missing or unknown common-universe provenance: %s',
     (provenance) => {
@@ -238,11 +279,6 @@ describe('fixed-trace common evaluator tool universe', () => {
     async (provenance) => {
     const router = new NeverDispatchProvider();
     const generation = new NeverDispatchProvider();
-    const firstTool = FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools[0]!;
-    const originalHandler = FIXED_TRACE_DIRECT_TOOL_HANDLERS.get(firstTool.definition.name)!;
-    const handler = vi.fn(originalHandler);
-    FIXED_TRACE_DIRECT_TOOL_HANDLERS.set(firstTool.definition.name, handler);
-    try {
       const runConfig = config(router, generation, [FIXED_TRACE_SUITE[0]!]);
       runConfig.toolDefinitionProvenance = provenance as unknown as FixedTraceRunnerConfig['toolDefinitionProvenance'];
       await expect(runFixedTraceDiagnosticCandidate(runConfig))
@@ -251,10 +287,6 @@ describe('fixed-trace common evaluator tool universe', () => {
       expect(router.respond).not.toHaveBeenCalled();
       expect(generation.prepare).not.toHaveBeenCalled();
       expect(generation.respond).not.toHaveBeenCalled();
-      expect(handler).not.toHaveBeenCalled();
-    } finally {
-      FIXED_TRACE_DIRECT_TOOL_HANDLERS.set(firstTool.definition.name, originalHandler);
-    }
     },
   );
 });

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -250,7 +250,11 @@ describe('fixed-trace common evaluator tool universe', () => {
 
     expect(replacement).not.toHaveBeenCalled();
     expect(generation.requests).toHaveLength(2);
+    const searchDocs = FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools.find(
+      (tool) => tool.definition.name === 'search_docs',
+    )!;
     expect(JSON.stringify(generation.requests[1])).toContain('synthetic_direct_tool_receipt');
+    expect(JSON.stringify(generation.requests[1])).toContain(searchDocs.handlerIdentitySha256);
     expect(result.observations[0]!.metadata.toolUniverse).toMatchObject({
       source: 'evaluator_owned_common_tool_universe',
       definitionHandlerSha256: FIXED_TRACE_DIRECT_TOOL_UNIVERSE.definitionHandlerSha256,

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  admitFixedTraceCommonToolUniverse,
+  assertFixedTraceCommonToolUniverseAdmission,
+  FixedTraceCommonToolUniverseAdmissionError,
+  fixedTraceCommonToolDefinitions,
+  fixedTraceCommonToolUniverseProvenance,
+} from '../../../src/addie/eval/fixed-trace-architecture.js';
+import { FIXED_TRACE_DIRECT_TOOL_HANDLERS, FIXED_TRACE_DIRECT_TOOL_UNIVERSE } from '../../../src/addie/direct-tool-universe.js';
+import { runFixedTraceDiagnosticCandidate } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
+import { FIXED_TRACE_SUITE, fixedTraceSuiteSha256, type FixedTraceCase } from '../../../src/addie/eval/fixed-trace-suite.js';
+import type {
+  ModelProvider,
+  ModelProviderCapabilities,
+  ModelRequest,
+  ModelRespondOptions,
+  ModelResponse,
+  NormalizedModelEvent,
+  PreparedModelInvocation,
+} from '../../../src/addie/model-providers/model-provider.js';
+import type { FixedTraceRunnerConfig } from '../../../src/addie/eval/fixed-trace-runner.js';
+
+const CAPABILITIES: ModelProviderCapabilities = {
+  streaming: false,
+  structuredOutput: true,
+  reasoning: true,
+  reasoningEfforts: ['provider_default', 'none', 'low', 'medium', 'high'],
+  customTools: true,
+  providerWebSearch: false,
+  imageInput: false,
+  documentInput: false,
+};
+
+class NeverDispatchProvider implements ModelProvider {
+  readonly id = 'anthropic' as const;
+  readonly capabilities = CAPABILITIES;
+  readonly prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({
+    provider: this.id,
+    model: request.model,
+    capabilities: this.capabilities,
+    requestMetadata: request.requestMetadata,
+    providerRequest: request as unknown as Readonly<Record<string, unknown>>,
+  }));
+  readonly respond = vi.fn(async function* (
+    _request: ModelRequest,
+    _options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    throw new Error('must not dispatch');
+  });
+}
+
+class ScriptedProvider implements ModelProvider {
+  readonly id = 'anthropic' as const;
+  readonly capabilities = CAPABILITIES;
+  readonly requests: ModelRequest[] = [];
+  readonly prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({
+    provider: this.id,
+    model: request.model,
+    capabilities: this.capabilities,
+    requestMetadata: request.requestMetadata,
+    providerRequest: structuredClone(request) as unknown as Readonly<Record<string, unknown>>,
+  }));
+
+  constructor(private readonly responses: ModelResponse[]) {}
+
+  async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request);
+    await options.beforeDispatch?.(prepared);
+    this.requests.push(structuredClone(request));
+    const response = this.responses.shift();
+    if (!response) throw new Error('Script exhausted');
+    yield { type: 'response_start', provider: this.id, model: response.model, id: response.id };
+    for (const [index, content] of response.content.entries()) {
+      if (content.type === 'text') yield { type: 'text_delta', index, text: content.text };
+    }
+    yield { type: 'response_complete', response };
+  }
+}
+
+function scriptedResponse(id: string, text: string): ModelResponse {
+  return {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    id,
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    providerFinishReason: 'stop',
+    usage: { inputTokens: 10, outputTokens: 5 },
+  };
+}
+
+function stage(provider: ModelProvider) {
+  return {
+    provider,
+    model: 'claude-haiku-4-5',
+    reasoningEffort: 'none' as const,
+    maxOutputTokens: 300,
+    timeoutMs: 30_000,
+    maxIterations: 1,
+    transportRetries: 0 as const,
+    samplingMode: 'provider_no_sampling_control' as const,
+    temperature: null,
+    pricing: {
+      profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+      inputUsdPerMillionTokens: 1,
+      outputUsdPerMillionTokens: 5,
+      cacheReadUsdPerMillionTokens: 0.1,
+      cacheWriteUsdPerMillionTokens: 1.25,
+      cacheReadAccounting: 'additive' as const,
+      cacheWriteAccounting: 'additive' as const,
+      source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+    },
+  };
+}
+
+function config(
+  routerProvider: ModelProvider,
+  generationProvider: ModelProvider,
+  traceSuite: readonly FixedTraceCase[],
+): FixedTraceRunnerConfig {
+  return {
+    runId: 'common-tool-universe-test',
+    sourceBundleSha256: 'a'.repeat(64),
+    gitCommit: 'abcdef0',
+    gitDirty: false,
+    promptConfigVersion: 'test',
+    traceSuite,
+    traceSuiteSha256: fixedTraceSuiteSha256(traceSuite),
+    // Deliberately retain the legacy fixture list: the diagnostic admission
+    // must reject it before either provider or handler boundary.
+    toolDefinitions: [],
+    toolDefinitionProvenance: 'fixture_local',
+    architectureArm: 'two_stage_llm_router',
+    router: stage(routerProvider),
+    generation: stage(generationProvider),
+  };
+}
+
+describe('fixed-trace common evaluator tool universe', () => {
+  it('is identical for routed, direct, and hybrid arms', () => {
+    const arms = [
+      'two_stage_llm_router',
+      'direct_generation',
+      'deterministic_policy_llm_fallback_hybrid',
+    ] as const;
+    const definitions = arms.map((arm) => fixedTraceCommonToolDefinitions(arm));
+    const provenance = arms.map((arm) => fixedTraceCommonToolUniverseProvenance(arm));
+
+    expect(definitions.map((tools) => tools.map((tool) => tool.name))).toEqual([
+      definitions[0]!.map((tool) => tool.name),
+      definitions[0]!.map((tool) => tool.name),
+      definitions[0]!.map((tool) => tool.name),
+    ]);
+    expect(provenance[1]).toEqual(provenance[0]);
+    expect(provenance[2]).toEqual(provenance[0]);
+  });
+
+  it('does not let scoring-label or fixture mutation alter candidate-visible definitions', async () => {
+    const original = FIXED_TRACE_SUITE.find((trace) => trace.id === 'knowledge-task-model')!;
+    const labelMutated: FixedTraceCase = {
+      ...original,
+      routing: { action: 'respond', toolSets: ['admin_events'] },
+      toolFixtures: [],
+      expectation: { ...original.expectation, requiredTools: ['fixture_oracle_only'], allowedTools: ['fixture_oracle_only'] },
+      answerRubric: ['Fixture oracle only.'],
+    };
+    // Change only labels used for scoring; request facts remain fixed.
+    expect(labelMutated.request).toEqual(original.request);
+    const originalRouter = new ScriptedProvider([
+      // Keep the established fixed-trace `respond` plan shape intact.
+      scriptedResponse('router-response', JSON.stringify({
+        action: 'respond',
+        tool_sets: [],
+        confidence: 'high',
+        requires_depth: false,
+        reason: 'Synthetic route.',
+      })),
+    ]);
+    const originalGeneration = new ScriptedProvider([
+      scriptedResponse('generation-response', 'Synthetic terminal response.'),
+    ]);
+    const mutatedRouter = new ScriptedProvider([
+      scriptedResponse('router-response', JSON.stringify({
+        action: 'respond',
+        tool_sets: [],
+        confidence: 'high',
+        requires_depth: false,
+        reason: 'Synthetic route.',
+      })),
+    ]);
+    const mutatedGeneration = new ScriptedProvider([
+      scriptedResponse('generation-response', 'Synthetic terminal response.'),
+    ]);
+
+    const originalResult = await runFixedTraceDiagnosticCandidate({
+      ...config(originalRouter, originalGeneration, [original]),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
+    });
+    const mutatedResult = await runFixedTraceDiagnosticCandidate({
+      ...config(mutatedRouter, mutatedGeneration, [labelMutated]),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
+    });
+
+    expect(originalResult.observations[0]!.metadata.executionEnvelope.source)
+      .toBe('evaluator_owned_synthetic_receipt_envelope');
+    expect(mutatedResult.observations[0]!.terminalStage).toBe('generation');
+    expect(originalGeneration.requests).toHaveLength(1);
+    expect(mutatedGeneration.requests).toHaveLength(1);
+    expect(mutatedGeneration.requests[0]!.tools.map((tool) => tool.name)).toEqual(
+      originalGeneration.requests[0]!.tools.map((tool) => tool.name),
+    );
+    expect(mutatedGeneration.requests[0]!.tools.map((tool) => tool.name))
+      .toEqual(FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames);
+  });
+
+  it.each([undefined, 'fixture_local', 'forged'])(
+    'fails closed with typed provenance for missing or unknown common-universe provenance: %s',
+    (provenance) => {
+      const admission = admitFixedTraceCommonToolUniverse('two_stage_llm_router', provenance);
+      expect(admission).toMatchObject({
+        admitted: false,
+        provenance: {
+          source: 'evaluator_owned_common_tool_universe',
+          admission: 'blocked_missing_authenticated_definition_handler_intersection',
+        },
+      });
+      expect(admission.reasons).toContain('common_tool_universe_provenance_missing_or_unknown');
+      expect(() => assertFixedTraceCommonToolUniverseAdmission('two_stage_llm_router', provenance))
+        .toThrow(FixedTraceCommonToolUniverseAdmissionError);
+    },
+  );
+
+  it.each([undefined, 'fixture_local', 'forged'])(
+    'blocks %s provenance before provider preparation, dispatch, or handler execution',
+    async (provenance) => {
+    const router = new NeverDispatchProvider();
+    const generation = new NeverDispatchProvider();
+    const firstTool = FIXED_TRACE_DIRECT_TOOL_UNIVERSE.tools[0]!;
+    const originalHandler = FIXED_TRACE_DIRECT_TOOL_HANDLERS.get(firstTool.definition.name)!;
+    const handler = vi.fn(originalHandler);
+    FIXED_TRACE_DIRECT_TOOL_HANDLERS.set(firstTool.definition.name, handler);
+    try {
+      const runConfig = config(router, generation, [FIXED_TRACE_SUITE[0]!]);
+      runConfig.toolDefinitionProvenance = provenance as unknown as FixedTraceRunnerConfig['toolDefinitionProvenance'];
+      await expect(runFixedTraceDiagnosticCandidate(runConfig))
+        .rejects.toThrow(FixedTraceCommonToolUniverseAdmissionError);
+      expect(router.prepare).not.toHaveBeenCalled();
+      expect(router.respond).not.toHaveBeenCalled();
+      expect(generation.prepare).not.toHaveBeenCalled();
+      expect(generation.respond).not.toHaveBeenCalled();
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      FIXED_TRACE_DIRECT_TOOL_HANDLERS.set(firstTool.definition.name, originalHandler);
+    }
+    },
+  );
+});

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -4,6 +4,7 @@ import {
   assertFixedTraceCommonToolUniverseAdmission,
   FixedTraceCommonToolUniverseAdmissionError,
   fixedTraceCommonToolDefinitions,
+  fixedTraceHybridPolicy,
   fixedTraceCommonToolUniverseProvenance,
 } from '../../../src/addie/eval/fixed-trace-architecture.js';
 import {
@@ -11,7 +12,14 @@ import {
   FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
 } from '../../../src/addie/direct-tool-universe.js';
 import { runFixedTraceDiagnosticCandidate } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
-import { FIXED_TRACE_SUITE, fixedTraceSuiteSha256, type FixedTraceCase } from '../../../src/addie/eval/fixed-trace-suite.js';
+import {
+  FIXED_TRACE_SUITE,
+  fixedTraceSuiteSha256,
+  gradeFixedTrace,
+  summarizeFixedTraceRun,
+  type FixedTraceCase,
+  type FixedTraceObservation,
+} from '../../../src/addie/eval/fixed-trace-suite.js';
 import type {
   ModelProvider,
   ModelProviderCapabilities,
@@ -160,6 +168,88 @@ describe('fixed-trace common evaluator tool universe', () => {
     ]);
     expect(provenance[1]).toEqual(provenance[0]);
     expect(provenance[2]).toEqual(provenance[0]);
+  });
+
+  it.each([
+    'two_stage_llm_router',
+    'deterministic_policy_llm_fallback_hybrid',
+  ] as const)('serializes valid common-universe %s observations without legacy provenance failures', async (architectureArm) => {
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'knowledge-task-model')!;
+    const router = new ScriptedProvider([
+      scriptedResponse('router-response', JSON.stringify({
+        action: 'respond',
+        tool_sets: [],
+        confidence: 'high',
+        requires_depth: false,
+        reason: 'Synthetic route.',
+      })),
+    ]);
+    const generation = new ScriptedProvider([
+      scriptedResponse('generation-response', 'Synthetic terminal response.'),
+    ]);
+
+    const result = await runFixedTraceDiagnosticCandidate({
+      ...config(router, generation, [trace]),
+      toolDefinitions: fixedTraceCommonToolDefinitions(architectureArm),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
+      architectureArm,
+      ...(architectureArm === 'deterministic_policy_llm_fallback_hybrid'
+        ? { hybridPolicy: fixedTraceHybridPolicy() }
+        : {}),
+    });
+    const serialized = JSON.parse(JSON.stringify(result.observations)) as FixedTraceObservation[];
+    const regraded = summarizeFixedTraceRun(serialized, [trace]);
+
+    expect(router.requests).toHaveLength(1);
+    expect(generation.requests).toHaveLength(1);
+    expect(serialized[0]!.metadata.toolDefinitionProvenance).toBe('evaluator_owned_common_tool_universe');
+    expect(regraded.grades[0]).toMatchObject({ metadataPass: true });
+    expect(regraded.grades[0]!.failures).not.toContain('tool_universe_provenance_invalid');
+    expect(regraded.grades[0]!.failures).not.toContain('execution_envelope_provenance_invalid');
+    expect(regraded.summary).toMatchObject({
+      expected: 1,
+      observed: 1,
+      metadataPassRate: 1,
+    });
+  });
+
+  it('does not let invalid common provenance escape through the valid hybrid legacy path', async () => {
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.id === 'knowledge-task-model')!;
+    const router = new ScriptedProvider([
+      scriptedResponse('router-response', JSON.stringify({
+        action: 'respond',
+        tool_sets: [],
+        confidence: 'high',
+        requires_depth: false,
+        reason: 'Synthetic route.',
+      })),
+    ]);
+    const generation = new ScriptedProvider([
+      scriptedResponse('generation-response', 'Synthetic terminal response.'),
+    ]);
+    const result = await runFixedTraceDiagnosticCandidate({
+      ...config(router, generation, [trace]),
+      toolDefinitions: fixedTraceCommonToolDefinitions('deterministic_policy_llm_fallback_hybrid'),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
+      architectureArm: 'deterministic_policy_llm_fallback_hybrid',
+      hybridPolicy: fixedTraceHybridPolicy(),
+    });
+    const invalid = JSON.parse(JSON.stringify(result.observations[0])) as FixedTraceObservation;
+    invalid.metadata.toolUniverse = {
+      ...invalid.metadata.toolUniverse,
+      source: 'fixture_local_routed_replay',
+      intentNarrowing: 'production_quick_match_or_llm_router',
+    };
+    invalid.metadata.executionEnvelope = {
+      ...invalid.metadata.executionEnvelope,
+      source: 'fixture_expectation',
+    };
+
+    const grade = gradeFixedTrace(trace, invalid);
+
+    expect(grade.metadataPass).toBe(false);
+    expect(grade.failures).toContain('tool_universe_provenance_invalid');
+    expect(grade.failures).toContain('execution_envelope_provenance_invalid');
   });
 
   it('does not let scoring-label or fixture mutation alter candidate-visible definitions', async () => {

--- a/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
+++ b/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
@@ -13,8 +13,10 @@ import {
   type FixedTraceDiagnosticProviderPlan,
 } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
 import { reserveFixedTraceDiagnosticOutput } from '../../../src/addie/eval/fixed-trace-diagnostic-output.js';
-import { canonicalFixedTraceToolDefinitions } from '../../../src/addie/eval/fixed-trace-tools.js';
-import { fixedTraceHybridPolicy } from '../../../src/addie/eval/fixed-trace-architecture.js';
+import {
+  fixedTraceCommonToolDefinitions,
+  fixedTraceHybridPolicy,
+} from '../../../src/addie/eval/fixed-trace-architecture.js';
 import type { FixedTraceProviderStageConfig } from '../../../src/addie/eval/fixed-trace-runner.js';
 import {
   FIXED_TRACE_SUITE,
@@ -82,6 +84,10 @@ const DIAGNOSTIC_TEST_REQUEST: ModelRequest = {
   tools: [],
   maxOutputTokens: 1,
 };
+
+// Diagnostic artifacts are architecture-comparison components. Every test
+// therefore uses the same evaluator-owned candidate surface, never fixtures.
+const COMMON_TOOL_DEFINITIONS = fixedTraceCommonToolDefinitions('two_stage_llm_router');
 
 function scriptedRouter(
   afterFinalResponse?: (response: ModelResponse) => void,
@@ -288,8 +294,8 @@ describe('fixed-trace diagnostic output reservation', () => {
         promptConfigVersion: 'synthetic-manual-prompt-v1',
         traceSuite: [selectedTrace],
         traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]),
-        toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local',
+        toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
         architectureArm: 'deterministic_policy_llm_fallback_hybrid',
         hybridPolicy: fixedTraceHybridPolicy(),
       },
@@ -352,8 +358,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       promptConfigVersion: 'before-prompt',
       traceSuite: [selectedTrace],
       traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]),
-      toolDefinitions: [],
-      toolDefinitionProvenance: 'fixture_local' as const,
+      toolDefinitions: COMMON_TOOL_DEFINITIONS,
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe' as const,
       architectureArm: 'two_stage_llm_router' as const,
     };
     let secondPlan!: FixedTraceDiagnosticProviderPlan;
@@ -432,8 +438,8 @@ describe('fixed-trace diagnostic output reservation', () => {
     const baseConfig = {
       sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
       promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-      traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-      toolDefinitionProvenance: 'fixture_local' as const,
+      traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe' as const,
       architectureArm: 'two_stage_llm_router' as const,
     };
     const invoke = (plans: FixedTraceDiagnosticProviderPlan[]) => runFixedTraceDiagnosticArtifact({
@@ -493,8 +499,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -537,8 +543,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -575,8 +581,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -622,8 +628,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -666,8 +672,8 @@ describe('fixed-trace diagnostic output reservation', () => {
         promptConfigVersion: 'synthetic-manual-prompt-v1',
         traceSuite: [selectedTrace],
         traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]),
-        toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local',
+        toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
         architectureArm: 'two_stage_llm_router',
       },
       budget,
@@ -695,8 +701,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       // This former input is intentionally ignored at runtime as well as
       // removed from the public type, so a JavaScript caller cannot forge it.
@@ -746,8 +752,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -777,8 +783,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -816,8 +822,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -865,8 +871,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -911,8 +917,8 @@ describe('fixed-trace diagnostic output reservation', () => {
       baseConfig: {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -982,8 +988,8 @@ describe('fixed-trace diagnostic output reservation', () => {
         sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
         promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
         traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]),
-        toolDefinitions: canonicalFixedTraceToolDefinitions().filter((tool) => ['search_docs', 'get_doc'].includes(tool.name)),
-        toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+        toolDefinitions: COMMON_TOOL_DEFINITIONS,
+        toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
       },
       budget,
       outputReservation: reserveFixedTraceDiagnosticOutput(path),
@@ -1015,8 +1021,8 @@ describe('fixed-trace diagnostic output reservation', () => {
         baseConfig: {
           sourceBundleSha256: 'a'.repeat(64), gitCommit: 'abcdef0', gitDirty: false,
           promptConfigVersion: 'synthetic-manual-prompt-v1', traceSuite: [selectedTrace],
-          traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: [],
-          toolDefinitionProvenance: 'fixture_local', architectureArm: 'two_stage_llm_router',
+          traceSuiteSha256: fixedTraceSuiteSha256([selectedTrace]), toolDefinitions: COMMON_TOOL_DEFINITIONS,
+          toolDefinitionProvenance: 'evaluator_owned_common_tool_universe', architectureArm: 'two_stage_llm_router',
         },
         budget,
         outputReservation: reserveFixedTraceDiagnosticOutput(join(directory, `${suffix}.json`)),

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -31,6 +31,7 @@ import {
   admitFixedTraceDirectArm,
   decideFixedTraceHybridRoute,
   deriveFixedTraceDirectToolUniverse,
+  fixedTraceCommonToolDefinitions,
   FixedTraceHybridAdmissionSnapshotError,
   fixedTraceHybridPolicy,
 } from '../../../src/addie/eval/fixed-trace-architecture.js';
@@ -1395,13 +1396,17 @@ describe('fixed trace artifact runner', () => {
     expect(router.respondCalls).toHaveLength(1);
   });
 
-  it('does not construct a manual diagnostic candidate summary after final-response identity mutation', async () => {
+  it('does not construct a manual diagnostic candidate summary after final-response identity mutation under a valid neutral universe', async () => {
     const selectedTrace = trace('knowledge-task-model');
     let runConfig!: FixedTraceRunnerConfig;
     const router = new MutatingResponseProvider([routeResponse('ignore')], () => {
       runConfig.runId = 'mutated-after-final-response';
     });
-    runConfig = config(router, new ScriptedProvider([]), { traceSuite: [selectedTrace] });
+    runConfig = config(router, new ScriptedProvider([]), {
+      traceSuite: [selectedTrace],
+      toolDefinitions: fixedTraceCommonToolDefinitions('two_stage_llm_router'),
+      toolDefinitionProvenance: 'evaluator_owned_common_tool_universe',
+    });
 
     await expect(runFixedTraceDiagnosticCandidate(runConfig))
       .rejects.toThrow('Fixed trace runner execution identity changed before provider dispatch');


### PR DESCRIPTION
## Summary
- use an evaluator-owned, registry-derived candidate tool universe for routed/hybrid diagnostic generation
- reject absent, legacy, or forged common-universe provenance before provider or handler boundaries
- retain direct-arm non-admission and use synthetic receipt handlers only for component evaluation

## Verification
- npm run typecheck
- focused fixed-trace tests (66 passing)
- npm run validate:addie-fixed-traces
- generated tool reference and inventory checks
- git diff --check

Implements an evaluation prerequisite for #6842 and #6846.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4afb0f51-2387-4561-b76d-dfe4702cb67f)
