### PR TITLE
fix(addie): correct Sonnet 5 pricing

### DIFF
--- a/server/src/addie/claude-pricing.ts
+++ b/server/src/addie/claude-pricing.ts
@@ -11,7 +11,7 @@
  *     cap by rewriting pricing).
  *
  * Update these alongside Anthropic's pricing page when model rates
- * change. Last refresh: August 2026.
+ * change. Last refresh: September 2026.
  */
 
 /** Per-million-token prices. Converted to per-token via × 1/1_000_000 downstream. */
@@ -24,7 +24,7 @@ interface ModelRates {
   cacheReadUsd: number;
 }
 
-export const CLAUDE_PRICING_VERSION = 'anthropic-standard-2026-08' as const;
+export const CLAUDE_PRICING_VERSION = 'anthropic-standard-2026-09' as const;
 
 const PRICING_PER_MILLION_TOKENS: Record<string, ModelRates> = {
   // Claude Fable — highest-cost generally available tier
@@ -34,11 +34,12 @@ const PRICING_PER_MILLION_TOKENS: Record<string, ModelRates> = {
   'claude-opus-4-7': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
   'claude-opus-4-8': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
   'claude-opus-5': { inputUsd: 5, outputUsd: 25, cacheCreationUsd: 6.25, cacheReadUsd: 0.5 },
-  // Claude Sonnet — balanced tier (most Addie calls). Sonnet 5 is kept at
-  // its standard post-promotion rate so the daily cap remains conservative.
+  // Claude Sonnet — balanced tier (most Addie calls). Anthropic pricing
+  // checked 2026-09-05: Sonnet 5 uses its exact public standard rate,
+  // including the 5-minute cache-write rate.
   'claude-sonnet-4-5': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
   'claude-sonnet-4-6': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
-  'claude-sonnet-5': { inputUsd: 3, outputUsd: 15, cacheCreationUsd: 3.75, cacheReadUsd: 0.3 },
+  'claude-sonnet-5': { inputUsd: 2, outputUsd: 10, cacheCreationUsd: 2.5, cacheReadUsd: 0.2 },
   // Claude Haiku 4.x — fast / cheap tier (routing, classification)
   'claude-haiku-4-5': { inputUsd: 1, outputUsd: 5, cacheCreationUsd: 1.25, cacheReadUsd: 0.1 },
 };

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -80,20 +80,20 @@ export function fixedTraceModelResolutionPolicy(
 const FIXED_TRACE_APPROVED_PRICING = Object.freeze(([
   {
     expectedProvider: 'anthropic', expectedModel: 'claude-haiku-4-5',
-    profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+    profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
     inputUsdPerMillionTokens: 1, outputUsdPerMillionTokens: 5,
     cacheReadUsdPerMillionTokens: 0.1, cacheWriteUsdPerMillionTokens: 1.25,
     cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
-    source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+    source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
     modelResolutionPolicy: 'exact_model_identity_v1',
   },
   {
     expectedProvider: 'anthropic', expectedModel: 'claude-sonnet-5',
-    profileId: 'anthropic-standard-2026-08:claude-sonnet-5',
-    inputUsdPerMillionTokens: 3, outputUsdPerMillionTokens: 15,
-    cacheReadUsdPerMillionTokens: 0.3, cacheWriteUsdPerMillionTokens: 3.75,
+    profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
+    inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 10,
+    cacheReadUsdPerMillionTokens: 0.2, cacheWriteUsdPerMillionTokens: 2.5,
     cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
-    source: 'Repository Anthropic pricing table: Claude Sonnet 5 standard, refreshed August 2026.',
+    source: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
     modelResolutionPolicy: 'exact_model_identity_v1',
   },
   {

--- a/server/tests/manual/fixed-trace-provider-eval.ts
+++ b/server/tests/manual/fixed-trace-provider-eval.ts
@@ -77,24 +77,24 @@ type ProviderPlan = FixedTraceDiagnosticProviderPlan & { name: ProviderName };
 
 const PRICING = {
   anthropicRouter: {
-    profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+    profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
     inputUsdPerMillionTokens: 1,
     outputUsdPerMillionTokens: 5,
     cacheReadUsdPerMillionTokens: 0.1,
     cacheWriteUsdPerMillionTokens: 1.25,
     cacheReadAccounting: 'additive',
     cacheWriteAccounting: 'additive',
-    source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+    source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
   },
   anthropicGeneration: {
-    profileId: 'anthropic-standard-2026-08:claude-sonnet-5',
-    inputUsdPerMillionTokens: 3,
-    outputUsdPerMillionTokens: 15,
-    cacheReadUsdPerMillionTokens: 0.3,
-    cacheWriteUsdPerMillionTokens: 3.75,
+    profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
+    inputUsdPerMillionTokens: 2,
+    outputUsdPerMillionTokens: 10,
+    cacheReadUsdPerMillionTokens: 0.2,
+    cacheWriteUsdPerMillionTokens: 2.5,
     cacheReadAccounting: 'additive',
     cacheWriteAccounting: 'additive',
-    source: 'Repository Anthropic pricing table: Claude Sonnet 5 standard, refreshed August 2026.',
+    source: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
   },
   openai: {
     profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -64,6 +64,39 @@ const RESPONSE_PRICING_POLICY = fixedTraceResponsePricingPolicy(
   PRICING,
 );
 
+const SONNET_5_PRICING = {
+  profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
+  inputUsdPerMillionTokens: 2,
+  outputUsdPerMillionTokens: 10,
+  cacheReadUsdPerMillionTokens: 0.2,
+  cacheWriteUsdPerMillionTokens: 2.5,
+  cacheReadAccounting: 'additive' as const,
+  cacheWriteAccounting: 'additive' as const,
+  source: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
+};
+
+const HAIKU_4_5_PRICING = {
+  profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
+  inputUsdPerMillionTokens: 1,
+  outputUsdPerMillionTokens: 5,
+  cacheReadUsdPerMillionTokens: 0.1,
+  cacheWriteUsdPerMillionTokens: 1.25,
+  cacheReadAccounting: 'additive' as const,
+  cacheWriteAccounting: 'additive' as const,
+  source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
+};
+
+const GOOGLE_PRICING = {
+  profileId: 'google-gemini-3.7-flash-through-2026-12-31',
+  inputUsdPerMillionTokens: 0.75,
+  outputUsdPerMillionTokens: 3.75,
+  cacheReadUsdPerMillionTokens: 0.075,
+  cacheWriteUsdPerMillionTokens: 0.75,
+  cacheReadAccounting: 'subset' as const,
+  cacheWriteAccounting: 'additive' as const,
+  source: 'Google Gemini 3.7 Flash introductory standard, checked 2026-08-25.',
+};
+
 class BudgetScriptedProvider implements ModelProvider {
   readonly id = 'openai' as const;
   readonly capabilities = CAPABILITIES;
@@ -115,6 +148,56 @@ describe('fixed trace provider budget', () => {
       source: 'Synthetic manual artifact pricing.',
     })).toThrow('Fixed trace pricing profile is not evaluator approved');
     expect(delegate.dispatches).not.toHaveBeenCalled();
+  });
+
+  it('accepts only the reviewed September Sonnet 5 policy and applies its additive cache rates', () => {
+    expect(fixedTraceApprovedPricingProfiles()).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        expectedProvider: 'anthropic',
+        expectedModel: 'claude-sonnet-5',
+        profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
+      }),
+      expect.objectContaining({
+        expectedProvider: 'openai',
+        expectedModel: 'gpt-5.6-luna',
+        profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',
+      }),
+      expect.objectContaining({
+        expectedProvider: 'google',
+        expectedModel: 'gemini-3.7-flash',
+        profileId: 'google-gemini-3.7-flash-through-2026-12-31',
+      }),
+    ]));
+    expect(fixedTraceResponsePricingPolicy('anthropic', 'claude-sonnet-5', SONNET_5_PRICING))
+      .toMatchObject({ pricingProfileId: SONNET_5_PRICING.profileId });
+    expect(fixedTraceEstimatedCostUsd({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 1_000,
+      cacheWriteTokens: 200,
+    }, SONNET_5_PRICING)).toBe(0.0011);
+    // A previous live cohort is historical evidence, not an approval for a
+    // new fixed-trace run at a new date.
+    expect(() => fixedTraceResponsePricingPolicy('anthropic', 'claude-sonnet-5', {
+      ...SONNET_5_PRICING,
+      profileId: 'anthropic-standard-2026-08:claude-sonnet-5',
+    })).toThrow('Fixed trace pricing profile is not evaluator approved');
+  });
+
+  it('retains the reviewed Haiku, Luna, and Gemini rate cohorts', () => {
+    expect(fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', HAIKU_4_5_PRICING))
+      .toMatchObject({ pricingProfileId: HAIKU_4_5_PRICING.profileId });
+    expect(fixedTraceEstimatedCostUsd({
+      inputTokens: 100, outputTokens: 20, cacheReadTokens: 1_000, cacheWriteTokens: 200,
+    }, HAIKU_4_5_PRICING)).toBe(0.00055);
+    expect(fixedTraceEstimatedCostUsd({
+      inputTokens: 100, outputTokens: 20, cacheReadTokens: 20, cacheWriteTokens: 0,
+    }, PRICING)).toBeCloseTo(0.0000404);
+    expect(fixedTraceResponsePricingPolicy('google', 'gemini-3.7-flash', GOOGLE_PRICING))
+      .toMatchObject({ pricingProfileId: GOOGLE_PRICING.profileId });
+    expect(fixedTraceEstimatedCostUsd({
+      inputTokens: 100, outputTokens: 20, cacheReadTokens: 20, cacheWriteTokens: 0,
+    }, GOOGLE_PRICING)).toBeCloseTo(0.0001365);
   });
 
   it('prices Google-style subset reads plus additive writes explicitly', () => {

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -116,14 +116,14 @@ function stage(provider: ModelProvider) {
     samplingMode: 'provider_no_sampling_control' as const,
     temperature: null,
     pricing: {
-      profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+      profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
       inputUsdPerMillionTokens: 1,
       outputUsdPerMillionTokens: 5,
       cacheReadUsdPerMillionTokens: 0.1,
       cacheWriteUsdPerMillionTokens: 1.25,
       cacheReadAccounting: 'additive' as const,
       cacheWriteAccounting: 'additive' as const,
-      source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+      source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
     },
   };
 }

--- a/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
+++ b/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
@@ -46,14 +46,14 @@ const CAPABILITIES: ModelProviderCapabilities = {
 };
 
 const PRICING: FixedTracePricing = {
-  profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+  profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
   inputUsdPerMillionTokens: 1,
   outputUsdPerMillionTokens: 5,
   cacheReadUsdPerMillionTokens: 0.1,
   cacheWriteUsdPerMillionTokens: 1.25,
   cacheReadAccounting: 'additive',
   cacheWriteAccounting: 'additive',
-  source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+  source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
 };
 
 const MODEL = 'claude-haiku-4-5';

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -342,14 +342,14 @@ function stage(provider: ModelProvider, maxIterations: number): FixedTraceProvid
     samplingMode: 'provider_no_sampling_control',
     temperature: null,
     pricing: {
-      profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+      profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
       inputUsdPerMillionTokens: 1,
       outputUsdPerMillionTokens: 5,
       cacheReadUsdPerMillionTokens: 0.1,
       cacheWriteUsdPerMillionTokens: 1.25,
       cacheReadAccounting: 'additive',
       cacheWriteAccounting: 'additive',
-      source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+      source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
     },
   };
 }
@@ -918,7 +918,7 @@ describe('fixed trace artifact runner', () => {
       usageKnown: true,
       usage: { inputTokens: 30, outputTokens: 15 },
       estimatedCostUsd: 0.000105,
-      pricingSource: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+      pricingSource: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
     });
     expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({
       deterministicPass: false,
@@ -1050,14 +1050,14 @@ describe('fixed trace artifact runner', () => {
     const delegate = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
     const budget = new FixedTraceBudget(0.000001);
     const router = new BudgetedFixedTraceProvider(delegate, budget, {
-      profileId: 'anthropic-standard-2026-08:claude-haiku-4-5',
+      profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
       inputUsdPerMillionTokens: 1,
       outputUsdPerMillionTokens: 5,
       cacheReadUsdPerMillionTokens: 0.1,
       cacheWriteUsdPerMillionTokens: 1.25,
       cacheReadAccounting: 'additive',
       cacheWriteAccounting: 'additive',
-      source: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+      source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
     }, fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', stage(delegate, 1).pricing));
     const generation = new ScriptedProvider([]);
 
@@ -1159,7 +1159,7 @@ describe('fixed trace artifact runner', () => {
           usageKnown: true,
           usage: { inputTokens: 10, outputTokens: 5 },
           estimatedCostUsd: 0.000035,
-          pricingSource: 'Repository Anthropic pricing table: Claude Haiku 4.5, refreshed August 2026.',
+          pricingSource: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
         },
       },
     });

--- a/server/tests/unit/addie/shadow-replay-judge.test.ts
+++ b/server/tests/unit/addie/shadow-replay-judge.test.ts
@@ -282,7 +282,7 @@ describe('shadow replay independent judge', () => {
       cacheReadTokens: 5,
       cacheWriteTokens: 2,
       usageAvailable: true,
-      pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+      pricingVersion: 'anthropic-standard-2026-09:claude-opus-4-6',
       latencyMs: 250,
     });
     expect(result.judgePromptHmac).toMatch(/^[0-9a-f]{64}$/);
@@ -410,7 +410,7 @@ describe('shadow replay independent judge', () => {
     expect(result).toMatchObject({
       status: 'error',
       reason: 'judge_provider_error',
-      pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+      pricingVersion: 'anthropic-standard-2026-09:claude-opus-4-6',
       usageAvailable: false,
       inputTokens: 0,
       outputTokens: 0,

--- a/server/tests/unit/addie/shadow-replay-pricing.test.ts
+++ b/server/tests/unit/addie/shadow-replay-pricing.test.ts
@@ -7,13 +7,13 @@ import {
 describe('shadow replay pricing', () => {
   it('prices exact Anthropic usage including cache reads and writes', () => {
     const pricing = resolveShadowReplayPricing('anthropic', 'claude-sonnet-5');
-    expect(pricing?.version).toBe('anthropic-standard-2026-08:claude-sonnet-5');
+    expect(pricing?.version).toBe('anthropic-standard-2026-09:claude-sonnet-5');
     expect(pricing?.estimateCostMicros({
       inputTokens: 100,
       outputTokens: 20,
       cacheReadTokens: 1_000,
       cacheWriteTokens: 200,
-    })).toBe(1_650);
+    })).toBe(1_100);
   });
 
   it('prices only the exact reviewed Google model', () => {

--- a/server/tests/unit/addie/shadow-replay-rollout.test.ts
+++ b/server/tests/unit/addie/shadow-replay-rollout.test.ts
@@ -59,7 +59,7 @@ function judgment(
     judge_model: 'claude-opus-4-6',
     self_judged: false,
     judge_prompt_version: 'official-docs-independent-judge:v1',
-    pricing_version: 'anthropic-standard-2026-08:claude-opus-4-6',
+    pricing_version: 'anthropic-standard-2026-09:claude-opus-4-6',
     status: 'judged',
     reason: 'judgment_succeeded',
     evaluation_valid: true,

--- a/server/tests/unit/addie/shadow-replay-trace.test.ts
+++ b/server/tests/unit/addie/shadow-replay-trace.test.ts
@@ -50,7 +50,7 @@ const COMPLETE_JUDGMENT_USAGE = {
   cacheReadTokens: 6,
   cacheWriteTokens: 3,
   usageAvailable: true,
-  pricingVersion: 'anthropic-standard-2026-08:claude-opus-4-6',
+  pricingVersion: 'anthropic-standard-2026-09:claude-opus-4-6',
   latencyMs: 125,
 } as const;
 const NO_JUDGE_USAGE = {
@@ -637,7 +637,7 @@ describe('shadow replay trace authorization', () => {
       trace.expected.effective_model,
       trace.expected.provider_request_hmac,
       CODE_VERSION,
-      'anthropic-standard-2026-08:claude-sonnet-5',
+      'anthropic-standard-2026-09:claude-sonnet-5',
     ]);
     expect(JSON.stringify(runQuery.mock.calls)).not.toContain(QUESTION);
   });
@@ -987,7 +987,7 @@ describe('shadow replay trace authorization', () => {
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
         usageAvailable: true,
-        pricingVersion: 'anthropic-standard-2026-08:claude-sonnet-5',
+        pricingVersion: 'anthropic-standard-2026-09:claude-sonnet-5',
         latencyMs: 125,
         startedAt: new Date(NOW.getTime() - 1_000),
         completedAt: NOW,
@@ -1150,7 +1150,7 @@ describe('shadow replay trace authorization', () => {
       false,
       500,
       null,
-      'anthropic-standard-2026-08:claude-sonnet-5',
+      'anthropic-standard-2026-09:claude-sonnet-5',
     ]);
   });
 
@@ -1289,6 +1289,8 @@ describe('shadow replay trace authorization', () => {
   });
 
   it('reports categorical judgment totals and a no-payload opportunity funnel', async () => {
+    // A stored August estimate is historical evidence. Reporting preserves its
+    // recorded cohort and amount; it must not be recalculated at September rates.
     const judgments = [{
       capture_version: 3,
       capture_policy_version: 'official-docs-capture:v3',

--- a/server/tests/unit/claude-pricing.test.ts
+++ b/server/tests/unit/claude-pricing.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { costUsdMicros, __hasKnownPricing } from '../../src/addie/claude-pricing.js';
+import {
+  __hasKnownPricing,
+  costUsdMicros,
+  resolveKnownClaudePricingModel,
+} from '../../src/addie/claude-pricing.js';
 
 /**
  * #2790 — pricing helper. Converts Anthropic `usage` to USD micros
@@ -13,9 +17,9 @@ describe('costUsdMicros', () => {
     expect(costUsdMicros('claude-haiku-4-5', { input_tokens: 1_000_000, output_tokens: 0 })).toBe(1_000_000);
   });
 
-  it('prices Sonnet at $3/M input, $15/M output', () => {
-    // 10k input, 5k output: 10_000*3 + 5_000*15 = 30_000 + 75_000 = 105_000 micros ($0.105)
-    expect(costUsdMicros('claude-sonnet-5', { input_tokens: 10_000, output_tokens: 5_000 })).toBe(105_000);
+  it('prices Sonnet 5 at $2/M input and $10/M output', () => {
+    // 10k input, 5k output: 10_000*2 + 5_000*10 = 70_000 micros ($0.070)
+    expect(costUsdMicros('claude-sonnet-5', { input_tokens: 10_000, output_tokens: 5_000 })).toBe(70_000);
   });
 
   it('prices Opus at $5/M input, $25/M output', () => {
@@ -23,15 +27,15 @@ describe('costUsdMicros', () => {
     expect(costUsdMicros('claude-opus-5', { input_tokens: 1000, output_tokens: 500 })).toBe(17_500);
   });
 
-  it('applies cache-creation and cache-read rates (Sonnet)', () => {
-    // 1000 input@3, 500 output@15, 2000 creation@3.75, 500 read@0.3
-    // = 3000 + 7500 + 7500 + 150 = 18_150 micros
-    expect(costUsdMicros('claude-sonnet-4-6', {
+  it('applies Sonnet 5 5-minute cache-creation and cache-read rates', () => {
+    // 1000 input@2, 500 output@10, 2000 creation@2.5, 500 read@0.2
+    // = 2000 + 5000 + 5000 + 100 = 12_100 micros
+    expect(costUsdMicros('claude-sonnet-5', {
       input_tokens: 1000,
       output_tokens: 500,
       cache_creation_input_tokens: 2000,
       cache_read_input_tokens: 500,
-    })).toBe(18_150);
+    })).toBe(12_100);
   });
 
   it('treats missing cache fields as zero', () => {
@@ -51,8 +55,8 @@ describe('costUsdMicros', () => {
 
   it('ceilings fractional results so a sub-micro charge still increments the counter', () => {
     // 1 token at Haiku ($1/M): 1 * 1 = 1 micro. Integer already.
-    // 1 token at Sonnet cache-read ($0.3/M): 1 * 0.3 = 0.3 → ceil to 1.
-    expect(costUsdMicros('claude-sonnet-4-6', {
+    // 1 token at Sonnet 5 cache-read ($0.2/M): 1 * 0.2 = 0.2 → ceil to 1.
+    expect(costUsdMicros('claude-sonnet-5', {
       input_tokens: 0,
       output_tokens: 0,
       cache_read_input_tokens: 1,
@@ -61,6 +65,16 @@ describe('costUsdMicros', () => {
 
   it('is zero for a zero-usage response (rare but possible)', () => {
     expect(costUsdMicros('claude-haiku-4-5', { input_tokens: 0, output_tokens: 0 })).toBe(0);
+  });
+});
+
+describe('resolveKnownClaudePricingModel', () => {
+  it('maps a dated Sonnet 5 response to its reviewed canonical rate', () => {
+    expect(resolveKnownClaudePricingModel('claude-sonnet-5-20260905')).toBe('claude-sonnet-5');
+  });
+
+  it('does not resolve an unknown model family', () => {
+    expect(resolveKnownClaudePricingModel('claude-sonnet-6-20260905')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Correct Claude Sonnet 5 exact standard pricing to $2/M input, $10/M output, $2.50/M 5-minute cache writes, and $0.20/M cache reads.
- Advance current Anthropic pricing identities to `anthropic-standard-2026-09`; retain explicit August records only as historical evidence and reject them for new fixed-trace runs.
- Keep Haiku ($1/$5, $1.25 write, $0.10 read), Luna ($0.20/$1.20), and Gemini 3.7 Flash introductory pricing unchanged.
- Add deterministic coverage for micros, cache semantics, dated model resolution, conservative unknown-model fallback, reviewed fixed-trace policy identity, historic-row preservation, and unaffected cohorts.

Sources checked 2026-09-05: [Sonnet 5 documentation](https://platform.claude.com/docs/en/models/sonnet-5/whats-new-sonnet-5) and [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing).

## Immutable reconciliation note

No source run artifact is changed and this PR does not claim billed truth. User-supplied local, immutable, cohort-tagged reconciliation addenda remain outside this PR:

- `fixed-traces-v31-openai-2026-09-04.price-reconciliation-2026-09.json` (`4abc524750350739cbf56cd1c631c93e0b4b171ef371ee5ee1cb2bb7b22930d3`): total estimate $0.4394153 → $0.3823133; all-judge estimate $0.1962225 → $0.1391205.
- `fixed-traces-v31-openai-2026-09-05-boundary-fix.price-reconciliation-2026-09.json` (`420ccb1c844ca25511ec65b9ef752d82d6b125e3c276d17398f701a50d6669d7`): total estimate $0.4353643 → $0.3807663; all-judge estimate $0.1882455 → $0.1336475.

The price-gate result changes, but both source runs remain comparison-ineligible and `rolloutPass=false` because quality, coverage, safety, and consensus gates fail; first-run candidate cost remains unavailable. Anthropic also notes Sonnet 5 uses about 30% more tokens, so this price correction is not a substitute for metered workload measurement.

## Validation

- Focused pricing/budget/shadow suite: 181 passed across 9 files (rerun after rebase).
- `npm run typecheck`: passed.
- Root `tsc --project tsconfig.json --noEmit`: baseline failure in unrelated ES2020-lib configuration (`.at`, `replaceAll`, `Object.hasOwn`, etc.); no pricing-file diagnostics.
- `npm run test:migrations`: 3 passed.
- `npm run test:immutable-release-artifacts`, `node scripts/check-changeset-protocol-scope.cjs origin/main`, and `npm run test:addie-tools`: passed.
- Full `npm run test:registry`: 8,622 passed, 1,804 skipped, 8 unrelated failures/timeouts across 727 files (auth-session/webhook/fixed-trace CLI suites).
- Required pre-commit full server-unit stage reached its configured 600-second timeout before committing; the focused gates above pass. Normal pre-push hook passed.

Drafted for independent Sol review.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dc4bea27-cc82-4391-9ca9-067324e4b5d4)
