### PR TITLE
feat(addie): add dated evaluation pricing cohort

### DIFF
--- a/server/src/addie/eval/dated-pricing-cohort.ts
+++ b/server/src/addie/eval/dated-pricing-cohort.ts
@@ -87,6 +87,20 @@ export interface DatedPricingUsage {
   readonly cacheWriteTokens?: number;
 }
 
+/**
+ * The rate-bearing portion of a dated profile.  Keep this structural so every
+ * diagnostic ledger can use the same cache accounting model without copying
+ * provider-specific arithmetic.
+ */
+export interface DatedPricingCostProfile {
+  readonly inputUsdPerMillionTokens: number;
+  readonly outputUsdPerMillionTokens: number;
+  readonly cacheReadUsdPerMillionTokens?: number | null;
+  readonly cacheWriteUsdPerMillionTokens?: number | null;
+  readonly cacheReadAccounting?: CacheAccounting;
+  readonly cacheWriteAccounting?: CacheAccounting;
+}
+
 export type DatedPricingUnavailabilityReason =
   | 'candidate_model_drift'
   | 'returned_model_identity_unproven'
@@ -447,7 +461,10 @@ function decimalFraction(rate: number): readonly [number, number] {
 }
 
 /** Exact integer-micro accounting for a cohort profile; fractional micros round up once. */
-export function datedPricingCostMicros(profile: DatedPricingProfile, usage: DatedPricingUsage): number {
+function pricedUsageCategories(
+  profile: DatedPricingCostProfile,
+  usage: DatedPricingUsage,
+): Array<readonly [number, number | null]> {
   const token = (value: unknown, name: string): number => {
     if (!Number.isSafeInteger(value) || (value as number) < 0) throw new Error(`Invalid ${name}`);
     return value as number;
@@ -456,16 +473,43 @@ export function datedPricingCostMicros(profile: DatedPricingProfile, usage: Date
   const output = token(usage.outputTokens, 'output token count');
   const read = token(usage.cacheReadTokens ?? 0, 'cache-read token count');
   const write = token(usage.cacheWriteTokens ?? 0, 'cache-write token count');
-  if (profile.cacheReadAccounting === 'unsupported' && read > 0) throw new Error('Cache-read pricing is unavailable');
-  if (profile.cacheWriteAccounting === 'unsupported' && write > 0) throw new Error('Cache-write pricing is unavailable');
-  if (profile.cacheReadAccounting === 'subset' && read > input) throw new Error('Subset cache-read usage exceeds input');
-  if (profile.cacheWriteAccounting === 'subset' && write > input - (profile.cacheReadAccounting === 'subset' ? read : 0)) {
+  const readAccounting = profile.cacheReadAccounting ?? 'unsupported';
+  const writeAccounting = profile.cacheWriteAccounting ?? 'unsupported';
+  const readRate = profile.cacheReadUsdPerMillionTokens ?? null;
+  const writeRate = profile.cacheWriteUsdPerMillionTokens ?? null;
+  if (!(['additive', 'subset', 'unsupported'] as const).includes(readAccounting)) {
+    throw new Error('Cache-read accounting is invalid');
+  }
+  if (!(['additive', 'subset', 'unsupported'] as const).includes(writeAccounting)) {
+    throw new Error('Cache-write accounting is invalid');
+  }
+  for (const [rate, name] of [
+    [profile.inputUsdPerMillionTokens, 'input'],
+    [profile.outputUsdPerMillionTokens, 'output'],
+    [readRate, 'cache-read'],
+    [writeRate, 'cache-write'],
+  ] as const) {
+    if (rate !== null && (!Number.isFinite(rate) || rate < 0)) throw new Error(`Invalid ${name} pricing rate`);
+  }
+  if ((readAccounting === 'unsupported') !== (readRate === null)) throw new Error('Cache-read pricing is ambiguous');
+  if ((writeAccounting === 'unsupported') !== (writeRate === null)) throw new Error('Cache-write pricing is ambiguous');
+  if (readAccounting === 'unsupported' && read > 0) throw new Error('Cache-read pricing is unavailable');
+  if (writeAccounting === 'unsupported' && write > 0) throw new Error('Cache-write pricing is unavailable');
+  if (readAccounting === 'subset' && read > input) throw new Error('Subset cache-read usage exceeds input');
+  if (writeAccounting === 'subset' && write > input - (readAccounting === 'subset' ? read : 0)) {
     throw new Error('Subset cache-write usage exceeds input');
   }
-  const categories: Array<readonly [number, number | null]> = [
-    [input - (profile.cacheReadAccounting === 'subset' ? read : 0) - (profile.cacheWriteAccounting === 'subset' ? write : 0), profile.inputUsdPerMillionTokens],
-    [output, profile.outputUsdPerMillionTokens], [read, profile.cacheReadUsdPerMillionTokens], [write, profile.cacheWriteUsdPerMillionTokens],
+  return [
+    [input - (readAccounting === 'subset' ? read : 0) - (writeAccounting === 'subset' ? write : 0), profile.inputUsdPerMillionTokens],
+    [output, profile.outputUsdPerMillionTokens], [read, readRate], [write, writeRate],
   ];
+}
+
+function pricingCostFraction(
+  profile: DatedPricingCostProfile,
+  usage: DatedPricingUsage,
+): readonly [number, number] {
+  const categories = pricedUsageCategories(profile, usage);
   let denominator = 1;
   const fractions = categories.map(([count, rate]) => {
     if (rate === null && count !== 0) throw new Error('Cache pricing is unavailable');
@@ -478,6 +522,18 @@ export function datedPricingCostMicros(profile: DatedPricingProfile, usage: Date
     if (!Number.isSafeInteger(contribution) || !Number.isSafeInteger(sum + contribution)) throw new Error('Pricing cost exceeds exact accounting range');
     return sum + contribution;
   }, 0);
+  return [total, denominator];
+}
+
+/** Provider-profiled, unrounded accounting used by live diagnostic ledgers. */
+export function datedPricingCostUsd(profile: DatedPricingCostProfile, usage: DatedPricingUsage): number {
+  const [total, denominator] = pricingCostFraction(profile, usage);
+  return total / denominator / 1_000_000;
+}
+
+/** Exact integer-micro accounting for a cohort profile; fractional micros round up once. */
+export function datedPricingCostMicros(profile: DatedPricingCostProfile, usage: DatedPricingUsage): number {
+  const [total, denominator] = pricingCostFraction(profile, usage);
   return Math.ceil(total / denominator);
 }
 

--- a/server/src/addie/eval/dated-pricing-cohort.ts
+++ b/server/src/addie/eval/dated-pricing-cohort.ts
@@ -18,6 +18,7 @@ import {
 import type { ModelProviderId } from '../model-providers/model-provider.js';
 
 const COHORT_DIGEST_DOMAIN = 'adcp:addie:dated-prospective-pricing-cohort:v1\0';
+const PROFILE_DIGEST_DOMAIN = 'adcp:addie:dated-prospective-pricing-profile:v1\0';
 const CHECKED_AT = '2026-09-05T23:55:26.000Z';
 
 export type EvaluationPricingCandidateId =
@@ -78,6 +79,18 @@ export interface DatedPricingProfile {
   readonly effectiveFrom: string;
   readonly effectiveBefore: string | null;
   readonly identityDependency: DatedPricingRecord['identityDependency'];
+}
+
+/**
+ * Module-issued identity for an immutable profile. It prevents a diagnostic
+ * ledger from accepting a frozen lookalike at admission or settlement.
+ */
+export interface DatedPricingProfileIdentity {
+  readonly digest: string;
+  readonly candidateId: EvaluationPricingCandidateId;
+  readonly profileId: string;
+  readonly provider: ModelProviderId;
+  readonly model: string;
 }
 
 export interface DatedPricingUsage {
@@ -171,13 +184,16 @@ const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
     profileId: 'openai-gpt-5.6-luna-standard-2026-09-05',
     rates: {
       inputUsdPerMillionTokens: 0.2, outputUsdPerMillionTokens: 1.2,
-      cacheReadUsdPerMillionTokens: 0.02, cacheWriteUsdPerMillionTokens: null,
-      cacheReadAccounting: 'subset', cacheWriteAccounting: 'unsupported',
+      cacheReadUsdPerMillionTokens: 0.02, cacheWriteUsdPerMillionTokens: 0.25,
+      // Responses reports these as portions of input_tokens. Cached reads
+      // replace their input rate; cache writes replace it at the documented
+      // 1.25x multiplier rather than adding a second input charge.
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'subset',
     },
     source: {
       provider: 'openai', url: 'https://developers.openai.com/api/docs/models/gpt-5.6-luna',
       retrievedAt: CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
-      evidence: 'Responses API model card lists input, cached-input, and output rates. The adapter exposes cache-write usage, but no official normalized cache-write accounting relationship is established here, so that category is unavailable.',
+      evidence: 'Responses API model card lists input, cached-input, and output rates, and states cache writes are billed at 1.25x uncached input. The normalized cache read/write categories are portions of input_tokens.',
     },
     sourceLabel: 'OpenAI gpt-5.6-luna standard, checked 2026-09-05.',
     // origin/main@712ddc676 routes this same typed predicate through the
@@ -207,6 +223,42 @@ function deepFreeze<T>(value: T): T {
   if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
   for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
   return Object.freeze(value);
+}
+
+const datedPricingProfileIdentities = new WeakMap<DatedPricingProfile, DatedPricingProfileIdentity>();
+
+function canonicalProfile(profile: DatedPricingProfile): Record<string, unknown> {
+  return {
+    candidateId: profile.candidateId, provider: profile.provider, model: profile.model, profileId: profile.profileId,
+    effectiveFrom: profile.effectiveFrom, effectiveBefore: profile.effectiveBefore, identityDependency: profile.identityDependency,
+    rates: {
+      input: profile.inputUsdPerMillionTokens, output: profile.outputUsdPerMillionTokens,
+      cacheRead: profile.cacheReadUsdPerMillionTokens, cacheWrite: profile.cacheWriteUsdPerMillionTokens,
+      cacheReadAccounting: profile.cacheReadAccounting, cacheWriteAccounting: profile.cacheWriteAccounting,
+    },
+    source: profile.sourceEvidence,
+  };
+}
+
+function bindDatedPricingProfile(profile: DatedPricingProfile): DatedPricingProfile {
+  const identity = Object.freeze({
+    digest: `sha256:${createHash('sha256').update(PROFILE_DIGEST_DOMAIN, 'utf8').update(JSON.stringify(canonicalProfile(profile)), 'utf8').digest('hex')}`,
+    candidateId: profile.candidateId,
+    profileId: profile.profileId,
+    provider: profile.provider,
+    model: profile.model,
+  });
+  datedPricingProfileIdentities.set(profile, identity);
+  return profile;
+}
+
+/** Returns the module-issued identity only for an exact immutable cohort profile. */
+export function datedPricingProfileIdentity(profile: DatedPricingProfile): DatedPricingProfileIdentity {
+  const identity = datedPricingProfileIdentities.get(profile);
+  if (!identity || !Object.isFrozen(profile) || !Object.isFrozen(profile.sourceEvidence)) {
+    throw new Error('Dated pricing profile must be an immutable dated cohort profile');
+  }
+  return identity;
 }
 
 function safeDate(value: unknown): number | null {
@@ -307,12 +359,12 @@ function assertRecord(record: unknown): asserts record is DatedPricingRecord {
 }
 
 function profileFrom(record: DatedPricingRecord): DatedPricingProfile {
-  return deepFreeze({
+  return bindDatedPricingProfile(deepFreeze({
     candidateId: record.candidateId, provider: record.provider, model: record.model, serviceTier: record.serviceTier, profileId: record.profileId,
     ...record.rates, source: record.sourceLabel, sourceEvidence: { ...record.source },
     effectiveFrom: record.effectiveFrom, effectiveBefore: record.effectiveBefore,
     identityDependency: record.identityDependency,
-  });
+  }));
 }
 
 /** Validates a copied registry before it can become a cohort; no caller object is retained. */
@@ -355,14 +407,7 @@ function byCandidate<T extends { candidateId: string }>(left: T, right: T): numb
 }
 
 function cohortDigest(profiles: readonly DatedPricingProfile[]): string {
-  const canonical = profiles.map((profile) => ({
-    candidateId: profile.candidateId, provider: profile.provider, model: profile.model, profileId: profile.profileId,
-    effectiveFrom: profile.effectiveFrom, effectiveBefore: profile.effectiveBefore, identityDependency: profile.identityDependency, rates: {
-      input: profile.inputUsdPerMillionTokens, output: profile.outputUsdPerMillionTokens,
-      cacheRead: profile.cacheReadUsdPerMillionTokens, cacheWrite: profile.cacheWriteUsdPerMillionTokens,
-      cacheReadAccounting: profile.cacheReadAccounting, cacheWriteAccounting: profile.cacheWriteAccounting,
-    }, source: profile.sourceEvidence,
-  }));
+  const canonical = profiles.map(canonicalProfile);
   return `sha256:${createHash('sha256').update(COHORT_DIGEST_DOMAIN, 'utf8').update(JSON.stringify(canonical), 'utf8').digest('hex')}`;
 }
 
@@ -529,6 +574,36 @@ function pricingCostFraction(
 export function datedPricingCostUsd(profile: DatedPricingCostProfile, usage: DatedPricingUsage): number {
   const [total, denominator] = pricingCostFraction(profile, usage);
   return total / denominator / 1_000_000;
+}
+
+/**
+ * Worst-case supported cache exposure for one request. Subset categories
+ * replace input charges, so use the highest priced mutually-exclusive subset
+ * bucket; additive categories can each consume the complete input ceiling.
+ */
+export function datedPricingReservationCostUsd(
+  profile: DatedPricingCostProfile,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const input = Number.isSafeInteger(inputTokens) && inputTokens >= 0 ? inputTokens : null;
+  const output = Number.isSafeInteger(outputTokens) && outputTokens >= 0 ? outputTokens : null;
+  if (input === null || output === null) throw new Error('Invalid reservation token count');
+  const candidates: Array<readonly ['cacheReadTokens' | 'cacheWriteTokens' | null, number]> = [[null, profile.inputUsdPerMillionTokens]];
+  if (profile.cacheReadAccounting === 'subset' && profile.cacheReadUsdPerMillionTokens !== null && profile.cacheReadUsdPerMillionTokens !== undefined) {
+    candidates.push(['cacheReadTokens', profile.cacheReadUsdPerMillionTokens]);
+  }
+  if (profile.cacheWriteAccounting === 'subset' && profile.cacheWriteUsdPerMillionTokens !== null && profile.cacheWriteUsdPerMillionTokens !== undefined) {
+    candidates.push(['cacheWriteTokens', profile.cacheWriteUsdPerMillionTokens]);
+  }
+  const [subsetField] = candidates.reduce((highest, candidate) => candidate[1] > highest[1] ? candidate : highest);
+  return datedPricingCostUsd(profile, {
+    inputTokens: input,
+    outputTokens: output,
+    ...(profile.cacheReadAccounting === 'additive' ? { cacheReadTokens: input } : {}),
+    ...(profile.cacheWriteAccounting === 'additive' ? { cacheWriteTokens: input } : {}),
+    ...(subsetField === null ? {} : { [subsetField]: input }),
+  });
 }
 
 /** Exact integer-micro accounting for a cohort profile; fractional micros round up once. */

--- a/server/src/addie/eval/dated-pricing-cohort.ts
+++ b/server/src/addie/eval/dated-pricing-cohort.ts
@@ -1,0 +1,489 @@
+/**
+ * Immutable, credential-free price evidence for the prospective Addie model
+ * evaluation. This is accounting input only: it does not construct a provider
+ * or authorize a dispatch.
+ */
+import { createHash } from 'node:crypto';
+import { types as utilTypes } from 'node:util';
+import { ModelConfig } from '../../config/models.js';
+import { resolveKnownClaudePricingModel } from '../claude-pricing.js';
+import {
+  GOOGLE_ROUTER_MODEL,
+  isGoogleRouterModelRevision,
+} from '../model-providers/google-generate-content-provider.js';
+import {
+  OPENAI_ROUTER_MODEL,
+  openaiReturnedModelIdentityMatches,
+} from '../model-providers/openai-responses-provider.js';
+import type { ModelProviderId } from '../model-providers/model-provider.js';
+
+const COHORT_DIGEST_DOMAIN = 'adcp:addie:dated-prospective-pricing-cohort:v1\0';
+const CHECKED_AT = '2026-09-05T23:55:26.000Z';
+
+export type EvaluationPricingCandidateId =
+  | 'anthropic-router'
+  | 'anthropic-generation'
+  | 'openai-router-generator'
+  | 'google-router-generator';
+export type CacheAccounting = 'additive' | 'subset' | 'unsupported';
+
+export interface OfficialPricingSource {
+  readonly provider: ModelProviderId;
+  readonly url: string;
+  readonly retrievedAt: string;
+  readonly unit: 'USD per 1M tokens';
+  readonly serviceTier: 'standard';
+  readonly currency: 'USD';
+  readonly evidence: string;
+}
+
+export interface DatedPricingRecord {
+  readonly candidateId: EvaluationPricingCandidateId;
+  readonly provider: ModelProviderId;
+  readonly model: string;
+  readonly serviceTier: 'standard';
+  /** First instant this reviewed cohort, rather than an inferred provider rate, is usable. */
+  readonly effectiveFrom: string;
+  /** Exclusive upper bound; null only where the official evidence has no expiry. */
+  readonly effectiveBefore: string | null;
+  readonly profileId: string;
+  readonly rates: {
+    readonly inputUsdPerMillionTokens: number;
+    readonly outputUsdPerMillionTokens: number;
+    readonly cacheReadUsdPerMillionTokens: number | null;
+    readonly cacheWriteUsdPerMillionTokens: number | null;
+    readonly cacheReadAccounting: CacheAccounting;
+    readonly cacheWriteAccounting: CacheAccounting;
+  };
+  readonly source: OfficialPricingSource;
+  /** The pre-existing fixed-trace ledger description, retained for artifact compatibility. */
+  readonly sourceLabel: string;
+  readonly identityDependency: 'not_required' | 'exact_returned_model_identity_enforced';
+}
+
+export interface DatedPricingProfile {
+  readonly candidateId: EvaluationPricingCandidateId;
+  readonly provider: ModelProviderId;
+  readonly model: string;
+  readonly serviceTier: 'standard';
+  readonly profileId: string;
+  readonly inputUsdPerMillionTokens: number;
+  readonly outputUsdPerMillionTokens: number;
+  readonly cacheReadUsdPerMillionTokens: number | null;
+  readonly cacheWriteUsdPerMillionTokens: number | null;
+  readonly cacheReadAccounting: CacheAccounting;
+  readonly cacheWriteAccounting: CacheAccounting;
+  readonly source: string;
+  readonly sourceEvidence: OfficialPricingSource;
+  readonly effectiveFrom: string;
+  readonly effectiveBefore: string | null;
+  readonly identityDependency: DatedPricingRecord['identityDependency'];
+}
+
+export interface DatedPricingUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+}
+
+export type DatedPricingUnavailabilityReason =
+  | 'candidate_model_drift'
+  | 'returned_model_identity_unproven'
+  | 'pricing_record_missing'
+  | 'pricing_record_invalid'
+  | 'pricing_outside_effective_interval';
+
+export interface DatedPricingCohort {
+  readonly checkedAt: string;
+  readonly requestedAt: string;
+  readonly digest: string;
+  readonly profiles: readonly DatedPricingProfile[];
+}
+
+export type ResolveDatedPricingCohortResult =
+  | { readonly status: 'available'; readonly cohort: DatedPricingCohort }
+  | {
+    readonly status: 'unavailable';
+    readonly reasons: readonly { readonly candidateId: EvaluationPricingCandidateId; readonly reason: DatedPricingUnavailabilityReason }[];
+  };
+
+/** Candidate ownership is part of the reviewed cohort, not live configuration. */
+const CANDIDATE_PROVIDERS: Readonly<Record<EvaluationPricingCandidateId, ModelProviderId>> = Object.freeze({
+  'anthropic-router': 'anthropic',
+  'anthropic-generation': 'anthropic',
+  'openai-router-generator': 'openai',
+  'google-router-generator': 'google',
+});
+
+const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
+  {
+    candidateId: 'anthropic-router', provider: 'anthropic', model: 'claude-haiku-4-5',
+    serviceTier: 'standard', effectiveFrom: CHECKED_AT, effectiveBefore: null,
+    profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
+    rates: {
+      inputUsdPerMillionTokens: 1, outputUsdPerMillionTokens: 5,
+      cacheReadUsdPerMillionTokens: 0.1, cacheWriteUsdPerMillionTokens: 1.25,
+      cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
+    },
+    source: {
+      provider: 'anthropic', url: 'https://platform.claude.com/docs/en/about-claude/pricing',
+      retrievedAt: CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Claude API standard rates; cache reads are 0.1x and five-minute writes are 1.25x base input.',
+    },
+    sourceLabel: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
+    identityDependency: 'not_required',
+  },
+  {
+    candidateId: 'anthropic-generation', provider: 'anthropic', model: 'claude-sonnet-5',
+    serviceTier: 'standard', effectiveFrom: '2026-09-01T00:00:00.000Z', effectiveBefore: null,
+    profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
+    rates: {
+      inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 10,
+      cacheReadUsdPerMillionTokens: 0.2, cacheWriteUsdPerMillionTokens: 2.5,
+      cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
+    },
+    source: {
+      provider: 'anthropic', url: 'https://platform.claude.com/docs/en/about-claude/pricing',
+      retrievedAt: CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Claude Sonnet 5 standard rate; five-minute cache writes are 1.25x base input and reads are 0.1x.',
+    },
+    sourceLabel: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
+    identityDependency: 'not_required',
+  },
+  {
+    candidateId: 'openai-router-generator', provider: 'openai', model: 'gpt-5.6-luna',
+    serviceTier: 'standard', effectiveFrom: CHECKED_AT, effectiveBefore: null,
+    profileId: 'openai-gpt-5.6-luna-standard-2026-09-05',
+    rates: {
+      inputUsdPerMillionTokens: 0.2, outputUsdPerMillionTokens: 1.2,
+      cacheReadUsdPerMillionTokens: 0.02, cacheWriteUsdPerMillionTokens: null,
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'unsupported',
+    },
+    source: {
+      provider: 'openai', url: 'https://developers.openai.com/api/docs/models/gpt-5.6-luna',
+      retrievedAt: CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Responses API model card lists input, cached-input, and output rates. The adapter exposes cache-write usage, but no official normalized cache-write accounting relationship is established here, so that category is unavailable.',
+    },
+    sourceLabel: 'OpenAI gpt-5.6-luna standard, checked 2026-09-05.',
+    // origin/main@712ddc676 routes this same typed predicate through the
+    // Responses adapter before it emits a normalized result.
+    identityDependency: 'exact_returned_model_identity_enforced',
+  },
+  {
+    candidateId: 'google-router-generator', provider: 'google', model: 'gemini-3.7-flash',
+    serviceTier: 'standard', effectiveFrom: CHECKED_AT, effectiveBefore: '2027-01-01T00:00:00.000Z',
+    profileId: 'google-gemini-3.7-flash-through-2026-12-31',
+    rates: {
+      inputUsdPerMillionTokens: 0.75, outputUsdPerMillionTokens: 3.75,
+      cacheReadUsdPerMillionTokens: 0.075, cacheWriteUsdPerMillionTokens: null,
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'unsupported',
+    },
+    source: {
+      provider: 'google', url: 'https://ai.google.dev/gemini-api/docs/pricing',
+      retrievedAt: CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Paid standard introductory rates through December 31, 2026; output includes thinking tokens and the adapter exposes only cached-content reads, not a cache-write token category.',
+    },
+    sourceLabel: 'Google Gemini 3.7 Flash introductory standard, checked 2026-09-05.',
+    identityDependency: 'not_required',
+  },
+]);
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function safeDate(value: unknown): number | null {
+  if (typeof value !== 'string' || !/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value)) return null;
+  const instant = Date.parse(value);
+  return Number.isSafeInteger(instant) && new Date(instant).toISOString() === value ? instant : null;
+}
+
+function safeRequestedAt(value: unknown): string | null {
+  try {
+    const instant = Date.prototype.getTime.call(value);
+    return Number.isFinite(instant) ? new Date(instant).toISOString() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read only own data descriptors so hostile arrays cannot run a getter while being validated. */
+function ownArrayValues(value: unknown): unknown[] | null {
+  if (!Array.isArray(value) || utilTypes.isProxy(value) || Object.getPrototypeOf(value) !== Array.prototype) return null;
+  const length = Object.getOwnPropertyDescriptor(value, 'length');
+  if (!length || !('value' in length) || !Number.isSafeInteger(length.value) || length.value < 0) return null;
+  const values: unknown[] = [];
+  for (let index = 0; index < length.value; index++) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor || !('value' in descriptor) || descriptor.get || descriptor.set) return null;
+    values.push(descriptor.value);
+  }
+  return values;
+}
+
+function ownData(value: unknown, key: string): unknown {
+  if (!value || typeof value !== 'object' || utilTypes.isProxy(value)) throw new Error('record is not a plain data object');
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error('record has an unexpected prototype');
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor || !('value' in descriptor) || descriptor.get || descriptor.set) throw new Error(`record field ${key} is missing or accessor-backed`);
+  return descriptor.value;
+}
+
+function assertOfficialSource(source: unknown, provider: ModelProviderId): asserts source is OfficialPricingSource {
+  const sourceProvider = ownData(source, 'provider');
+  const url = ownData(source, 'url');
+  const retrievedAt = ownData(source, 'retrievedAt');
+  const unit = ownData(source, 'unit');
+  const serviceTier = ownData(source, 'serviceTier');
+  const currency = ownData(source, 'currency');
+  const evidence = ownData(source, 'evidence');
+  if (sourceProvider !== provider || unit !== 'USD per 1M tokens' || serviceTier !== 'standard' || currency !== 'USD'
+    || typeof evidence !== 'string' || !evidence.trim() || safeDate(retrievedAt) === null || typeof url !== 'string') throw new Error('official source fields are invalid');
+  const allowedHost: Record<ModelProviderId, string> = {
+    anthropic: 'platform.claude.com', openai: 'developers.openai.com', google: 'ai.google.dev',
+  };
+  let parsed: URL;
+  try { parsed = new URL(url); } catch { throw new Error('official source URL is invalid'); }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== allowedHost[provider] || parsed.username || parsed.password || parsed.hash) {
+    throw new Error('official source URL is not provider-owned HTTPS');
+  }
+}
+
+function assertRecord(record: unknown): asserts record is DatedPricingRecord {
+  const candidateId = ownData(record, 'candidateId');
+  const provider = ownData(record, 'provider');
+  const model = ownData(record, 'model');
+  const serviceTier = ownData(record, 'serviceTier');
+  const effectiveFrom = ownData(record, 'effectiveFrom');
+  const effectiveBefore = ownData(record, 'effectiveBefore');
+  const profileId = ownData(record, 'profileId');
+  const rates = ownData(record, 'rates');
+  const source = ownData(record, 'source');
+  const sourceLabel = ownData(record, 'sourceLabel');
+  const identityDependency = ownData(record, 'identityDependency');
+  if (!['anthropic-router', 'anthropic-generation', 'openai-router-generator', 'google-router-generator'].includes(candidateId as string)
+    || !['anthropic', 'openai', 'google'].includes(provider as string)
+    || typeof model !== 'string' || !model.trim() || serviceTier !== 'standard'
+    || typeof profileId !== 'string' || !profileId.trim() || typeof sourceLabel !== 'string' || !sourceLabel.trim()
+    || !['not_required', 'exact_returned_model_identity_enforced'].includes(identityDependency as string)) throw new Error('pricing record identity is invalid');
+  if (CANDIDATE_PROVIDERS[candidateId as EvaluationPricingCandidateId] !== provider) {
+    throw new Error('pricing record candidate provider is invalid');
+  }
+  const start = safeDate(effectiveFrom);
+  const end = effectiveBefore === null ? null : safeDate(effectiveBefore);
+  if (start === null || (effectiveBefore !== null && end === null) || (end !== null && end <= start)) throw new Error('pricing effective interval is invalid');
+  assertOfficialSource(source, provider as ModelProviderId);
+  const values = [
+    ownData(rates, 'inputUsdPerMillionTokens'), ownData(rates, 'outputUsdPerMillionTokens'),
+    ownData(rates, 'cacheReadUsdPerMillionTokens'), ownData(rates, 'cacheWriteUsdPerMillionTokens'),
+  ];
+  const readAccounting = ownData(rates, 'cacheReadAccounting');
+  const writeAccounting = ownData(rates, 'cacheWriteAccounting');
+  if (!Number.isFinite(values[0]) || (values[0] as number) < 0 || !Number.isFinite(values[1]) || (values[1] as number) < 0
+    || !['additive', 'subset', 'unsupported'].includes(readAccounting as string)
+    || !['additive', 'subset', 'unsupported'].includes(writeAccounting as string)) throw new Error('pricing token categories are invalid');
+  for (const [value, accounting] of [[values[2], readAccounting], [values[3], writeAccounting]] as const) {
+    if ((accounting === 'unsupported') !== (value === null)
+      || (value !== null && (!Number.isFinite(value) || (value as number) < 0))) throw new Error('pricing cache category is invalid');
+  }
+}
+
+function profileFrom(record: DatedPricingRecord): DatedPricingProfile {
+  return deepFreeze({
+    candidateId: record.candidateId, provider: record.provider, model: record.model, serviceTier: record.serviceTier, profileId: record.profileId,
+    ...record.rates, source: record.sourceLabel, sourceEvidence: { ...record.source },
+    effectiveFrom: record.effectiveFrom, effectiveBefore: record.effectiveBefore,
+    identityDependency: record.identityDependency,
+  });
+}
+
+/** Validates a copied registry before it can become a cohort; no caller object is retained. */
+export function buildDatedPricingCohort(
+  records: unknown,
+  requestedAt: unknown,
+): ResolveDatedPricingCohortResult {
+  const requestedAtIso = safeRequestedAt(requestedAt);
+  const recordValues = ownArrayValues(records);
+  if (!requestedAtIso || !recordValues) {
+    return { status: 'unavailable', reasons: deepFreeze([{ candidateId: 'anthropic-router', reason: 'pricing_record_invalid' }]) };
+  }
+  try {
+    const copied = recordValues.map((record) => {
+      assertRecord(record);
+      return profileFrom(record);
+    });
+    const keys = new Set<string>();
+    for (const profile of copied) {
+      const key = `${profile.provider}\0${profile.model}\0${profile.serviceTier ?? 'standard'}\0${profile.effectiveFrom}\0${profile.effectiveBefore ?? ''}`;
+      if (keys.has(key)) throw new Error('duplicate price record');
+      keys.add(key);
+    }
+    const at = Date.parse(requestedAtIso);
+    const reasons = copied
+      .filter((profile) => at < Date.parse(profile.effectiveFrom)
+        || (profile.effectiveBefore !== null && at >= Date.parse(profile.effectiveBefore)))
+      .map((profile) => ({ candidateId: profile.candidateId, reason: 'pricing_outside_effective_interval' as const }));
+    if (reasons.length) return { status: 'unavailable', reasons: deepFreeze(reasons.sort(byCandidate)) };
+    const profiles = copied.sort(byCandidate);
+    const digest = cohortDigest(profiles);
+    return { status: 'available', cohort: deepFreeze({ checkedAt: CHECKED_AT, requestedAt: requestedAtIso, digest, profiles }) };
+  } catch {
+    return { status: 'unavailable', reasons: deepFreeze([{ candidateId: 'anthropic-router', reason: 'pricing_record_invalid' }]) };
+  }
+}
+
+function byCandidate<T extends { candidateId: string }>(left: T, right: T): number {
+  return left.candidateId.localeCompare(right.candidateId);
+}
+
+function cohortDigest(profiles: readonly DatedPricingProfile[]): string {
+  const canonical = profiles.map((profile) => ({
+    candidateId: profile.candidateId, provider: profile.provider, model: profile.model, profileId: profile.profileId,
+    effectiveFrom: profile.effectiveFrom, effectiveBefore: profile.effectiveBefore, identityDependency: profile.identityDependency, rates: {
+      input: profile.inputUsdPerMillionTokens, output: profile.outputUsdPerMillionTokens,
+      cacheRead: profile.cacheReadUsdPerMillionTokens, cacheWrite: profile.cacheWriteUsdPerMillionTokens,
+      cacheReadAccounting: profile.cacheReadAccounting, cacheWriteAccounting: profile.cacheWriteAccounting,
+    }, source: profile.sourceEvidence,
+  }));
+  return `sha256:${createHash('sha256').update(COHORT_DIGEST_DOMAIN, 'utf8').update(JSON.stringify(canonical), 'utf8').digest('hex')}`;
+}
+
+/** Review-only profiles for fixed-trace artifact validation; this grants no provider admission. */
+export function datedPricingProfilesForFixedTrace(): readonly DatedPricingProfile[] {
+  const result = buildDatedPricingCohort(OFFICIAL_PRICING_RECORDS, new Date(CHECKED_AT));
+  if (result.status !== 'available') throw new Error('built-in dated pricing registry is invalid');
+  return result.cohort.profiles;
+}
+
+/** Immutable evidence copies for audit and deterministic downstream planning. */
+export function officialDatedPricingRecordsForAudit(): readonly DatedPricingRecord[] {
+  return deepFreeze(structuredClone(OFFICIAL_PRICING_RECORDS));
+}
+
+/** Exact candidates are derived from the live configuration and adapter constants. */
+export function currentEvaluationPricingCandidates(): readonly Readonly<{
+  candidateId: EvaluationPricingCandidateId;
+  provider: ModelProviderId;
+  model: string;
+}>[] {
+  return deepFreeze([
+    { candidateId: 'anthropic-router', provider: 'anthropic', model: ModelConfig.fast },
+    { candidateId: 'anthropic-generation', provider: 'anthropic', model: ModelConfig.primary },
+    { candidateId: 'openai-router-generator', provider: 'openai', model: OPENAI_ROUTER_MODEL },
+    { candidateId: 'google-router-generator', provider: 'google', model: GOOGLE_ROUTER_MODEL },
+  ]);
+}
+
+/**
+ * Returns a complete cohort only if every current candidate is interval-valid
+ * and its returned-model identity prerequisite is independently proven.
+ */
+export function resolveCurrentEvaluationPricingCohort(
+  requestedAt: Date = new Date(),
+  candidateIds: readonly EvaluationPricingCandidateId[] = currentEvaluationPricingCandidates().map((candidate) => candidate.candidateId),
+): ResolveDatedPricingCohortResult {
+  const candidateValues = ownArrayValues(candidateIds);
+  const allowed = new Set<EvaluationPricingCandidateId>([
+    'anthropic-router', 'anthropic-generation', 'openai-router-generator', 'google-router-generator',
+  ]);
+  if (!candidateValues || candidateValues.length === 0
+    || candidateValues.some((candidate) => typeof candidate !== 'string' || !allowed.has(candidate as EvaluationPricingCandidateId))
+    || new Set(candidateValues).size !== candidateValues.length) {
+    return { status: 'unavailable', reasons: deepFreeze([{ candidateId: 'anthropic-router', reason: 'pricing_record_invalid' }]) };
+  }
+  const selected = new Set(candidateValues as EvaluationPricingCandidateId[]);
+  const selectedRecords = [...selected].map((candidateId) => (
+    OFFICIAL_PRICING_RECORDS.find((record) => record.candidateId === candidateId)
+  ));
+  const missing = selectedRecords
+    .map((record, index) => record === undefined
+      ? { candidateId: candidateValues[index] as EvaluationPricingCandidateId, reason: 'pricing_record_missing' as const }
+      : null)
+    .filter((reason): reason is { candidateId: EvaluationPricingCandidateId; reason: 'pricing_record_missing' } => reason !== null);
+  if (missing.length) return { status: 'unavailable', reasons: deepFreeze(missing.sort(byCandidate)) };
+  const base = buildDatedPricingCohort(selectedRecords, requestedAt);
+  if (base.status !== 'available') return base;
+  const current = currentEvaluationPricingCandidates();
+  const reasons: Array<{ candidateId: EvaluationPricingCandidateId; reason: DatedPricingUnavailabilityReason }> = [];
+  for (const candidate of current) {
+    if (!selected.has(candidate.candidateId)) continue;
+    const profile = base.cohort.profiles.find((item) => item.candidateId === candidate.candidateId);
+    if (!profile || profile.provider !== candidate.provider || profile.model !== candidate.model) {
+      reasons.push({ candidateId: candidate.candidateId, reason: 'candidate_model_drift' });
+      continue;
+    }
+    if (profile.identityDependency === 'exact_returned_model_identity_enforced' && (
+      !openaiReturnedModelIdentityMatches(profile.model, profile.model)
+      || openaiReturnedModelIdentityMatches(profile.model, `${profile.model}-unreviewed-alias`)
+    )) {
+      reasons.push({ candidateId: candidate.candidateId, reason: 'returned_model_identity_unproven' });
+    }
+  }
+  if (reasons.length) return { status: 'unavailable', reasons: deepFreeze(reasons.sort(byCandidate)) };
+  return { status: 'available', cohort: deepFreeze({ ...base.cohort, profiles: base.cohort.profiles.filter((profile) => selected.has(profile.candidateId)) }) };
+}
+
+export function pricingProfileForCandidate(
+  cohort: DatedPricingCohort,
+  candidateId: EvaluationPricingCandidateId,
+): DatedPricingProfile {
+  const profile = cohort.profiles.find((entry) => entry.candidateId === candidateId);
+  if (!profile) throw new Error(`Dated pricing cohort is missing ${candidateId}`);
+  return profile;
+}
+
+function decimalFraction(rate: number): readonly [number, number] {
+  const text = String(rate);
+  if (!/^\d+(?:\.\d+)?$/.test(text)) throw new Error('pricing rate is not a finite decimal');
+  const decimals = text.split('.')[1]?.length ?? 0;
+  const denominator = 10 ** decimals;
+  const numerator = Number(text.replace('.', ''));
+  if (!Number.isSafeInteger(numerator) || !Number.isSafeInteger(denominator)) throw new Error('pricing rate exceeds exact accounting range');
+  return [numerator, denominator];
+}
+
+/** Exact integer-micro accounting for a cohort profile; fractional micros round up once. */
+export function datedPricingCostMicros(profile: DatedPricingProfile, usage: DatedPricingUsage): number {
+  const token = (value: unknown, name: string): number => {
+    if (!Number.isSafeInteger(value) || (value as number) < 0) throw new Error(`Invalid ${name}`);
+    return value as number;
+  };
+  const input = token(usage.inputTokens, 'input token count');
+  const output = token(usage.outputTokens, 'output token count');
+  const read = token(usage.cacheReadTokens ?? 0, 'cache-read token count');
+  const write = token(usage.cacheWriteTokens ?? 0, 'cache-write token count');
+  if (profile.cacheReadAccounting === 'unsupported' && read > 0) throw new Error('Cache-read pricing is unavailable');
+  if (profile.cacheWriteAccounting === 'unsupported' && write > 0) throw new Error('Cache-write pricing is unavailable');
+  if (profile.cacheReadAccounting === 'subset' && read > input) throw new Error('Subset cache-read usage exceeds input');
+  if (profile.cacheWriteAccounting === 'subset' && write > input - (profile.cacheReadAccounting === 'subset' ? read : 0)) {
+    throw new Error('Subset cache-write usage exceeds input');
+  }
+  const categories: Array<readonly [number, number | null]> = [
+    [input - (profile.cacheReadAccounting === 'subset' ? read : 0) - (profile.cacheWriteAccounting === 'subset' ? write : 0), profile.inputUsdPerMillionTokens],
+    [output, profile.outputUsdPerMillionTokens], [read, profile.cacheReadUsdPerMillionTokens], [write, profile.cacheWriteUsdPerMillionTokens],
+  ];
+  let denominator = 1;
+  const fractions = categories.map(([count, rate]) => {
+    if (rate === null && count !== 0) throw new Error('Cache pricing is unavailable');
+    const [numerator, nextDenominator] = decimalFraction(rate ?? 0);
+    denominator = Math.max(denominator, nextDenominator);
+    return [count, numerator, nextDenominator] as const;
+  });
+  const total = fractions.reduce((sum, [count, numerator, rateDenominator]) => {
+    const contribution = count * numerator * (denominator / rateDenominator);
+    if (!Number.isSafeInteger(contribution) || !Number.isSafeInteger(sum + contribution)) throw new Error('Pricing cost exceeds exact accounting range');
+    return sum + contribution;
+  }, 0);
+  return Math.ceil(total / denominator);
+}
+
+/** Existing adapter-specific identity rules remain the only alias authority. */
+export function cohortReturnedModelMatches(profile: DatedPricingProfile, returnedModel: string): boolean {
+  if (profile.provider === 'anthropic') return resolveKnownClaudePricingModel(returnedModel) === profile.model;
+  if (profile.provider === 'google') return profile.model === GOOGLE_ROUTER_MODEL && isGoogleRouterModelRevision(returnedModel);
+  return openaiReturnedModelIdentityMatches(profile.model, returnedModel);
+}

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -13,6 +13,7 @@ import {
 } from '../model-providers/google-generate-content-provider.js';
 import { GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION } from '../model-cost-pricing.js';
 import {
+  datedPricingCostUsd,
   datedPricingProfilesForFixedTrace,
   pricingProfileForCandidate,
   resolveCurrentEvaluationPricingCohort,
@@ -307,43 +308,23 @@ export function fixedTraceEstimatedCostUsd(
   pricing: FixedTraceBudgetPricing,
 ): number {
   validateFixedTracePricing(pricing);
-  const { inputTokens, outputTokens } = usage;
-  if (
-    !Number.isSafeInteger(inputTokens)
-    || inputTokens < 0
-    || !Number.isSafeInteger(outputTokens)
-    || outputTokens < 0
-  ) throw new Error('Fixed trace budget usage is invalid');
-  const cacheReadTokens = usage.cacheReadTokens ?? 0;
-  const cacheWriteTokens = usage.cacheWriteTokens ?? 0;
-  if (
-    !Number.isSafeInteger(cacheReadTokens) || cacheReadTokens < 0
-    || !Number.isSafeInteger(cacheWriteTokens) || cacheWriteTokens < 0
-  ) throw new Error('Fixed trace cache usage is invalid');
-  const readAccounting = pricing.cacheReadAccounting ?? 'unsupported';
-  const writeAccounting = pricing.cacheWriteAccounting ?? 'unsupported';
-  if (cacheReadTokens > 0 && readAccounting === 'unsupported') throw new Error('Fixed trace cache read accounting is unavailable');
-  if (cacheWriteTokens > 0 && writeAccounting === 'unsupported') throw new Error('Fixed trace cache write accounting is unavailable');
-  if (readAccounting === 'subset' && cacheReadTokens > inputTokens) throw new Error('Fixed trace subset cache read usage is invalid');
-  // A subset read and additive write (Google's profile) is valid. Two subset
-  // buckets must jointly fit the provider's normalized input total.
-  if (readAccounting === 'subset' && writeAccounting === 'subset' && cacheReadTokens + cacheWriteTokens > inputTokens) {
-    throw new Error('Fixed trace subset cache usage is invalid');
+  try {
+    return datedPricingCostUsd(pricing, usage);
+  } catch (error) {
+    // Keep fixed-trace's established error contract while delegating the
+    // category arithmetic itself to the dated-profile accounting model.
+    const message = error instanceof Error ? error.message : '';
+    if (message === 'Invalid input token count' || message === 'Invalid output token count') {
+      throw new Error('Fixed trace budget usage is invalid');
+    }
+    if (message === 'Invalid cache-read token count' || message === 'Invalid cache-write token count') {
+      throw new Error('Fixed trace cache usage is invalid');
+    }
+    if (message === 'Cache-read pricing is unavailable') throw new Error('Fixed trace cache read accounting is unavailable');
+    if (message === 'Cache-write pricing is unavailable') throw new Error('Fixed trace cache write accounting is unavailable');
+    if (message.startsWith('Subset cache-')) throw new Error('Fixed trace subset cache usage is invalid');
+    throw error;
   }
-  if (cacheReadTokens > 0 && pricing.cacheReadUsdPerMillionTokens == null) {
-    throw new Error('Fixed trace cache read pricing is unavailable');
-  }
-  if (cacheWriteTokens > 0 && pricing.cacheWriteUsdPerMillionTokens == null) {
-    throw new Error('Fixed trace cache write pricing is unavailable');
-  }
-  return (
-    (inputTokens
-      - (readAccounting === 'subset' ? cacheReadTokens : 0)
-      - (writeAccounting === 'subset' ? cacheWriteTokens : 0)) * pricing.inputUsdPerMillionTokens
-    + outputTokens * pricing.outputUsdPerMillionTokens
-    + cacheReadTokens * (pricing.cacheReadUsdPerMillionTokens ?? 0)
-    + cacheWriteTokens * (pricing.cacheWriteUsdPerMillionTokens ?? 0)
-  ) / 1_000_000;
 }
 
 /**

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -12,6 +12,12 @@ import {
   isGoogleRouterModelRevision,
 } from '../model-providers/google-generate-content-provider.js';
 import { GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION } from '../model-cost-pricing.js';
+import {
+  datedPricingProfilesForFixedTrace,
+  pricingProfileForCandidate,
+  resolveCurrentEvaluationPricingCohort,
+  type EvaluationPricingCandidateId,
+} from './dated-pricing-cohort.js';
 import type { FixedTraceModelResolutionPolicy } from './fixed-trace-suite.js';
 
 export interface FixedTraceBudgetPricing {
@@ -62,6 +68,7 @@ export interface FixedTraceBudgetSnapshot {
  * by supplying a matching-looking policy object or a zero-rate tuple.
  */
 interface FixedTraceApprovedPricing extends FixedTraceBudgetPricing {
+  readonly candidateId: EvaluationPricingCandidateId;
   readonly profileId: string;
   readonly expectedProvider: ModelProvider['id'];
   readonly expectedModel: string;
@@ -77,44 +84,22 @@ export function fixedTraceModelResolutionPolicy(
     : 'exact_model_identity_v1';
 }
 
-const FIXED_TRACE_APPROVED_PRICING = Object.freeze(([
-  {
-    expectedProvider: 'anthropic', expectedModel: 'claude-haiku-4-5',
-    profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
-    inputUsdPerMillionTokens: 1, outputUsdPerMillionTokens: 5,
-    cacheReadUsdPerMillionTokens: 0.1, cacheWriteUsdPerMillionTokens: 1.25,
-    cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
-    source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
-    modelResolutionPolicy: 'exact_model_identity_v1',
-  },
-  {
-    expectedProvider: 'anthropic', expectedModel: 'claude-sonnet-5',
-    profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
-    inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 10,
-    cacheReadUsdPerMillionTokens: 0.2, cacheWriteUsdPerMillionTokens: 2.5,
-    cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
-    source: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
-    modelResolutionPolicy: 'exact_model_identity_v1',
-  },
-  {
-    expectedProvider: 'openai', expectedModel: 'gpt-5.6-luna',
-    profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',
-    inputUsdPerMillionTokens: 0.2, outputUsdPerMillionTokens: 1.2,
-    cacheReadUsdPerMillionTokens: 0.02, cacheWriteUsdPerMillionTokens: null,
-    cacheReadAccounting: 'subset', cacheWriteAccounting: 'unsupported',
-    source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25.',
-    modelResolutionPolicy: 'exact_model_identity_v1',
-  },
-  {
-    expectedProvider: 'google', expectedModel: GOOGLE_ROUTER_MODEL,
-    profileId: GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION,
-    inputUsdPerMillionTokens: 0.75, outputUsdPerMillionTokens: 3.75,
-    cacheReadUsdPerMillionTokens: 0.075, cacheWriteUsdPerMillionTokens: 0.75,
-    cacheReadAccounting: 'subset', cacheWriteAccounting: 'additive',
-    source: 'Google Gemini 3.7 Flash introductory standard, checked 2026-08-25.',
-    modelResolutionPolicy: 'google_router_dated_revision_v1',
-  },
-] satisfies readonly FixedTraceApprovedPricing[]).map((entry) => Object.freeze(entry)));
+const FIXED_TRACE_APPROVED_PRICING = Object.freeze(datedPricingProfilesForFixedTrace().map((profile) => Object.freeze({
+  candidateId: profile.candidateId,
+  expectedProvider: profile.provider,
+  expectedModel: profile.model,
+  profileId: profile.profileId,
+  inputUsdPerMillionTokens: profile.inputUsdPerMillionTokens,
+  outputUsdPerMillionTokens: profile.outputUsdPerMillionTokens,
+  cacheReadUsdPerMillionTokens: profile.cacheReadUsdPerMillionTokens,
+  cacheWriteUsdPerMillionTokens: profile.cacheWriteUsdPerMillionTokens,
+  cacheReadAccounting: profile.cacheReadAccounting,
+  cacheWriteAccounting: profile.cacheWriteAccounting,
+  source: profile.source,
+  modelResolutionPolicy: profile.provider === 'google'
+    ? 'google_router_dated_revision_v1' as const
+    : 'exact_model_identity_v1' as const,
+} satisfies FixedTraceApprovedPricing)));
 
 /**
  * The complete live approval surface. It is intentionally inspectable for
@@ -182,6 +167,14 @@ export function fixedTraceResponsePricingPolicy(
     && sameApprovedPricing(entry, pricing)
   ));
   if (!approved) throw new Error('Fixed trace pricing profile is not evaluator approved');
+  const currentCohort = resolveCurrentEvaluationPricingCohort(new Date(), [approved.candidateId]);
+  if (currentCohort.status !== 'available') {
+    throw new Error('Fixed trace pricing profile is not currently effective');
+  }
+  const current = pricingProfileForCandidate(currentCohort.cohort, approved.candidateId);
+  if (current.profileId !== approved.profileId || !sameApprovedPricing(approved, current)) {
+    throw new Error('Fixed trace pricing profile does not match the current cohort');
+  }
   const policy = Object.freeze({
     expectedProvider: approved.expectedProvider,
     expectedModel: approved.expectedModel,

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -15,6 +15,7 @@ import { GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION } from '../model-cost-pricing.j
 import {
   datedPricingCostUsd,
   datedPricingProfilesForFixedTrace,
+  datedPricingReservationCostUsd,
   pricingProfileForCandidate,
   resolveCurrentEvaluationPricingCohort,
   type EvaluationPricingCandidateId,
@@ -371,18 +372,12 @@ export class FixedTraceBudget {
       this.budgetRejectedCalls++;
       throw new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared);
     }
-    // Request bytes are a deliberately high token bound for the request. An
-    // additive cache bucket is separately billable, so reserve that same
-    // bound for each such bucket as well. Subset buckets are already covered
-    // by inputTokens. This keeps the pre-dispatch reserve conservative under
-    // the recorded, fingerprinted cache formula.
+    // Request bytes are a deliberately high token bound for the request.
+    // The common dated-pricing helper includes every additive bucket and the
+    // highest-cost mutually-exclusive subset bucket (including an OpenAI
+    // cache write whose replacement rate exceeds ordinary input).
     const inputTokens = requestBytes(prepared);
-    const usd = fixedTraceEstimatedCostUsd({
-      inputTokens,
-      outputTokens: maxOutputTokens,
-      cacheReadTokens: pricing.cacheReadAccounting === 'additive' ? inputTokens : 0,
-      cacheWriteTokens: pricing.cacheWriteAccounting === 'additive' ? inputTokens : 0,
-    }, pricing);
+    const usd = datedPricingReservationCostUsd(pricing, inputTokens, maxOutputTokens);
     if (this.accountedSpendUsd + this.reservedUsd + usd > this.softMaxUsd) {
       this.admissionClosed = true;
       this.budgetRejectedCalls++;

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -24,6 +24,15 @@ import { validateNormalizedModelResponse } from './events.js';
 
 export const OPENAI_ROUTER_MODEL = 'gpt-5.6-luna';
 
+/**
+ * The Responses adapter has no reviewed alias allowlist. Keep this exported
+ * predicate as the shared, typed billing-identity boundary for consumers that
+ * must prove a returned response has the requested model's exact price.
+ */
+export function openaiReturnedModelIdentityMatches(requestedModel: string, returnedModel: string): boolean {
+  return requestedModel === returnedModel;
+}
+
 export interface OpenAIResponsesTransport {
   responses: {
     create(
@@ -309,7 +318,7 @@ export class OpenAIResponsesProvider implements ModelProvider {
     // Returned model identity is a billing and trust boundary. This adapter has
     // no reviewed, literal canonical-alias allowlist, so aliases and suffixes
     // must not inherit the requested model's approval or pricing.
-    if (normalized.model !== request.model) {
+    if (!openaiReturnedModelIdentityMatches(request.model, normalized.model)) {
       throw new UnexpectedModelIdentityError('openai', request.model, normalized.model);
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };

--- a/server/src/addie/testing/provider-router-eval.ts
+++ b/server/src/addie/testing/provider-router-eval.ts
@@ -21,6 +21,9 @@ import {
 import { getValidToolSetNames } from '../tool-sets.js';
 import {
   datedPricingCostUsd,
+  datedPricingProfileIdentity,
+  datedPricingReservationCostUsd,
+  type DatedPricingProfileIdentity,
   type DatedPricingProfile,
 } from '../eval/dated-pricing-cohort.js';
 
@@ -128,6 +131,13 @@ interface RouterEvalReservation {
   active: boolean;
 }
 
+interface RouterEvalReservationPricingBinding {
+  /** The exact module-issued profile object selected before dispatch. */
+  readonly pricing: DatedPricingProfile;
+  /** Snapshot of its issued digest, candidate, provider, and model. */
+  readonly pricingIdentity: DatedPricingProfileIdentity;
+}
+
 /**
  * Serial diagnostic ledger for router comparisons. Its cache exposure and
  * terminal accounting deliberately use the same dated-profile formula as the
@@ -141,6 +151,9 @@ export class RouterEvalBudget {
   private budgetRejectedCalls = 0;
   private admissionClosed = false;
   private exposureUnknown = false;
+  // Keep provenance outside the caller-held mutable reservation handle. This
+  // also makes a reservation issued by one ledger unusable by another.
+  private readonly reservationPricingBindings = new WeakMap<RouterEvalReservation, RouterEvalReservationPricingBinding>();
 
   constructor(readonly softMaxUsd: number) {
     if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
@@ -164,6 +177,7 @@ export class RouterEvalBudget {
       this.budgetRejectedCalls++;
       throw new RouterEvalBudgetAdmissionError('soft_limit_exceeded');
     }
+    const pricingIdentity = assertImmutableDatedPricingProfile(pricing);
     const usd = RouterEvalBudget.reservationUsd(prepared, maxOutputTokens, pricing);
     if (!shouldDispatchWithinSoftBudget(this.accountedSpendUsd + this.reservedUsd, usd, this.softMaxUsd)) {
       this.admissionClosed = true;
@@ -171,7 +185,9 @@ export class RouterEvalBudget {
       throw new RouterEvalBudgetAdmissionError('soft_limit_exceeded');
     }
     this.reservedUsd += usd;
-    return { usd, active: true };
+    const reservation = { usd, active: true };
+    this.reservationPricingBindings.set(reservation, { pricing, pricingIdentity });
+    return reservation;
   }
 
   static reservationUsd(
@@ -180,15 +196,9 @@ export class RouterEvalBudget {
     pricing: DatedPricingProfile,
   ): number {
     assertImmutableDatedPricingProfile(pricing);
+    assertPreparedDatedPricingIdentity(prepared, pricing);
     const inputTokens = Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8');
-    return datedPricingCostUsd(pricing, {
-      inputTokens,
-      outputTokens: maxOutputTokens,
-      // Input is already the ceiling for subset buckets. Each independently
-      // additive bucket can consume the full request ceiling as well.
-      cacheReadTokens: pricing.cacheReadAccounting === 'additive' ? inputTokens : 0,
-      cacheWriteTokens: pricing.cacheWriteAccounting === 'additive' ? inputTokens : 0,
-    });
+    return datedPricingReservationCostUsd(pricing, inputTokens, maxOutputTokens);
   }
 
   markDispatched(reservation: RouterEvalReservation): void {
@@ -197,7 +207,8 @@ export class RouterEvalBudget {
   }
 
   complete(reservation: RouterEvalReservation, usage: ModelUsage, pricing: DatedPricingProfile): number {
-    assertImmutableDatedPricingProfile(pricing);
+    const pricingIdentity = assertImmutableDatedPricingProfile(pricing);
+    this.assertReservationPricing(reservation, pricing, pricingIdentity);
     const actualCostUsd = datedPricingCostUsd(pricing, usage);
     this.release(reservation);
     this.accountedSpendUsd += actualCostUsd;
@@ -231,7 +242,9 @@ export class RouterEvalBudget {
   }
 
   private requireActive(reservation: RouterEvalReservation): void {
-    if (!reservation.active) throw new Error('Router eval budget reservation is inactive');
+    if (!reservation.active || !this.reservationPricingBindings.has(reservation)) {
+      throw new Error('Router eval budget reservation is inactive');
+    }
   }
 
   private release(reservation: RouterEvalReservation): void {
@@ -239,11 +252,39 @@ export class RouterEvalBudget {
     reservation.active = false;
     this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
   }
+
+  private assertReservationPricing(
+    reservation: RouterEvalReservation,
+    pricing: DatedPricingProfile,
+    pricingIdentity: DatedPricingProfileIdentity,
+  ): void {
+    const binding = this.reservationPricingBindings.get(reservation);
+    if (
+      !binding
+      || binding.pricing !== pricing
+      || binding.pricingIdentity.digest !== pricingIdentity.digest
+      || binding.pricingIdentity.candidateId !== pricingIdentity.candidateId
+      || binding.pricingIdentity.profileId !== pricingIdentity.profileId
+      || binding.pricingIdentity.provider !== pricingIdentity.provider
+      || binding.pricingIdentity.model !== pricingIdentity.model
+    ) throw new Error('Router eval budget reservation pricing profile does not match settlement profile');
+  }
 }
 
-function assertImmutableDatedPricingProfile(pricing: DatedPricingProfile): void {
-  if (!Object.isFrozen(pricing) || !Object.isFrozen(pricing.sourceEvidence)) {
+function assertImmutableDatedPricingProfile(pricing: DatedPricingProfile): DatedPricingProfileIdentity {
+  try {
+    return datedPricingProfileIdentity(pricing);
+  } catch {
     throw new Error('Router eval pricing profile must be an immutable dated cohort profile');
+  }
+}
+
+function assertPreparedDatedPricingIdentity(
+  prepared: PreparedModelInvocation,
+  pricing: DatedPricingProfile,
+): void {
+  if (prepared.provider !== pricing.provider || prepared.model !== pricing.model) {
+    throw new Error('Router eval prepared invocation identity does not match pricing profile');
   }
 }
 

--- a/server/src/addie/testing/provider-router-eval.ts
+++ b/server/src/addie/testing/provider-router-eval.ts
@@ -126,12 +126,17 @@ export interface RouterEvalBudgetSnapshot {
   readonly exposureUnknown: boolean;
 }
 
+declare const routerEvalReservationToken: unique symbol;
+
+/** Opaque frozen capability token; no accounting state is caller-visible. */
 interface RouterEvalReservation {
-  readonly usd: number;
-  active: boolean;
+  readonly [routerEvalReservationToken]: never;
 }
 
-interface RouterEvalReservationPricingBinding {
+interface RouterEvalReservationState {
+  readonly usd: number;
+  active: boolean;
+  dispatched: boolean;
   /** The exact module-issued profile object selected before dispatch. */
   readonly pricing: DatedPricingProfile;
   /** Snapshot of its issued digest, candidate, provider, and model. */
@@ -151,9 +156,10 @@ export class RouterEvalBudget {
   private budgetRejectedCalls = 0;
   private admissionClosed = false;
   private exposureUnknown = false;
-  // Keep provenance outside the caller-held mutable reservation handle. This
-  // also makes a reservation issued by one ledger unusable by another.
-  private readonly reservationPricingBindings = new WeakMap<RouterEvalReservation, RouterEvalReservationPricingBinding>();
+  // Every mutable reservation value is private. The returned frozen token is
+  // only a WeakMap identity capability, so it cannot alter its own refund or
+  // active state and cannot be replayed through another ledger.
+  private readonly reservationStates = new WeakMap<RouterEvalReservation, RouterEvalReservationState>();
 
   constructor(readonly softMaxUsd: number) {
     if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
@@ -185,8 +191,10 @@ export class RouterEvalBudget {
       throw new RouterEvalBudgetAdmissionError('soft_limit_exceeded');
     }
     this.reservedUsd += usd;
-    const reservation = { usd, active: true };
-    this.reservationPricingBindings.set(reservation, { pricing, pricingIdentity });
+    const reservation = Object.freeze({}) as RouterEvalReservation;
+    this.reservationStates.set(reservation, {
+      usd, active: true, dispatched: false, pricing, pricingIdentity,
+    });
     return reservation;
   }
 
@@ -202,13 +210,17 @@ export class RouterEvalBudget {
   }
 
   markDispatched(reservation: RouterEvalReservation): void {
-    this.requireActive(reservation);
+    const state = this.requireActive(reservation);
+    if (state.dispatched) throw new Error('Router eval budget reservation was already dispatched');
+    state.dispatched = true;
     this.dispatchedCalls++;
   }
 
   complete(reservation: RouterEvalReservation, usage: ModelUsage, pricing: DatedPricingProfile): number {
+    const state = this.requireActive(reservation);
+    if (!state.dispatched) throw new Error('Router eval budget reservation was not dispatched');
     const pricingIdentity = assertImmutableDatedPricingProfile(pricing);
-    this.assertReservationPricing(reservation, pricing, pricingIdentity);
+    this.assertReservationPricing(state, pricing, pricingIdentity);
     const actualCostUsd = datedPricingCostUsd(pricing, usage);
     this.release(reservation);
     this.accountedSpendUsd += actualCostUsd;
@@ -217,10 +229,14 @@ export class RouterEvalBudget {
   }
 
   cancel(reservation: RouterEvalReservation): void {
+    const state = this.requireActive(reservation);
+    if (state.dispatched) throw new Error('Router eval budget dispatched reservation cannot be cancelled');
     this.release(reservation);
   }
 
   markExposureUnknown(reservation: RouterEvalReservation): void {
+    const state = this.requireActive(reservation);
+    if (!state.dispatched) throw new Error('Router eval budget reservation was not dispatched');
     this.release(reservation);
     this.exposureUnknown = true;
   }
@@ -241,32 +257,36 @@ export class RouterEvalBudget {
     });
   }
 
-  private requireActive(reservation: RouterEvalReservation): void {
-    if (!reservation.active || !this.reservationPricingBindings.has(reservation)) {
+  private requireActive(reservation: RouterEvalReservation): RouterEvalReservationState {
+    const state = this.reservationStates.get(reservation);
+    if (!state || !state.active) {
       throw new Error('Router eval budget reservation is inactive');
     }
+    return state;
   }
 
   private release(reservation: RouterEvalReservation): void {
-    this.requireActive(reservation);
-    reservation.active = false;
-    this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
+    const state = this.requireActive(reservation);
+    const nextReservedUsd = this.reservedUsd - state.usd;
+    if (nextReservedUsd < -Number.EPSILON) {
+      throw new Error('Router eval budget reservation ledger is inconsistent');
+    }
+    state.active = false;
+    this.reservedUsd = nextReservedUsd <= Number.EPSILON ? 0 : nextReservedUsd;
   }
 
   private assertReservationPricing(
-    reservation: RouterEvalReservation,
+    state: RouterEvalReservationState,
     pricing: DatedPricingProfile,
     pricingIdentity: DatedPricingProfileIdentity,
   ): void {
-    const binding = this.reservationPricingBindings.get(reservation);
     if (
-      !binding
-      || binding.pricing !== pricing
-      || binding.pricingIdentity.digest !== pricingIdentity.digest
-      || binding.pricingIdentity.candidateId !== pricingIdentity.candidateId
-      || binding.pricingIdentity.profileId !== pricingIdentity.profileId
-      || binding.pricingIdentity.provider !== pricingIdentity.provider
-      || binding.pricingIdentity.model !== pricingIdentity.model
+      state.pricing !== pricing
+      || state.pricingIdentity.digest !== pricingIdentity.digest
+      || state.pricingIdentity.candidateId !== pricingIdentity.candidateId
+      || state.pricingIdentity.profileId !== pricingIdentity.profileId
+      || state.pricingIdentity.provider !== pricingIdentity.provider
+      || state.pricingIdentity.model !== pricingIdentity.model
     ) throw new Error('Router eval budget reservation pricing profile does not match settlement profile');
   }
 }

--- a/server/src/addie/testing/provider-router-eval.ts
+++ b/server/src/addie/testing/provider-router-eval.ts
@@ -19,6 +19,10 @@ import {
   type StrictRouterPlan,
 } from '../router.js';
 import { getValidToolSetNames } from '../tool-sets.js';
+import {
+  datedPricingCostUsd,
+  type DatedPricingProfile,
+} from '../eval/dated-pricing-cohort.js';
 
 export {
   parseStrictRouterPlan,
@@ -93,6 +97,154 @@ export interface RouterEvalMatrixRun<TCell extends RouterEvalMatrixCell> {
   complete: boolean;
   comparisonEligible: boolean;
   abortedAfter: RouterEvalMatrixCoordinate<TCell> | null;
+}
+
+export type RouterEvalBudgetRejectionReason =
+  | 'budget_exposure_unknown'
+  | 'soft_limit_exceeded';
+
+/** A local admission failure; providers have not been called when this is thrown. */
+export class RouterEvalBudgetAdmissionError extends Error {
+  constructor(readonly reason: RouterEvalBudgetRejectionReason) {
+    super(reason);
+    this.name = 'RouterEvalBudgetAdmissionError';
+  }
+}
+
+export interface RouterEvalBudgetSnapshot {
+  readonly softMaxUsd: number;
+  readonly accountedSpendUsd: number;
+  readonly reservedUsd: number;
+  readonly remainingUsd: number | null;
+  readonly dispatchedCalls: number;
+  readonly completedCalls: number;
+  readonly budgetRejectedCalls: number;
+  readonly admissionClosed: boolean;
+  readonly exposureUnknown: boolean;
+}
+
+interface RouterEvalReservation {
+  readonly usd: number;
+  active: boolean;
+}
+
+/**
+ * Serial diagnostic ledger for router comparisons. Its cache exposure and
+ * terminal accounting deliberately use the same dated-profile formula as the
+ * fixed-trace ledger.
+ */
+export class RouterEvalBudget {
+  private accountedSpendUsd = 0;
+  private reservedUsd = 0;
+  private dispatchedCalls = 0;
+  private completedCalls = 0;
+  private budgetRejectedCalls = 0;
+  private admissionClosed = false;
+  private exposureUnknown = false;
+
+  constructor(readonly softMaxUsd: number) {
+    if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
+      throw new RangeError('Router eval soft budget must be positive');
+    }
+  }
+
+  reserve(
+    prepared: PreparedModelInvocation,
+    maxOutputTokens: number,
+    pricing: DatedPricingProfile,
+  ): RouterEvalReservation {
+    if (!Number.isSafeInteger(maxOutputTokens) || maxOutputTokens < 1) {
+      throw new RangeError('Router eval output reserve must be a positive integer');
+    }
+    if (this.exposureUnknown) {
+      this.budgetRejectedCalls++;
+      throw new RouterEvalBudgetAdmissionError('budget_exposure_unknown');
+    }
+    if (this.admissionClosed) {
+      this.budgetRejectedCalls++;
+      throw new RouterEvalBudgetAdmissionError('soft_limit_exceeded');
+    }
+    const usd = RouterEvalBudget.reservationUsd(prepared, maxOutputTokens, pricing);
+    if (!shouldDispatchWithinSoftBudget(this.accountedSpendUsd + this.reservedUsd, usd, this.softMaxUsd)) {
+      this.admissionClosed = true;
+      this.budgetRejectedCalls++;
+      throw new RouterEvalBudgetAdmissionError('soft_limit_exceeded');
+    }
+    this.reservedUsd += usd;
+    return { usd, active: true };
+  }
+
+  static reservationUsd(
+    prepared: PreparedModelInvocation,
+    maxOutputTokens: number,
+    pricing: DatedPricingProfile,
+  ): number {
+    assertImmutableDatedPricingProfile(pricing);
+    const inputTokens = Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8');
+    return datedPricingCostUsd(pricing, {
+      inputTokens,
+      outputTokens: maxOutputTokens,
+      // Input is already the ceiling for subset buckets. Each independently
+      // additive bucket can consume the full request ceiling as well.
+      cacheReadTokens: pricing.cacheReadAccounting === 'additive' ? inputTokens : 0,
+      cacheWriteTokens: pricing.cacheWriteAccounting === 'additive' ? inputTokens : 0,
+    });
+  }
+
+  markDispatched(reservation: RouterEvalReservation): void {
+    this.requireActive(reservation);
+    this.dispatchedCalls++;
+  }
+
+  complete(reservation: RouterEvalReservation, usage: ModelUsage, pricing: DatedPricingProfile): number {
+    assertImmutableDatedPricingProfile(pricing);
+    const actualCostUsd = datedPricingCostUsd(pricing, usage);
+    this.release(reservation);
+    this.accountedSpendUsd += actualCostUsd;
+    this.completedCalls++;
+    return actualCostUsd;
+  }
+
+  cancel(reservation: RouterEvalReservation): void {
+    this.release(reservation);
+  }
+
+  markExposureUnknown(reservation: RouterEvalReservation): void {
+    this.release(reservation);
+    this.exposureUnknown = true;
+  }
+
+  snapshot(): RouterEvalBudgetSnapshot {
+    return Object.freeze({
+      softMaxUsd: this.softMaxUsd,
+      accountedSpendUsd: this.accountedSpendUsd,
+      reservedUsd: this.reservedUsd,
+      remainingUsd: this.exposureUnknown
+        ? null
+        : Math.max(0, this.softMaxUsd - this.accountedSpendUsd - this.reservedUsd),
+      dispatchedCalls: this.dispatchedCalls,
+      completedCalls: this.completedCalls,
+      budgetRejectedCalls: this.budgetRejectedCalls,
+      admissionClosed: this.admissionClosed,
+      exposureUnknown: this.exposureUnknown,
+    });
+  }
+
+  private requireActive(reservation: RouterEvalReservation): void {
+    if (!reservation.active) throw new Error('Router eval budget reservation is inactive');
+  }
+
+  private release(reservation: RouterEvalReservation): void {
+    this.requireActive(reservation);
+    reservation.active = false;
+    this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
+  }
+}
+
+function assertImmutableDatedPricingProfile(pricing: DatedPricingProfile): void {
+  if (!Object.isFrozen(pricing) || !Object.isFrozen(pricing.sourceEvidence)) {
+    throw new Error('Router eval pricing profile must be an immutable dated cohort profile');
+  }
 }
 
 export const ROUTER_PLAN_SCHEMA = Object.freeze({
@@ -308,6 +460,9 @@ export async function evaluateRouterCase(
     }
   } catch (error) {
     if (controller.signal.aborted) status = 'timeout_after_dispatch';
+    else if (error instanceof RouterEvalBudgetAdmissionError) {
+      status = 'not_dispatched_budget';
+    }
     else if (error instanceof UnexpectedModelIdentityError) {
       returnedModel = error.actualModel;
       status = 'provider_error';
@@ -542,17 +697,4 @@ export function shouldDispatchWithinSoftBudget(
     && expectedNextCallUsd >= 0
     && softMaxUsd > 0
     && accountedSpendUsd + expectedNextCallUsd <= softMaxUsd;
-}
-
-export function accountRouterCallCostUsd(
-  usage: ModelUsage,
-  ratesPerMillion: { input: number; output: number },
-): number {
-  const inputTokens = usage.inputTokens;
-  const outputTokens = usage.outputTokens;
-  if (
-    ![inputTokens, outputTokens, ratesPerMillion.input, ratesPerMillion.output].every(Number.isFinite)
-    || inputTokens < 0 || outputTokens < 0 || ratesPerMillion.input < 0 || ratesPerMillion.output < 0
-  ) throw new Error('Invalid router eval cost inputs');
-  return (inputTokens * ratesPerMillion.input + outputTokens * ratesPerMillion.output) / 1_000_000;
 }

--- a/server/tests/manual/provider-router-eval.ts
+++ b/server/tests/manual/provider-router-eval.ts
@@ -32,15 +32,15 @@ import {
   SYNTHETIC_ROUTER_CORPUS,
   type RouterEvalResult,
 } from '../../src/addie/testing/provider-router-eval.js';
+import {
+  pricingProfileForCandidate,
+  resolveCurrentEvaluationPricingCohort,
+  type DatedPricingProfile,
+  type EvaluationPricingCandidateId,
+} from '../../src/addie/eval/dated-pricing-cohort.js';
 
 type ProviderName = 'anthropic' | 'openai' | 'google';
 type Profile = 'prompt_parity' | 'native_structured';
-
-const RATES: Record<ProviderName, { input: number; output: number; source: string }> = {
-  anthropic: { input: 1, output: 5, source: 'Anthropic Haiku 4.5 standard, checked 2026-08-25' },
-  openai: { input: 0.2, output: 1.2, source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25' },
-  google: { input: 0.75, output: 3.75, source: 'Google Gemini 3.7 Flash introductory standard, checked 2026-08-25' },
-};
 
 function argument(name: string): string | undefined {
   const prefix = `--${name}=`;
@@ -51,12 +51,54 @@ const providerNames = (argument('providers') ?? 'anthropic,openai,google').split
 const profiles = (argument('profiles') ?? 'prompt_parity,native_structured').split(',') as Profile[];
 const repetitions = Number(argument('repetitions') ?? '3');
 const softMaxUsd = Number(argument('soft-max-usd'));
+const validateOnly = process.argv.includes('--validate-only');
 if (!Number.isSafeInteger(repetitions) || repetitions < 1 || repetitions > 10) throw new Error('--repetitions must be 1..10');
 if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) throw new Error('--soft-max-usd is required and must be positive');
 if (providerNames.some((name) => !['anthropic', 'openai', 'google'].includes(name))) throw new Error('Unknown --providers value');
 if (profiles.some((name) => !['prompt_parity', 'native_structured'].includes(name))) throw new Error('Unknown --profiles value');
 if (new Set(providerNames).size !== providerNames.length) throw new Error('--providers must not contain duplicates');
 if (new Set(profiles).size !== profiles.length) throw new Error('--profiles must not contain duplicates');
+
+const cohortCandidateForProvider: Record<ProviderName, EvaluationPricingCandidateId> = {
+  anthropic: 'anthropic-router',
+  openai: 'openai-router-generator',
+  google: 'google-router-generator',
+};
+const cohortResult = resolveCurrentEvaluationPricingCohort(
+  new Date(),
+  providerNames.map((provider) => cohortCandidateForProvider[provider]),
+);
+if (cohortResult.status !== 'available') {
+  throw new Error(`Dated pricing cohort unavailable: ${cohortResult.reasons.map((entry) => `${entry.candidateId}:${entry.reason}`).join(', ')}`);
+}
+const RATES: Record<ProviderName, DatedPricingProfile> = {
+  anthropic: providerNames.includes('anthropic')
+    ? pricingProfileForCandidate(cohortResult.cohort, 'anthropic-router')
+    : undefined as never,
+  openai: providerNames.includes('openai')
+    ? pricingProfileForCandidate(cohortResult.cohort, 'openai-router-generator')
+    : undefined as never,
+  google: providerNames.includes('google')
+    ? pricingProfileForCandidate(cohortResult.cohort, 'google-router-generator')
+    : undefined as never,
+};
+
+// This is intentionally before credential reads and provider construction.
+// It validates the candidate cohort only; it cannot establish a provider
+// request bundle or authorize a live comparison.
+if (validateOnly) {
+  console.log(JSON.stringify({
+    diagnosticOnly: true,
+    validated: {
+      providers: providerNames,
+      profiles,
+      repetitions,
+      softMaxUsd,
+      pricingCohortDigest: cohortResult.cohort.digest,
+    },
+  }));
+  process.exit(0);
+}
 
 const providers: Partial<Record<ProviderName, { provider: ModelProvider; model: string }>> = {};
 if (providerNames.includes('anthropic')) {
@@ -95,6 +137,7 @@ const sourceFiles = [
   'server/src/addie/model-providers/anthropic-router-provider.ts',
   'server/src/addie/model-providers/openai-responses-provider.ts',
   'server/src/addie/model-providers/google-generate-content-provider.ts',
+  'server/src/addie/eval/dated-pricing-cohort.ts',
   'server/tests/manual/provider-router-eval.ts',
 ];
 const sourceBundleSha256 = sha256(sourceFiles.map((file) => [file, readFileSync(file, 'utf8')]));
@@ -109,7 +152,7 @@ const projectedReservedCost = plannedCells.reduce((total, cell) => {
     const request = buildRouterEvalRequest(selected.model, cell.profile, testCase, reasoningEffort);
     return tokens + Buffer.byteLength(JSON.stringify(selected.provider.prepare(request).providerRequest), 'utf8');
   }, 0);
-  return total + repetitions * ((reservedInput * rate.input + MODEL_ROUTER_CORPUS.length * reservedOutput * rate.output) / 1_000_000);
+  return total + repetitions * ((reservedInput * rate.inputUsdPerMillionTokens + MODEL_ROUTER_CORPUS.length * reservedOutput * rate.outputUsdPerMillionTokens) / 1_000_000);
 }, 0);
 if (projectedReservedCost > softMaxUsd) {
   throw new Error(`Projected reserved cost $${projectedReservedCost.toFixed(4)} exceeds --soft-max-usd=$${softMaxUsd.toFixed(4)}`);
@@ -136,7 +179,7 @@ const matrixRun = await runRouterEvalMatrix({
         'utf8',
       );
       const reserveOutputTokens = cell.provider === 'google' ? 1_200 : 300;
-      const reserveUsd = (reserveInputTokens * rate.input + reserveOutputTokens * rate.output) / 1_000_000;
+      const reserveUsd = (reserveInputTokens * rate.inputUsdPerMillionTokens + reserveOutputTokens * rate.outputUsdPerMillionTokens) / 1_000_000;
       if (!shouldDispatchWithinSoftBudget(accountedSpendUsd, reserveUsd, softMaxUsd)) {
         return {
           caseId: testCase.id,
@@ -177,7 +220,10 @@ const matrixRun = await runRouterEvalMatrix({
           },
         },
       );
-      if (result.usage) accountedSpendUsd += accountRouterCallCostUsd(result.usage, rate);
+      if (result.usage) accountedSpendUsd += accountRouterCallCostUsd(result.usage, {
+        input: rate.inputUsdPerMillionTokens,
+        output: rate.outputUsdPerMillionTokens,
+      });
       return result;
   },
 });
@@ -194,14 +240,16 @@ const report = plannedCells.map((cell) => {
   const cellResults = results.filter((result) => result.provider === cell.provider && result.profile === cell.profile);
   const summary = summarizeRouterEval(cellResults, repetitions * MODEL_ROUTER_CORPUS.length);
   const rate = RATES[cell.provider];
-  const actualCostUsd = (summary.inputTokens * rate.input + summary.outputTokens * rate.output) / 1_000_000;
+  const actualCostUsd = (summary.inputTokens * rate.inputUsdPerMillionTokens + summary.outputTokens * rate.outputUsdPerMillionTokens) / 1_000_000;
   return {
     provider: cell.provider,
     requestedModel: providers[cell.provider]!.model,
     returnedModels: [...new Set(cellResults.map((result) => result.returnedModel).filter(Boolean))],
     profile: cell.profile,
     reasoningEffort: cell.provider === 'openai' ? 'none' : cell.provider === 'google' ? 'low' : 'provider_default',
-    pricingSource: rate.source,
+    pricingSource: rate.sourceEvidence.url,
+    pricingCheckedAt: rate.sourceEvidence.retrievedAt,
+    pricingCohortDigest: cohortResult.cohort.digest,
     ...summary,
     actualCostUsd,
     cases: cellResults.map((result) => ({

--- a/server/tests/manual/provider-router-eval.ts
+++ b/server/tests/manual/provider-router-eval.ts
@@ -26,14 +26,14 @@ import {
   buildRouterEvalRequest,
   MODEL_ROUTER_CORPUS,
   summarizeRouterEval,
-  shouldDispatchWithinSoftBudget,
-  accountRouterCallCostUsd,
+  RouterEvalBudget,
   runRouterEvalMatrix,
   SYNTHETIC_ROUTER_CORPUS,
   type RouterEvalResult,
 } from '../../src/addie/testing/provider-router-eval.js';
 import {
   pricingProfileForCandidate,
+  cohortReturnedModelMatches,
   resolveCurrentEvaluationPricingCohort,
   type DatedPricingProfile,
   type EvaluationPricingCandidateId,
@@ -82,6 +82,12 @@ const RATES: Record<ProviderName, DatedPricingProfile> = {
     ? pricingProfileForCandidate(cohortResult.cohort, 'google-router-generator')
     : undefined as never,
 };
+const requestedCells = providerNames.flatMap((provider) => profiles.map((profile) => ({ provider, profile })));
+const excludedCells = requestedCells
+  .filter((cell) => cell.provider === 'anthropic' && cell.profile === 'native_structured')
+  .map((cell) => ({ ...cell, reason: 'anthropic_router_has_no_native_structured_profile' as const }));
+const plannedCells = requestedCells.filter((cell) => !(cell.provider === 'anthropic' && cell.profile === 'native_structured'));
+if (plannedCells.length === 0) throw new Error('Requested provider/profile matrix has no supported cells');
 
 // This is intentionally before credential reads and provider construction.
 // It validates the candidate cohort only; it cannot establish a provider
@@ -95,6 +101,9 @@ if (validateOnly) {
       repetitions,
       softMaxUsd,
       pricingCohortDigest: cohortResult.cohort.digest,
+      requestedCells,
+      plannedCells,
+      excludedCells,
     },
   }));
   process.exit(0);
@@ -118,12 +127,6 @@ if (providerNames.includes('google')) {
   providers.google = { provider: new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY), model: GOOGLE_ROUTER_MODEL };
 }
 
-const requestedCells = providerNames.flatMap((provider) => profiles.map((profile) => ({ provider, profile })));
-const excludedCells = requestedCells
-  .filter((cell) => cell.provider === 'anthropic' && cell.profile === 'native_structured')
-  .map((cell) => ({ ...cell, reason: 'anthropic_router_has_no_native_structured_profile' as const }));
-const plannedCells = requestedCells.filter((cell) => !(cell.provider === 'anthropic' && cell.profile === 'native_structured'));
-if (plannedCells.length === 0) throw new Error('Requested provider/profile matrix has no supported cells');
 const sha256 = (value: unknown) => createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex');
 const sourceFiles = [
   'package.json',
@@ -144,22 +147,26 @@ const sourceBundleSha256 = sha256(sourceFiles.map((file) => [file, readFileSync(
 const gitCommit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
 const workingTreeDirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim().length > 0;
 const projectedReservedCost = plannedCells.reduce((total, cell) => {
-  const rate = RATES[cell.provider];
   const reservedOutput = cell.provider === 'google' ? 1_200 : 300;
   const selected = providers[cell.provider]!;
   const reasoningEffort = cell.provider === 'openai' ? 'none' as const : cell.provider === 'google' ? 'low' as const : undefined;
-  const reservedInput = MODEL_ROUTER_CORPUS.reduce((tokens, testCase) => {
+  const perRepetition = MODEL_ROUTER_CORPUS.reduce((usd, testCase) => {
     const request = buildRouterEvalRequest(selected.model, cell.profile, testCase, reasoningEffort);
-    return tokens + Buffer.byteLength(JSON.stringify(selected.provider.prepare(request).providerRequest), 'utf8');
+    return usd + RouterEvalBudget.reservationUsd(
+      selected.provider.prepare(request),
+      reservedOutput,
+      RATES[cell.provider],
+    );
   }, 0);
-  return total + repetitions * ((reservedInput * rate.inputUsdPerMillionTokens + MODEL_ROUTER_CORPUS.length * reservedOutput * rate.outputUsdPerMillionTokens) / 1_000_000);
+  return total + repetitions * perRepetition;
 }, 0);
 if (projectedReservedCost > softMaxUsd) {
   throw new Error(`Projected reserved cost $${projectedReservedCost.toFixed(4)} exceeds --soft-max-usd=$${softMaxUsd.toFixed(4)}`);
 }
 
 const dispatchedInvocations: Array<Record<string, unknown>> = [];
-let accountedSpendUsd = 0;
+const budget = new RouterEvalBudget(softMaxUsd);
+const settledCosts = new WeakMap<RouterEvalResult, number>();
 const matrixRun = await runRouterEvalMatrix({
   repetitions,
   cases: MODEL_ROUTER_CORPUS,
@@ -173,33 +180,8 @@ const matrixRun = await runRouterEvalMatrix({
           ? 'low' as const
           : undefined;
       const evalRequest = buildRouterEvalRequest(selected.model, cell.profile, testCase, reasoningEffort);
-      const prepared = selected.provider.prepare(evalRequest);
-      const reserveInputTokens = Buffer.byteLength(
-        JSON.stringify(prepared.providerRequest),
-        'utf8',
-      );
       const reserveOutputTokens = cell.provider === 'google' ? 1_200 : 300;
-      const reserveUsd = (reserveInputTokens * rate.inputUsdPerMillionTokens + reserveOutputTokens * rate.outputUsdPerMillionTokens) / 1_000_000;
-      if (!shouldDispatchWithinSoftBudget(accountedSpendUsd, reserveUsd, softMaxUsd)) {
-        return {
-          caseId: testCase.id,
-          provider: cell.provider,
-          requestedModel: selected.model,
-          profile: cell.profile,
-          status: 'not_dispatched_budget',
-          latencyMs: 0,
-          scores: {
-            actionExact: false, toolsExact: false, privilegeLeak: false, invalidToolSet: false,
-            confidenceExact: false, depthExact: false, emojiExact: false,
-          },
-          applicable: {
-            tools: testCase.expected.action === 'respond',
-            confidence: testCase.expected.confidence !== undefined,
-            depth: testCase.expected.requiresDepth !== undefined,
-            emoji: testCase.expected.emoji !== undefined,
-          },
-        };
-      }
+      let reservation: ReturnType<RouterEvalBudget['reserve']> | null = null;
       const result = await evaluateRouterCase(
         selected.provider,
         selected.model,
@@ -209,26 +191,51 @@ const matrixRun = await runRouterEvalMatrix({
           reasoningEffort,
           timeoutMs: 120_000,
           beforeDispatch: (actualPrepared) => {
-            dispatchedInvocations.push({
-              repetition,
-              caseId: testCase.id,
-              provider: cell.provider,
-              profile: cell.profile,
-              reasoningEffort: reasoningEffort ?? 'provider_default',
-              providerRequest: actualPrepared.providerRequest,
-            });
+            if (actualPrepared.provider !== rate.provider || actualPrepared.model !== rate.model) {
+              throw new Error(`Dated pricing prepared invocation drift: expected ${rate.provider}/${rate.model}, received ${actualPrepared.provider}/${actualPrepared.model}`);
+            }
+            reservation = budget.reserve(actualPrepared, reserveOutputTokens, rate);
+            try {
+              dispatchedInvocations.push({
+                repetition,
+                caseId: testCase.id,
+                provider: cell.provider,
+                profile: cell.profile,
+                pricingProfileId: rate.profileId,
+                pricingCohortDigest: cohortResult.cohort.digest,
+                reasoningEffort: reasoningEffort ?? 'provider_default',
+                providerRequest: actualPrepared.providerRequest,
+              });
+              budget.markDispatched(reservation);
+            } catch (error) {
+              budget.cancel(reservation);
+              reservation = null;
+              throw error;
+            }
           },
         },
       );
-      if (result.usage) accountedSpendUsd += accountRouterCallCostUsd(result.usage, {
-        input: rate.inputUsdPerMillionTokens,
-        output: rate.outputUsdPerMillionTokens,
-      });
+      if (!reservation) return result;
+      if (!result.usage) {
+        budget.markExposureUnknown(reservation);
+        return result;
+      }
+      if (!result.returnedModel || !cohortReturnedModelMatches(rate, result.returnedModel)) {
+        budget.markExposureUnknown(reservation);
+        throw new Error(`Dated pricing returned-model drift: expected ${rate.provider}/${rate.model}, received ${result.returnedModel ?? 'missing'}`);
+      }
+      try {
+        settledCosts.set(result, budget.complete(reservation, result.usage, rate));
+      } catch (error) {
+        budget.markExposureUnknown(reservation);
+        throw error;
+      }
       return result;
   },
 });
 const results = matrixRun.results;
-const budgetExposureUnknown = matrixRun.abortedAfter !== null;
+const budgetSnapshot = budget.snapshot();
+const budgetExposureUnknown = budgetSnapshot.exposureUnknown;
 const runAbortedAfter = matrixRun.abortedAfter && {
   repetition: matrixRun.abortedAfter.repetition,
   caseId: matrixRun.abortedAfter.testCase.id,
@@ -240,7 +247,7 @@ const report = plannedCells.map((cell) => {
   const cellResults = results.filter((result) => result.provider === cell.provider && result.profile === cell.profile);
   const summary = summarizeRouterEval(cellResults, repetitions * MODEL_ROUTER_CORPUS.length);
   const rate = RATES[cell.provider];
-  const actualCostUsd = (summary.inputTokens * rate.inputUsdPerMillionTokens + summary.outputTokens * rate.outputUsdPerMillionTokens) / 1_000_000;
+  const actualCostUsd = cellResults.reduce((total, result) => total + (settledCosts.get(result) ?? 0), 0);
   return {
     provider: cell.provider,
     requestedModel: providers[cell.provider]!.model,
@@ -250,6 +257,11 @@ const report = plannedCells.map((cell) => {
     pricingSource: rate.sourceEvidence.url,
     pricingCheckedAt: rate.sourceEvidence.retrievedAt,
     pricingCohortDigest: cohortResult.cohort.digest,
+    pricingProfileId: rate.profileId,
+    cacheAccounting: {
+      cacheRead: rate.cacheReadAccounting,
+      cacheWrite: rate.cacheWriteAccounting,
+    },
     ...summary,
     actualCostUsd,
     cases: cellResults.map((result) => ({
@@ -259,16 +271,24 @@ const report = plannedCells.map((cell) => {
       scores: result.scores,
       latencyMs: result.latencyMs,
       usage: result.usage,
+      actualCostUsd: settledCosts.get(result) ?? 0,
     })),
   };
 });
+const reportedSpendUsd = report.reduce((total, cell) => total + cell.actualCostUsd, 0);
+if (Math.abs(reportedSpendUsd - budgetSnapshot.accountedSpendUsd) > Number.EPSILON * Math.max(1, reportedSpendUsd, budgetSnapshot.accountedSpendUsd)) {
+  throw new Error('Router evaluation pricing evidence does not reconcile with its reservation ledger');
+}
 
 const exactInvocationBundle = plannedCells.flatMap((cell) => {
   const selected = providers[cell.provider]!;
   const reasoningEffort = cell.provider === 'openai' ? 'none' as const : cell.provider === 'google' ? 'low' as const : undefined;
+  const rate = RATES[cell.provider];
   return MODEL_ROUTER_CORPUS.map((testCase) => ({
     provider: cell.provider,
     profile: cell.profile,
+    pricingProfileId: rate.profileId,
+    pricingCohortDigest: cohortResult.cohort.digest,
     caseId: testCase.id,
     request: selected.provider.prepare(
       buildRouterEvalRequest(selected.model, cell.profile, testCase, reasoningEffort),
@@ -302,6 +322,7 @@ console.log(JSON.stringify({
   budgetNote: 'The target gates dispatch using a per-call reserve; it is not a hard spend cap. Remote work may continue after a client timeout. The run halts after any dispatched call whose provider omits usage.',
   budgetExposureUnknown,
   runAbortedAfter,
-  accountedSpendUsd,
+  budget: budgetSnapshot,
+  accountedSpendUsd: budgetSnapshot.accountedSpendUsd,
   report,
 }, null, 2));

--- a/server/tests/unit/addie/dated-pricing-cohort.test.ts
+++ b/server/tests/unit/addie/dated-pricing-cohort.test.ts
@@ -23,6 +23,12 @@ describe('dated prospective evaluation pricing cohort', () => {
     if (all.status !== 'available') return;
     expect(pricingProfileForCandidate(all.cohort, 'openai-router-generator').identityDependency)
       .toBe('exact_returned_model_identity_enforced');
+    expect(pricingProfileForCandidate(all.cohort, 'openai-router-generator')).toMatchObject({
+      cacheReadUsdPerMillionTokens: 0.02,
+      cacheReadAccounting: 'subset',
+      cacheWriteUsdPerMillionTokens: 0.25,
+      cacheWriteAccounting: 'subset',
+    });
 
     const available = resolveCurrentEvaluationPricingCohort(AT, ['anthropic-router', 'anthropic-generation', 'google-router-generator']);
     expect(available.status).toBe('available');

--- a/server/tests/unit/addie/dated-pricing-cohort.test.ts
+++ b/server/tests/unit/addie/dated-pricing-cohort.test.ts
@@ -1,0 +1,156 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  buildDatedPricingCohort,
+  cohortReturnedModelMatches,
+  datedPricingCostMicros,
+  datedPricingProfilesForFixedTrace,
+  officialDatedPricingRecordsForAudit,
+  pricingProfileForCandidate,
+  resolveCurrentEvaluationPricingCohort,
+} from '../../../src/addie/eval/dated-pricing-cohort.js';
+
+const AT = new Date('2026-09-05T23:55:26.000Z');
+
+function records() {
+  return structuredClone(officialDatedPricingRecordsForAudit());
+}
+
+describe('dated prospective evaluation pricing cohort', () => {
+  it('derives exact configured candidates and admits OpenAI only through the merged literal-identity boundary', () => {
+    const all = resolveCurrentEvaluationPricingCohort(AT);
+    expect(all.status).toBe('available');
+    if (all.status !== 'available') return;
+    expect(pricingProfileForCandidate(all.cohort, 'openai-router-generator').identityDependency)
+      .toBe('exact_returned_model_identity_enforced');
+
+    const available = resolveCurrentEvaluationPricingCohort(AT, ['anthropic-router', 'anthropic-generation', 'google-router-generator']);
+    expect(available.status).toBe('available');
+    if (available.status !== 'available') return;
+    expect(available.cohort.profiles.map((profile) => [profile.candidateId, profile.model])).toEqual([
+      ['anthropic-generation', 'claude-sonnet-5'],
+      ['anthropic-router', 'claude-haiku-4-5'],
+      ['google-router-generator', 'gemini-3.7-flash'],
+    ]);
+    const sonnet = pricingProfileForCandidate(available.cohort, 'anthropic-generation');
+    expect(sonnet).toMatchObject({
+      inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 10,
+      cacheWriteUsdPerMillionTokens: 2.5, cacheReadUsdPerMillionTokens: 0.2,
+      effectiveFrom: '2026-09-01T00:00:00.000Z', effectiveBefore: null,
+    });
+    expect(sonnet.sourceEvidence.url).toBe('https://platform.claude.com/docs/en/about-claude/pricing');
+    expect(sonnet.sourceEvidence.retrievedAt).toBe('2026-09-05T23:55:26.000Z');
+    expect(officialDatedPricingRecordsForAudit().map((record) => record.source.url)).toEqual([
+      'https://platform.claude.com/docs/en/about-claude/pricing',
+      'https://platform.claude.com/docs/en/about-claude/pricing',
+      'https://developers.openai.com/api/docs/models/gpt-5.6-luna',
+      'https://ai.google.dev/gemini-api/docs/pricing',
+    ]);
+  });
+
+  it('uses an inclusive lower bound and exclusive effective-before bound', () => {
+    const source = records().find((record) => record.candidateId === 'google-router-generator')!;
+    expect(buildDatedPricingCohort([source], new Date(source.effectiveFrom)).status).toBe('available');
+    expect(buildDatedPricingCohort([source], new Date(source.effectiveBefore!))).toEqual({
+      status: 'unavailable',
+      reasons: [{ candidateId: 'google-router-generator', reason: 'pricing_outside_effective_interval' }],
+    });
+    expect(buildDatedPricingCohort([source], new Date('2026-08-12T23:59:59.999Z')).status).toBe('unavailable');
+    expect(resolveCurrentEvaluationPricingCohort(AT, []).status).toBe('unavailable');
+    expect(resolveCurrentEvaluationPricingCohort(AT, ['anthropic-router', 'anthropic-router']).status).toBe('unavailable');
+  });
+
+  it('evaluates only selected records, so an expired unrelated record cannot block a valid cohort', () => {
+    const afterGoogleExpiry = new Date('2027-01-01T00:00:00.000Z');
+    const anthropic = resolveCurrentEvaluationPricingCohort(afterGoogleExpiry, ['anthropic-router']);
+    expect(anthropic.status).toBe('available');
+    expect(resolveCurrentEvaluationPricingCohort(afterGoogleExpiry, ['google-router-generator'])).toEqual({
+      status: 'unavailable',
+      reasons: [{ candidateId: 'google-router-generator', reason: 'pricing_outside_effective_interval' }],
+    });
+  });
+
+  it('fails closed for missing fields, unowned URLs, malformed intervals, duplicate records, and invalid rates', () => {
+    const sample = records()[0]!;
+    const invalids: unknown[][] = [
+      [{ ...sample, source: { ...sample.source, url: 'https://example.test/pricing' } }],
+      [{ ...sample, source: { ...sample.source, url: 'http://platform.claude.com/docs' } }],
+      [{ ...sample, effectiveBefore: sample.effectiveFrom }],
+      [{ ...sample, rates: { ...sample.rates, inputUsdPerMillionTokens: Number.NaN } }],
+      [{ ...sample, rates: { ...sample.rates, outputUsdPerMillionTokens: -1 } }],
+      [{ ...sample, rates: { ...sample.rates, cacheReadAccounting: 'unsupported' } }],
+      [{ ...sample, source: { ...sample.source, currency: 'EUR' } }],
+      [{ ...sample, model: '' }],
+      [{ ...sample, provider: 'google' }],
+      [sample, structuredClone(sample)],
+    ];
+    for (const invalid of invalids) {
+      expect(buildDatedPricingCohort(invalid, AT).status).toBe('unavailable');
+    }
+    const missing = structuredClone(sample) as Record<string, unknown>;
+    delete missing.source;
+    expect(buildDatedPricingCohort([missing], AT).status).toBe('unavailable');
+  });
+
+  it('rejects accessors, foreign prototypes, and proxy inputs without invoking them', () => {
+    const sample = records()[0]!;
+    const accessor = Object.create(null);
+    Object.assign(accessor, sample);
+    Object.defineProperty(accessor, 'model', { enumerable: true, get: () => { throw new Error('getter invoked'); } });
+    expect(buildDatedPricingCohort([accessor], AT).status).toBe('unavailable');
+    expect(buildDatedPricingCohort([new (class RecordLike {})()], AT).status).toBe('unavailable');
+    expect(buildDatedPricingCohort(new Proxy([sample], {}), AT).status).toBe('unavailable');
+    expect(buildDatedPricingCohort([new Proxy(sample, {})], AT).status).toBe('unavailable');
+    const getterArray: unknown[] = [];
+    Object.defineProperty(getterArray, '0', { enumerable: true, get: () => { throw new Error('array getter invoked'); } });
+    getterArray.length = 1;
+    expect(buildDatedPricingCohort(getterArray, AT).status).toBe('unavailable');
+    expect(resolveCurrentEvaluationPricingCohort(AT, new Proxy(['anthropic-router'], {}))).toEqual({
+      status: 'unavailable',
+      reasons: [{ candidateId: 'anthropic-router', reason: 'pricing_record_invalid' }],
+    });
+  });
+
+  it('uses only existing adapter alias rules for returned identities', () => {
+    const profiles = datedPricingProfilesForFixedTrace();
+    const anthropic = profiles.find((profile) => profile.candidateId === 'anthropic-router')!;
+    const google = profiles.find((profile) => profile.candidateId === 'google-router-generator')!;
+    const openai = profiles.find((profile) => profile.candidateId === 'openai-router-generator')!;
+    expect(cohortReturnedModelMatches(anthropic, 'claude-haiku-4-5-20251001')).toBe(true);
+    expect(cohortReturnedModelMatches(anthropic, 'claude-sonnet-5-20260801')).toBe(false);
+    expect(cohortReturnedModelMatches(google, 'gemini-3.7-flash-20260801')).toBe(true);
+    expect(cohortReturnedModelMatches(google, 'gemini-3.7-flash-20271231')).toBe(false);
+    expect(cohortReturnedModelMatches(google, 'gemini-3.7-pro-20260801')).toBe(false);
+    expect(cohortReturnedModelMatches(openai, 'gpt-5.6-luna-20260801')).toBe(false);
+  });
+
+  it('canonicalizes order, freezes snapshots, and domain-separates the digest', () => {
+    const first = buildDatedPricingCohort(records(), AT);
+    const reordered = buildDatedPricingCohort(records().reverse(), AT);
+    expect(first.status).toBe('available');
+    expect(reordered.status).toBe('available');
+    if (first.status !== 'available' || reordered.status !== 'available') return;
+    expect(first.cohort.digest).toBe(reordered.cohort.digest);
+    expect(Object.isFrozen(first.cohort)).toBe(true);
+    expect(Object.isFrozen(first.cohort.profiles)).toBe(true);
+    expect(() => { (first.cohort.profiles[0] as { model: string }).model = 'forged'; }).toThrow();
+    const unseparated = `sha256:${createHash('sha256').update(JSON.stringify(first.cohort.profiles)).digest('hex')}`;
+    expect(first.cohort.digest).not.toBe(unseparated);
+    const altered = records();
+    altered[0]!.rates.inputUsdPerMillionTokens = 1.001;
+    const changed = buildDatedPricingCohort(altered, AT);
+    expect(changed.status).toBe('available');
+    if (changed.status === 'available') expect(changed.cohort.digest).not.toBe(first.cohort.digest);
+  });
+
+  it('keeps fractional token rates in integer micros and rounds only the final total', () => {
+    const profiles = datedPricingProfilesForFixedTrace();
+    const google = profiles.find((profile) => profile.candidateId === 'google-router-generator')!;
+    const sonnet = profiles.find((profile) => profile.candidateId === 'anthropic-generation')!;
+    expect(datedPricingCostMicros(google, { inputTokens: 1, outputTokens: 0, cacheReadTokens: 1 })).toBe(1);
+    expect(datedPricingCostMicros(google, { inputTokens: 4, outputTokens: 0 })).toBe(3);
+    expect(datedPricingCostMicros(sonnet, { inputTokens: 0, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1 })).toBe(3);
+    expect(() => datedPricingCostMicros(google, { inputTokens: 0, outputTokens: 0, cacheWriteTokens: 1 })).toThrow('Cache-write');
+    expect(() => datedPricingCostMicros(google, { inputTokens: 1, outputTokens: 0, cacheReadTokens: 2 })).toThrow('Subset cache-read');
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -7,6 +7,7 @@ import {
   fixedTraceApprovedPricingProfiles,
   fixedTraceResponsePricingPolicy,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
 import type {
   ModelProvider,
@@ -47,16 +48,8 @@ const RESPONSE: ModelResponse = {
   usage: { inputTokens: 10, outputTokens: 5 },
 };
 
-const PRICING = {
-  profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',
-  inputUsdPerMillionTokens: 0.2,
-  outputUsdPerMillionTokens: 1.2,
-  cacheReadUsdPerMillionTokens: 0.02,
-  cacheWriteUsdPerMillionTokens: null,
-  cacheReadAccounting: 'subset' as const,
-  cacheWriteAccounting: 'unsupported' as const,
-  source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25.',
-};
+const DATED_PROFILES = datedPricingProfilesForFixedTrace();
+const PRICING = DATED_PROFILES.find((profile) => profile.candidateId === 'openai-router-generator')!;
 
 const RESPONSE_PRICING_POLICY = fixedTraceResponsePricingPolicy(
   'openai',
@@ -64,38 +57,9 @@ const RESPONSE_PRICING_POLICY = fixedTraceResponsePricingPolicy(
   PRICING,
 );
 
-const SONNET_5_PRICING = {
-  profileId: 'anthropic-standard-2026-09:claude-sonnet-5',
-  inputUsdPerMillionTokens: 2,
-  outputUsdPerMillionTokens: 10,
-  cacheReadUsdPerMillionTokens: 0.2,
-  cacheWriteUsdPerMillionTokens: 2.5,
-  cacheReadAccounting: 'additive' as const,
-  cacheWriteAccounting: 'additive' as const,
-  source: 'Anthropic pricing page: Claude Sonnet 5 standard (5-minute cache write), checked 2026-09-05.',
-};
-
-const HAIKU_4_5_PRICING = {
-  profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
-  inputUsdPerMillionTokens: 1,
-  outputUsdPerMillionTokens: 5,
-  cacheReadUsdPerMillionTokens: 0.1,
-  cacheWriteUsdPerMillionTokens: 1.25,
-  cacheReadAccounting: 'additive' as const,
-  cacheWriteAccounting: 'additive' as const,
-  source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
-};
-
-const GOOGLE_PRICING = {
-  profileId: 'google-gemini-3.7-flash-through-2026-12-31',
-  inputUsdPerMillionTokens: 0.75,
-  outputUsdPerMillionTokens: 3.75,
-  cacheReadUsdPerMillionTokens: 0.075,
-  cacheWriteUsdPerMillionTokens: 0.75,
-  cacheReadAccounting: 'subset' as const,
-  cacheWriteAccounting: 'additive' as const,
-  source: 'Google Gemini 3.7 Flash introductory standard, checked 2026-08-25.',
-};
+const SONNET_5_PRICING = DATED_PROFILES.find((profile) => profile.candidateId === 'anthropic-generation')!;
+const HAIKU_4_5_PRICING = DATED_PROFILES.find((profile) => profile.candidateId === 'anthropic-router')!;
+const GOOGLE_PRICING = DATED_PROFILES.find((profile) => profile.candidateId === 'google-router-generator')!;
 
 class BudgetScriptedProvider implements ModelProvider {
   readonly id = 'openai' as const;
@@ -160,7 +124,7 @@ describe('fixed trace provider budget', () => {
       expect.objectContaining({
         expectedProvider: 'openai',
         expectedModel: 'gpt-5.6-luna',
-        profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',
+        profileId: 'openai-gpt-5.6-luna-standard-2026-09-05',
       }),
       expect.objectContaining({
         expectedProvider: 'google',

--- a/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
+++ b/server/tests/unit/addie/fixed-trace-diagnostic-output.test.ts
@@ -13,6 +13,7 @@ import {
   type FixedTraceDiagnosticProviderPlan,
 } from '../../../src/addie/eval/fixed-trace-diagnostic-run.js';
 import { reserveFixedTraceDiagnosticOutput } from '../../../src/addie/eval/fixed-trace-diagnostic-output.js';
+import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 import {
   fixedTraceCommonToolDefinitions,
   fixedTraceHybridPolicy,
@@ -45,29 +46,27 @@ const CAPABILITIES: ModelProviderCapabilities = {
   documentInput: false,
 };
 
-const PRICING: FixedTracePricing = {
-  profileId: 'anthropic-standard-2026-09:claude-haiku-4-5',
-  inputUsdPerMillionTokens: 1,
-  outputUsdPerMillionTokens: 5,
-  cacheReadUsdPerMillionTokens: 0.1,
-  cacheWriteUsdPerMillionTokens: 1.25,
-  cacheReadAccounting: 'additive',
-  cacheWriteAccounting: 'additive',
-  source: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
-};
+const DATED_PROFILES = datedPricingProfilesForFixedTrace();
+function approvedFixturePricing(candidateId: 'anthropic-router' | 'openai-router-generator'): FixedTracePricing {
+  const profile = DATED_PROFILES.find((entry) => entry.candidateId === candidateId);
+  if (!profile) throw new Error(`Missing dated pricing fixture for ${candidateId}`);
+  return {
+    profileId: profile.profileId,
+    inputUsdPerMillionTokens: profile.inputUsdPerMillionTokens,
+    outputUsdPerMillionTokens: profile.outputUsdPerMillionTokens,
+    cacheReadUsdPerMillionTokens: profile.cacheReadUsdPerMillionTokens,
+    cacheWriteUsdPerMillionTokens: profile.cacheWriteUsdPerMillionTokens,
+    cacheReadAccounting: profile.cacheReadAccounting,
+    cacheWriteAccounting: profile.cacheWriteAccounting,
+    source: profile.source,
+  };
+}
+
+const PRICING = approvedFixturePricing('anthropic-router');
 
 const MODEL = 'claude-haiku-4-5';
 const OPENAI_MODEL = 'gpt-5.6-luna';
-const OPENAI_PRICING: FixedTracePricing = {
-  profileId: 'openai-gpt-5.6-luna-standard-2026-08-25',
-  inputUsdPerMillionTokens: 0.2,
-  outputUsdPerMillionTokens: 1.2,
-  cacheReadUsdPerMillionTokens: 0.02,
-  cacheWriteUsdPerMillionTokens: null,
-  cacheReadAccounting: 'subset',
-  cacheWriteAccounting: 'unsupported',
-  source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25.',
-};
+const OPENAI_PRICING = approvedFixturePricing('openai-router-generator');
 
 const ZERO_RATE_PRICING: FixedTracePricing = {
   ...PRICING,
@@ -411,7 +410,7 @@ describe('fixed-trace diagnostic output reservation', () => {
     expect(persisted.runs[1].requestedConfig.router).toMatchObject({
       provider: 'openai',
       maxOutputTokens: 300,
-      pricing: { source: 'OpenAI gpt-5.6-luna standard, checked 2026-08-25.' },
+      pricing: { source: 'OpenAI gpt-5.6-luna standard, checked 2026-09-05.' },
     });
     expect(persisted.runs[0].observations[0].metadata.router).toMatchObject({
       usage: { inputTokens: 10, outputTokens: 5 },

--- a/server/tests/unit/addie/provider-router-diagnostic-cli.test.ts
+++ b/server/tests/unit/addie/provider-router-diagnostic-cli.test.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+describe('provider router diagnostic CLI', () => {
+  it('validates the dated cohort before credentials or provider construction', () => {
+    const result = execFileSync('npx', [
+      'tsx', 'server/tests/manual/provider-router-eval.ts',
+      '--validate-only', '--providers=openai', '--soft-max-usd=10',
+    ], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: { ...process.env, OPENAI_API_KEY: '' },
+    });
+    const diagnostic = result.split('\n').map((line) => {
+      try { return JSON.parse(line) as Record<string, unknown>; } catch { return null; }
+    }).find((line) => line?.diagnosticOnly === true);
+    expect(diagnostic).toMatchObject({
+      diagnosticOnly: true,
+      validated: { providers: ['openai'], profiles: ['prompt_parity', 'native_structured'], repetitions: 3, softMaxUsd: 10 },
+    });
+  });
+});

--- a/server/tests/unit/addie/provider-router-diagnostic-cli.test.ts
+++ b/server/tests/unit/addie/provider-router-diagnostic-cli.test.ts
@@ -19,4 +19,42 @@ describe('provider router diagnostic CLI', () => {
       validated: { providers: ['openai'], profiles: ['prompt_parity', 'native_structured'], repetitions: 3, softMaxUsd: 10 },
     });
   });
+
+  it('inventories every selected matrix cell and its sole unsupported candidate without credentials', () => {
+    const result = execFileSync('npx', [
+      'tsx', 'server/tests/manual/provider-router-eval.ts',
+      '--validate-only', '--providers=anthropic,openai,google', '--soft-max-usd=10',
+    ], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: { ...process.env, ANTHROPIC_API_KEY: '', OPENAI_API_KEY: '', GEMINI_API_KEY: '' },
+    });
+    const diagnostic = result.split('\n').map((line) => {
+      try { return JSON.parse(line) as Record<string, unknown>; } catch { return null; }
+    }).find((line) => line?.diagnosticOnly === true);
+    expect(diagnostic).toMatchObject({
+      diagnosticOnly: true,
+      validated: {
+        requestedCells: expect.arrayContaining([
+          { provider: 'anthropic', profile: 'prompt_parity' },
+          { provider: 'anthropic', profile: 'native_structured' },
+          { provider: 'openai', profile: 'prompt_parity' },
+          { provider: 'openai', profile: 'native_structured' },
+          { provider: 'google', profile: 'prompt_parity' },
+          { provider: 'google', profile: 'native_structured' },
+        ]),
+        plannedCells: expect.arrayContaining([
+          { provider: 'anthropic', profile: 'prompt_parity' },
+          { provider: 'openai', profile: 'prompt_parity' },
+          { provider: 'openai', profile: 'native_structured' },
+          { provider: 'google', profile: 'prompt_parity' },
+          { provider: 'google', profile: 'native_structured' },
+        ]),
+        excludedCells: [{
+          provider: 'anthropic', profile: 'native_structured',
+          reason: 'anthropic_router_has_no_native_structured_profile',
+        }],
+      },
+    });
+  });
 });

--- a/server/tests/unit/addie/provider-router-eval.test.ts
+++ b/server/tests/unit/addie/provider-router-eval.test.ts
@@ -88,11 +88,28 @@ const PREPARED_ROUTER_CALL = {
   capabilities: fakeProvider('').capabilities,
   providerRequest: { model: 'gpt-5.6-luna', input: 'synthetic' },
 };
+const PREPARED_ANTHROPIC_ROUTER_CALL = {
+  ...PREPARED_ROUTER_CALL,
+  provider: 'anthropic' as const,
+  model: 'claude-haiku-4-5',
+  providerRequest: { model: 'claude-haiku-4-5', input: 'synthetic' },
+};
 
 describe('router evaluation dated-pricing ledger', () => {
   it('prices subset cached input once and matches fixed-trace accounting', () => {
     const usage = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 40 };
     const expected = 0.0000368;
+    expect(datedPricingCostUsd(OPENAI_PRICING, usage)).toBe(expected);
+    expect(fixedTraceEstimatedCostUsd(usage, OPENAI_PRICING)).toBe(expected);
+  });
+
+  it('prices documented OpenAI cache writes as a subset replacement and matches fixed-trace accounting', () => {
+    const usage = { inputTokens: 100, outputTokens: 20, cacheWriteTokens: 40 };
+    const expected = 0.000046;
+    expect(OPENAI_PRICING).toMatchObject({
+      cacheWriteUsdPerMillionTokens: 0.25,
+      cacheWriteAccounting: 'subset',
+    });
     expect(datedPricingCostUsd(OPENAI_PRICING, usage)).toBe(expected);
     expect(fixedTraceEstimatedCostUsd(usage, OPENAI_PRICING)).toBe(expected);
   });
@@ -104,35 +121,37 @@ describe('router evaluation dated-pricing ledger', () => {
     expect(datedPricingCostUsd(ANTHROPIC_PRICING, { inputTokens: 100, outputTokens: 20 })).toBe(0.0002);
   });
 
-  it('fails closed for malformed usage, unsupported cache categories, and overlapping subset buckets', () => {
+  it('fails closed for malformed usage and overlapping subset buckets', () => {
     expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: -1, outputTokens: 0 })).toThrow('Invalid input');
     expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: 10, outputTokens: 0, cacheReadTokens: 11 })).toThrow('Subset cache-read');
-    expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: 10, outputTokens: 0, cacheWriteTokens: 1 })).toThrow('Cache-write');
-    const overlappingSubset = {
-      ...OPENAI_PRICING,
-      cacheWriteAccounting: 'subset' as const,
-      cacheWriteUsdPerMillionTokens: 0.1,
-    };
-    expect(() => datedPricingCostUsd(overlappingSubset, {
+    expect(() => datedPricingCostUsd(OPENAI_PRICING, {
       inputTokens: 10, outputTokens: 0, cacheReadTokens: 6, cacheWriteTokens: 5,
     })).toThrow('Subset cache-write');
   });
 
-  it('reserves all additive cache exposure, settles exact usage, refunds cancellation, and closes before dispatch at the ceiling', () => {
+  it('reserves maximum OpenAI cache-write exposure, settles exact usage, refunds cancellation, and closes before dispatch at the ceiling', () => {
     const probe = new RouterEvalBudget(1);
-    const conservative = RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, ANTHROPIC_PRICING);
+    const conservative = RouterEvalBudget.reservationUsd(PREPARED_ANTHROPIC_ROUTER_CALL, 300, ANTHROPIC_PRICING);
     const baseOnly = datedPricingCostUsd(ANTHROPIC_PRICING, {
-      inputTokens: Buffer.byteLength(JSON.stringify(PREPARED_ROUTER_CALL.providerRequest), 'utf8'),
+      inputTokens: Buffer.byteLength(JSON.stringify(PREPARED_ANTHROPIC_ROUTER_CALL.providerRequest), 'utf8'),
       outputTokens: 300,
     });
     expect(conservative).toBeGreaterThan(baseOnly);
+    const requestBytes = Buffer.byteLength(JSON.stringify(PREPARED_ROUTER_CALL.providerRequest), 'utf8');
+    const openaiReserve = RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    expect(openaiReserve).toBe(datedPricingCostUsd(OPENAI_PRICING, {
+      inputTokens: requestBytes, outputTokens: 300, cacheWriteTokens: requestBytes,
+    }));
+    expect(openaiReserve).toBeGreaterThan(datedPricingCostUsd(OPENAI_PRICING, {
+      inputTokens: requestBytes, outputTokens: 300,
+    }));
 
     const budget = new RouterEvalBudget(1);
     const completed = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
     expect(budget.snapshot().reservedUsd).toBeGreaterThan(0);
     budget.markDispatched(completed);
-    const actual = budget.complete(completed, { inputTokens: 100, outputTokens: 20, cacheReadTokens: 40 }, OPENAI_PRICING);
-    expect(actual).toBe(0.0000368);
+    const actual = budget.complete(completed, { inputTokens: 100, outputTokens: 20, cacheWriteTokens: 40 }, OPENAI_PRICING);
+    expect(actual).toBe(0.000046);
     expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: actual, reservedUsd: 0, dispatchedCalls: 1, completedCalls: 1 });
 
     const cancelled = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
@@ -140,12 +159,34 @@ describe('router evaluation dated-pricing ledger', () => {
     expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: actual, reservedUsd: 0 });
 
     const overBudget = new RouterEvalBudget(conservative / 2);
-    expect(() => overBudget.reserve(PREPARED_ROUTER_CALL, 300, ANTHROPIC_PRICING))
+    expect(() => overBudget.reserve(PREPARED_ANTHROPIC_ROUTER_CALL, 300, ANTHROPIC_PRICING))
       .toThrow(RouterEvalBudgetAdmissionError);
     expect(overBudget.snapshot()).toMatchObject({ reservedUsd: 0, dispatchedCalls: 0, budgetRejectedCalls: 1, admissionClosed: true });
     expect(probe.snapshot().reservedUsd).toBe(0);
+    expect(() => RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, ANTHROPIC_PRICING))
+      .toThrow('prepared invocation identity does not match pricing profile');
     expect(() => RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, structuredClone(OPENAI_PRICING)))
       .toThrow('immutable dated cohort profile');
+  });
+
+  it('binds settlement to the exact issued profile, not a frozen substitute or another genuine profile', () => {
+    const budget = new RouterEvalBudget(1);
+    const reservation = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    budget.markDispatched(reservation);
+
+    expect(() => budget.complete(reservation, { inputTokens: 10, outputTokens: 2 }, ANTHROPIC_PRICING))
+      .toThrow('reservation pricing profile does not match settlement profile');
+    expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: 0, reservedUsd: reservation.usd, completedCalls: 0 });
+    budget.markExposureUnknown(reservation);
+
+    const frozenSubstitute = Object.freeze({
+      ...structuredClone(OPENAI_PRICING),
+      sourceEvidence: Object.freeze(structuredClone(OPENAI_PRICING.sourceEvidence)),
+    });
+    expect(() => RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, frozenSubstitute))
+      .toThrow('immutable dated cohort profile');
+    expect(() => { (OPENAI_PRICING as { model: string }).model = 'forged'; }).toThrow();
+    expect(OPENAI_PRICING.model).toBe('gpt-5.6-luna');
   });
 });
 

--- a/server/tests/unit/addie/provider-router-eval.test.ts
+++ b/server/tests/unit/addie/provider-router-eval.test.ts
@@ -11,13 +11,19 @@ import {
   MODEL_ROUTER_CORPUS,
   parseStrictRouterPlan,
   RouterPlanParseError,
+  RouterEvalBudget,
+  RouterEvalBudgetAdmissionError,
   scoreRouterPlan,
   shouldDispatchWithinSoftBudget,
-  accountRouterCallCostUsd,
   runRouterEvalMatrix,
   summarizeRouterEval,
   SYNTHETIC_ROUTER_CORPUS,
 } from '../../../src/addie/testing/provider-router-eval.js';
+import {
+  datedPricingCostUsd,
+  datedPricingProfilesForFixedTrace,
+} from '../../../src/addie/eval/dated-pricing-cohort.js';
+import { fixedTraceEstimatedCostUsd } from '../../../src/addie/eval/fixed-trace-budget.js';
 import {
   AddieRouter,
   buildRouterModelRequest,
@@ -72,6 +78,76 @@ function fakeProvider(text: string | string[], finishReason: 'stop' | 'length' |
     },
   };
 }
+
+const DATED_PRICING = datedPricingProfilesForFixedTrace();
+const OPENAI_PRICING = DATED_PRICING.find((profile) => profile.candidateId === 'openai-router-generator')!;
+const ANTHROPIC_PRICING = DATED_PRICING.find((profile) => profile.candidateId === 'anthropic-router')!;
+const PREPARED_ROUTER_CALL = {
+  provider: 'openai' as const,
+  model: 'gpt-5.6-luna',
+  capabilities: fakeProvider('').capabilities,
+  providerRequest: { model: 'gpt-5.6-luna', input: 'synthetic' },
+};
+
+describe('router evaluation dated-pricing ledger', () => {
+  it('prices subset cached input once and matches fixed-trace accounting', () => {
+    const usage = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 40 };
+    const expected = 0.0000368;
+    expect(datedPricingCostUsd(OPENAI_PRICING, usage)).toBe(expected);
+    expect(fixedTraceEstimatedCostUsd(usage, OPENAI_PRICING)).toBe(expected);
+  });
+
+  it('charges additive cache reads and writes and handles zero-cache usage', () => {
+    const additiveUsage = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 40, cacheWriteTokens: 10 };
+    expect(datedPricingCostUsd(ANTHROPIC_PRICING, additiveUsage)).toBe(0.0002165);
+    expect(fixedTraceEstimatedCostUsd(additiveUsage, ANTHROPIC_PRICING)).toBe(0.0002165);
+    expect(datedPricingCostUsd(ANTHROPIC_PRICING, { inputTokens: 100, outputTokens: 20 })).toBe(0.0002);
+  });
+
+  it('fails closed for malformed usage, unsupported cache categories, and overlapping subset buckets', () => {
+    expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: -1, outputTokens: 0 })).toThrow('Invalid input');
+    expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: 10, outputTokens: 0, cacheReadTokens: 11 })).toThrow('Subset cache-read');
+    expect(() => datedPricingCostUsd(OPENAI_PRICING, { inputTokens: 10, outputTokens: 0, cacheWriteTokens: 1 })).toThrow('Cache-write');
+    const overlappingSubset = {
+      ...OPENAI_PRICING,
+      cacheWriteAccounting: 'subset' as const,
+      cacheWriteUsdPerMillionTokens: 0.1,
+    };
+    expect(() => datedPricingCostUsd(overlappingSubset, {
+      inputTokens: 10, outputTokens: 0, cacheReadTokens: 6, cacheWriteTokens: 5,
+    })).toThrow('Subset cache-write');
+  });
+
+  it('reserves all additive cache exposure, settles exact usage, refunds cancellation, and closes before dispatch at the ceiling', () => {
+    const probe = new RouterEvalBudget(1);
+    const conservative = RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, ANTHROPIC_PRICING);
+    const baseOnly = datedPricingCostUsd(ANTHROPIC_PRICING, {
+      inputTokens: Buffer.byteLength(JSON.stringify(PREPARED_ROUTER_CALL.providerRequest), 'utf8'),
+      outputTokens: 300,
+    });
+    expect(conservative).toBeGreaterThan(baseOnly);
+
+    const budget = new RouterEvalBudget(1);
+    const completed = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    expect(budget.snapshot().reservedUsd).toBeGreaterThan(0);
+    budget.markDispatched(completed);
+    const actual = budget.complete(completed, { inputTokens: 100, outputTokens: 20, cacheReadTokens: 40 }, OPENAI_PRICING);
+    expect(actual).toBe(0.0000368);
+    expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: actual, reservedUsd: 0, dispatchedCalls: 1, completedCalls: 1 });
+
+    const cancelled = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    budget.cancel(cancelled);
+    expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: actual, reservedUsd: 0 });
+
+    const overBudget = new RouterEvalBudget(conservative / 2);
+    expect(() => overBudget.reserve(PREPARED_ROUTER_CALL, 300, ANTHROPIC_PRICING))
+      .toThrow(RouterEvalBudgetAdmissionError);
+    expect(overBudget.snapshot()).toMatchObject({ reservedUsd: 0, dispatchedCalls: 0, budgetRejectedCalls: 1, admissionClosed: true });
+    expect(probe.snapshot().reservedUsd).toBe(0);
+    expect(() => RouterEvalBudget.reservationUsd(PREPARED_ROUTER_CALL, 300, structuredClone(OPENAI_PRICING)))
+      .toThrow('immutable dated cohort profile');
+  });
+});
 
 describe('strict router eval', () => {
   it('returns the production plan even when its detached observer rejects', async () => {
@@ -755,14 +831,6 @@ describe('strict router eval', () => {
     expect(shouldDispatchWithinSoftBudget(0.4, 0.1, 0.5)).toBe(true);
     expect(shouldDispatchWithinSoftBudget(0.4, 0.100_001, 0.5)).toBe(false);
     expect(shouldDispatchWithinSoftBudget(Number.NaN, 0.1, 0.5)).toBe(false);
-    expect(accountRouterCallCostUsd(
-      { inputTokens: 1_000, outputTokens: 100 },
-      { input: 1, output: 5 },
-    )).toBe(0.0015);
-    expect(accountRouterCallCostUsd(
-      { inputTokens: 10, outputTokens: 5 },
-      { input: 1, output: 5 },
-    )).toBe(0.000035);
     expect(shouldDispatchWithinSoftBudget(0.25326, 0.01, 0.26)).toBe(false);
   });
 

--- a/server/tests/unit/addie/provider-router-eval.test.ts
+++ b/server/tests/unit/addie/provider-router-eval.test.ts
@@ -173,10 +173,11 @@ describe('router evaluation dated-pricing ledger', () => {
     const budget = new RouterEvalBudget(1);
     const reservation = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
     budget.markDispatched(reservation);
+    const reservedBeforeRejectedSettlement = budget.snapshot().reservedUsd;
 
     expect(() => budget.complete(reservation, { inputTokens: 10, outputTokens: 2 }, ANTHROPIC_PRICING))
       .toThrow('reservation pricing profile does not match settlement profile');
-    expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: 0, reservedUsd: reservation.usd, completedCalls: 0 });
+    expect(budget.snapshot()).toMatchObject({ accountedSpendUsd: 0, reservedUsd: reservedBeforeRejectedSettlement, completedCalls: 0 });
     budget.markExposureUnknown(reservation);
 
     const frozenSubstitute = Object.freeze({
@@ -187,6 +188,45 @@ describe('router evaluation dated-pricing ledger', () => {
       .toThrow('immutable dated cohort profile');
     expect(() => { (OPENAI_PRICING as { model: string }).model = 'forged'; }).toThrow();
     expect(OPENAI_PRICING.model).toBe('gpt-5.6-luna');
+  });
+
+  it('uses opaque frozen handles so caller mutations cannot refund another active reservation', () => {
+    const budget = new RouterEvalBudget(1);
+    const first = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    const firstReservedUsd = budget.snapshot().reservedUsd;
+    const second = budget.reserve(PREPARED_ROUTER_CALL, 300, OPENAI_PRICING);
+    const totalReservedUsd = budget.snapshot().reservedUsd;
+    const secondReservedUsd = totalReservedUsd - firstReservedUsd;
+    const callerView = first as unknown as object;
+
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(first, 'usd')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(first, 'active')).toBe(false);
+    expect(Reflect.set(callerView, 'usd', 0)).toBe(false);
+    expect(Reflect.set(callerView, 'active', false)).toBe(false);
+    expect(Reflect.deleteProperty(callerView, 'usd')).toBe(true);
+    expect(Reflect.deleteProperty(callerView, 'active')).toBe(true);
+    expect(budget.snapshot().reservedUsd).toBe(totalReservedUsd);
+
+    const clone = Object.freeze(structuredClone(first)) as typeof first;
+    const proxy = new Proxy(first, {}) as typeof first;
+    const lookalike = Object.freeze({}) as typeof first;
+    const otherBudget = new RouterEvalBudget(1);
+    for (const invalid of [clone, proxy, lookalike]) {
+      expect(() => budget.cancel(invalid)).toThrow('reservation is inactive');
+    }
+    expect(() => otherBudget.cancel(second)).toThrow('reservation is inactive');
+    expect(otherBudget.snapshot()).toMatchObject({ reservedUsd: 0, accountedSpendUsd: 0 });
+
+    budget.cancel(first);
+    expect(budget.snapshot()).toMatchObject({ reservedUsd: secondReservedUsd, accountedSpendUsd: 0 });
+    expect(() => budget.cancel(first)).toThrow('reservation is inactive');
+    budget.markDispatched(second);
+    const actual = budget.complete(second, { inputTokens: 100, outputTokens: 20, cacheWriteTokens: 40 }, OPENAI_PRICING);
+    expect(actual).toBe(0.000046);
+    expect(budget.snapshot()).toMatchObject({ reservedUsd: 0, accountedSpendUsd: actual, dispatchedCalls: 1, completedCalls: 1 });
+    expect(() => budget.complete(second, { inputTokens: 0, outputTokens: 0 }, OPENAI_PRICING))
+      .toThrow('reservation is inactive');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a credential-free, immutable, dated prospective pricing cohort for the current Addie evaluation candidates. The resolver returns immutable profiles and a domain-separated SHA-256 digest only after candidate, interval, evidence, and returned-model checks pass. It is accounting input only and does not create providers or authorize dispatch.

This revision makes the router evaluator consume that same immutable profile for admission, reservation, settlement, per-cell actual cost, and evidence hashing. Cache accounting is profile-driven: subset cache reads are never charged twice, while additive cache reads/writes are reserved conservatively and settled explicitly. Missing, unavailable, ambiguous, malformed, overlapping, or drifted cache usage fails closed; pre-dispatch refusal leaves no reservation.

OpenAI Luna cache writes are now recorded as a subset replacement bucket at `$0.25/MTok` (the official model card's documented 1.25× `$0.20` uncached-input rate). Shared reservation accounting selects the costliest valid subset category, so that higher cache-write rate is covered before dispatch. Router reservations also retain the module-issued profile identity, digest, candidate, profile ID, provider, and model; settlement rejects cross-profile or frozen-substitute pricing before it can account spend.

Router reservation handles are opaque frozen identity tokens. Their USD amount, active/dispatched lifecycle, and profile binding reside only in the owning ledger's private `WeakMap`, preventing a caller from altering a refund or clearing another live reservation. Clone, proxy, lookalike, cross-ledger, inactive, and reused handles fail before accounting.

The fixed-trace diagnostic fixtures now obtain their dated cohort evidence and rates from the canonical profile, rather than carrying stale standalone policy data.

## Base and head

- Base: `main` / `origin/main` at `ebe3f6c87bc61b2cab5bccd97253f845e056ceba` (`#7313`); verified as this branch's exact merge base.
- Head: `5ea401d334829fecd3051e2d4d6ee8cda7dc044a`

The #7305 dormant fixed-trace CLI, its local-`tsx` child contract, unknown-exposure evidence, and restored active coverage are retained unchanged. The fixed-trace budget continues to use the shared cache-aware dated pricing reservation helper.

The #7313 fixed-trace smoke-overlay source and tests remain untouched by this branch and pass alongside the #7305 and pricing/router coverage.

## Coverage and validation

- Router-ledger tests cover OpenAI subset cached input and 1.25× cache writes, Anthropic additive cache reads/writes, zero-cache usage, malformed/overlapping or unavailable cache categories, reservation ceilings, settlement/refund, cross-profile settlement rejection, frozen profile substitution, opaque concurrent handles, immutable-profile admission, and exact fixed-trace pricing parity.
- Focused pricing/router, all #7305 fixed-trace coverage, and #7313 smoke overlays — 12 files, 215 tests passed.
- Prior required server-unit shard `2/4` passed on the immediately preceding #7305 base rebase: 144 files, 1,979 tests.
- `npm run typecheck` passed.
- `git diff --check origin/main...HEAD` passed.
- Credential-free manual router inventory and the #7305 dormant fixed-trace CLI passed with provider credentials unset; no provider construction, dispatch, or spend occurred.

The repository's broad automatic pre-commit suite still encountered unrelated existing server database-fixture failures outside this change; the affected shard and focused changed-area suite above are green.

## Review feedback disposition

- Ladon approved this exact head with no findings in [top-level review `5124430581`](https://github.com/adcontextprotocol/adcp/pull/7312#pullrequestreview-5124430581).
- Its informational Google post-2026 pricing follow-up is not a current defect. The dated record intentionally uses an exclusive `effectiveBefore` of `2027-01-01T00:00:00.000Z` with the provider-owned [Google pricing evidence](https://github.com/adcontextprotocol/adcp/blob/5ea401d334829fecd3051e2d4d6ee8cda7dc044a/server/src/addie/eval/dated-pricing-cohort.ts#L203-L218). The focused [expiry-boundary test](https://github.com/adcontextprotocol/adcp/blob/5ea401d334829fecd3051e2d4d6ee8cda7dc044a/server/tests/unit/addie/dated-pricing-cohort.test.ts#L57-L77) proves selection becomes unavailable at that instant, and the [router harness checks cohort availability before credentials or provider construction](https://github.com/adcontextprotocol/adcp/blob/5ea401d334829fecd3051e2d4d6ee8cda7dc044a/server/tests/manual/provider-router-eval.ts#L67-L94). Therefore expiry fails closed before dispatch. Operationally, the recorded Google rate/evidence must be refreshed before that date.

## Scope and authorization

No production provider activation, routing, replay execution behavior, rollout decision, quality claim, or spend authority is added. This remains a diagnostic-only pricing/admission change. No provider calls were made, no API key or secret is committed, and this PR is ready for merge with exact-head Sol and Ladon approval.
