### PR TITLE
fix(addie): pin truthful component smoke dispatch plan

### DIFF
--- a/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
@@ -72,6 +72,9 @@ export type FixedTraceComponentSmokeAdmissionReason =
   | 'component_admission_fingerprint_mismatch'
   | 'component_protocol_or_design_invalid';
 
+type FixedTraceComponentSmokeDispatchDisposition =
+  | 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+
 interface FixedTraceComponentSmokeStageControl {
   readonly armId: string;
   readonly architecture: string;
@@ -114,7 +117,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
     readonly parentId: string;
     readonly parentSemanticSha256: string;
     /** Terminal-path disposition, pinned before any private runtime exists. */
-    readonly dispatchDisposition: 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+    readonly dispatchDisposition: FixedTraceComponentSmokeDispatchDisposition;
   }[];
   readonly cells: readonly { readonly id: string; readonly role: 'router' | 'generation'; readonly provider: string; readonly model: string; readonly effort: string; readonly pricingProfileId: string; readonly adapterCapabilitySource: string }[];
   readonly stageControls: Readonly<{
@@ -154,7 +157,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
   readonly privateRuntimePlan: ReadonlyArray<Readonly<{
     readonly probeId: string;
     readonly cellId: string;
-    readonly dispatchDisposition: 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+    readonly dispatchDisposition: FixedTraceComponentSmokeDispatchDisposition;
     readonly maximumProviderInvocations: number;
     readonly pricingProfileId: string;
     readonly preparedRequestHmac: 'required_before_intent';
@@ -287,11 +290,24 @@ function validStageOnePlan(plan: FixedTraceComponentSmokeStagePlan | null): plan
   });
 }
 
-function dispatchDispositionForProbe(probe: typeof FIXED_TRACE_COMPONENT_SMOKE_PROBES[number]): 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault' | null {
+function dispatchDispositionForProbe(probe: typeof FIXED_TRACE_COMPONENT_SMOKE_PROBES[number]): FixedTraceComponentSmokeDispatchDisposition | null {
   if (probe.terminalInvariant.path === 'model_loop') return 'provider_dispatch';
   if (probe.terminalInvariant.path === 'local_terminal') return 'local_terminal';
   if (probe.terminalInvariant.path === 'pre_dispatch_fault') return 'pre_dispatch_fault';
   return null;
+}
+
+/** Derived from the same terminal-path dispositions placed in the pinned manifest. */
+function pinnedDispatchDispositionCounts(): Readonly<Record<FixedTraceComponentSmokeDispatchDisposition, number>> | null {
+  const counts: Record<FixedTraceComponentSmokeDispatchDisposition, number> = {
+    provider_dispatch: 0, local_terminal: 0, pre_dispatch_fault: 0,
+  };
+  for (const probe of FIXED_TRACE_COMPONENT_SMOKE_PROBES) {
+    const disposition = dispatchDispositionForProbe(probe);
+    if (!disposition) return null;
+    counts[disposition] += 1;
+  }
+  return Object.freeze(counts);
 }
 
 function privateRuntimePlan(
@@ -409,7 +425,8 @@ function pricingForPinnedArtifacts(plan: FixedTraceComponentSmokeStagePlan | nul
 function cardinalityForPinnedPlan(
   plan: FixedTraceComponentSmokeStagePlan | null,
 ): FixedTraceComponentSmokeAdmissionManifest['cardinality'] {
-  if (!plan || !validStageOnePlan(plan)) return Object.freeze({
+  const dispositionCounts = pinnedDispatchDispositionCounts();
+  if (!plan || !validStageOnePlan(plan) || !dispositionCounts) return Object.freeze({
     probes: 8 as const, routerCells: 10 as const, generationCells: 11 as const,
     totalCells: 21 as const, repetitions: 1 as const,
     caseCellAssignments: 0, providerDispatchCaseCellAssignments: 0,
@@ -421,14 +438,14 @@ function cardinalityForPinnedPlan(
     probes: 8 as const, routerCells: 10 as const, generationCells: 11 as const,
     totalCells: 21 as const, repetitions: 1 as const,
     caseCellAssignments: plan.cases * plan.repetitions * plan.controls.length,
-    providerDispatchCaseCellAssignments: 6 * plan.controls.length,
-    localTerminalCaseCellAssignments: plan.controls.length,
-    preDispatchFaultCaseCellAssignments: plan.controls.length,
+    providerDispatchCaseCellAssignments: dispositionCounts.provider_dispatch * plan.controls.length,
+    localTerminalCaseCellAssignments: dispositionCounts.local_terminal * plan.controls.length,
+    preDispatchFaultCaseCellAssignments: dispositionCounts.pre_dispatch_fault * plan.controls.length,
     maximumPlannedInvocationSlots: plan.controls.reduce(
       (total, control) => total + plan.cases * plan.repetitions * control.maxInvocationsPerCase, 0,
     ),
     maximumProviderInvocations: plan.controls.reduce(
-      (total, control) => total + 6 * plan.repetitions * control.maxInvocationsPerCase, 0,
+      (total, control) => total + dispositionCounts.provider_dispatch * plan.repetitions * control.maxInvocationsPerCase, 0,
     ),
   });
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
@@ -108,7 +108,14 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
   readonly asOf: typeof FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF;
   readonly status: 'ready_for_explicit_paid_authorization' | 'not_admitted';
   readonly missingReasons: readonly FixedTraceComponentSmokeAdmissionReason[];
-  readonly probes: readonly { readonly id: string; readonly semanticSha256: string; readonly parentId: string; readonly parentSemanticSha256: string }[];
+  readonly probes: readonly {
+    readonly id: string;
+    readonly semanticSha256: string;
+    readonly parentId: string;
+    readonly parentSemanticSha256: string;
+    /** Terminal-path disposition, pinned before any private runtime exists. */
+    readonly dispatchDisposition: 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+  }[];
   readonly cells: readonly { readonly id: string; readonly role: 'router' | 'generation'; readonly provider: string; readonly model: string; readonly effort: string; readonly pricingProfileId: string; readonly adapterCapabilitySource: string }[];
   readonly stageControls: Readonly<{
     phaseId: 'stage_1_smoke';
@@ -125,6 +132,10 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
     totalCells: 21;
     repetitions: 1;
     caseCellAssignments: number;
+    providerDispatchCaseCellAssignments: number;
+    localTerminalCaseCellAssignments: number;
+    preDispatchFaultCaseCellAssignments: number;
+    maximumPlannedInvocationSlots: number;
     maximumProviderInvocations: number;
   }>;
   readonly pricing: Readonly<{
@@ -132,8 +143,27 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
     checkedAt: string | null;
     profiles: readonly { readonly candidateId: string; readonly profileId: string; readonly effectiveFrom: string; readonly effectiveBefore: string | null }[];
     maximumReservationUsd: number | null;
+    reservationMicrodollars: number | null;
     providerCeilingUsd: 5;
   }>;
+  /**
+   * Exact, admission-pinned provider disposition and per-attempt reservation.
+   * Prepared-request HMAC, limits, timeout, profile and reservation are here
+   * so a later private runtime cannot invent them after authorization.
+   */
+  readonly privateRuntimePlan: ReadonlyArray<Readonly<{
+    readonly probeId: string;
+    readonly cellId: string;
+    readonly dispatchDisposition: 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+    readonly maximumProviderInvocations: number;
+    readonly pricingProfileId: string;
+    readonly preparedRequestHmac: 'required_before_intent';
+    readonly maxInputTokensPerInvocation: number;
+    readonly maxOutputTokensPerInvocation: number;
+    readonly timeoutMs: number;
+    readonly sdkAutomaticRetries: 0;
+    readonly perAttemptReservationMicrodollars: readonly number[];
+  }>>;
   readonly fingerprints: Readonly<{
     protocol: string;
     corpus: string;
@@ -178,7 +208,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
 
 /** Independently reviewed integrity pin; it is never an authorization artifact. */
 const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN =
-  'c8e386ae7e218e7c731bf6ea71af2c03f6372b8207ea680e32ab0fc875aefe7b' as const;
+  '3594f3e20f363093f4c35e433f2b019de32345fe705312e1d8a771dee12fbed6' as const;
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -257,30 +287,54 @@ function validStageOnePlan(plan: FixedTraceComponentSmokeStagePlan | null): plan
   });
 }
 
-function maximumReservationUsd(
+function dispatchDispositionForProbe(probe: typeof FIXED_TRACE_COMPONENT_SMOKE_PROBES[number]): 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault' | null {
+  if (probe.terminalInvariant.path === 'model_loop') return 'provider_dispatch';
+  if (probe.terminalInvariant.path === 'local_terminal') return 'local_terminal';
+  if (probe.terminalInvariant.path === 'pre_dispatch_fault') return 'pre_dispatch_fault';
+  return null;
+}
+
+function privateRuntimePlan(
   cohort: DatedPricingCohort,
   plan: FixedTraceComponentSmokeStagePlan,
-): number {
-  const unnormalized = plan.controls.reduce((total, control) => {
-    const cell = FIXED_TRACE_ADMITTED_CELLS.find((candidate) => candidate.id === control.cellId);
-    if (!cell) throw new Error('unknown component cell');
-    const candidateId = candidateIdFor(cell);
-    if (!candidateId) throw new Error('unknown component pricing candidate');
-    const profile = pricingProfileForCandidate(cohort, candidateId);
-    const invocations = plan.cases * plan.repetitions * control.maxInvocationsPerCase;
-    return total + invocations * datedPricingReservationCostUsd(
-      profile,
-      control.maxInputTokensPerInvocation,
-      control.maxOutputTokensPerInvocation,
-    );
-  }, 0);
-  // Admission currency is pinned in integer microdollars. This is the source
-  // artifact used by the aggregate fingerprint, never a runner-edge display fix.
-  const microdollars = Math.round(unnormalized * 1_000_000);
-  if (!Number.isSafeInteger(microdollars)) {
-    throw new Error('component reservation is not representable in microdollars');
+): FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'] {
+  const cells = new Map(FIXED_TRACE_ADMITTED_CELLS.map((cell) => [cell.id, cell]));
+  const unrounded: Array<{ entry: Omit<FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'][number], 'perAttemptReservationMicrodollars'>; rawMicrodollars: number }> = [];
+  for (const probe of FIXED_TRACE_COMPONENT_SMOKE_PROBES) {
+    const dispatchDisposition = dispatchDispositionForProbe(probe);
+    if (!dispatchDisposition) throw new Error('unknown probe disposition');
+    for (const control of plan.controls) {
+      const cell = cells.get(control.cellId);
+      if (!cell) throw new Error('unknown component cell');
+      const candidateId = candidateIdFor(cell);
+      if (!candidateId) throw new Error('unknown component pricing candidate');
+      const profile = pricingProfileForCandidate(cohort, candidateId);
+      const rawMicrodollars = dispatchDisposition === 'provider_dispatch'
+        ? datedPricingReservationCostUsd(profile, control.maxInputTokensPerInvocation, control.maxOutputTokensPerInvocation) * 1_000_000
+        : 0;
+      unrounded.push({
+        entry: Object.freeze({ probeId: probe.id, cellId: cell.id, dispatchDisposition,
+          maximumProviderInvocations: dispatchDisposition === 'provider_dispatch' ? control.maxInvocationsPerCase : 0,
+          pricingProfileId: profile.profileId, preparedRequestHmac: 'required_before_intent' as const,
+          maxInputTokensPerInvocation: control.maxInputTokensPerInvocation,
+          maxOutputTokensPerInvocation: control.maxOutputTokensPerInvocation, timeoutMs: control.timeoutMs,
+          sdkAutomaticRetries: 0 as const }),
+        rawMicrodollars,
+      });
+    }
   }
-  return microdollars / 1_000_000;
+  const totalMicrodollars = Math.round(unrounded.reduce((total, item) => total + item.rawMicrodollars * item.entry.maximumProviderInvocations, 0));
+  if (!Number.isSafeInteger(totalMicrodollars) || totalMicrodollars < 0) throw new Error('component reservation is not representable in microdollars');
+  const allocations = unrounded.flatMap(({ entry, rawMicrodollars }) =>
+    Array.from({ length: entry.maximumProviderInvocations }, () => Math.floor(rawMicrodollars)),
+  );
+  const remainder = totalMicrodollars - allocations.reduce((total, amount) => total + amount, 0);
+  if (!Number.isSafeInteger(remainder) || remainder < 0 || remainder > allocations.length) throw new Error('component reservation allocation is invalid');
+  for (let index = 0; index < remainder; index += 1) allocations[index] += 1;
+  let allocationIndex = 0;
+  return Object.freeze(unrounded.map(({ entry }) => Object.freeze({ ...entry,
+    perAttemptReservationMicrodollars: Object.freeze(Array.from({ length: entry.maximumProviderInvocations }, () => allocations[allocationIndex++]!)),
+  })));
 }
 
 function reasonsForPinnedArtifacts(
@@ -324,10 +378,11 @@ function pricingForPinnedArtifacts(plan: FixedTraceComponentSmokeStagePlan | nul
   readonly reasons: readonly FixedTraceComponentSmokeAdmissionReason[];
   readonly cohort: DatedPricingCohort | null;
   readonly reservation: number | null;
+  readonly privateRuntimePlan: FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'];
 } {
-  if (!validStageOnePlan(plan)) return { reasons: Object.freeze(['component_cell_set_mismatch']), cohort: null, reservation: null };
+  if (!validStageOnePlan(plan)) return { reasons: Object.freeze(['component_cell_set_mismatch']), cohort: null, reservation: null, privateRuntimePlan: Object.freeze([]) };
   const resolved = resolveCurrentEvaluationPricingCohort(new Date(FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF));
-  if (resolved.status !== 'available') return { reasons: Object.freeze(['component_pricing_unavailable']), cohort: null, reservation: null };
+  if (resolved.status !== 'available') return { reasons: Object.freeze(['component_pricing_unavailable']), cohort: null, reservation: null, privateRuntimePlan: Object.freeze([]) };
   try {
     for (const cell of FIXED_TRACE_ADMITTED_CELLS) {
       const candidateId = candidateIdFor(cell);
@@ -337,13 +392,17 @@ function pricingForPinnedArtifacts(plan: FixedTraceComponentSmokeStagePlan | nul
         throw new Error('cell/profile mismatch');
       }
     }
-    const reservation = maximumReservationUsd(resolved.cohort, plan);
+    const planForRuntime = privateRuntimePlan(resolved.cohort, plan);
+    const reservationMicrodollars = planForRuntime.reduce(
+      (total, entry) => total + entry.perAttemptReservationMicrodollars.reduce((sum, amount) => sum + amount, 0), 0,
+    );
+    const reservation = reservationMicrodollars / 1_000_000;
     if (!Number.isFinite(reservation) || reservation > FIXED_TRACE_COMPONENT_SMOKE_READINESS.policy.providerCeilingUsd) {
-      return { reasons: Object.freeze(['component_budget_ceiling_exceeded']), cohort: resolved.cohort, reservation };
+      return { reasons: Object.freeze(['component_budget_ceiling_exceeded']), cohort: resolved.cohort, reservation, privateRuntimePlan: planForRuntime };
     }
-    return { reasons: Object.freeze([]), cohort: resolved.cohort, reservation };
+    return { reasons: Object.freeze([]), cohort: resolved.cohort, reservation, privateRuntimePlan: planForRuntime };
   } catch {
-    return { reasons: Object.freeze(['component_pricing_cell_mismatch']), cohort: resolved.cohort, reservation: null };
+    return { reasons: Object.freeze(['component_pricing_cell_mismatch']), cohort: resolved.cohort, reservation: null, privateRuntimePlan: Object.freeze([]) };
   }
 }
 
@@ -353,16 +412,23 @@ function cardinalityForPinnedPlan(
   if (!plan || !validStageOnePlan(plan)) return Object.freeze({
     probes: 8 as const, routerCells: 10 as const, generationCells: 11 as const,
     totalCells: 21 as const, repetitions: 1 as const,
-    caseCellAssignments: 0,
+    caseCellAssignments: 0, providerDispatchCaseCellAssignments: 0,
+    localTerminalCaseCellAssignments: 0, preDispatchFaultCaseCellAssignments: 0,
+    maximumPlannedInvocationSlots: 0,
     maximumProviderInvocations: 0,
   });
   return Object.freeze({
     probes: 8 as const, routerCells: 10 as const, generationCells: 11 as const,
     totalCells: 21 as const, repetitions: 1 as const,
     caseCellAssignments: plan.cases * plan.repetitions * plan.controls.length,
+    providerDispatchCaseCellAssignments: 6 * plan.controls.length,
+    localTerminalCaseCellAssignments: plan.controls.length,
+    preDispatchFaultCaseCellAssignments: plan.controls.length,
+    maximumPlannedInvocationSlots: plan.controls.reduce(
+      (total, control) => total + plan.cases * plan.repetitions * control.maxInvocationsPerCase, 0,
+    ),
     maximumProviderInvocations: plan.controls.reduce(
-      (total, control) => total + plan.cases * plan.repetitions * control.maxInvocationsPerCase,
-      0,
+      (total, control) => total + 6 * plan.repetitions * control.maxInvocationsPerCase, 0,
     ),
   });
 }
@@ -381,6 +447,7 @@ function pricingManifestForPinnedArtifacts(
       effectiveBefore: profile.effectiveBefore,
     }))),
     maximumReservationUsd: pricing.reservation,
+    reservationMicrodollars: pricing.reservation === null ? null : Math.round(pricing.reservation * 1_000_000),
     providerCeilingUsd: FIXED_TRACE_COMPONENT_SMOKE_READINESS.policy.providerCeilingUsd,
   });
 }
@@ -392,6 +459,7 @@ function aggregateAdmissionFingerprint(
   cohort: DatedPricingCohort | null,
   cardinality: FixedTraceComponentSmokeAdmissionManifest['cardinality'],
   pricing: FixedTraceComponentSmokeAdmissionManifest['pricing'],
+  runtimePlan: FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'],
 ): string {
   return sha256({
     domain: 'adcp:addie:fixed-trace-component-smoke-admission:v1\0',
@@ -416,7 +484,7 @@ function aggregateAdmissionFingerprint(
     screeningConfiguration: FIXED_TRACE_SCREENING_CONFIG_FINGERPRINT,
     pricingCohort: cohort,
     readiness: FIXED_TRACE_COMPONENT_SMOKE_READINESS,
-    derived: { cardinality, pricing },
+    derived: { cardinality, pricing, runtimePlan },
   });
 }
 
@@ -424,10 +492,15 @@ function pinnedManifest(): FixedTraceComponentSmokeAdmissionManifest {
   const plan = stageOnePlan();
   const pricing = pricingForPinnedArtifacts(plan);
   const reasons = [...reasonsForPinnedArtifacts(plan), ...pricing.reasons];
-  const probes = FIXED_TRACE_COMPONENT_SMOKE_PROBES.map((probe) => Object.freeze({
+  const probes = FIXED_TRACE_COMPONENT_SMOKE_PROBES.map((probe) => {
+    const dispatchDisposition = dispatchDispositionForProbe(probe);
+    if (!dispatchDisposition) throw new Error('unknown component smoke dispatch disposition');
+    return Object.freeze({
     id: probe.id, semanticSha256: probe.semanticSha256,
     parentId: probe.parent.id, parentSemanticSha256: probe.parent.semanticSha256,
-  }));
+    dispatchDisposition,
+    });
+  });
   const cells = FIXED_TRACE_ADMITTED_CELLS.map((cell) => Object.freeze({
     id: cell.id, role: cell.role, provider: cell.provider, model: cell.model,
     effort: cell.effort, pricingProfileId: cell.pricingProfileId ?? '',
@@ -437,7 +510,7 @@ function pinnedManifest(): FixedTraceComponentSmokeAdmissionManifest {
   const cardinality = cardinalityForPinnedPlan(plan);
   const pricingManifest = pricingManifestForPinnedArtifacts(pricing);
   const aggregate = aggregateAdmissionFingerprint(
-    probes, cells, plan, cohort, cardinality, pricingManifest,
+    probes, cells, plan, cohort, cardinality, pricingManifest, pricing.privateRuntimePlan,
   );
   if (aggregate !== FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN) {
     reasons.push('component_admission_fingerprint_mismatch');
@@ -458,6 +531,7 @@ function pinnedManifest(): FixedTraceComponentSmokeAdmissionManifest {
     }),
     cardinality,
     pricing: pricingManifest,
+    privateRuntimePlan: pricing.privateRuntimePlan,
     fingerprints: Object.freeze({
       protocol: fixedTraceEvaluationProtocolFingerprint(FIXED_TRACE_PROPOSED_EVALUATION_PROTOCOL),
       corpus: fixedTraceCorpusSha256(FIXED_TRACE_CORPUS), partition: FIXED_TRACE_PARTITION_MANIFEST_SHA256,

--- a/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
@@ -46,7 +46,7 @@ import { FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_POLICY } from './fixed-trace-comp
  */
 export const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF = '2026-09-06T00:00:00.000Z' as const;
 export const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION =
-  'addie-fixed-trace-component-smoke-admission-v1' as const;
+  'addie-fixed-trace-component-smoke-admission-v2' as const;
 
 /** One detached, evaluator-owned source for every emitted readiness policy value. */
 const FIXED_TRACE_COMPONENT_SMOKE_READINESS = Object.freeze({
@@ -211,7 +211,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
 
 /** Independently reviewed integrity pin; it is never an authorization artifact. */
 const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN =
-  'fcd48ebdfa1c89a500a660edebe66b82bfa18f363cd2c176df7890003bd00d38' as const;
+  '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d' as const;
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -487,7 +487,7 @@ function aggregateAdmissionFingerprint(
   runtimePlan: FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'],
 ): string {
   return sha256({
-    domain: 'adcp:addie:fixed-trace-component-smoke-admission:v1\0',
+    domain: 'adcp:addie:fixed-trace-component-smoke-admission:v2\0',
     version: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
     asOf: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF,
     probes,

--- a/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
@@ -211,7 +211,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
 
 /** Independently reviewed integrity pin; it is never an authorization artifact. */
 const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN =
-  '3594f3e20f363093f4c35e433f2b019de32345fe705312e1d8a771dee12fbed6' as const;
+  'fcd48ebdfa1c89a500a660edebe66b82bfa18f363cd2c176df7890003bd00d38' as const;
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -315,7 +315,7 @@ function privateRuntimePlan(
   plan: FixedTraceComponentSmokeStagePlan,
 ): FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'] {
   const cells = new Map(FIXED_TRACE_ADMITTED_CELLS.map((cell) => [cell.id, cell]));
-  const unrounded: Array<{ entry: Omit<FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'][number], 'perAttemptReservationMicrodollars'>; rawMicrodollars: number }> = [];
+  const pricedEntries: Array<{ entry: Omit<FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'][number], 'perAttemptReservationMicrodollars'>; rawMicrodollars: number }> = [];
   for (const probe of FIXED_TRACE_COMPONENT_SMOKE_PROBES) {
     const dispatchDisposition = dispatchDispositionForProbe(probe);
     if (!dispatchDisposition) throw new Error('unknown probe disposition');
@@ -328,7 +328,7 @@ function privateRuntimePlan(
       const rawMicrodollars = dispatchDisposition === 'provider_dispatch'
         ? datedPricingReservationCostUsd(profile, control.maxInputTokensPerInvocation, control.maxOutputTokensPerInvocation) * 1_000_000
         : 0;
-      unrounded.push({
+      pricedEntries.push({
         entry: Object.freeze({ probeId: probe.id, cellId: cell.id, dispatchDisposition,
           maximumProviderInvocations: dispatchDisposition === 'provider_dispatch' ? control.maxInvocationsPerCase : 0,
           pricingProfileId: profile.profileId, preparedRequestHmac: 'required_before_intent' as const,
@@ -339,18 +339,22 @@ function privateRuntimePlan(
       });
     }
   }
-  const totalMicrodollars = Math.round(unrounded.reduce((total, item) => total + item.rawMicrodollars * item.entry.maximumProviderInvocations, 0));
-  if (!Number.isSafeInteger(totalMicrodollars) || totalMicrodollars < 0) throw new Error('component reservation is not representable in microdollars');
-  const allocations = unrounded.flatMap(({ entry, rawMicrodollars }) =>
-    Array.from({ length: entry.maximumProviderInvocations }, () => Math.floor(rawMicrodollars)),
-  );
-  const remainder = totalMicrodollars - allocations.reduce((total, amount) => total + amount, 0);
-  if (!Number.isSafeInteger(remainder) || remainder < 0 || remainder > allocations.length) throw new Error('component reservation allocation is invalid');
-  for (let index = 0; index < remainder; index += 1) allocations[index] += 1;
-  let allocationIndex = 0;
-  return Object.freeze(unrounded.map(({ entry }) => Object.freeze({ ...entry,
-    perAttemptReservationMicrodollars: Object.freeze(Array.from({ length: entry.maximumProviderInvocations }, () => allocations[allocationIndex++]!)),
-  })));
+  return Object.freeze(pricedEntries.map(({ entry, rawMicrodollars }) => {
+    // Reservation is a ceiling per independently dispatchable attempt. Never
+    // redistribute fractional micros across positions: a later attempt could
+    // otherwise be under-reserved before it is ever eligible for dispatch.
+    const perAttemptReservationMicrodollars = entry.maximumProviderInvocations === 0
+      ? 0
+      : Math.ceil(rawMicrodollars);
+    if (!Number.isSafeInteger(perAttemptReservationMicrodollars) || perAttemptReservationMicrodollars < 0) {
+      throw new Error('component per-attempt reservation is not representable in microdollars');
+    }
+    return Object.freeze({ ...entry,
+      perAttemptReservationMicrodollars: Object.freeze(
+        Array.from({ length: entry.maximumProviderInvocations }, () => perAttemptReservationMicrodollars),
+      ),
+    });
+  }));
 }
 
 function reasonsForPinnedArtifacts(
@@ -394,11 +398,12 @@ function pricingForPinnedArtifacts(plan: FixedTraceComponentSmokeStagePlan | nul
   readonly reasons: readonly FixedTraceComponentSmokeAdmissionReason[];
   readonly cohort: DatedPricingCohort | null;
   readonly reservation: number | null;
+  readonly reservationMicrodollars: number | null;
   readonly privateRuntimePlan: FixedTraceComponentSmokeAdmissionManifest['privateRuntimePlan'];
 } {
-  if (!validStageOnePlan(plan)) return { reasons: Object.freeze(['component_cell_set_mismatch']), cohort: null, reservation: null, privateRuntimePlan: Object.freeze([]) };
+  if (!validStageOnePlan(plan)) return { reasons: Object.freeze(['component_cell_set_mismatch']), cohort: null, reservation: null, reservationMicrodollars: null, privateRuntimePlan: Object.freeze([]) };
   const resolved = resolveCurrentEvaluationPricingCohort(new Date(FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF));
-  if (resolved.status !== 'available') return { reasons: Object.freeze(['component_pricing_unavailable']), cohort: null, reservation: null, privateRuntimePlan: Object.freeze([]) };
+  if (resolved.status !== 'available') return { reasons: Object.freeze(['component_pricing_unavailable']), cohort: null, reservation: null, reservationMicrodollars: null, privateRuntimePlan: Object.freeze([]) };
   try {
     for (const cell of FIXED_TRACE_ADMITTED_CELLS) {
       const candidateId = candidateIdFor(cell);
@@ -412,13 +417,16 @@ function pricingForPinnedArtifacts(plan: FixedTraceComponentSmokeStagePlan | nul
     const reservationMicrodollars = planForRuntime.reduce(
       (total, entry) => total + entry.perAttemptReservationMicrodollars.reduce((sum, amount) => sum + amount, 0), 0,
     );
+    if (!Number.isSafeInteger(reservationMicrodollars) || reservationMicrodollars < 0) {
+      throw new Error('component total reservation is not representable in microdollars');
+    }
     const reservation = reservationMicrodollars / 1_000_000;
     if (!Number.isFinite(reservation) || reservation > FIXED_TRACE_COMPONENT_SMOKE_READINESS.policy.providerCeilingUsd) {
-      return { reasons: Object.freeze(['component_budget_ceiling_exceeded']), cohort: resolved.cohort, reservation, privateRuntimePlan: planForRuntime };
+      return { reasons: Object.freeze(['component_budget_ceiling_exceeded']), cohort: resolved.cohort, reservation, reservationMicrodollars, privateRuntimePlan: planForRuntime };
     }
-    return { reasons: Object.freeze([]), cohort: resolved.cohort, reservation, privateRuntimePlan: planForRuntime };
+    return { reasons: Object.freeze([]), cohort: resolved.cohort, reservation, reservationMicrodollars, privateRuntimePlan: planForRuntime };
   } catch {
-    return { reasons: Object.freeze(['component_pricing_cell_mismatch']), cohort: resolved.cohort, reservation: null, privateRuntimePlan: Object.freeze([]) };
+    return { reasons: Object.freeze(['component_pricing_cell_mismatch']), cohort: resolved.cohort, reservation: null, reservationMicrodollars: null, privateRuntimePlan: Object.freeze([]) };
   }
 }
 
@@ -464,7 +472,7 @@ function pricingManifestForPinnedArtifacts(
       effectiveBefore: profile.effectiveBefore,
     }))),
     maximumReservationUsd: pricing.reservation,
-    reservationMicrodollars: pricing.reservation === null ? null : Math.round(pricing.reservation * 1_000_000),
+    reservationMicrodollars: pricing.reservationMicrodollars,
     providerCeilingUsd: FIXED_TRACE_COMPONENT_SMOKE_READINESS.policy.providerCeilingUsd,
   });
 }

--- a/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
@@ -245,7 +245,8 @@ describe('fixed-trace component-smoke credential-free admission', () => {
       protocol.phases.find((phase: any) => phase.id === 'stage_1_smoke').arms[0].stages[0].maxInvocationsPerCase += 1;
     });
     expect(admission.cardinality.maximumProviderInvocations).toBe(
-      baseline.cardinality.maximumProviderInvocations + 6,
+      baseline.cardinality.maximumProviderInvocations
+        + baseline.probes.filter((probe) => probe.dispatchDisposition === 'provider_dispatch').length,
     );
     expect(admission).toMatchObject({ status: 'not_admitted' });
     expect(admission.missingReasons).toContain('component_admission_fingerprint_mismatch');

--- a/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
@@ -5,9 +5,13 @@ import {
   fixedTraceComponentSmokeAdmission,
   isFixedTraceComponentSmokeAdmissionManifest,
 } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import {
+  datedPricingReservationCostUsd,
+  resolveCurrentEvaluationPricingCohort,
+} from '../../../src/addie/eval/dated-pricing-cohort.js';
 
 describe('fixed-trace component-smoke credential-free admission', () => {
-  it('pins eight probes, 21 cells, truthful non-dispatch paths, and the reduced provider reservation', () => {
+  it('pins eight probes, 21 cells, truthful non-dispatch paths, and the independently conservative provider reservation', () => {
     const admission = fixedTraceComponentSmokeAdmission();
     expect(admission).toBe(fixedTraceComponentSmokeAdmission());
     expect(Object.isFrozen(admission)).toBe(true);
@@ -21,7 +25,7 @@ describe('fixed-trace component-smoke credential-free admission', () => {
         localTerminalCaseCellAssignments: 21, preDispatchFaultCaseCellAssignments: 21,
         maximumPlannedInvocationSlots: 256, maximumProviderInvocations: 192,
       },
-      pricing: { providerCeilingUsd: 5, maximumReservationUsd: 2.819472, reservationMicrodollars: 2819472 },
+      pricing: { providerCeilingUsd: 5, maximumReservationUsd: 2.819484, reservationMicrodollars: 2819484 },
       dispatch: {
         defaultOff: true, currentModuleCanDispatch: false,
         ambientEnvironmentAuthority: false,
@@ -56,7 +60,7 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     ]);
     expect(admission.privateRuntimePlan).toHaveLength(168);
     expect(admission.privateRuntimePlan.reduce((total, entry) => total + entry.maximumProviderInvocations, 0)).toBe(192);
-    expect(admission.privateRuntimePlan.reduce((total, entry) => total + entry.perAttemptReservationMicrodollars.reduce((sum, amount) => sum + amount, 0), 0)).toBe(2819472);
+    expect(admission.privateRuntimePlan.reduce((total, entry) => total + entry.perAttemptReservationMicrodollars.reduce((sum, amount) => sum + amount, 0), 0)).toBe(2819484);
     expect(admission.privateRuntimePlan.filter((entry) => entry.dispatchDisposition !== 'provider_dispatch').every((entry) => entry.maximumProviderInvocations === 0 && entry.perAttemptReservationMicrodollars.length === 0)).toBe(true);
     expect(admission.privateRuntimePlan.every((entry) => entry.preparedRequestHmac === 'required_before_intent'
       && entry.sdkAutomaticRetries === 0
@@ -67,6 +71,29 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     expect(admission.pricing.profiles.every((profile) => profile.effectiveFrom <= admission.asOf
       && (profile.effectiveBefore === null || admission.asOf < profile.effectiveBefore))).toBe(true);
     expect(Object.values(admission.fingerprints).every((value) => typeof value === 'string' && value.length > 0)).toBe(true);
+  });
+
+  it('reserves each provider attempt independently at or above its exact dated maximum', () => {
+    const admission = fixedTraceComponentSmokeAdmission();
+    const resolved = resolveCurrentEvaluationPricingCohort(new Date(admission.asOf));
+    expect(resolved.status).toBe('available');
+    if (resolved.status !== 'available') throw new Error('expected pinned dated pricing cohort');
+    const profiles = new Map(resolved.cohort.profiles.map((profile) => [profile.profileId, profile]));
+    let summedReservations = 0;
+    for (const entry of admission.privateRuntimePlan) {
+      const profile = profiles.get(entry.pricingProfileId);
+      expect(profile).toBeDefined();
+      const exactMicrodollars = entry.dispatchDisposition === 'provider_dispatch'
+        ? datedPricingReservationCostUsd(profile!, entry.maxInputTokensPerInvocation, entry.maxOutputTokensPerInvocation) * 1_000_000
+        : 0;
+      expect(entry.perAttemptReservationMicrodollars).toHaveLength(entry.maximumProviderInvocations);
+      for (const reservedMicrodollars of entry.perAttemptReservationMicrodollars) {
+        expect(reservedMicrodollars).toBeGreaterThanOrEqual(exactMicrodollars);
+        expect(reservedMicrodollars).toBe(Math.ceil(exactMicrodollars));
+        summedReservations += reservedMicrodollars;
+      }
+    }
+    expect(summedReservations).toBe(admission.pricing.reservationMicrodollars);
   });
 
   it.each([

--- a/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
 
 describe('fixed-trace component-smoke credential-free admission', () => {
-  it('pins all and only the eight probes, 21 cells, one repetition, pricing, and $5 reservation', () => {
+  it('pins eight probes, 21 cells, truthful non-dispatch paths, and the reduced provider reservation', () => {
     const admission = fixedTraceComponentSmokeAdmission();
     expect(admission).toBe(fixedTraceComponentSmokeAdmission());
     expect(Object.isFrozen(admission)).toBe(true);
@@ -17,9 +17,11 @@ describe('fixed-trace component-smoke credential-free admission', () => {
       missingReasons: [],
       cardinality: {
         probes: 8, routerCells: 10, generationCells: 11, totalCells: 21,
-        repetitions: 1, caseCellAssignments: 168, maximumProviderInvocations: 256,
+        repetitions: 1, caseCellAssignments: 168, providerDispatchCaseCellAssignments: 126,
+        localTerminalCaseCellAssignments: 21, preDispatchFaultCaseCellAssignments: 21,
+        maximumPlannedInvocationSlots: 256, maximumProviderInvocations: 192,
       },
-      pricing: { providerCeilingUsd: 5, maximumReservationUsd: 3.759296 },
+      pricing: { providerCeilingUsd: 5, maximumReservationUsd: 2.819472, reservationMicrodollars: 2819472 },
       dispatch: {
         defaultOff: true, currentModuleCanDispatch: false,
         ambientEnvironmentAuthority: false,
@@ -41,7 +43,26 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     expect(admission.stageControls.controls.reduce(
       (total, control) => total + admission.stageControls.cases * admission.stageControls.repetitions * control.maxInvocationsPerCase,
       0,
-    )).toBe(admission.cardinality.maximumProviderInvocations);
+    )).toBe(admission.cardinality.maximumPlannedInvocationSlots);
+    expect(admission.probes.map((probe) => [probe.parentId, probe.dispatchDisposition])).toEqual([
+      ['surface-channel-chatter', 'local_terminal'],
+      ['knowledge-task-model', 'provider_dispatch'],
+      ['admin-member-records-without-slack', 'provider_dispatch'],
+      ['billing-invoice-confirmed', 'provider_dispatch'],
+      ['tool-result-prompt-injection', 'provider_dispatch'],
+      ['dev-tool-error-retry', 'provider_dispatch'],
+      ['dev-truncation-boundary', 'provider_dispatch'],
+      ['provider-unavailable', 'pre_dispatch_fault'],
+    ]);
+    expect(admission.privateRuntimePlan).toHaveLength(168);
+    expect(admission.privateRuntimePlan.reduce((total, entry) => total + entry.maximumProviderInvocations, 0)).toBe(192);
+    expect(admission.privateRuntimePlan.reduce((total, entry) => total + entry.perAttemptReservationMicrodollars.reduce((sum, amount) => sum + amount, 0), 0)).toBe(2819472);
+    expect(admission.privateRuntimePlan.filter((entry) => entry.dispatchDisposition !== 'provider_dispatch').every((entry) => entry.maximumProviderInvocations === 0 && entry.perAttemptReservationMicrodollars.length === 0)).toBe(true);
+    expect(admission.privateRuntimePlan.every((entry) => entry.preparedRequestHmac === 'required_before_intent'
+      && entry.sdkAutomaticRetries === 0
+      && entry.perAttemptReservationMicrodollars.length === entry.maximumProviderInvocations
+      && entry.perAttemptReservationMicrodollars.every((amount) => Number.isSafeInteger(amount) && amount >= 0)
+      && Number.isSafeInteger(entry.timeoutMs) && entry.timeoutMs > 0)).toBe(true);
     expect(admission.pricing.profiles).toHaveLength(4);
     expect(admission.pricing.profiles.every((profile) => profile.effectiveFrom <= admission.asOf
       && (profile.effectiveBefore === null || admission.asOf < profile.effectiveBefore))).toBe(true);
@@ -53,6 +74,7 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     (manifest: any) => { manifest.probes.push(structuredClone(manifest.probes[0])); },
     (manifest: any) => { manifest.probes.pop(); },
     (manifest: any) => { manifest.probes[0].semanticSha256 = '0'.repeat(64); },
+    (manifest: any) => { manifest.probes[0].dispatchDisposition = 'provider_dispatch'; },
     (manifest: any) => { manifest.probes[0].parentSemanticSha256 = '0'.repeat(64); },
     (manifest: any) => { manifest.cells.reverse(); },
     (manifest: any) => { manifest.cells.push(structuredClone(manifest.cells[0])); },
@@ -61,7 +83,9 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     (manifest: any) => { manifest.pricing.profiles[0].effectiveBefore = '2026-09-06T00:00:00.000Z'; },
     (manifest: any) => { manifest.pricing.cohortDigest = 'sha256:forged'; },
     (manifest: any) => { manifest.pricing.maximumReservationUsd = 0; },
+    (manifest: any) => { manifest.pricing.reservationMicrodollars = 0; },
     (manifest: any) => { manifest.cardinality.caseCellAssignments = 0; },
+    (manifest: any) => { manifest.privateRuntimePlan[0].preparedRequestHmac = 'optional'; },
     (manifest: any) => { manifest.dispatch.currentModuleCanDispatch = true; },
     (manifest: any) => { manifest.evidence.permittedClaims = 'production'; },
   ])('rejects a forged, reordered, incomplete, stale, promoted, or budget-replayed manifest', (mutate) => {
@@ -221,7 +245,7 @@ describe('fixed-trace component-smoke credential-free admission', () => {
       protocol.phases.find((phase: any) => phase.id === 'stage_1_smoke').arms[0].stages[0].maxInvocationsPerCase += 1;
     });
     expect(admission.cardinality.maximumProviderInvocations).toBe(
-      baseline.cardinality.maximumProviderInvocations + baseline.stageControls.cases,
+      baseline.cardinality.maximumProviderInvocations + 6,
     );
     expect(admission).toMatchObject({ status: 'not_admitted' });
     expect(admission.missingReasons).toContain('component_admission_fingerprint_mismatch');

--- a/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-admission.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import {
   FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF,
+  FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
   fixedTraceComponentSmokeAdmission,
   isFixedTraceComponentSmokeAdmissionManifest,
 } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
@@ -13,9 +14,11 @@ import {
 describe('fixed-trace component-smoke credential-free admission', () => {
   it('pins eight probes, 21 cells, truthful non-dispatch paths, and the independently conservative provider reservation', () => {
     const admission = fixedTraceComponentSmokeAdmission();
+    expect(FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION).toBe('addie-fixed-trace-component-smoke-admission-v2');
     expect(admission).toBe(fixedTraceComponentSmokeAdmission());
     expect(Object.isFrozen(admission)).toBe(true);
     expect(admission).toMatchObject({
+      version: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
       asOf: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF,
       status: 'ready_for_explicit_paid_authorization',
       missingReasons: [],
@@ -71,6 +74,7 @@ describe('fixed-trace component-smoke credential-free admission', () => {
     expect(admission.pricing.profiles.every((profile) => profile.effectiveFrom <= admission.asOf
       && (profile.effectiveBefore === null || admission.asOf < profile.effectiveBefore))).toBe(true);
     expect(Object.values(admission.fingerprints).every((value) => typeof value === 'string' && value.length > 0)).toBe(true);
+    expect(admission.fingerprints.aggregateAdmission).toBe('731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d');
   });
 
   it('reserves each provider attempt independently at or above its exact dated maximum', () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
@@ -126,13 +126,13 @@ describe('fixed-trace component-smoke private execution control', () => {
     ledger.seedIssuedGrant(value);
     const reserved = await ledger.reserveAndConsume({ grant: value, admission: fixedTraceComponentSmokeAdmission() });
     if (reserved.status !== 'reserved') throw new Error('expected reservation');
-    expect(reserved.reservation).toMatchObject({ maximumProviderInvocations: 256, maximumReservationUsd: 3.759296 });
-    expect(reserved.reservation.maximumReservationUsd).toBe(3.759296);
+    expect(reserved.reservation).toMatchObject({ maximumProviderInvocations: 192, maximumReservationUsd: 2.819472 });
+    expect(reserved.reservation.maximumReservationUsd).toBe(2.819472);
     expect(reserved.reservation).not.toHaveProperty('grantId');
-    for (let index = 0; index < 256; index += 1) {
+    for (let index = 0; index < 192; index += 1) {
       await expect(ledger.recordAttemptIntent({ reservation: reserved.reservation, attemptCorrelationId: attemptId(index), probeId: 'probe', cellId: 'cell', invocationOrdinal: 1 })).resolves.toEqual({ status: 'recorded' });
     }
-    await expect(ledger.recordAttemptIntent({ reservation: reserved.reservation, attemptCorrelationId: attemptId(256), probeId: 'probe', cellId: 'cell', invocationOrdinal: 1 })).resolves.toEqual({ status: 'refused', reason: 'count_exhausted' });
+    await expect(ledger.recordAttemptIntent({ reservation: reserved.reservation, attemptCorrelationId: attemptId(192), probeId: 'probe', cellId: 'cell', invocationOrdinal: 1 })).resolves.toEqual({ status: 'refused', reason: 'count_exhausted' });
     const stored = JSON.stringify(ledger.snapshotForTest());
     expect(ledger.snapshotForTest().consumedGrantCount).toBe(1);
     expect(stored).not.toContain(value.grantId);

--- a/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
-import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
+  fixedTraceComponentSmokeAdmission,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
 import {
   FIXED_TRACE_COMPONENT_SMOKE_GRANT_VERSION,
   FIXED_TRACE_COMPONENT_SMOKE_RUNTIME_DISABLED,
@@ -43,9 +46,11 @@ describe('fixed-trace component-smoke private execution control', () => {
     const ledger = { durability: 'private_durable_atomic', reserveAndConsume: vi.fn(), recordAttemptIntent: vi.fn(), recordAttemptTerminal: vi.fn() };
     expect(fixedTraceComponentSmokeGrantIssuanceRequest()).toMatchObject({
       stageId: FIXED_TRACE_COMPONENT_SMOKE_STAGE_ID,
+      aggregateAdmissionFingerprint: fixedTraceComponentSmokeAdmission().fingerprints.aggregateAdmission,
       cardinality: fixedTraceComponentSmokeAdmission().cardinality,
       pricing: fixedTraceComponentSmokeAdmission().pricing,
     });
+    expect(fixedTraceComponentSmokeAdmission().version).toBe(FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION);
     await expect(runFixedTraceComponentSmoke({ grant: undefined, now: NOW })).resolves.toEqual({ status: 'refused', reason: 'invalid_grant' });
     await expect(runFixedTraceComponentSmoke({ grant: grant(), adapter: { invoke }, runtimeEnablement: FIXED_TRACE_COMPONENT_SMOKE_RUNTIME_DISABLED, now: NOW })).resolves.toEqual({ status: 'refused', reason: 'runtime_not_enabled' });
     await expect(runFixedTraceComponentSmoke({ grant: grant(), ledger: ledger as never, adapter: { invoke }, runtimeEnablement: enabled(), now: NOW })).resolves.toEqual({ status: 'refused', reason: 'private_durable_runtime_unavailable' });
@@ -67,6 +72,7 @@ describe('fixed-trace component-smoke private execution control', () => {
     ['future issued', { issuedAt: '2026-09-06T12:00:00.001Z' }],
     ['hostile grant id', { grantId: 'Authorization:Bearer_PRIVATE_GRANT_123' }],
     ['hostile nonce', { nonce: 'Bearer_PRIVATE_GRANT_123' }],
+    ['v1 admission fingerprint', { binding: { ...grant().binding, aggregateAdmissionFingerprint: 'fcd48ebdfa1c89a500a660edebe66b82bfa18f363cd2c176df7890003bd00d38' } }],
     ['stale fingerprint', { binding: { ...grant().binding, aggregateAdmissionFingerprint: '0'.repeat(64) } }],
     ['altered cardinality', { binding: { ...grant().binding, cardinality: { ...grant().binding.cardinality, maximumProviderInvocations: 257 } } }],
     ['altered reservation', { binding: { ...grant().binding, pricing: { ...grant().binding.pricing, maximumReservationUsd: 3.8 } } }],

--- a/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-execution.test.ts
@@ -126,8 +126,8 @@ describe('fixed-trace component-smoke private execution control', () => {
     ledger.seedIssuedGrant(value);
     const reserved = await ledger.reserveAndConsume({ grant: value, admission: fixedTraceComponentSmokeAdmission() });
     if (reserved.status !== 'reserved') throw new Error('expected reservation');
-    expect(reserved.reservation).toMatchObject({ maximumProviderInvocations: 192, maximumReservationUsd: 2.819472 });
-    expect(reserved.reservation.maximumReservationUsd).toBe(2.819472);
+    expect(reserved.reservation).toMatchObject({ maximumProviderInvocations: 192, maximumReservationUsd: 2.819484 });
+    expect(reserved.reservation.maximumReservationUsd).toBe(2.819484);
     expect(reserved.reservation).not.toHaveProperty('grantId');
     for (let index = 0; index < 192; index += 1) {
       await expect(ledger.recordAttemptIntent({ reservation: reserved.reservation, attemptCorrelationId: attemptId(index), probeId: 'probe', cellId: 'cell', invocationOrdinal: 1 })).resolves.toEqual({ status: 'recorded' });


### PR DESCRIPTION
## Summary

Corrects the fixed-trace component-smoke admission contract before any paid private runtime can be considered.

- Pins every probe execution disposition: six probes are provider-dispatched, `surface-channel-chatter` is locally terminal, and `provider-unavailable` is a pre-dispatch fault.
- Derives dispatchable cardinality from those pinned dispositions rather than a hard-coded probe count.
- Re-derives the truthful provider ceiling and exact reservation from the private plan: 192 provider invocations and USD 2.819484. The 256-slot planned-slot envelope remains; the prior USD 3.759296 cost figure is not retained and is not a provider-dispatch reservation.
- Bumps the incompatible admission artifact and aggregate-fingerprint domain to v2; issuer requests and grants bind its exact v2 aggregate. The private plan includes per-slot disposition, zero-retry policy, timeout, bounded request/result limits, per-attempt reservation, and a required prepared-request HMAC marker.
- Leaves the repository-visible orchestrator hard-disabled. This adds no route, job, cron, canary, rollout, provider call, credential, activation path, grant issuance, durable runtime, or migration.

## Explicit audit disposition

1. **Strict categorical receipt/result attestation:** deferred safely. The existing `Promise<void>` adapter cannot attest an actual provider result; this correction adds no runtime that could manufacture a mechanical-feasibility success.
2. **Truthful per-probe dispatch disposition:** fixed here. Local-terminal and pre-dispatch-fault slots are not adapter work and reserve neither invocation count nor provider cost.
3. **Intent-bound HMAC, limits, timeout, pricing, and per-attempt reservation:** represented in the admission-pinned private plan for a future runtime; no intent or dispatch is implemented here.
4. **Module-pinned Ed25519 trust root and durable one-use consume/reservation:** deferred. No caller-constructible runtime activation, issuer, trust root, or grant consumer exists in this PR.
5. **No generic-query auto-retries; timeout/transport loss as terminal unknown exposure:** deferred with the runtime. No database or dispatch boundary exists here.

The correction is **no-spend**, **default-off**, and permanently **non-promotable** mechanical-feasibility evidence. It does not provision the real issuer, pinned trust root, provider credentials, or any authorization grant, and it does not close #6842.

## Feedback and annotation disposition

- GraphQL review threads and nested comments: zero after full pagination.
- REST issue comments: zero after full pagination.
- REST inline review comments: zero after full pagination.
- REST reviews: exact-head Ladon approval [review 5124963371](https://github.com/adcontextprotocol/adcp/pull/7318#pullrequestreview-5124963371), with no findings.
- The six warning annotations on [Ladon check run 101464821099](https://github.com/adcontextprotocol/adcp/actions/runs/34025201650/job/101464821099) are non-actionable for this PR: four duplicate deprecation notices for an existing GitHub Action `app-id` input and two existing `allowed_non_write_users` permission-bypass notices. This diff changes only the Addie admission module and its two unit-test files; it does not touch `.github/**`, workflow permissions, or review authentication.
- The two warning annotations on [IPR check run 101464486345](https://github.com/adcontextprotocol/adcp/actions/runs/34025076964/job/101464486345) are duplicate deprecation notices for the same existing GitHub Action `app-id` input and are non-actionable for this PR for the same path/scope reason.
- CodeQL and Semgrep completed successfully with zero annotations.

## Verification

- `npx vitest run tests/unit/addie/fixed-trace-component-smoke-admission.test.ts tests/unit/addie/fixed-trace-component-smoke-execution.test.ts --config server/vitest.config.ts`
- `npm run typecheck`
