### PR TITLE
feat(addie): add private smoke authority ledger

### DIFF
--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -45,9 +45,14 @@ export interface FixedTraceComponentSmokeSignedGrant {
 export interface FixedTraceComponentSmokeVerifiedGrant {
   readonly signedPayloadDigest: string;
   readonly grantDigest: string;
-  readonly signature: Buffer;
   readonly payload: FixedTraceComponentSmokeSignedGrantPayload;
 }
+export interface FixedTraceComponentSmokeTestGrantVerification {
+  readonly valid: true;
+  readonly signedPayloadDigest: string;
+}
+/** A one-shot smoke grant may not outlive this bounded interval. */
+export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_000;
 
 /**
  * Production is intentionally unprovisioned.  There is no environment lookup,
@@ -57,7 +62,7 @@ export interface FixedTraceComponentSmokeVerifiedGrant {
  */
 const PRODUCTION_SPKI_BY_KID: Readonly<Record<string, string>> | null = null;
 /** Capability marker: only this verifier can create an input accepted by the ledger. */
-const VERIFIED_GRANTS = new WeakSet<object>();
+const VERIFIED_GRANTS = new WeakMap<object, Buffer>();
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -80,6 +85,9 @@ function exactKeys(value: object, keys: readonly string[]): boolean {
 }
 function hexDigest(value: unknown): value is string {
   return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+function pricingCohortDigest(value: unknown): value is string {
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value);
 }
 function kid(value: unknown): value is string {
   return typeof value === 'string' && /^[a-z0-9][a-z0-9._-]{0,63}$/.test(value);
@@ -123,7 +131,7 @@ function parsePayload(value: unknown, admission: Admission): FixedTraceComponent
       || !exactCardinality(payload.cardinality, admission)
       || payload.reservationMicrodollars !== pricing.reservationMicrodollars
       || payload.providerCeilingMicrodollars !== pricing.providerCeilingUsd * 1_000_000
-      || payload.pricingCohortDigest !== pricing.cohortDigest
+      || !pricingCohortDigest(payload.pricingCohortDigest) || payload.pricingCohortDigest !== pricing.cohortDigest
       || !hexDigest(payload.nonceCommitment)
       || Date.parse(payload.issuedAt as string) >= Date.parse(payload.expiresAt as string)) return null;
     return Object.freeze(payload) as unknown as FixedTraceComponentSmokeSignedGrantPayload;
@@ -142,11 +150,12 @@ function parseGrant(value: unknown, admission: Admission): { payload: FixedTrace
   } catch { return null; }
 }
 
-function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null): FixedTraceComponentSmokeVerifiedGrant | null {
+function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null, mintLedgerCapability: boolean): FixedTraceComponentSmokeVerifiedGrant | null {
   const admission = fixedTraceComponentSmokeAdmission();
   if (!(now instanceof Date) || !Number.isFinite(now.valueOf()) || registry === null) return null;
   const parsed = parseGrant(value, admission);
-  if (!parsed || Date.parse(parsed.payload.issuedAt) > now.valueOf() || Date.parse(parsed.payload.expiresAt) <= now.valueOf()) return null;
+  if (!parsed || Date.parse(parsed.payload.issuedAt) > now.valueOf() || Date.parse(parsed.payload.expiresAt) <= now.valueOf()
+    || Date.parse(parsed.payload.expiresAt) - Date.parse(parsed.payload.issuedAt) > FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS) return null;
   const spki = registry[parsed.payload.kid];
   if (typeof spki !== 'string') return null;
   try {
@@ -155,20 +164,27 @@ function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record
     const signedPayloadDigest = fixedTraceComponentSmokeSignedPayloadDigest(parsed.payload);
     const verified = Object.freeze({ signedPayloadDigest,
       grantDigest: createHash('sha256').update(parsed.signature).update(signedPayloadDigest, 'utf8').digest('hex'),
-      signature: Buffer.from(parsed.signature), payload: parsed.payload });
-    VERIFIED_GRANTS.add(verified);
+      payload: parsed.payload });
+    if (mintLedgerCapability) VERIFIED_GRANTS.set(verified, Buffer.from(parsed.signature));
     return verified;
   } catch { return null; }
 }
 
 /** Production entry point: always fail-closed until its module-owned registry is provisioned. */
 export function verifyFixedTraceComponentSmokeSignedGrant(value: unknown, now: Date): FixedTraceComponentSmokeVerifiedGrant | null {
-  return verifyWithRegistry(value, now, PRODUCTION_SPKI_BY_KID);
+  return verifyWithRegistry(value, now, PRODUCTION_SPKI_BY_KID, true);
 }
 
 /** Internal capability check used by the adjacent private ledger, never a boolean authorization API. */
 export function isFixedTraceComponentSmokeVerifiedGrant(value: unknown): value is FixedTraceComponentSmokeVerifiedGrant {
   return typeof value === 'object' && value !== null && VERIFIED_GRANTS.has(value);
+}
+
+/** Returns a fresh audit copy; mutating it cannot affect verifier-held bytes. */
+export function fixedTraceComponentSmokeVerifiedGrantSignatureForLedger(value: unknown): Buffer | null {
+  if (!isFixedTraceComponentSmokeVerifiedGrant(value)) return null;
+  const signature = VERIFIED_GRANTS.get(value);
+  return signature ? Buffer.from(signature) : null;
 }
 
 /**
@@ -180,8 +196,9 @@ export function verifyFixedTraceComponentSmokeSignedGrantForTest(
   value: unknown,
   now: Date,
   testTrustRoot: Readonly<{ kid: string; publicKey: KeyObject }>,
-): FixedTraceComponentSmokeVerifiedGrant | null {
+): FixedTraceComponentSmokeTestGrantVerification | null {
   if (!kid(testTrustRoot.kid) || testTrustRoot.publicKey.asymmetricKeyType !== 'ed25519') return null;
   const spki = testTrustRoot.publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
-  return verifyWithRegistry(value, now, Object.freeze({ [testTrustRoot.kid]: spki.toString('base64url') }));
+  const verified = verifyWithRegistry(value, now, Object.freeze({ [testTrustRoot.kid]: spki.toString('base64url') }), false);
+  return verified ? Object.freeze({ valid: true as const, signedPayloadDigest: verified.signedPayloadDigest }) : null;
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -1,0 +1,187 @@
+import { createHash, createPublicKey, verify, type KeyObject } from 'node:crypto';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
+  fixedTraceComponentSmokeAdmission,
+} from './fixed-trace-component-smoke-admission.js';
+import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+
+/**
+ * This is a verifier and persistence contract only.  It deliberately has no
+ * issuer, key provisioning, provider adapter, environment switch, or runtime
+ * construction path.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION =
+  'addie-fixed-trace-component-smoke-signed-grant-v1' as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM = 'Ed25519' as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_DOMAIN =
+  'adcp:addie:fixed-trace-component-smoke:private-grant:v1\0' as const;
+
+type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
+type Cardinality = Admission['cardinality'];
+
+export interface FixedTraceComponentSmokeSignedGrantPayload {
+  readonly grantVersion: typeof FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION;
+  readonly kid: string;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly stageId: 'stage_1_smoke';
+  readonly admissionVersion: typeof FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION;
+  readonly aggregateAdmissionFingerprint: string;
+  readonly cardinality: Cardinality;
+  readonly reservationMicrodollars: number;
+  readonly providerCeilingMicrodollars: number;
+  readonly pricingCohortDigest: string;
+  /** SHA-256 commitment only. The nonce is never accepted or retained here. */
+  readonly nonceCommitment: string;
+}
+
+export interface FixedTraceComponentSmokeSignedGrant {
+  readonly algorithm: typeof FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM;
+  readonly payload: FixedTraceComponentSmokeSignedGrantPayload;
+  /** RFC 4648 base64url, unpadded. */
+  readonly signature: string;
+}
+
+export interface FixedTraceComponentSmokeVerifiedGrant {
+  readonly signedPayloadDigest: string;
+  readonly grantDigest: string;
+  readonly signature: Buffer;
+  readonly payload: FixedTraceComponentSmokeSignedGrantPayload;
+}
+
+/**
+ * Production is intentionally unprovisioned.  There is no environment lookup,
+ * dynamic JWKS, key callback, key negotiation, or caller-supplied key path.
+ * A later separately-reviewed private deployment must replace this module-owned
+ * null registry in a dedicated change before it can verify anything.
+ */
+const PRODUCTION_SPKI_BY_KID: Readonly<Record<string, string>> | null = null;
+/** Capability marker: only this verifier can create an input accepted by the ledger. */
+const VERIFIED_GRANTS = new WeakSet<object>();
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new Error('canonical JSON permits only safe integers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
+  }
+  throw new Error('non-JSON canonical value');
+}
+
+function exactKeys(value: object, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+function hexDigest(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+function kid(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-z0-9][a-z0-9._-]{0,63}$/.test(value);
+}
+function exactIso(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+function base64url(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{86}$/.test(value);
+}
+function exactCardinality(value: unknown, admission: Admission): value is Cardinality {
+  try {
+    const candidate = snapshotFixedTraceJson(value, 'signed grant cardinality') as Record<string, unknown>;
+    return exactKeys(candidate, Object.keys(admission.cardinality))
+      && canonicalJson(candidate) === canonicalJson(admission.cardinality);
+  } catch { return false; }
+}
+
+/** Returns exactly the bytes covered by Ed25519, including a non-JSON domain prefix. */
+export function fixedTraceComponentSmokeSignedGrantBytes(payload: FixedTraceComponentSmokeSignedGrantPayload): Buffer {
+  return Buffer.from(FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_DOMAIN + canonicalJson(payload), 'utf8');
+}
+
+export function fixedTraceComponentSmokeSignedPayloadDigest(payload: FixedTraceComponentSmokeSignedGrantPayload): string {
+  return createHash('sha256').update(fixedTraceComponentSmokeSignedGrantBytes(payload)).digest('hex');
+}
+
+function parsePayload(value: unknown, admission: Admission): FixedTraceComponentSmokeSignedGrantPayload | null {
+  try {
+    const payload = snapshotFixedTraceJson(value, 'signed private grant payload') as Record<string, unknown>;
+    const pricing = admission.pricing;
+    if (pricing.cohortDigest === null || pricing.reservationMicrodollars === null) return null;
+    if (!exactKeys(payload, ['admissionVersion', 'aggregateAdmissionFingerprint', 'cardinality', 'expiresAt', 'grantVersion', 'issuedAt', 'kid', 'nonceCommitment', 'pricingCohortDigest', 'providerCeilingMicrodollars', 'reservationMicrodollars', 'stageId'])) return null;
+    if (payload.grantVersion !== FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION
+      || !kid(payload.kid) || !exactIso(payload.issuedAt) || !exactIso(payload.expiresAt)
+      || payload.stageId !== admission.stageControls.phaseId
+      || payload.admissionVersion !== FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION
+      || payload.aggregateAdmissionFingerprint !== admission.fingerprints.aggregateAdmission
+      || !exactCardinality(payload.cardinality, admission)
+      || payload.reservationMicrodollars !== pricing.reservationMicrodollars
+      || payload.providerCeilingMicrodollars !== pricing.providerCeilingUsd * 1_000_000
+      || payload.pricingCohortDigest !== pricing.cohortDigest
+      || !hexDigest(payload.nonceCommitment)
+      || Date.parse(payload.issuedAt as string) >= Date.parse(payload.expiresAt as string)) return null;
+    return Object.freeze(payload) as unknown as FixedTraceComponentSmokeSignedGrantPayload;
+  } catch { return null; }
+}
+
+function parseGrant(value: unknown, admission: Admission): { payload: FixedTraceComponentSmokeSignedGrantPayload; signature: Buffer } | null {
+  try {
+    const grant = snapshotFixedTraceJson(value, 'signed private grant') as Record<string, unknown>;
+    if (!exactKeys(grant, ['algorithm', 'payload', 'signature'])
+      || grant.algorithm !== FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM || !base64url(grant.signature)) return null;
+    const payload = parsePayload(grant.payload, admission);
+    if (!payload) return null;
+    const signature = Buffer.from(grant.signature, 'base64url');
+    return signature.length === 64 ? { payload, signature } : null;
+  } catch { return null; }
+}
+
+function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null): FixedTraceComponentSmokeVerifiedGrant | null {
+  const admission = fixedTraceComponentSmokeAdmission();
+  if (!(now instanceof Date) || !Number.isFinite(now.valueOf()) || registry === null) return null;
+  const parsed = parseGrant(value, admission);
+  if (!parsed || Date.parse(parsed.payload.issuedAt) > now.valueOf() || Date.parse(parsed.payload.expiresAt) <= now.valueOf()) return null;
+  const spki = registry[parsed.payload.kid];
+  if (typeof spki !== 'string') return null;
+  try {
+    const publicKey = createPublicKey({ key: Buffer.from(spki, 'base64url'), format: 'der', type: 'spki' });
+    if (publicKey.asymmetricKeyType !== 'ed25519' || !verify(null, fixedTraceComponentSmokeSignedGrantBytes(parsed.payload), publicKey, parsed.signature)) return null;
+    const signedPayloadDigest = fixedTraceComponentSmokeSignedPayloadDigest(parsed.payload);
+    const verified = Object.freeze({ signedPayloadDigest,
+      grantDigest: createHash('sha256').update(parsed.signature).update(signedPayloadDigest, 'utf8').digest('hex'),
+      signature: Buffer.from(parsed.signature), payload: parsed.payload });
+    VERIFIED_GRANTS.add(verified);
+    return verified;
+  } catch { return null; }
+}
+
+/** Production entry point: always fail-closed until its module-owned registry is provisioned. */
+export function verifyFixedTraceComponentSmokeSignedGrant(value: unknown, now: Date): FixedTraceComponentSmokeVerifiedGrant | null {
+  return verifyWithRegistry(value, now, PRODUCTION_SPKI_BY_KID);
+}
+
+/** Internal capability check used by the adjacent private ledger, never a boolean authorization API. */
+export function isFixedTraceComponentSmokeVerifiedGrant(value: unknown): value is FixedTraceComponentSmokeVerifiedGrant {
+  return typeof value === 'object' && value !== null && VERIFIED_GRANTS.has(value);
+}
+
+/**
+ * Test-only pure verification seam.  It is intentionally separate from the
+ * production entry point; no production caller can select or inject a trust
+ * root.  Tests may pass only a concrete Ed25519 KeyObject created in-process.
+ */
+export function verifyFixedTraceComponentSmokeSignedGrantForTest(
+  value: unknown,
+  now: Date,
+  testTrustRoot: Readonly<{ kid: string; publicKey: KeyObject }>,
+): FixedTraceComponentSmokeVerifiedGrant | null {
+  if (!kid(testTrustRoot.kid) || testTrustRoot.publicKey.asymmetricKeyType !== 'ed25519') return null;
+  const spki = testTrustRoot.publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  return verifyWithRegistry(value, now, Object.freeze({ [testTrustRoot.kid]: spki.toString('base64url') }));
+}

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -51,6 +51,18 @@ export interface FixedTraceComponentSmokeTestGrantVerification {
   readonly valid: true;
   readonly signedPayloadDigest: string;
 }
+/**
+ * An explicitly supplied SPKI is useful only when it matches the separately
+ * provisioned module pin. The pin is deliberately null in this tranche, so
+ * this shape is not an authority-minting caller-selected-root escape hatch.
+ */
+export interface FixedTraceComponentSmokeOneShotTrustRoot {
+  readonly kid: string;
+  readonly spki: string;
+}
+export interface FixedTraceComponentSmokeOneShotGrantVerifier {
+  verify(value: unknown, now: Date): FixedTraceComponentSmokeVerifiedGrant | null;
+}
 /** A one-shot smoke grant may not outlive this bounded interval. */
 export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_000;
 
@@ -61,6 +73,8 @@ export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_0
  * null registry in a dedicated change before it can verify anything.
  */
 const PRODUCTION_SPKI_BY_KID: Readonly<Record<string, string>> | null = null;
+/** Separate deployment authority must pin this SHA-256 before a root can be used. */
+const PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN: string | null = null;
 /** Capability marker: only this verifier can create an input accepted by the ledger. */
 const VERIFIED_GRANTS = new WeakMap<object, Buffer>();
 
@@ -168,6 +182,30 @@ function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record
     if (mintLedgerCapability) VERIFIED_GRANTS.set(verified, Buffer.from(parsed.signature));
     return verified;
   } catch { return null; }
+}
+
+function exactOneShotTrustRoot(value: unknown): FixedTraceComponentSmokeOneShotTrustRoot | null {
+  try {
+    const root = snapshotFixedTraceJson(value, 'private one-shot trust root') as Record<string, unknown>;
+    if (!exactKeys(root, ['kid', 'spki']) || !kid(root.kid) || typeof root.spki !== 'string' || !/^[A-Za-z0-9_-]+$/.test(root.spki)) return null;
+    const publicKey = createPublicKey({ key: Buffer.from(root.spki, 'base64url'), format: 'der', type: 'spki' });
+    return publicKey.asymmetricKeyType === 'ed25519' ? Object.freeze({ kid: root.kid, spki: root.spki }) : null;
+  } catch { return null; }
+}
+
+/**
+ * A later isolated composition root may inject one exact separately provisioned
+ * root. Until that root's immutable module pin is reviewed and provisioned,
+ * this always returns null: arbitrary callers cannot mint ledger authority.
+ */
+export function createFixedTraceComponentSmokeOneShotGrantVerifier(
+  trustRoot: unknown,
+): FixedTraceComponentSmokeOneShotGrantVerifier | null {
+  const root = exactOneShotTrustRoot(trustRoot);
+  if (!root || PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN === null
+    || createHash('sha256').update(canonicalJson(root), 'utf8').digest('hex') !== PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN) return null;
+  const registry = Object.freeze({ [root.kid]: root.spki });
+  return Object.freeze({ verify: (value: unknown, now: Date) => verifyWithRegistry(value, now, registry, true) });
 }
 
 /** Production entry point: always fail-closed until its module-owned registry is provisioned. */

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -180,11 +180,11 @@ export function isFixedTraceComponentSmokeVerifiedGrant(value: unknown): value i
   return typeof value === 'object' && value !== null && VERIFIED_GRANTS.has(value);
 }
 
-/** Returns a fresh audit copy; mutating it cannot affect verifier-held bytes. */
-export function fixedTraceComponentSmokeVerifiedGrantSignatureForLedger(value: unknown): Buffer | null {
+/** Returns only an irreversible digest; raw signatures never cross into the ledger. */
+export function fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(value: unknown): string | null {
   if (!isFixedTraceComponentSmokeVerifiedGrant(value)) return null;
   const signature = VERIFIED_GRANTS.get(value);
-  return signature ? Buffer.from(signature) : null;
+  return signature ? createHash('sha256').update(signature).digest('hex') : null;
 }
 
 /**

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -268,7 +268,12 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     const parsed = parseProviderIntent(input);
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
-      return await this.transaction(async (client) => {
+      let recoverUnresolvedIntent = false;
+      const outcome = await this.transaction(async (client) => {
+        // Recovery is intentionally decided before this mutation locks its
+        // target plan row. It runs in a separate standalone transaction below.
+        const unresolvedBeforeTarget = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1', [parsed.reservation.authorizationDigest]);
+        if (unresolvedBeforeTarget.rowCount !== 0) { recoverUnresolvedIntent = true; return result('recorded'); }
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
@@ -301,6 +306,10 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
+        // Recheck under the authorization lock. Do not invoke broad recovery
+        // here: this transaction already owns a target plan row.
+        const unresolvedAfterAuthorization = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1', [parsed.reservation.authorizationDigest]);
+        if (unresolvedAfterAuthorization.rowCount !== 0) { recoverUnresolvedIntent = true; return result('recorded'); }
         await client.query(
           `INSERT INTO addie_fixed_trace_component_smoke_attempts
            (attempt_id, authorization_digest, assignment_id, invocation_ordinal, status, prepared_request_hmac)
@@ -309,6 +318,9 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         );
         return result('recorded');
       });
+      if (!recoverUnresolvedIntent) return outcome;
+      await this.recordUnknownExposure(parsed.reservation);
+      return result('refused', 'unknown_exposure');
     } catch { return result('refused', 'persistence_uncertain'); }
   }
 
@@ -354,18 +366,13 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         );
         if (parsed.usage && (parsed.usage.inputTokens > maxInput || additiveCacheOverLimit
           || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
-        // PostgreSQL forbids FOR UPDATE directly on an aggregate. Lock the
-        // contributing rows first; the authorization row above serializes all
-        // settlements, and this preserves a real checked-out-client boundary.
+        // The target attempt is locked before the authorization above. Every
+        // direct terminal trigger follows that order, so the authorization
+        // serializes settlements; never broad-lock peer attempts afterwards.
         const prior = await client.query<{ spent: unknown }>(
-          `WITH locked_attempts AS (
-             SELECT actual_cost_microdollars
-               FROM addie_fixed_trace_component_smoke_attempts
-              WHERE authorization_digest = $1
-              FOR UPDATE
-           )
-           SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent
-             FROM locked_attempts`,
+          `SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent
+             FROM addie_fixed_trace_component_smoke_attempts
+            WHERE authorization_digest = $1`,
           [parsed.reservation.authorizationDigest],
         );
         const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
@@ -603,16 +610,15 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected) || expected.disposition !== 'provider_dispatch'
           || parsed.finalInvocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
         const evidence = await client.query<{ count: unknown; open: unknown; failures: unknown; last_response_disposition: unknown }>(
-          `WITH locked_attempts AS (
+          `WITH assignment_attempts AS (
              SELECT status, response_disposition, invocation_ordinal
                FROM addie_fixed_trace_component_smoke_attempts
               WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal <= $3
-              FOR UPDATE
            )
            SELECT count(*)::bigint AS count, bool_or(status = 'intent_recorded') AS open,
                   bool_or(status <> 'succeeded') AS failures,
                   (array_agg(response_disposition ORDER BY invocation_ordinal DESC))[1] AS last_response_disposition
-             FROM locked_attempts`,
+             FROM assignment_attempts`,
           [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.finalInvocationOrdinal],
         );
         const row = evidence.rows[0];

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -1,0 +1,362 @@
+import { createHash } from 'node:crypto';
+import type { Pool, PoolClient } from 'pg';
+import { fixedTraceComponentSmokeAdmission } from './fixed-trace-component-smoke-admission.js';
+import {
+  isFixedTraceComponentSmokeVerifiedGrant,
+  type FixedTraceComponentSmokeVerifiedGrant,
+} from './fixed-trace-component-smoke-private-authorization.js';
+import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+
+/**
+ * No code constructs this ledger in the application. It is a database-only
+ * state machine for a later, separately reviewed private one-shot runtime.
+ * It has no provider dependency and cannot dispatch anything.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LEDGER_IS_CONSTRUCTED = false as const;
+
+type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
+type Disposition = Admission['privateRuntimePlan'][number]['dispatchDisposition'];
+export type FixedTraceComponentSmokeLedgerRefusal =
+  | 'grant_not_active' | 'grant_already_consumed' | 'admission_drift'
+  | 'unknown_exposure' | 'run_halted' | 'duplicate_attempt_id' | 'intent_required'
+  | 'plan_mismatch' | 'persistence_uncertain';
+
+export interface FixedTraceComponentSmokeReservation {
+  readonly reservationId: string;
+  readonly authorizationDigest: string;
+  readonly entryCount: 168;
+  readonly providerDispatchEntryCount: 126;
+  readonly reservationMicrodollars: 2819484;
+}
+export interface FixedTraceComponentSmokePlanEntry {
+  readonly assignmentId: string;
+  readonly probeId: string;
+  readonly cellId: string;
+  readonly disposition: Disposition;
+  readonly maximumProviderInvocations: number;
+  readonly provider: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly pricingProfileId: string;
+  readonly maxInputTokens: number;
+  readonly maxOutputTokens: number;
+  readonly timeoutMs: number;
+  readonly retries: 0;
+  readonly reservedMicrodollars: readonly number[];
+}
+export interface FixedTraceComponentSmokeProviderIntent {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly attemptId: string;
+  readonly assignmentId: string;
+  readonly invocationOrdinal: number;
+  /** HMAC of the exact frozen provider request. Never the request itself. */
+  readonly preparedRequestHmac: string;
+}
+export interface FixedTraceComponentSmokeTerminal {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly attemptId: string;
+  readonly status: 'succeeded' | 'provider_failed' | 'timeout_after_dispatch' | 'malformed_response' | 'identity_mismatch' | 'missing_usage';
+  readonly usage: Readonly<{ inputTokens: number; outputTokens: number; costMicrodollars: number; latencyMs: number }> | null;
+  readonly returnedIdentity: Readonly<{ provider: string; model: string; effort: string }> | null;
+  readonly responseHmac: string | null;
+}
+export interface FixedTraceComponentSmokeNonDispatchTerminal {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly assignmentId: string;
+  readonly status: 'local_terminal' | 'pre_dispatch_fault';
+}
+
+const HEX = /^[a-f0-9]{64}$/;
+const ATTEMPT_ID = /^attempt_[a-f0-9]{32}$/;
+const MAX_LATENCY_MS = 86_400_000;
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new Error('non-canonical number');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`).join(',')}}`;
+  }
+  throw new Error('non-canonical value');
+}
+function sha256(value: unknown): string { return createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex'); }
+function exactKeys(value: object, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort(); const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+function isHash(value: unknown): value is string { return typeof value === 'string' && HEX.test(value); }
+function safeString(value: unknown, max: number): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= max && /^[a-z0-9._:-]+$/i.test(value);
+}
+
+/** Derives, rather than accepts, the exact 168-entry admitted plan. */
+export function fixedTraceComponentSmokePrivateLedgerPlan(): readonly FixedTraceComponentSmokePlanEntry[] | null {
+  const admission = fixedTraceComponentSmokeAdmission();
+  if (admission.status !== 'ready_for_explicit_paid_authorization'
+    || admission.fingerprints.aggregateAdmission !== '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d'
+    || admission.cardinality.caseCellAssignments !== 168
+    || admission.cardinality.providerDispatchCaseCellAssignments !== 126
+    || admission.cardinality.preDispatchFaultCaseCellAssignments !== 21
+    || admission.cardinality.maximumProviderInvocations !== 192
+    || admission.pricing.reservationMicrodollars !== 2_819_484
+    || admission.pricing.providerCeilingUsd !== 5) return null;
+  const cells = new Map(admission.cells.map((cell) => [cell.id, cell]));
+  const entries = admission.privateRuntimePlan.map((entry) => {
+    const cell = cells.get(entry.cellId);
+    if (!cell || entry.maximumProviderInvocations !== entry.perAttemptReservationMicrodollars.length || entry.sdkAutomaticRetries !== 0) return null;
+    return Object.freeze({
+      assignmentId: sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:plan-entry:v1\0', fingerprint: admission.fingerprints.aggregateAdmission, probeId: entry.probeId, cellId: entry.cellId }),
+      probeId: entry.probeId, cellId: entry.cellId, disposition: entry.dispatchDisposition,
+      maximumProviderInvocations: entry.maximumProviderInvocations, provider: cell.provider, model: cell.model, effort: cell.effort,
+      pricingProfileId: entry.pricingProfileId, maxInputTokens: entry.maxInputTokensPerInvocation,
+      maxOutputTokens: entry.maxOutputTokensPerInvocation, timeoutMs: entry.timeoutMs, retries: 0 as const,
+      reservedMicrodollars: Object.freeze([...entry.perAttemptReservationMicrodollars]),
+    });
+  });
+  if (entries.some((entry) => entry === null)) return null;
+  const plan = entries as FixedTraceComponentSmokePlanEntry[];
+  const total = plan.reduce((sum, entry) => sum + entry.reservedMicrodollars.reduce((subtotal, micros) => subtotal + micros, 0), 0);
+  const dispatch = plan.filter((entry) => entry.disposition === 'provider_dispatch');
+  const nonDispatchValid = plan.filter((entry) => entry.disposition !== 'provider_dispatch')
+    .every((entry) => entry.maximumProviderInvocations === 0 && entry.reservedMicrodollars.length === 0);
+  return plan.length === 168 && new Set(plan.map((entry) => entry.assignmentId)).size === 168
+    && dispatch.length === 126 && dispatch.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0) === 192
+    && total === 2_819_484 && nonDispatchValid ? Object.freeze(plan) : null;
+}
+
+function reservationFor(grant: FixedTraceComponentSmokeVerifiedGrant): FixedTraceComponentSmokeReservation {
+  return Object.freeze({ reservationId: `reservation_${sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0', authorizationDigest: grant.grantDigest }).slice(0, 32)}`,
+    authorizationDigest: grant.grantDigest, entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 });
+}
+function result(status: 'reserved', reservation: FixedTraceComponentSmokeReservation): Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }>;
+function result(status: 'recorded'): Readonly<{ status: 'recorded' }>;
+function result(status: 'refused', reason: FixedTraceComponentSmokeLedgerRefusal): Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>;
+function result(status: string, value?: unknown) { return status === 'reserved' ? Object.freeze({ status, reservation: value }) : status === 'recorded' ? Object.freeze({ status }) : Object.freeze({ status, reason: value }); }
+
+/**
+ * Checked-out-client only implementation.  Every mutating method has one
+ * transaction and never retries a statement, a transaction, or a commit.
+ */
+export class PostgresFixedTraceComponentSmokePrivateLedger {
+  constructor(private readonly pool: Pick<Pool, 'connect'>) {}
+
+  private async transaction<T>(work: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    let began = false;
+    try {
+      await client.query('BEGIN'); began = true;
+      const output = await work(client);
+      await client.query('COMMIT');
+      return output;
+    } catch (error) {
+      if (began) await client.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally { client.release(); }
+  }
+
+  async reserveAndConsume(grant: FixedTraceComponentSmokeVerifiedGrant): Promise<Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const plan = fixedTraceComponentSmokePrivateLedgerPlan();
+    if (!plan || !isFixedTraceComponentSmokeVerifiedGrant(grant) || !isHash(grant.grantDigest) || !isHash(grant.signedPayloadDigest) || !isHash(grant.payload.nonceCommitment)) return result('refused', 'admission_drift');
+    const reservation = reservationFor(grant);
+    try {
+      return await this.transaction(async (client) => {
+        const inserted = await client.query<{ authorization_digest: string }>(
+          `INSERT INTO addie_fixed_trace_component_smoke_authorizations (
+             authorization_digest, signed_payload_digest, signature, kid, nonce_commitment, grant_version,
+             stage_id, admission_version, aggregate_admission_fingerprint, probes, router_cells, generation_cells, total_cells, repetitions, assignments,
+             provider_dispatch_assignments, local_terminal_assignments, pre_dispatch_fault_assignments,
+             maximum_planned_invocation_slots, maximum_provider_invocations, reservation_microdollars, provider_ceiling_microdollars,
+             pricing_cohort_digest, issued_at, expires_at, status, consumed_at, reservation_id
+           )
+           SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24::timestamptz,$25::timestamptz,'consumed',clock_timestamp(),$26
+           WHERE $24::timestamptz <= clock_timestamp() AND $25::timestamptz > clock_timestamp()
+           ON CONFLICT (authorization_digest) DO NOTHING
+           RETURNING authorization_digest`,
+          [grant.grantDigest, grant.signedPayloadDigest, grant.signature, grant.payload.kid, grant.payload.nonceCommitment,
+            grant.payload.grantVersion, grant.payload.stageId, grant.payload.admissionVersion, grant.payload.aggregateAdmissionFingerprint,
+            grant.payload.cardinality.probes, grant.payload.cardinality.routerCells, grant.payload.cardinality.generationCells,
+            grant.payload.cardinality.totalCells, grant.payload.cardinality.repetitions, grant.payload.cardinality.caseCellAssignments,
+            grant.payload.cardinality.providerDispatchCaseCellAssignments, grant.payload.cardinality.localTerminalCaseCellAssignments,
+            grant.payload.cardinality.preDispatchFaultCaseCellAssignments, grant.payload.cardinality.maximumPlannedInvocationSlots,
+            grant.payload.cardinality.maximumProviderInvocations, grant.payload.reservationMicrodollars,
+            grant.payload.providerCeilingMicrodollars, grant.payload.pricingCohortDigest, grant.payload.issuedAt,
+            grant.payload.expiresAt, reservation.reservationId],
+        );
+        if (inserted.rowCount !== 1) {
+          const existing = await client.query<{ status: string; expires_at: string }>(
+            'SELECT status, expires_at FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [grant.grantDigest]);
+          if (existing.rowCount !== 1) return result('refused', 'persistence_uncertain');
+          if (existing.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+          return result('refused', 'grant_already_consumed');
+        }
+        for (const entry of plan) {
+          await client.query(
+            `INSERT INTO addie_fixed_trace_component_smoke_run_plan
+             (authorization_digest, assignment_id, probe_id, cell_id, disposition, maximum_provider_invocations,
+              requested_provider, requested_model, requested_effort, pricing_profile_id, max_input_tokens,
+              max_output_tokens, timeout_ms, retries, reserved_microdollars)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+            [grant.grantDigest, entry.assignmentId, entry.probeId, entry.cellId, entry.disposition, entry.maximumProviderInvocations,
+              entry.provider, entry.model, entry.effort, entry.pricingProfileId, entry.maxInputTokens, entry.maxOutputTokens,
+              entry.timeoutMs, entry.retries, entry.reservedMicrodollars],
+          );
+        }
+        return result('reserved', reservation);
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  async recordProviderIntent(input: unknown): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const parsed = parseProviderIntent(input);
+    if (!parsed) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
+        const plan = await client.query<{ disposition: string; maximum_provider_invocations: number }>(
+          'SELECT disposition, maximum_provider_invocations FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
+        if (plan.rowCount !== 1 || plan.rows[0]!.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > plan.rows[0]!.maximum_provider_invocations) return result('refused', 'plan_mismatch');
+        const duplicate = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1 FOR UPDATE', [parsed.attemptId]);
+        if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
+        const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
+        if (slot.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
+        await client.query(
+          `INSERT INTO addie_fixed_trace_component_smoke_attempts
+           (attempt_id, authorization_digest, assignment_id, invocation_ordinal, status, prepared_request_hmac)
+           VALUES ($1,$2,$3,$4,'intent_recorded',$5)`,
+          [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal, parsed.preparedRequestHmac],
+        );
+        return result('recorded');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  async recordTerminal(input: unknown): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const parsed = parseTerminal(input);
+    if (!parsed) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
+        const attempt = await client.query<{ status: string; requested_provider: string; requested_model: string; requested_effort: string }>(
+          `SELECT a.status, p.requested_provider, p.requested_model, p.requested_effort
+           FROM addie_fixed_trace_component_smoke_attempts a
+           JOIN addie_fixed_trace_component_smoke_run_plan p ON p.authorization_digest = a.authorization_digest AND p.assignment_id = a.assignment_id
+           WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
+        if (attempt.rowCount !== 1 || attempt.rows[0]!.status !== 'intent_recorded') return result('refused', 'intent_required');
+        if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== attempt.rows[0]!.requested_provider
+          || parsed.returnedIdentity?.model !== attempt.rows[0]!.requested_model
+          || parsed.returnedIdentity?.effort !== attempt.rows[0]!.requested_effort)) return result('refused', 'plan_mismatch');
+        await client.query(
+          `UPDATE addie_fixed_trace_component_smoke_attempts
+           SET status = $3, input_tokens = $4, output_tokens = $5, actual_cost_microdollars = $6, latency_ms = $7, response_hmac = $8, terminal_at = clock_timestamp()
+           WHERE attempt_id = $1 AND authorization_digest = $2`,
+          [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.status, parsed.usage?.inputTokens ?? null,
+            parsed.usage?.outputTokens ?? null, parsed.usage?.costMicrodollars ?? null, parsed.usage?.latencyMs ?? null, parsed.responseHmac],
+        );
+        if (parsed.status !== 'succeeded') {
+          await client.query(
+            `UPDATE addie_fixed_trace_component_smoke_authorizations
+             SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
+             WHERE authorization_digest = $1`,
+            [parsed.reservation.authorizationDigest, parsed.status === 'timeout_after_dispatch' ? 'unknown_exposure' : 'halted'],
+          );
+        }
+        return result('recorded');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /** Must be called after every post-intent ambiguity; it permanently halts the run. */
+  async recordUnknownExposure(reservation: FixedTraceComponentSmokeReservation): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    if (!exactReservation(reservation)) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const changed = await client.query(
+          `UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp()
+           WHERE authorization_digest = $1 AND status = 'consumed'`, [reservation.authorizationDigest]);
+        return changed.rowCount === 1 ? result('recorded') : result('refused', 'unknown_exposure');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /** Local and pre-dispatch terminal plan entries accept no HMAC, cost, or invocation claim. */
+  async recordNonDispatchTerminal(input: unknown): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const parsed = parseNonDispatchTerminal(input);
+    if (!parsed) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        const updated = await client.query(
+          `UPDATE addie_fixed_trace_component_smoke_run_plan
+           SET non_dispatch_status = $3, non_dispatch_terminal_at = clock_timestamp()
+           WHERE authorization_digest = $1 AND assignment_id = $2 AND disposition = $3 AND non_dispatch_status IS NULL`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.status],
+        );
+        return updated.rowCount === 1 ? result('recorded') : result('refused', 'plan_mismatch');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+}
+
+function exactReservation(value: unknown): value is FixedTraceComponentSmokeReservation {
+  try {
+    const object = snapshotFixedTraceJson(value, 'private ledger reservation') as Record<string, unknown>;
+    return exactKeys(object, ['authorizationDigest', 'entryCount', 'providerDispatchEntryCount', 'reservationId', 'reservationMicrodollars'])
+      && typeof object.reservationId === 'string' && /^reservation_[a-f0-9]{32}$/.test(object.reservationId)
+      && isHash(object.authorizationDigest) && object.entryCount === 168 && object.providerDispatchEntryCount === 126 && object.reservationMicrodollars === 2_819_484;
+  } catch { return false; }
+}
+function parseProviderIntent(value: unknown): FixedTraceComponentSmokeProviderIntent | null {
+  try {
+    const object = snapshotFixedTraceJson(value, 'provider intent') as Record<string, unknown>;
+    if (!exactKeys(object, ['assignmentId', 'attemptId', 'invocationOrdinal', 'preparedRequestHmac', 'reservation'])
+      || !exactReservation(object.reservation) || typeof object.attemptId !== 'string' || !ATTEMPT_ID.test(object.attemptId)
+      || !isHash(object.assignmentId) || !Number.isSafeInteger(object.invocationOrdinal) || (object.invocationOrdinal as number) < 1 || !isHash(object.preparedRequestHmac)) return null;
+    return Object.freeze(object) as unknown as FixedTraceComponentSmokeProviderIntent;
+  } catch { return null; }
+}
+function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null {
+  try {
+    const object = snapshotFixedTraceJson(value, 'provider terminal') as Record<string, unknown>;
+    const statuses = new Set(['succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage']);
+    if (!exactKeys(object, ['attemptId', 'reservation', 'responseHmac', 'returnedIdentity', 'status', 'usage']) || !exactReservation(object.reservation)
+      || typeof object.attemptId !== 'string' || !ATTEMPT_ID.test(object.attemptId) || typeof object.status !== 'string' || !statuses.has(object.status)) return null;
+    if (object.status === 'succeeded' && (object.usage === null || !isHash(object.responseHmac) || !exactIdentity(object.returnedIdentity))) return null;
+    if (object.status !== 'succeeded' && (object.responseHmac !== null || object.returnedIdentity !== null)) return null;
+    if (object.usage === null) return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
+    if (!object.usage || typeof object.usage !== 'object' || !exactKeys(object.usage, ['costMicrodollars', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
+    const usage = object.usage as Record<string, unknown>;
+    if (![usage.inputTokens, usage.outputTokens, usage.costMicrodollars, usage.latencyMs].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)
+      || (usage.latencyMs as number) > MAX_LATENCY_MS || (usage.costMicrodollars as number) > 2_819_484) return null;
+    return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
+  } catch { return null; }
+}
+function exactIdentity(value: unknown): value is Readonly<{ provider: string; model: string; effort: string }> {
+  try {
+    const object = snapshotFixedTraceJson(value, 'returned provider identity') as Record<string, unknown>;
+    return exactKeys(object, ['effort', 'model', 'provider']) && safeString(object.provider, 32)
+      && safeString(object.model, 128) && safeString(object.effort, 64);
+  } catch { return false; }
+}
+function parseNonDispatchTerminal(value: unknown): FixedTraceComponentSmokeNonDispatchTerminal | null {
+  try {
+    const object = snapshotFixedTraceJson(value, 'non-dispatch terminal') as Record<string, unknown>;
+    if (!exactKeys(object, ['assignmentId', 'reservation', 'status']) || !exactReservation(object.reservation)
+      || !isHash(object.assignmentId) || (object.status !== 'local_terminal' && object.status !== 'pre_dispatch_fault')) return null;
+    return Object.freeze(object) as unknown as FixedTraceComponentSmokeNonDispatchTerminal;
+  } catch { return null; }
+}

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -459,20 +459,22 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
   * usage, identity, response HMAC, or cost.
   */
   private async closeOpenIntentsAsUnknownExposure(client: PoolClient, reservation: FixedTraceComponentSmokeReservation): Promise<boolean> {
-    // Direct attempt/plan mutations acquire their target row before the
-    // authorization in row triggers. Acquire all recovery targets first too;
-    // subsequent updates reuse these locks and cannot form auth->target cycles.
+    // Recovery has no single target. It first locks the complete immutable
+    // plan in assignment order, which is the insertion gate for both the
+    // application and the INSERT trigger. Only then can it snapshot every
+    // attempt safely: an intent that began earlier either committed before
+    // this point or holds a plan row we wait for; no later intent can appear.
+    // Terminal UPDATE deliberately remains attempt -> authorization and never
+    // acquires a plan row, so it cannot invert this recovery order.
     await client.query(
-      `SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts
-        WHERE authorization_digest = $1 FOR UPDATE`,
+      `SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan
+        WHERE authorization_digest = $1 ORDER BY assignment_id FOR UPDATE`,
       [reservation.authorizationDigest],
     );
     await client.query(
-      `SELECT p.assignment_id FROM addie_fixed_trace_component_smoke_run_plan AS p
-        WHERE p.authorization_digest = $1 AND p.assignment_outcome IS NULL
-          AND EXISTS (SELECT 1 FROM addie_fixed_trace_component_smoke_attempts a
-                       WHERE a.authorization_digest = p.authorization_digest AND a.assignment_id = p.assignment_id)
-        FOR UPDATE OF p`,
+      `SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts
+        WHERE authorization_digest = $1
+        ORDER BY assignment_id, invocation_ordinal, attempt_id FOR UPDATE`,
       [reservation.authorizationDigest],
     );
     const authorization = await client.query<{ status: string }>(

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -86,6 +86,11 @@ export interface FixedTraceComponentSmokeProviderAssignmentTerminal {
   readonly status: 'provider_completed' | 'provider_failed';
   readonly finalInvocationOrdinal: number;
 }
+/** Closes a started assignment whose committed provider exposure is ambiguous. */
+export interface FixedTraceComponentSmokeProviderUnknownExposure {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly assignmentId: string;
+}
 
 const HEX = /^[a-f0-9]{64}$/;
 const ATTEMPT_ID = /^attempt_[a-f0-9]{32}$/;
@@ -271,7 +276,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         const unresolved = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
         if (unresolved.rowCount !== 0) {
-          await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+          await this.closeOpenIntentsAsUnknownExposure(client, parsed.reservation);
           return result('refused', 'unknown_exposure');
         }
         const expected = expectedPlanEntry(parsed.assignmentId);
@@ -284,6 +289,14 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           [parsed.reservation.authorizationDigest, parsed.assignmentId]);
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
           || expected.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
+        if (parsed.invocationOrdinal > 1) {
+          const predecessor = await client.query<{ status: string; response_disposition: string | null }>(
+            'SELECT status, response_disposition FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE',
+            [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal - 1],
+          );
+          if (predecessor.rowCount !== 1 || predecessor.rows[0]!.status !== 'succeeded'
+            || predecessor.rows[0]!.response_disposition !== 'tool_continuation_required') return result('refused', 'intent_required');
+        }
         const duplicate = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1 FOR UPDATE', [parsed.attemptId]);
         if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
         const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
@@ -319,7 +332,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         const row = attempt.rows[0]!;
         const expected = expectedPlanEntry(row.assignment_id);
         if (!expected || !pgPlanMatches(row as unknown as Record<string, unknown>, expected)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
-        if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== row.requested_provider
+        if (parsed.usage && (parsed.returnedIdentity?.provider !== row.requested_provider
           || parsed.returnedIdentity?.model !== row.requested_model
           || parsed.returnedIdentity?.effort !== row.requested_effort)) return this.settlePostIntentFailure(client, parsed, 'identity_mismatch', 'unknown_exposure');
         const ordinal = pgSafeInt(row.invocation_ordinal, 2);
@@ -328,10 +341,15 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         const timeout = pgSafeInt(row.timeout_ms, MAX_LATENCY_MS);
         if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
         const reservedForOrdinal = pgSafeInt(row.reserved_microdollars[ordinal - 1], 2_819_484);
+        const maximumInvocations = pgSafeInt(row.maximum_provider_invocations, 2);
         const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === row.pricing_profile_id);
         if (parsed.usage && (!profile || profile.provider !== row.requested_provider || profile.model !== row.requested_model)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
         let spent: number | null = null;
         try { spent = parsed.usage ? datedPricingCostMicros(profile!, parsed.usage) : null; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
+        if (parsed.status === 'succeeded' && parsed.responseDisposition === 'tool_continuation_required'
+          && (maximumInvocations === null || ordinal === maximumInvocations)) {
+          return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
+        }
         // A complete receipt remains accounting evidence even if it breaches a
         // pinned input/output/timeout limit. Never replace known exposure with
         // NULL merely because this one-shot run must halt.
@@ -402,12 +420,56 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!exactReservation(reservation)) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const changed = await client.query(
-          `UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp()
-           WHERE authorization_digest = $1 AND reservation_id = $2 AND status = 'consumed'`, [reservation.authorizationDigest, reservation.reservationId]);
-        return changed.rowCount === 1 ? result('recorded') : result('refused', 'unknown_exposure');
+        const changed = await this.closeOpenIntentsAsUnknownExposure(client, reservation);
+        return changed ? result('recorded') : result('refused', 'unknown_exposure');
       });
     } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /**
+   * Turns every still-open committed intent into categorical ambiguity before
+   * closing its corresponding assignment.  It records no invented receipt,
+   * usage, identity, response HMAC, or cost.
+   */
+  private async closeOpenIntentsAsUnknownExposure(client: PoolClient, reservation: FixedTraceComponentSmokeReservation): Promise<boolean> {
+    const changed = await client.query(
+      `UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp()
+       WHERE authorization_digest = $1 AND reservation_id = $2 AND status = 'consumed'`,
+      [reservation.authorizationDigest, reservation.reservationId],
+    );
+    if (changed.rowCount !== 1) return false;
+    await client.query(
+      `UPDATE addie_fixed_trace_component_smoke_attempts
+          SET status = 'unknown_exposure', response_disposition = NULL, response_hmac = NULL,
+              returned_provider = NULL, returned_model = NULL, returned_effort = NULL,
+              input_tokens = NULL, output_tokens = NULL, cache_read_tokens = NULL, cache_write_tokens = NULL,
+              actual_cost_microdollars = NULL, observed_cost_microdollars = NULL, latency_ms = NULL,
+              terminal_at = clock_timestamp()
+        WHERE authorization_digest = $1 AND status = 'intent_recorded'`,
+      [reservation.authorizationDigest],
+    );
+    await client.query(
+      `WITH started AS (
+         SELECT authorization_digest, assignment_id, max(invocation_ordinal) AS final_ordinal,
+                bool_or(status = 'unknown_exposure') AS ambiguous,
+                bool_or(status <> 'succeeded') AS failed,
+                (array_agg(response_disposition ORDER BY invocation_ordinal DESC))[1] AS last_disposition
+           FROM addie_fixed_trace_component_smoke_attempts
+          WHERE authorization_digest = $1
+          GROUP BY authorization_digest, assignment_id
+       )
+       UPDATE addie_fixed_trace_component_smoke_run_plan AS p
+          SET assignment_outcome = CASE
+                WHEN started.ambiguous OR started.last_disposition <> 'final_response' THEN 'provider_unknown_exposure'
+                WHEN started.failed THEN 'provider_failed'
+                ELSE 'provider_completed' END,
+              assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = started.final_ordinal
+         FROM started
+        WHERE p.authorization_digest = started.authorization_digest AND p.assignment_id = started.assignment_id
+          AND p.assignment_outcome IS NULL`,
+      [reservation.authorizationDigest],
+    );
+    return true;
   }
 
   /** Local and pre-dispatch terminal plan entries accept no HMAC, cost, or invocation claim. */

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -63,6 +63,8 @@ export interface FixedTraceComponentSmokeTerminal {
   readonly reservation: FixedTraceComponentSmokeReservation;
   readonly attemptId: string;
   readonly status: 'succeeded' | 'provider_failed' | 'timeout_after_dispatch' | 'malformed_response' | 'identity_mismatch' | 'missing_usage';
+  /** HMAC-bound normalized response effect; only successes can be final or continue. */
+  readonly responseDisposition: 'final_response' | 'tool_continuation_required' | null;
   readonly usage: Readonly<{ inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; latencyMs: number }> | null;
   readonly returnedIdentity: Readonly<{ provider: string; model: string; effort: string }> | null;
   readonly responseHmac: string | null;
@@ -71,6 +73,18 @@ export interface FixedTraceComponentSmokeNonDispatchTerminal {
   readonly reservation: FixedTraceComponentSmokeReservation;
   readonly assignmentId: string;
   readonly status: 'local_terminal' | 'pre_dispatch_fault';
+}
+/** Zero-call assignment outcome used only to close an already halted denominator. */
+export interface FixedTraceComponentSmokeNotExecutedAfterHalt {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly assignmentId: string;
+}
+/** One terminal outcome for a provider-dispatch assignment, never an attempt. */
+export interface FixedTraceComponentSmokeProviderAssignmentTerminal {
+  readonly reservation: FixedTraceComponentSmokeReservation;
+  readonly assignmentId: string;
+  readonly status: 'provider_completed' | 'provider_failed';
+  readonly finalInvocationOrdinal: number;
 }
 
 const HEX = /^[a-f0-9]{64}$/;
@@ -313,27 +327,30 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         const maxOutput = pgSafeInt(row.max_output_tokens, 1_000_000);
         const timeout = pgSafeInt(row.timeout_ms, MAX_LATENCY_MS);
         if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
-        if (parsed.usage && (parsed.usage.inputTokens + parsed.usage.cacheReadTokens + parsed.usage.cacheWriteTokens > maxInput
-          || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted');
         const reservedForOrdinal = pgSafeInt(row.reserved_microdollars[ordinal - 1], 2_819_484);
         const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === row.pricing_profile_id);
         if (parsed.usage && (!profile || profile.provider !== row.requested_provider || profile.model !== row.requested_model)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
-        let spent = 0;
-        try { spent = parsed.usage ? datedPricingCostMicros(profile!, parsed.usage) : 0; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
+        let spent: number | null = null;
+        try { spent = parsed.usage ? datedPricingCostMicros(profile!, parsed.usage) : null; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
+        // A complete receipt remains accounting evidence even if it breaches a
+        // pinned input/output/timeout limit. Never replace known exposure with
+        // NULL merely because this one-shot run must halt.
+        if (parsed.usage && (parsed.usage.inputTokens + parsed.usage.cacheReadTokens + parsed.usage.cacheWriteTokens > maxInput
+          || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
         const prior = await client.query<{ spent: unknown }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
         const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
         const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
         const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
-        if (reservedForOrdinal === null || spent > reservedForOrdinal || priorSpent === null || reservationLimit === null || providerLimit === null
-          || priorSpent + spent > reservationLimit || priorSpent + spent > providerLimit) {
-          return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'cost_exhausted');
+        if (reservedForOrdinal === null || priorSpent === null || reservationLimit === null || providerLimit === null
+          || (spent !== null && (spent > reservedForOrdinal || priorSpent + spent > reservationLimit || priorSpent + spent > providerLimit))) {
+          return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'cost_exhausted', spent);
         }
         await client.query(
           `UPDATE addie_fixed_trace_component_smoke_attempts
-           SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7, actual_cost_microdollars = $8, latency_ms = $9, response_hmac = $10,
-               returned_provider = $11, returned_model = $12, returned_effort = $13, terminal_at = clock_timestamp()
+          SET status = $3, response_disposition = $4, input_tokens = $5, output_tokens = $6, cache_read_tokens = $7, cache_write_tokens = $8, actual_cost_microdollars = $9, latency_ms = $10, response_hmac = $11,
+               returned_provider = $12, returned_model = $13, returned_effort = $14, terminal_at = clock_timestamp()
            WHERE attempt_id = $1 AND authorization_digest = $2`,
-          [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.status, parsed.usage?.inputTokens ?? null,
+          [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.status, parsed.responseDisposition, parsed.usage?.inputTokens ?? null,
             parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null,
             parsed.usage ? spent : null, parsed.usage?.latencyMs ?? null, parsed.responseHmac,
             parsed.returnedIdentity?.provider ?? null, parsed.returnedIdentity?.model ?? null, parsed.returnedIdentity?.effort ?? null],
@@ -358,15 +375,16 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     terminalStatus: 'invalid_limits' | 'pricing_unavailable' | 'identity_mismatch',
     authorizationStatus: 'halted' | 'unknown_exposure',
     refusal: FixedTraceComponentSmokeLedgerRefusal = 'plan_mismatch',
+    observedCostMicrodollars: number | null = null,
   ): Promise<Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
     await client.query(
       `UPDATE addie_fixed_trace_component_smoke_attempts
           SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7,
-              actual_cost_microdollars = NULL, latency_ms = $8, response_hmac = $9, returned_provider = $10,
-              returned_model = $11, returned_effort = $12, terminal_at = clock_timestamp()
+              actual_cost_microdollars = NULL, observed_cost_microdollars = $8, latency_ms = $9, response_hmac = $10, returned_provider = $11,
+              returned_model = $12, returned_effort = $13, terminal_at = clock_timestamp()
         WHERE attempt_id = $1 AND authorization_digest = $2 AND status = 'intent_recorded'`,
       [parsed.attemptId, parsed.reservation.authorizationDigest, terminalStatus, parsed.usage?.inputTokens ?? null,
-        parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null,
+        parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null, observedCostMicrodollars,
         parsed.usage?.latencyMs ?? null, parsed.responseHmac, parsed.returnedIdentity?.provider ?? null,
         parsed.returnedIdentity?.model ?? null, parsed.returnedIdentity?.effort ?? null],
     );
@@ -415,9 +433,94 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           || expected.disposition !== parsed.status) return result('refused', 'plan_mismatch');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
-           SET non_dispatch_status = $3, non_dispatch_terminal_at = clock_timestamp()
-           WHERE authorization_digest = $1 AND assignment_id = $2 AND disposition = $3 AND non_dispatch_status IS NULL`,
+          SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp()
+           WHERE authorization_digest = $1 AND assignment_id = $2 AND disposition = $3 AND assignment_outcome IS NULL`,
           [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.status],
+        );
+        return updated.rowCount === 1 ? result('recorded') : result('refused', 'plan_mismatch');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /**
+   * Closes an unstarted assignment after permanent halt without claiming an
+   * intent, provider invocation, HMAC, receipt, or cost. It remains a failed
+   * denominator entry, never a provider attempt terminal.
+   */
+  async recordNotExecutedAfterHalt(input: unknown): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const parsed = parseNotExecutedAfterHalt(input);
+    if (!parsed) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status !== 'halted' && auth.rows[0]!.status !== 'unknown_exposure') return result('refused', 'run_halted');
+        const expected = expectedPlanEntry(parsed.assignmentId);
+        const plan = await client.query<Record<string, unknown>>(
+          `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
+                  requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
+                  reserved_microdollars
+             FROM addie_fixed_trace_component_smoke_run_plan
+            WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId],
+        );
+        if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)) return result('refused', 'plan_mismatch');
+        const started = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
+        if (started.rowCount !== 0) return result('refused', 'plan_mismatch');
+        const updated = await client.query(
+          `UPDATE addie_fixed_trace_component_smoke_run_plan
+              SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp()
+            WHERE authorization_digest = $1 AND assignment_id = $2 AND assignment_outcome IS NULL`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId],
+        );
+        return updated.rowCount === 1 ? result('recorded') : result('refused', 'plan_mismatch');
+      });
+    } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /**
+   * Records the single denominator outcome for a provider assignment only
+   * after its contiguous terminal invocation evidence is durable. Completion
+   * requires the last started ordinal to carry a final-response disposition;
+   * a continuation requires the next eligible ordinal first. Neither case is
+   * a provider-attempt terminal itself.
+   */
+  async recordProviderAssignmentTerminal(input: unknown): Promise<Readonly<{ status: 'recorded' }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    const parsed = parseProviderAssignmentTerminal(input);
+    if (!parsed) return result('refused', 'plan_mismatch');
+    try {
+      return await this.transaction(async (client) => {
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        const expected = expectedPlanEntry(parsed.assignmentId);
+        const plan = await client.query<Record<string, unknown>>(
+          `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
+                  requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
+                  reserved_microdollars
+             FROM addie_fixed_trace_component_smoke_run_plan
+            WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId],
+        );
+        if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected) || expected.disposition !== 'provider_dispatch'
+          || parsed.finalInvocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
+        const evidence = await client.query<{ count: unknown; open: unknown; failures: unknown; last_response_disposition: unknown }>(
+          `SELECT count(*)::bigint AS count, bool_or(status = 'intent_recorded') AS open,
+                  bool_or(status <> 'succeeded') AS failures,
+                  (array_agg(response_disposition ORDER BY invocation_ordinal DESC))[1] AS last_response_disposition
+             FROM addie_fixed_trace_component_smoke_attempts
+            WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal <= $3 FOR UPDATE`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.finalInvocationOrdinal],
+        );
+        const row = evidence.rows[0];
+        const count = row ? pgSafeInt(row.count, 2) : null;
+        if (count !== parsed.finalInvocationOrdinal || row?.open === true
+          || (parsed.status === 'provider_completed' && (row?.failures === true || row?.last_response_disposition !== 'final_response'))
+          || (parsed.status === 'provider_failed' && row?.failures !== true)) return result('refused', 'intent_required');
+        const updated = await client.query(
+          `UPDATE addie_fixed_trace_component_smoke_run_plan
+              SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = $4
+            WHERE authorization_digest = $1 AND assignment_id = $2 AND assignment_outcome IS NULL`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.status, parsed.finalInvocationOrdinal],
         );
         return updated.rowCount === 1 ? result('recorded') : result('refused', 'plan_mismatch');
       });
@@ -447,7 +550,7 @@ function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null 
   try {
     const object = snapshotFixedTraceJson(value, 'provider terminal') as Record<string, unknown>;
     const statuses = new Set(['succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage']);
-    if (!exactKeys(object, ['attemptId', 'reservation', 'responseHmac', 'returnedIdentity', 'status', 'usage']) || !exactReservation(object.reservation)
+    if (!exactKeys(object, ['attemptId', 'reservation', 'responseDisposition', 'responseHmac', 'returnedIdentity', 'status', 'usage']) || !exactReservation(object.reservation)
       || typeof object.attemptId !== 'string' || !ATTEMPT_ID.test(object.attemptId) || typeof object.status !== 'string' || !statuses.has(object.status)) return null;
     const usageIsExact = object.usage !== null && typeof object.usage === 'object'
       && exactKeys(object.usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])
@@ -461,6 +564,8 @@ function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null 
     const responseBearing = object.status === 'succeeded' || object.status === 'provider_failed'
       || object.status === 'malformed_response' || object.status === 'identity_mismatch' || object.status === 'missing_usage';
     if (responseBearing && !isHash(object.responseHmac)) return null;
+    if (object.status === 'succeeded' && object.responseDisposition !== 'final_response' && object.responseDisposition !== 'tool_continuation_required') return null;
+    if (object.status !== 'succeeded' && object.responseDisposition !== null) return null;
     if (object.status === 'timeout_after_dispatch' && (object.usage !== null || object.responseHmac !== null || object.returnedIdentity !== null)) return null;
     if ((object.status === 'succeeded' || object.status === 'provider_failed' || object.status === 'identity_mismatch')
       && (!usageIsExact || !exactIdentity(object.returnedIdentity))) return null;
@@ -482,5 +587,21 @@ function parseNonDispatchTerminal(value: unknown): FixedTraceComponentSmokeNonDi
     if (!exactKeys(object, ['assignmentId', 'reservation', 'status']) || !exactReservation(object.reservation)
       || !isHash(object.assignmentId) || (object.status !== 'local_terminal' && object.status !== 'pre_dispatch_fault')) return null;
     return Object.freeze(object) as unknown as FixedTraceComponentSmokeNonDispatchTerminal;
+  } catch { return null; }
+}
+function parseNotExecutedAfterHalt(value: unknown): FixedTraceComponentSmokeNotExecutedAfterHalt | null {
+  try {
+    const object = snapshotFixedTraceJson(value, 'post-halt assignment omission') as Record<string, unknown>;
+    if (!exactKeys(object, ['assignmentId', 'reservation']) || !exactReservation(object.reservation) || !isHash(object.assignmentId)) return null;
+    return Object.freeze(object) as unknown as FixedTraceComponentSmokeNotExecutedAfterHalt;
+  } catch { return null; }
+}
+function parseProviderAssignmentTerminal(value: unknown): FixedTraceComponentSmokeProviderAssignmentTerminal | null {
+  try {
+    const object = snapshotFixedTraceJson(value, 'provider assignment terminal') as Record<string, unknown>;
+    if (!exactKeys(object, ['assignmentId', 'finalInvocationOrdinal', 'reservation', 'status']) || !exactReservation(object.reservation)
+      || !isHash(object.assignmentId) || !Number.isSafeInteger(object.finalInvocationOrdinal) || (object.finalInvocationOrdinal as number) < 1
+      || (object.status !== 'provider_completed' && object.status !== 'provider_failed')) return null;
+    return Object.freeze(object) as unknown as FixedTraceComponentSmokeProviderAssignmentTerminal;
   } catch { return null; }
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -284,23 +284,9 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         const expected = expectedPlanEntry(parsed.assignmentId);
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
           || expected.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
-        const unresolved = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1', [parsed.reservation.authorizationDigest]);
-        if (unresolved.rowCount !== 0) {
-          await this.closeOpenIntentsAsUnknownExposure(client, parsed.reservation);
-          return result('refused', 'unknown_exposure');
-        }
-        if (parsed.invocationOrdinal > 1) {
-          const predecessor = await client.query<{ status: string; response_disposition: string | null }>(
-            'SELECT status, response_disposition FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE',
-            [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal - 1],
-          );
-          if (predecessor.rowCount !== 1 || predecessor.rows[0]!.status !== 'succeeded'
-            || predecessor.rows[0]!.response_disposition !== 'tool_continuation_required') return result('refused', 'intent_required');
-        }
-        const duplicate = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1 FOR UPDATE', [parsed.attemptId]);
-        if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
-        const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
-        if (slot.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
+        // Do not reconcile here. This transaction owns the target plan row;
+        // standalone recovery deliberately acquires its complete target set
+        // before the authorization, so it must run only after this commits.
         const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
@@ -310,6 +296,18 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         // here: this transaction already owns a target plan row.
         const unresolvedAfterAuthorization = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1', [parsed.reservation.authorizationDigest]);
         if (unresolvedAfterAuthorization.rowCount !== 0) { recoverUnresolvedIntent = true; return result('recorded'); }
+        if (parsed.invocationOrdinal > 1) {
+          const predecessor = await client.query<{ status: string; response_disposition: string | null }>(
+            'SELECT status, response_disposition FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3',
+            [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal - 1],
+          );
+          if (predecessor.rowCount !== 1 || predecessor.rows[0]!.status !== 'succeeded'
+            || predecessor.rows[0]!.response_disposition !== 'tool_continuation_required') return result('refused', 'intent_required');
+        }
+        const duplicate = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [parsed.attemptId]);
+        if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
+        const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
+        if (slot.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
         await client.query(
           `INSERT INTO addie_fixed_trace_component_smoke_attempts
            (attempt_id, authorization_digest, assignment_id, invocation_ordinal, status, prepared_request_hmac)
@@ -319,8 +317,13 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         return result('recorded');
       });
       if (!recoverUnresolvedIntent) return outcome;
-      await this.recordUnknownExposure(parsed.reservation);
-      return result('refused', 'unknown_exposure');
+      const recovery = await this.recordUnknownExposure(parsed.reservation);
+      // A caller may only treat this as durable poisoning after standalone
+      // recovery commits. A failed recovery leaves the prior open intent and
+      // authorization state intact, so report uncertainty rather than a lie.
+      return recovery.status === 'recorded'
+        ? result('refused', 'unknown_exposure')
+        : result('refused', 'persistence_uncertain');
     } catch { return result('refused', 'persistence_uncertain'); }
   }
 
@@ -369,17 +372,17 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         // The target attempt is locked before the authorization above. Every
         // direct terminal trigger follows that order, so the authorization
         // serializes settlements; never broad-lock peer attempts afterwards.
+        const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         const prior = await client.query<{ spent: unknown }>(
           `SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent
              FROM addie_fixed_trace_component_smoke_attempts
             WHERE authorization_digest = $1`,
           [parsed.reservation.authorizationDigest],
         );
-        const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
-        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
-        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
         const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
         const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
@@ -570,11 +573,13 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           [parsed.reservation.authorizationDigest, parsed.assignmentId],
         );
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)) return result('refused', 'plan_mismatch');
-        const started = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
-        if (started.rowCount !== 0) return result('refused', 'plan_mismatch');
         const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status !== 'halted' && auth.rows[0]!.status !== 'unknown_exposure') return result('refused', 'run_halted');
+        // The target plan row then authorization serialize this decision with
+        // every direct trigger. Do not broad-lock attempts after a target.
+        const started = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 LIMIT 1', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
+        if (started.rowCount !== 0) return result('refused', 'plan_mismatch');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
               SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp()
@@ -609,6 +614,11 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         const expected = expectedPlanEntry(parsed.assignmentId);
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected) || expected.disposition !== 'provider_dispatch'
           || parsed.finalInvocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status !== 'consumed' && !(auth.rows[0]!.status === 'unknown_exposure' && parsed.status === 'provider_failed')) return result('refused', auth.rows[0]!.status === 'unknown_exposure' ? 'unknown_exposure' : 'run_halted');
+        // Target plan then authorization is the universal ordinary-mutation
+        // order. This aggregate deliberately takes no peer-row locks.
         const evidence = await client.query<{ count: unknown; open: unknown; failures: unknown; last_response_disposition: unknown }>(
           `WITH assignment_attempts AS (
              SELECT status, response_disposition, invocation_ordinal
@@ -626,9 +636,6 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (count !== parsed.finalInvocationOrdinal || row?.open === true
           || (parsed.status === 'provider_completed' && (row?.failures === true || row?.last_response_disposition !== 'final_response'))
           || (parsed.status === 'provider_failed' && row?.failures !== true)) return result('refused', 'intent_required');
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status !== 'consumed' && !(auth.rows[0]!.status === 'unknown_exposure' && parsed.status === 'provider_failed')) return result('refused', auth.rows[0]!.status === 'unknown_exposure' ? 'unknown_exposure' : 'run_halted');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
               SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = $4

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -15,6 +15,11 @@ import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
  * It has no provider dependency and cannot dispatch anything.
  */
 export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LEDGER_IS_CONSTRUCTED = false as const;
+/** Domain prefixes that a later isolated runtime must use when HMACing evidence. */
+export const FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN =
+  'adcp:addie:fixed-trace-component-smoke:prepared-request:v1\0' as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN =
+  'adcp:addie:fixed-trace-component-smoke:provider-response:v1\0' as const;
 
 type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
 type Disposition = Admission['privateRuntimePlan'][number]['dispatchDisposition'];
@@ -99,6 +104,23 @@ function pgSafeInt(value: unknown, maximum: number): number | null {
 }
 function safeString(value: unknown, max: number): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= max && /^[a-z0-9._:-]+$/i.test(value);
+}
+function expectedPlanEntry(assignmentId: string): FixedTraceComponentSmokePlanEntry | null {
+  return fixedTraceComponentSmokePrivateLedgerPlan()?.find((entry) => entry.assignmentId === assignmentId) ?? null;
+}
+function pgPlanMatches(row: Record<string, unknown>, expected: FixedTraceComponentSmokePlanEntry): boolean {
+  const reservations = row.reserved_microdollars;
+  return row.probe_id === expected.probeId && row.cell_id === expected.cellId
+    && row.disposition === expected.disposition
+    && pgSafeInt(row.maximum_provider_invocations, 2) === expected.maximumProviderInvocations
+    && row.requested_provider === expected.provider && row.requested_model === expected.model
+    && row.requested_effort === expected.effort && row.pricing_profile_id === expected.pricingProfileId
+    && pgSafeInt(row.max_input_tokens, 1_000_000) === expected.maxInputTokens
+    && pgSafeInt(row.max_output_tokens, 1_000_000) === expected.maxOutputTokens
+    && pgSafeInt(row.timeout_ms, MAX_LATENCY_MS) === expected.timeoutMs
+    && pgSafeInt(row.retries, 0) === 0
+    && Array.isArray(reservations) && reservations.length === expected.reservedMicrodollars.length
+    && reservations.every((value, index) => pgSafeInt(value, 2_819_484) === expected.reservedMicrodollars[index]);
 }
 
 /** Derives, rather than accepts, the exact 168-entry admitted plan. */
@@ -238,9 +260,16 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
           return result('refused', 'unknown_exposure');
         }
-        const plan = await client.query<{ disposition: string; maximum_provider_invocations: number }>(
-          'SELECT disposition, maximum_provider_invocations FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
-        if (plan.rowCount !== 1 || plan.rows[0]!.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > plan.rows[0]!.maximum_provider_invocations) return result('refused', 'plan_mismatch');
+        const expected = expectedPlanEntry(parsed.assignmentId);
+        const plan = await client.query<Record<string, unknown>>(
+          `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
+                  requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
+                  reserved_microdollars
+             FROM addie_fixed_trace_component_smoke_run_plan
+            WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId]);
+        if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
+          || expected.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
         const duplicate = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1 FOR UPDATE', [parsed.attemptId]);
         if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
         const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
@@ -266,53 +295,88 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
-        const attempt = await client.query<{ status: string; invocation_ordinal: unknown; requested_provider: string; requested_model: string; requested_effort: string; pricing_profile_id: string; max_input_tokens: unknown; max_output_tokens: unknown; timeout_ms: unknown; reserved_microdollars: unknown[] }>(
-          `SELECT a.status, a.invocation_ordinal, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id, p.max_input_tokens, p.max_output_tokens, p.timeout_ms, p.reserved_microdollars
+        const attempt = await client.query<{ assignment_id: string; status: string; invocation_ordinal: unknown; probe_id: unknown; cell_id: unknown; disposition: unknown; maximum_provider_invocations: unknown; retries: unknown; requested_provider: string; requested_model: string; requested_effort: string; pricing_profile_id: string; max_input_tokens: unknown; max_output_tokens: unknown; timeout_ms: unknown; reserved_microdollars: unknown[] }>(
+          `SELECT a.assignment_id, a.status, a.invocation_ordinal, p.probe_id, p.cell_id, p.disposition, p.maximum_provider_invocations, p.retries,
+                  p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id, p.max_input_tokens, p.max_output_tokens, p.timeout_ms, p.reserved_microdollars
            FROM addie_fixed_trace_component_smoke_attempts a
            JOIN addie_fixed_trace_component_smoke_run_plan p ON p.authorization_digest = a.authorization_digest AND p.assignment_id = a.assignment_id
            WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
         if (attempt.rowCount !== 1 || attempt.rows[0]!.status !== 'intent_recorded') return result('refused', 'intent_required');
-        if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== attempt.rows[0]!.requested_provider
-          || parsed.returnedIdentity?.model !== attempt.rows[0]!.requested_model
-          || parsed.returnedIdentity?.effort !== attempt.rows[0]!.requested_effort)) return result('refused', 'plan_mismatch');
-        const ordinal = pgSafeInt(attempt.rows[0]!.invocation_ordinal, 2);
-        const maxInput = pgSafeInt(attempt.rows[0]!.max_input_tokens, 1_000_000);
-        const maxOutput = pgSafeInt(attempt.rows[0]!.max_output_tokens, 1_000_000);
-        const timeout = pgSafeInt(attempt.rows[0]!.timeout_ms, MAX_LATENCY_MS);
-        if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return result('refused', 'persistence_uncertain');
-        if (parsed.usage && (parsed.usage.inputTokens > maxInput || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return result('refused', 'cost_exhausted');
-        const reservedForOrdinal = pgSafeInt(attempt.rows[0]!.reserved_microdollars[ordinal - 1], 2_819_484);
-        const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === attempt.rows[0]!.pricing_profile_id);
+        const row = attempt.rows[0]!;
+        const expected = expectedPlanEntry(row.assignment_id);
+        if (!expected || !pgPlanMatches(row as unknown as Record<string, unknown>, expected)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
+        if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== row.requested_provider
+          || parsed.returnedIdentity?.model !== row.requested_model
+          || parsed.returnedIdentity?.effort !== row.requested_effort)) return this.settlePostIntentFailure(client, parsed, 'identity_mismatch', 'unknown_exposure');
+        const ordinal = pgSafeInt(row.invocation_ordinal, 2);
+        const maxInput = pgSafeInt(row.max_input_tokens, 1_000_000);
+        const maxOutput = pgSafeInt(row.max_output_tokens, 1_000_000);
+        const timeout = pgSafeInt(row.timeout_ms, MAX_LATENCY_MS);
+        if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
+        if (parsed.usage && (parsed.usage.inputTokens + parsed.usage.cacheReadTokens + parsed.usage.cacheWriteTokens > maxInput
+          || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted');
+        const reservedForOrdinal = pgSafeInt(row.reserved_microdollars[ordinal - 1], 2_819_484);
+        const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === row.pricing_profile_id);
+        if (parsed.usage && (!profile || profile.provider !== row.requested_provider || profile.model !== row.requested_model)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
         let spent = 0;
-        try { spent = parsed.usage && profile ? datedPricingCostMicros(profile, parsed.usage) : 0; } catch { return result('refused', 'plan_mismatch'); }
+        try { spent = parsed.usage ? datedPricingCostMicros(profile!, parsed.usage) : 0; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
         const prior = await client.query<{ spent: unknown }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
         const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
         const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
         const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
         if (reservedForOrdinal === null || spent > reservedForOrdinal || priorSpent === null || reservationLimit === null || providerLimit === null
           || priorSpent + spent > reservationLimit || priorSpent + spent > providerLimit) {
-          await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-          return result('refused', 'cost_exhausted');
+          return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'cost_exhausted');
         }
         await client.query(
           `UPDATE addie_fixed_trace_component_smoke_attempts
-           SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7, actual_cost_microdollars = $8, latency_ms = $9, response_hmac = $10, terminal_at = clock_timestamp()
+           SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7, actual_cost_microdollars = $8, latency_ms = $9, response_hmac = $10,
+               returned_provider = $11, returned_model = $12, returned_effort = $13, terminal_at = clock_timestamp()
            WHERE attempt_id = $1 AND authorization_digest = $2`,
           [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.status, parsed.usage?.inputTokens ?? null,
             parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null,
-            parsed.usage ? spent : null, parsed.usage?.latencyMs ?? null, parsed.responseHmac],
+            parsed.usage ? spent : null, parsed.usage?.latencyMs ?? null, parsed.responseHmac,
+            parsed.returnedIdentity?.provider ?? null, parsed.returnedIdentity?.model ?? null, parsed.returnedIdentity?.effort ?? null],
         );
         if (parsed.status !== 'succeeded') {
           await client.query(
             `UPDATE addie_fixed_trace_component_smoke_authorizations
              SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
              WHERE authorization_digest = $1 AND reservation_id = $3`,
-            [parsed.reservation.authorizationDigest, ['timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage'].includes(parsed.status) ? 'unknown_exposure' : 'halted', parsed.reservation.reservationId],
+            [parsed.reservation.authorizationDigest, 'unknown_exposure', parsed.reservation.reservationId],
           );
         }
         return result('recorded');
       });
     } catch { return result('refused', 'persistence_uncertain'); }
+  }
+
+  /** A committed intent is never left open on any later validation failure. */
+  private async settlePostIntentFailure(
+    client: PoolClient,
+    parsed: FixedTraceComponentSmokeTerminal,
+    terminalStatus: 'invalid_limits' | 'pricing_unavailable' | 'identity_mismatch',
+    authorizationStatus: 'halted' | 'unknown_exposure',
+    refusal: FixedTraceComponentSmokeLedgerRefusal = 'plan_mismatch',
+  ): Promise<Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
+    await client.query(
+      `UPDATE addie_fixed_trace_component_smoke_attempts
+          SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7,
+              actual_cost_microdollars = NULL, latency_ms = $8, response_hmac = $9, returned_provider = $10,
+              returned_model = $11, returned_effort = $12, terminal_at = clock_timestamp()
+        WHERE attempt_id = $1 AND authorization_digest = $2 AND status = 'intent_recorded'`,
+      [parsed.attemptId, parsed.reservation.authorizationDigest, terminalStatus, parsed.usage?.inputTokens ?? null,
+        parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null,
+        parsed.usage?.latencyMs ?? null, parsed.responseHmac, parsed.returnedIdentity?.provider ?? null,
+        parsed.returnedIdentity?.model ?? null, parsed.returnedIdentity?.effort ?? null],
+    );
+    await client.query(
+      `UPDATE addie_fixed_trace_component_smoke_authorizations
+          SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
+        WHERE authorization_digest = $1 AND reservation_id = $3`,
+      [parsed.reservation.authorizationDigest, authorizationStatus, parsed.reservation.reservationId],
+    );
+    return result('refused', refusal);
   }
 
   /** Must be called after every post-intent ambiguity; it permanently halts the run. */
@@ -338,6 +402,17 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        const expected = expectedPlanEntry(parsed.assignmentId);
+        const plan = await client.query<Record<string, unknown>>(
+          `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
+                  requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
+                  reserved_microdollars
+             FROM addie_fixed_trace_component_smoke_run_plan
+            WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
+          [parsed.reservation.authorizationDigest, parsed.assignmentId],
+        );
+        if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
+          || expected.disposition !== parsed.status) return result('refused', 'plan_mismatch');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
            SET non_dispatch_status = $3, non_dispatch_terminal_at = clock_timestamp()
@@ -374,13 +449,23 @@ function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null 
     const statuses = new Set(['succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage']);
     if (!exactKeys(object, ['attemptId', 'reservation', 'responseHmac', 'returnedIdentity', 'status', 'usage']) || !exactReservation(object.reservation)
       || typeof object.attemptId !== 'string' || !ATTEMPT_ID.test(object.attemptId) || typeof object.status !== 'string' || !statuses.has(object.status)) return null;
-    if (object.status === 'succeeded' && (object.usage === null || !isHash(object.responseHmac) || !exactIdentity(object.returnedIdentity))) return null;
-    if (object.status !== 'succeeded' && (object.responseHmac !== null || object.returnedIdentity !== null)) return null;
-    if (object.usage === null) return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
-    if (!object.usage || typeof object.usage !== 'object' || !exactKeys(object.usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
-    const usage = object.usage as Record<string, unknown>;
-    if (![usage.inputTokens, usage.outputTokens, usage.cacheReadTokens, usage.cacheWriteTokens, usage.latencyMs].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)
-      || (usage.latencyMs as number) > MAX_LATENCY_MS) return null;
+    const usageIsExact = object.usage !== null && typeof object.usage === 'object'
+      && exactKeys(object.usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])
+      && [
+        (object.usage as Record<string, unknown>).inputTokens, (object.usage as Record<string, unknown>).outputTokens,
+        (object.usage as Record<string, unknown>).cacheReadTokens, (object.usage as Record<string, unknown>).cacheWriteTokens,
+        (object.usage as Record<string, unknown>).latencyMs,
+      ].every((entry, index) => Number.isSafeInteger(entry) && (entry as number) >= 0
+        && (index === 4 ? (entry as number) <= MAX_LATENCY_MS : (entry as number) <= 1_000_000))
+      && ((object.usage as Record<string, unknown>).latencyMs as number) <= MAX_LATENCY_MS;
+    const responseBearing = object.status === 'succeeded' || object.status === 'provider_failed'
+      || object.status === 'malformed_response' || object.status === 'identity_mismatch' || object.status === 'missing_usage';
+    if (responseBearing && !isHash(object.responseHmac)) return null;
+    if (object.status === 'timeout_after_dispatch' && (object.usage !== null || object.responseHmac !== null || object.returnedIdentity !== null)) return null;
+    if ((object.status === 'succeeded' || object.status === 'provider_failed' || object.status === 'identity_mismatch')
+      && (!usageIsExact || !exactIdentity(object.returnedIdentity))) return null;
+    if (object.status === 'malformed_response' && (object.usage !== null || object.returnedIdentity !== null)) return null;
+    if (object.status === 'missing_usage' && (object.usage !== null || !exactIdentity(object.returnedIdentity))) return null;
     return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
   } catch { return null; }
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -211,6 +211,18 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     } finally { client.release(); }
   }
 
+  /**
+   * Every ordinary plan-outcome writer takes this table gate before a target
+   * plan row. PostgreSQL direct UPDATE already takes ROW EXCLUSIVE before its
+   * row locks; matching it here prevents a ROW SHARE -> ROW EXCLUSIVE upgrade
+   * after an authorization lock while standalone recovery is waiting on that
+   * target. Recovery instead takes SHARE ROW EXCLUSIVE first, then its full
+   * deterministic plan set, attempts, and authorization.
+   */
+  private async lockPlanOutcomeWriter(client: PoolClient): Promise<void> {
+    await client.query('LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN ROW EXCLUSIVE MODE');
+  }
+
   async reserveAndConsume(grant: FixedTraceComponentSmokeVerifiedGrant): Promise<Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
     const plan = fixedTraceComponentSmokePrivateLedgerPlan();
     const signatureDigest = fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(grant);
@@ -537,6 +549,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     try {
       return await this.transaction(async (client) => {
         const expected = expectedPlanEntry(parsed.assignmentId);
+        await this.lockPlanOutcomeWriter(client);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
@@ -573,6 +586,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     try {
       return await this.transaction(async (client) => {
         const expected = expectedPlanEntry(parsed.assignmentId);
+        await this.lockPlanOutcomeWriter(client);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
@@ -612,6 +626,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
+        await this.lockPlanOutcomeWriter(client);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -432,12 +432,18 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
    * usage, identity, response HMAC, or cost.
    */
   private async closeOpenIntentsAsUnknownExposure(client: PoolClient, reservation: FixedTraceComponentSmokeReservation): Promise<boolean> {
-    const changed = await client.query(
+    const authorization = await client.query<{ status: string }>(
+      `SELECT status FROM addie_fixed_trace_component_smoke_authorizations
+        WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE`,
+      [reservation.authorizationDigest, reservation.reservationId],
+    );
+    if (authorization.rowCount !== 1
+      || (authorization.rows[0]!.status !== 'consumed' && authorization.rows[0]!.status !== 'unknown_exposure')) return false;
+    if (authorization.rows[0]!.status === 'consumed') await client.query(
       `UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp()
        WHERE authorization_digest = $1 AND reservation_id = $2 AND status = 'consumed'`,
       [reservation.authorizationDigest, reservation.reservationId],
     );
-    if (changed.rowCount !== 1) return false;
     await client.query(
       `UPDATE addie_fixed_trace_component_smoke_attempts
           SET status = 'unknown_exposure', response_disposition = NULL, response_hmac = NULL,

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { Pool, PoolClient } from 'pg';
 import { fixedTraceComponentSmokeAdmission } from './fixed-trace-component-smoke-admission.js';
 import {
+  fixedTraceComponentSmokeVerifiedGrantSignatureForLedger,
   isFixedTraceComponentSmokeVerifiedGrant,
   type FixedTraceComponentSmokeVerifiedGrant,
 } from './fixed-trace-component-smoke-private-authorization.js';
@@ -19,7 +20,7 @@ type Disposition = Admission['privateRuntimePlan'][number]['dispatchDisposition'
 export type FixedTraceComponentSmokeLedgerRefusal =
   | 'grant_not_active' | 'grant_already_consumed' | 'admission_drift'
   | 'unknown_exposure' | 'run_halted' | 'duplicate_attempt_id' | 'intent_required'
-  | 'plan_mismatch' | 'persistence_uncertain';
+  | 'plan_mismatch' | 'cost_exhausted' | 'persistence_uncertain';
 
 export interface FixedTraceComponentSmokeReservation {
   readonly reservationId: string;
@@ -125,11 +126,15 @@ export function fixedTraceComponentSmokePrivateLedgerPlan(): readonly FixedTrace
     .every((entry) => entry.maximumProviderInvocations === 0 && entry.reservedMicrodollars.length === 0);
   return plan.length === 168 && new Set(plan.map((entry) => entry.assignmentId)).size === 168
     && dispatch.length === 126 && dispatch.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0) === 192
-    && total === 2_819_484 && nonDispatchValid ? Object.freeze(plan) : null;
+    && total === 2_819_484 && plan.every((entry) => entry.reservedMicrodollars.every((micros) => Number.isSafeInteger(micros) && micros > 0 && micros <= 2_819_484))
+    && nonDispatchValid ? Object.freeze(plan) : null;
 }
 
+function reservationIdForAuthorizationDigest(authorizationDigest: string): string {
+  return `reservation_${sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0', authorizationDigest }).slice(0, 32)}`;
+}
 function reservationFor(grant: FixedTraceComponentSmokeVerifiedGrant): FixedTraceComponentSmokeReservation {
-  return Object.freeze({ reservationId: `reservation_${sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0', authorizationDigest: grant.grantDigest }).slice(0, 32)}`,
+  return Object.freeze({ reservationId: reservationIdForAuthorizationDigest(grant.grantDigest),
     authorizationDigest: grant.grantDigest, entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 });
 }
 function result(status: 'reserved', reservation: FixedTraceComponentSmokeReservation): Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }>;
@@ -160,7 +165,8 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
 
   async reserveAndConsume(grant: FixedTraceComponentSmokeVerifiedGrant): Promise<Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
     const plan = fixedTraceComponentSmokePrivateLedgerPlan();
-    if (!plan || !isFixedTraceComponentSmokeVerifiedGrant(grant) || !isHash(grant.grantDigest) || !isHash(grant.signedPayloadDigest) || !isHash(grant.payload.nonceCommitment)) return result('refused', 'admission_drift');
+    const signature = fixedTraceComponentSmokeVerifiedGrantSignatureForLedger(grant);
+    if (!plan || !isFixedTraceComponentSmokeVerifiedGrant(grant) || !signature || !isHash(grant.grantDigest) || !isHash(grant.signedPayloadDigest) || !isHash(grant.payload.nonceCommitment)) return result('refused', 'admission_drift');
     const reservation = reservationFor(grant);
     try {
       return await this.transaction(async (client) => {
@@ -176,7 +182,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
            WHERE $24::timestamptz <= clock_timestamp() AND $25::timestamptz > clock_timestamp()
            ON CONFLICT (authorization_digest) DO NOTHING
            RETURNING authorization_digest`,
-          [grant.grantDigest, grant.signedPayloadDigest, grant.signature, grant.payload.kid, grant.payload.nonceCommitment,
+          [grant.grantDigest, grant.signedPayloadDigest, signature, grant.payload.kid, grant.payload.nonceCommitment,
             grant.payload.grantVersion, grant.payload.stageId, grant.payload.admissionVersion, grant.payload.aggregateAdmissionFingerprint,
             grant.payload.cardinality.probes, grant.payload.cardinality.routerCells, grant.payload.cardinality.generationCells,
             grant.payload.cardinality.totalCells, grant.payload.cardinality.repetitions, grant.payload.cardinality.caseCellAssignments,
@@ -215,7 +221,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
@@ -243,13 +249,13 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        const auth = await client.query<{ status: string; reservation_microdollars: number; provider_ceiling_microdollars: number }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
-        const attempt = await client.query<{ status: string; requested_provider: string; requested_model: string; requested_effort: string }>(
-          `SELECT a.status, p.requested_provider, p.requested_model, p.requested_effort
+        const attempt = await client.query<{ status: string; invocation_ordinal: number; requested_provider: string; requested_model: string; requested_effort: string; reserved_microdollars: number[] }>(
+          `SELECT a.status, a.invocation_ordinal, p.requested_provider, p.requested_model, p.requested_effort, p.reserved_microdollars
            FROM addie_fixed_trace_component_smoke_attempts a
            JOIN addie_fixed_trace_component_smoke_run_plan p ON p.authorization_digest = a.authorization_digest AND p.assignment_id = a.assignment_id
            WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
@@ -257,6 +263,16 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== attempt.rows[0]!.requested_provider
           || parsed.returnedIdentity?.model !== attempt.rows[0]!.requested_model
           || parsed.returnedIdentity?.effort !== attempt.rows[0]!.requested_effort)) return result('refused', 'plan_mismatch');
+        const reservedForOrdinal = attempt.rows[0]!.reserved_microdollars[attempt.rows[0]!.invocation_ordinal - 1];
+        const spent = parsed.usage?.costMicrodollars ?? 0;
+        const prior = await client.query<{ spent: number }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
+        if (!Number.isSafeInteger(reservedForOrdinal) || spent > reservedForOrdinal
+          || prior.rowCount !== 1 || !Number.isSafeInteger(prior.rows[0]!.spent)
+          || prior.rows[0]!.spent + spent > auth.rows[0]!.reservation_microdollars
+          || prior.rows[0]!.spent + spent > auth.rows[0]!.provider_ceiling_microdollars) {
+          await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+          return result('refused', 'cost_exhausted');
+        }
         await client.query(
           `UPDATE addie_fixed_trace_component_smoke_attempts
            SET status = $3, input_tokens = $4, output_tokens = $5, actual_cost_microdollars = $6, latency_ms = $7, response_hmac = $8, terminal_at = clock_timestamp()
@@ -284,7 +300,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
       return await this.transaction(async (client) => {
         const changed = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp()
-           WHERE authorization_digest = $1 AND status = 'consumed'`, [reservation.authorizationDigest]);
+           WHERE authorization_digest = $1 AND reservation_id = $2 AND status = 'consumed'`, [reservation.authorizationDigest, reservation.reservationId]);
         return changed.rowCount === 1 ? result('recorded') : result('refused', 'unknown_exposure');
       });
     } catch { return result('refused', 'persistence_uncertain'); }
@@ -296,7 +312,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
@@ -317,7 +333,8 @@ function exactReservation(value: unknown): value is FixedTraceComponentSmokeRese
     const object = snapshotFixedTraceJson(value, 'private ledger reservation') as Record<string, unknown>;
     return exactKeys(object, ['authorizationDigest', 'entryCount', 'providerDispatchEntryCount', 'reservationId', 'reservationMicrodollars'])
       && typeof object.reservationId === 'string' && /^reservation_[a-f0-9]{32}$/.test(object.reservationId)
-      && isHash(object.authorizationDigest) && object.entryCount === 168 && object.providerDispatchEntryCount === 126 && object.reservationMicrodollars === 2_819_484;
+      && isHash(object.authorizationDigest) && object.reservationId === reservationIdForAuthorizationDigest(object.authorizationDigest)
+      && object.entryCount === 168 && object.providerDispatchEntryCount === 126 && object.reservationMicrodollars === 2_819_484;
   } catch { return false; }
 }
 function parseProviderIntent(value: unknown): FixedTraceComponentSmokeProviderIntent | null {
@@ -341,7 +358,7 @@ function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null 
     if (!object.usage || typeof object.usage !== 'object' || !exactKeys(object.usage, ['costMicrodollars', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
     const usage = object.usage as Record<string, unknown>;
     if (![usage.inputTokens, usage.outputTokens, usage.costMicrodollars, usage.latencyMs].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)
-      || (usage.latencyMs as number) > MAX_LATENCY_MS || (usage.costMicrodollars as number) > 2_819_484) return null;
+      || (usage.latencyMs as number) > MAX_LATENCY_MS || (usage.costMicrodollars as number) > 5_000_000) return null;
     return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
   } catch { return null; }
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -353,9 +353,26 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         // A complete receipt remains accounting evidence even if it breaches a
         // pinned input/output/timeout limit. Never replace known exposure with
         // NULL merely because this one-shot run must halt.
-        if (parsed.usage && (parsed.usage.inputTokens + parsed.usage.cacheReadTokens + parsed.usage.cacheWriteTokens > maxInput
+        const additiveCacheOverLimit = parsed.usage !== null && profile !== undefined && (
+          (profile.cacheReadAccounting === 'additive' && parsed.usage.cacheReadTokens > maxInput)
+          || (profile.cacheWriteAccounting === 'additive' && parsed.usage.cacheWriteTokens > maxInput)
+        );
+        if (parsed.usage && (parsed.usage.inputTokens > maxInput || additiveCacheOverLimit
           || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
-        const prior = await client.query<{ spent: unknown }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
+        // PostgreSQL forbids FOR UPDATE directly on an aggregate. Lock the
+        // contributing rows first; the authorization row above serializes all
+        // settlements, and this preserves a real checked-out-client boundary.
+        const prior = await client.query<{ spent: unknown }>(
+          `WITH locked_attempts AS (
+             SELECT actual_cost_microdollars
+               FROM addie_fixed_trace_component_smoke_attempts
+              WHERE authorization_digest = $1
+              FOR UPDATE
+           )
+           SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent
+             FROM locked_attempts`,
+          [parsed.reservation.authorizationDigest],
+        );
         const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
         const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
         const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
@@ -377,7 +394,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           await client.query(
             `UPDATE addie_fixed_trace_component_smoke_authorizations
              SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
-             WHERE authorization_digest = $1 AND reservation_id = $3`,
+             WHERE authorization_digest = $1 AND reservation_id = $3 AND status = 'consumed'`,
             [parsed.reservation.authorizationDigest, 'unknown_exposure', parsed.reservation.reservationId],
           );
         }
@@ -409,7 +426,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     await client.query(
       `UPDATE addie_fixed_trace_component_smoke_authorizations
           SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
-        WHERE authorization_digest = $1 AND reservation_id = $3`,
+        WHERE authorization_digest = $1 AND reservation_id = $3 AND status = 'consumed'`,
       [parsed.reservation.authorizationDigest, authorizationStatus, parsed.reservation.reservationId],
     );
     return result('refused', refusal);

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto';
 import type { Pool, PoolClient } from 'pg';
 import { fixedTraceComponentSmokeAdmission } from './fixed-trace-component-smoke-admission.js';
+import { datedPricingCostMicros, datedPricingProfilesForFixedTrace } from './dated-pricing-cohort.js';
 import {
-  fixedTraceComponentSmokeVerifiedGrantSignatureForLedger,
+  fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger,
   isFixedTraceComponentSmokeVerifiedGrant,
   type FixedTraceComponentSmokeVerifiedGrant,
 } from './fixed-trace-component-smoke-private-authorization.js';
@@ -57,7 +58,7 @@ export interface FixedTraceComponentSmokeTerminal {
   readonly reservation: FixedTraceComponentSmokeReservation;
   readonly attemptId: string;
   readonly status: 'succeeded' | 'provider_failed' | 'timeout_after_dispatch' | 'malformed_response' | 'identity_mismatch' | 'missing_usage';
-  readonly usage: Readonly<{ inputTokens: number; outputTokens: number; costMicrodollars: number; latencyMs: number }> | null;
+  readonly usage: Readonly<{ inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; latencyMs: number }> | null;
   readonly returnedIdentity: Readonly<{ provider: string; model: string; effort: string }> | null;
   readonly responseHmac: string | null;
 }
@@ -90,6 +91,12 @@ function exactKeys(value: object, keys: readonly string[]): boolean {
   return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
 }
 function isHash(value: unknown): value is string { return typeof value === 'string' && HEX.test(value); }
+function pgSafeInt(value: unknown, maximum: number): number | null {
+  if (typeof value === 'number') return Number.isSafeInteger(value) && value >= 0 && value <= maximum ? value : null;
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed <= maximum ? parsed : null;
+}
 function safeString(value: unknown, max: number): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= max && /^[a-z0-9._:-]+$/i.test(value);
 }
@@ -165,14 +172,14 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
 
   async reserveAndConsume(grant: FixedTraceComponentSmokeVerifiedGrant): Promise<Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Readonly<{ status: 'refused'; reason: FixedTraceComponentSmokeLedgerRefusal }>> {
     const plan = fixedTraceComponentSmokePrivateLedgerPlan();
-    const signature = fixedTraceComponentSmokeVerifiedGrantSignatureForLedger(grant);
-    if (!plan || !isFixedTraceComponentSmokeVerifiedGrant(grant) || !signature || !isHash(grant.grantDigest) || !isHash(grant.signedPayloadDigest) || !isHash(grant.payload.nonceCommitment)) return result('refused', 'admission_drift');
+    const signatureDigest = fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(grant);
+    if (!plan || !isFixedTraceComponentSmokeVerifiedGrant(grant) || !signatureDigest || !isHash(grant.grantDigest) || !isHash(grant.signedPayloadDigest) || !isHash(grant.payload.nonceCommitment)) return result('refused', 'admission_drift');
     const reservation = reservationFor(grant);
     try {
       return await this.transaction(async (client) => {
         const inserted = await client.query<{ authorization_digest: string }>(
           `INSERT INTO addie_fixed_trace_component_smoke_authorizations (
-             authorization_digest, signed_payload_digest, signature, kid, nonce_commitment, grant_version,
+             authorization_digest, signed_payload_digest, signature_digest, kid, nonce_commitment, grant_version,
              stage_id, admission_version, aggregate_admission_fingerprint, probes, router_cells, generation_cells, total_cells, repetitions, assignments,
              provider_dispatch_assignments, local_terminal_assignments, pre_dispatch_fault_assignments,
              maximum_planned_invocation_slots, maximum_provider_invocations, reservation_microdollars, provider_ceiling_microdollars,
@@ -182,7 +189,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
            WHERE $24::timestamptz <= clock_timestamp() AND $25::timestamptz > clock_timestamp()
            ON CONFLICT (authorization_digest) DO NOTHING
            RETURNING authorization_digest`,
-          [grant.grantDigest, grant.signedPayloadDigest, signature, grant.payload.kid, grant.payload.nonceCommitment,
+          [grant.grantDigest, grant.signedPayloadDigest, signatureDigest, grant.payload.kid, grant.payload.nonceCommitment,
             grant.payload.grantVersion, grant.payload.stageId, grant.payload.admissionVersion, grant.payload.aggregateAdmissionFingerprint,
             grant.payload.cardinality.probes, grant.payload.cardinality.routerCells, grant.payload.cardinality.generationCells,
             grant.payload.cardinality.totalCells, grant.payload.cardinality.repetitions, grant.payload.cardinality.caseCellAssignments,
@@ -226,6 +233,11 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
+        const unresolved = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
+        if (unresolved.rowCount !== 0) {
+          await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+          return result('refused', 'unknown_exposure');
+        }
         const plan = await client.query<{ disposition: string; maximum_provider_invocations: number }>(
           'SELECT disposition, maximum_provider_invocations FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
         if (plan.rowCount !== 1 || plan.rows[0]!.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > plan.rows[0]!.maximum_provider_invocations) return result('refused', 'plan_mismatch');
@@ -249,13 +261,13 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string; reservation_microdollars: number; provider_ceiling_microdollars: number }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
         if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
         if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
-        const attempt = await client.query<{ status: string; invocation_ordinal: number; requested_provider: string; requested_model: string; requested_effort: string; reserved_microdollars: number[] }>(
-          `SELECT a.status, a.invocation_ordinal, p.requested_provider, p.requested_model, p.requested_effort, p.reserved_microdollars
+        const attempt = await client.query<{ status: string; invocation_ordinal: unknown; requested_provider: string; requested_model: string; requested_effort: string; pricing_profile_id: string; max_input_tokens: unknown; max_output_tokens: unknown; timeout_ms: unknown; reserved_microdollars: unknown[] }>(
+          `SELECT a.status, a.invocation_ordinal, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id, p.max_input_tokens, p.max_output_tokens, p.timeout_ms, p.reserved_microdollars
            FROM addie_fixed_trace_component_smoke_attempts a
            JOIN addie_fixed_trace_component_smoke_run_plan p ON p.authorization_digest = a.authorization_digest AND p.assignment_id = a.assignment_id
            WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
@@ -263,29 +275,39 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (parsed.status === 'succeeded' && (parsed.returnedIdentity?.provider !== attempt.rows[0]!.requested_provider
           || parsed.returnedIdentity?.model !== attempt.rows[0]!.requested_model
           || parsed.returnedIdentity?.effort !== attempt.rows[0]!.requested_effort)) return result('refused', 'plan_mismatch');
-        const reservedForOrdinal = attempt.rows[0]!.reserved_microdollars[attempt.rows[0]!.invocation_ordinal - 1];
-        const spent = parsed.usage?.costMicrodollars ?? 0;
-        const prior = await client.query<{ spent: number }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
-        if (!Number.isSafeInteger(reservedForOrdinal) || spent > reservedForOrdinal
-          || prior.rowCount !== 1 || !Number.isSafeInteger(prior.rows[0]!.spent)
-          || prior.rows[0]!.spent + spent > auth.rows[0]!.reservation_microdollars
-          || prior.rows[0]!.spent + spent > auth.rows[0]!.provider_ceiling_microdollars) {
+        const ordinal = pgSafeInt(attempt.rows[0]!.invocation_ordinal, 2);
+        const maxInput = pgSafeInt(attempt.rows[0]!.max_input_tokens, 1_000_000);
+        const maxOutput = pgSafeInt(attempt.rows[0]!.max_output_tokens, 1_000_000);
+        const timeout = pgSafeInt(attempt.rows[0]!.timeout_ms, MAX_LATENCY_MS);
+        if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return result('refused', 'persistence_uncertain');
+        if (parsed.usage && (parsed.usage.inputTokens > maxInput || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return result('refused', 'cost_exhausted');
+        const reservedForOrdinal = pgSafeInt(attempt.rows[0]!.reserved_microdollars[ordinal - 1], 2_819_484);
+        const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === attempt.rows[0]!.pricing_profile_id);
+        let spent = 0;
+        try { spent = parsed.usage && profile ? datedPricingCostMicros(profile, parsed.usage) : 0; } catch { return result('refused', 'plan_mismatch'); }
+        const prior = await client.query<{ spent: unknown }>('SELECT COALESCE(SUM(actual_cost_microdollars), 0)::bigint AS spent FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [parsed.reservation.authorizationDigest]);
+        const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
+        const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
+        const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
+        if (reservedForOrdinal === null || spent > reservedForOrdinal || priorSpent === null || reservationLimit === null || providerLimit === null
+          || priorSpent + spent > reservationLimit || priorSpent + spent > providerLimit) {
           await client.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1 AND reservation_id = $2", [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
           return result('refused', 'cost_exhausted');
         }
         await client.query(
           `UPDATE addie_fixed_trace_component_smoke_attempts
-           SET status = $3, input_tokens = $4, output_tokens = $5, actual_cost_microdollars = $6, latency_ms = $7, response_hmac = $8, terminal_at = clock_timestamp()
+           SET status = $3, input_tokens = $4, output_tokens = $5, cache_read_tokens = $6, cache_write_tokens = $7, actual_cost_microdollars = $8, latency_ms = $9, response_hmac = $10, terminal_at = clock_timestamp()
            WHERE attempt_id = $1 AND authorization_digest = $2`,
           [parsed.attemptId, parsed.reservation.authorizationDigest, parsed.status, parsed.usage?.inputTokens ?? null,
-            parsed.usage?.outputTokens ?? null, parsed.usage?.costMicrodollars ?? null, parsed.usage?.latencyMs ?? null, parsed.responseHmac],
+            parsed.usage?.outputTokens ?? null, parsed.usage?.cacheReadTokens ?? null, parsed.usage?.cacheWriteTokens ?? null,
+            parsed.usage ? spent : null, parsed.usage?.latencyMs ?? null, parsed.responseHmac],
         );
         if (parsed.status !== 'succeeded') {
           await client.query(
             `UPDATE addie_fixed_trace_component_smoke_authorizations
              SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
-             WHERE authorization_digest = $1`,
-            [parsed.reservation.authorizationDigest, parsed.status === 'timeout_after_dispatch' ? 'unknown_exposure' : 'halted'],
+             WHERE authorization_digest = $1 AND reservation_id = $3`,
+            [parsed.reservation.authorizationDigest, ['timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage'].includes(parsed.status) ? 'unknown_exposure' : 'halted', parsed.reservation.reservationId],
           );
         }
         return result('recorded');
@@ -355,10 +377,10 @@ function parseTerminal(value: unknown): FixedTraceComponentSmokeTerminal | null 
     if (object.status === 'succeeded' && (object.usage === null || !isHash(object.responseHmac) || !exactIdentity(object.returnedIdentity))) return null;
     if (object.status !== 'succeeded' && (object.responseHmac !== null || object.returnedIdentity !== null)) return null;
     if (object.usage === null) return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
-    if (!object.usage || typeof object.usage !== 'object' || !exactKeys(object.usage, ['costMicrodollars', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
+    if (!object.usage || typeof object.usage !== 'object' || !exactKeys(object.usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
     const usage = object.usage as Record<string, unknown>;
-    if (![usage.inputTokens, usage.outputTokens, usage.costMicrodollars, usage.latencyMs].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)
-      || (usage.latencyMs as number) > MAX_LATENCY_MS || (usage.costMicrodollars as number) > 5_000_000) return null;
+    if (![usage.inputTokens, usage.outputTokens, usage.cacheReadTokens, usage.cacheWriteTokens, usage.latencyMs].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)
+      || (usage.latencyMs as number) > MAX_LATENCY_MS) return null;
     return Object.freeze(object) as unknown as FixedTraceComponentSmokeTerminal;
   } catch { return null; }
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -269,17 +269,6 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
-        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
-        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
-        const unresolved = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest]);
-        if (unresolved.rowCount !== 0) {
-          await this.closeOpenIntentsAsUnknownExposure(client, parsed.reservation);
-          return result('refused', 'unknown_exposure');
-        }
-        const expected = expectedPlanEntry(parsed.assignmentId);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
@@ -287,8 +276,14 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
              FROM addie_fixed_trace_component_smoke_run_plan
             WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
           [parsed.reservation.authorizationDigest, parsed.assignmentId]);
+        const expected = expectedPlanEntry(parsed.assignmentId);
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
           || expected.disposition !== 'provider_dispatch' || parsed.invocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
+        const unresolved = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND status = \'intent_recorded\' LIMIT 1', [parsed.reservation.authorizationDigest]);
+        if (unresolved.rowCount !== 0) {
+          await this.closeOpenIntentsAsUnknownExposure(client, parsed.reservation);
+          return result('refused', 'unknown_exposure');
+        }
         if (parsed.invocationOrdinal > 1) {
           const predecessor = await client.query<{ status: string; response_disposition: string | null }>(
             'SELECT status, response_disposition FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE',
@@ -301,6 +296,11 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (duplicate.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
         const slot = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal = $3 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.invocationOrdinal]);
         if (slot.rowCount !== 0) return result('refused', 'duplicate_attempt_id');
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         await client.query(
           `INSERT INTO addie_fixed_trace_component_smoke_attempts
            (attempt_id, authorization_digest, assignment_id, invocation_ordinal, status, prepared_request_hmac)
@@ -317,17 +317,12 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
-        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
-        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         const attempt = await client.query<{ assignment_id: string; status: string; invocation_ordinal: unknown; probe_id: unknown; cell_id: unknown; disposition: unknown; maximum_provider_invocations: unknown; retries: unknown; requested_provider: string; requested_model: string; requested_effort: string; pricing_profile_id: string; max_input_tokens: unknown; max_output_tokens: unknown; timeout_ms: unknown; reserved_microdollars: unknown[] }>(
           `SELECT a.assignment_id, a.status, a.invocation_ordinal, p.probe_id, p.cell_id, p.disposition, p.maximum_provider_invocations, p.retries,
                   p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id, p.max_input_tokens, p.max_output_tokens, p.timeout_ms, p.reserved_microdollars
            FROM addie_fixed_trace_component_smoke_attempts a
            JOIN addie_fixed_trace_component_smoke_run_plan p ON p.authorization_digest = a.authorization_digest AND p.assignment_id = a.assignment_id
-           WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
+           WHERE a.attempt_id = $1 AND a.authorization_digest = $2 FOR UPDATE OF a`, [parsed.attemptId, parsed.reservation.authorizationDigest]);
         if (attempt.rowCount !== 1 || attempt.rows[0]!.status !== 'intent_recorded') return result('refused', 'intent_required');
         const row = attempt.rows[0]!;
         const expected = expectedPlanEntry(row.assignment_id);
@@ -373,6 +368,11 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
              FROM locked_attempts`,
           [parsed.reservation.authorizationDigest],
         );
+        const auth = await client.query<{ status: string; reservation_microdollars: unknown; provider_ceiling_microdollars: unknown }>('SELECT status, reservation_microdollars, provider_ceiling_microdollars FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
+        if (auth.rows[0]!.status !== 'consumed') return result('refused', 'admission_drift');
         const priorSpent = prior.rowCount === 1 ? pgSafeInt(prior.rows[0]!.spent, 5_000_000) : null;
         const reservationLimit = pgSafeInt(auth.rows[0]!.reservation_microdollars, 2_819_484);
         const providerLimit = pgSafeInt(auth.rows[0]!.provider_ceiling_microdollars, 5_000_000);
@@ -393,7 +393,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (parsed.status !== 'succeeded') {
           await client.query(
             `UPDATE addie_fixed_trace_component_smoke_authorizations
-             SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
+             SET status = $2::varchar, unknown_exposure_at = CASE WHEN $2::varchar = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
              WHERE authorization_digest = $1 AND reservation_id = $3 AND status = 'consumed'`,
             [parsed.reservation.authorizationDigest, 'unknown_exposure', parsed.reservation.reservationId],
           );
@@ -425,7 +425,7 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     );
     await client.query(
       `UPDATE addie_fixed_trace_component_smoke_authorizations
-          SET status = $2, unknown_exposure_at = CASE WHEN $2 = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
+          SET status = $2::varchar, unknown_exposure_at = CASE WHEN $2::varchar = 'unknown_exposure' THEN clock_timestamp() ELSE NULL END
         WHERE authorization_digest = $1 AND reservation_id = $3 AND status = 'consumed'`,
       [parsed.reservation.authorizationDigest, authorizationStatus, parsed.reservation.reservationId],
     );
@@ -446,9 +446,25 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
   /**
    * Turns every still-open committed intent into categorical ambiguity before
    * closing its corresponding assignment.  It records no invented receipt,
-   * usage, identity, response HMAC, or cost.
-   */
+  * usage, identity, response HMAC, or cost.
+  */
   private async closeOpenIntentsAsUnknownExposure(client: PoolClient, reservation: FixedTraceComponentSmokeReservation): Promise<boolean> {
+    // Direct attempt/plan mutations acquire their target row before the
+    // authorization in row triggers. Acquire all recovery targets first too;
+    // subsequent updates reuse these locks and cannot form auth->target cycles.
+    await client.query(
+      `SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts
+        WHERE authorization_digest = $1 FOR UPDATE`,
+      [reservation.authorizationDigest],
+    );
+    await client.query(
+      `SELECT p.assignment_id FROM addie_fixed_trace_component_smoke_run_plan AS p
+        WHERE p.authorization_digest = $1 AND p.assignment_outcome IS NULL
+          AND EXISTS (SELECT 1 FROM addie_fixed_trace_component_smoke_attempts a
+                       WHERE a.authorization_digest = p.authorization_digest AND a.assignment_id = p.assignment_id)
+        FOR UPDATE OF p`,
+      [reservation.authorizationDigest],
+    );
     const authorization = await client.query<{ status: string }>(
       `SELECT status FROM addie_fixed_trace_component_smoke_authorizations
         WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE`,
@@ -501,10 +517,6 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
-        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         const expected = expectedPlanEntry(parsed.assignmentId);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
@@ -516,6 +528,10 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         );
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)
           || expected.disposition !== parsed.status) return result('refused', 'plan_mismatch');
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status === 'unknown_exposure') return result('refused', 'unknown_exposure');
+        if (auth.rows[0]!.status === 'halted') return result('refused', 'run_halted');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
           SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp()
@@ -537,9 +553,6 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status !== 'halted' && auth.rows[0]!.status !== 'unknown_exposure') return result('refused', 'run_halted');
         const expected = expectedPlanEntry(parsed.assignmentId);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
@@ -552,6 +565,9 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected)) return result('refused', 'plan_mismatch');
         const started = await client.query('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1 AND assignment_id = $2 LIMIT 1 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.assignmentId]);
         if (started.rowCount !== 0) return result('refused', 'plan_mismatch');
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status !== 'halted' && auth.rows[0]!.status !== 'unknown_exposure') return result('refused', 'run_halted');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
               SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp()
@@ -575,9 +591,6 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     if (!parsed) return result('refused', 'plan_mismatch');
     try {
       return await this.transaction(async (client) => {
-        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
-        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        const expected = expectedPlanEntry(parsed.assignmentId);
         const plan = await client.query<Record<string, unknown>>(
           `SELECT probe_id, cell_id, disposition, maximum_provider_invocations, requested_provider, requested_model,
                   requested_effort, pricing_profile_id, max_input_tokens, max_output_tokens, timeout_ms, retries,
@@ -586,14 +599,20 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
             WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE`,
           [parsed.reservation.authorizationDigest, parsed.assignmentId],
         );
+        const expected = expectedPlanEntry(parsed.assignmentId);
         if (!expected || plan.rowCount !== 1 || !pgPlanMatches(plan.rows[0]!, expected) || expected.disposition !== 'provider_dispatch'
           || parsed.finalInvocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
         const evidence = await client.query<{ count: unknown; open: unknown; failures: unknown; last_response_disposition: unknown }>(
-          `SELECT count(*)::bigint AS count, bool_or(status = 'intent_recorded') AS open,
+          `WITH locked_attempts AS (
+             SELECT status, response_disposition, invocation_ordinal
+               FROM addie_fixed_trace_component_smoke_attempts
+              WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal <= $3
+              FOR UPDATE
+           )
+           SELECT count(*)::bigint AS count, bool_or(status = 'intent_recorded') AS open,
                   bool_or(status <> 'succeeded') AS failures,
                   (array_agg(response_disposition ORDER BY invocation_ordinal DESC))[1] AS last_response_disposition
-             FROM addie_fixed_trace_component_smoke_attempts
-            WHERE authorization_digest = $1 AND assignment_id = $2 AND invocation_ordinal <= $3 FOR UPDATE`,
+             FROM locked_attempts`,
           [parsed.reservation.authorizationDigest, parsed.assignmentId, parsed.finalInvocationOrdinal],
         );
         const row = evidence.rows[0];
@@ -601,6 +620,9 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (count !== parsed.finalInvocationOrdinal || row?.open === true
           || (parsed.status === 'provider_completed' && (row?.failures === true || row?.last_response_disposition !== 'final_response'))
           || (parsed.status === 'provider_failed' && row?.failures !== true)) return result('refused', 'intent_required');
+        const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
+        if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
+        if (auth.rows[0]!.status !== 'consumed' && !(auth.rows[0]!.status === 'unknown_exposure' && parsed.status === 'provider_failed')) return result('refused', auth.rows[0]!.status === 'unknown_exposure' ? 'unknown_exposure' : 'run_halted');
         const updated = await client.query(
           `UPDATE addie_fixed_trace_component_smoke_run_plan
               SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = $4

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -459,11 +459,18 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
   * usage, identity, response HMAC, or cost.
   */
   private async closeOpenIntentsAsUnknownExposure(client: PoolClient, reservation: FixedTraceComponentSmokeReservation): Promise<boolean> {
-    // Recovery has no single target. It first locks the complete immutable
-    // plan in assignment order, which is the insertion gate for both the
-    // application and the INSERT trigger. Only then can it snapshot every
-    // attempt safely: an intent that began earlier either committed before
-    // this point or holds a plan row we wait for; no later intent can appear.
+    // Recovery has no single target. First serialize against any direct plan
+    // writer *before* it can hold one plan row and the authorization then ask
+    // for another plan row. SHARE ROW EXCLUSIVE conflicts with UPDATE, so
+    // that writer either finishes before our snapshot or cannot acquire its
+    // first target. Attempt INSERT's RowShare table lock is compatible, but
+    // its target-row FOR UPDATE is gated by the complete row lock below.
+    await client.query('LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN SHARE ROW EXCLUSIVE MODE');
+    // Then lock the complete immutable plan in assignment order, which is the
+    // insertion gate for both the application and the INSERT trigger. Only
+    // then can it snapshot every attempt safely: an intent that began earlier
+    // either committed before this point or holds a plan row we waited for;
+    // no later intent can appear.
     // Terminal UPDATE deliberately remains attempt -> authorization and never
     // acquires a plan row, so it cannot invert this recovery order.
     await client.query(

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -403,13 +403,30 @@ BEGIN
   IF TG_OP = 'INSERT' AND NEW.status <> 'intent_recorded' THEN
     RAISE EXCEPTION 'a provider attempt must begin as an intent';
   END IF;
-  SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id,
-         p.max_input_tokens, p.max_output_tokens, p.timeout_ms,
-         p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
-    INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, pricing_profile,
-         max_input, max_output, timeout_limit, reserved, assignment_outcome
-    FROM addie_fixed_trace_component_smoke_run_plan AS p
-   WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
+  -- INSERT is the recovery insertion gate: it locks its one immutable plan
+  -- row before authorization. Standalone recovery locks the complete plan
+  -- set in the same assignment order before snapshotting attempts, so an
+  -- uncommitted/new intent cannot become a post-snapshot phantom. UPDATE is
+  -- intentionally attempt -> authorization only; do not add a plan lock and
+  -- recreate that inverse edge.
+  IF TG_OP = 'INSERT' THEN
+    SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id,
+           p.max_input_tokens, p.max_output_tokens, p.timeout_ms,
+           p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
+      INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, pricing_profile,
+           max_input, max_output, timeout_limit, reserved, assignment_outcome
+      FROM addie_fixed_trace_component_smoke_run_plan AS p
+     WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id
+       FOR UPDATE;
+  ELSE
+    SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id,
+           p.max_input_tokens, p.max_output_tokens, p.timeout_ms,
+           p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
+      INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, pricing_profile,
+           max_input, max_output, timeout_limit, reserved, assignment_outcome
+      FROM addie_fixed_trace_component_smoke_run_plan AS p
+     WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
+  END IF;
   IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
     RAISE EXCEPTION 'attempt is not an admitted provider-dispatch ordinal';
   END IF;

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -107,7 +107,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   CHECK (status <> 'malformed_response' OR returned_provider IS NULL),
   CHECK (status <> 'missing_usage' OR returned_provider IS NOT NULL),
   CHECK (status <> 'identity_mismatch' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
-  CHECK (status <> 'invalid_limits' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
+  CHECK (status <> 'invalid_limits' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NOT NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
   CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
   CHECK (status <> 'unknown_exposure' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
   CHECK (status NOT IN ('succeeded', 'provider_failed', 'malformed_response', 'identity_mismatch', 'missing_usage') OR response_hmac IS NOT NULL)
@@ -333,6 +333,53 @@ AFTER INSERT OR UPDATE OR DELETE ON addie_fixed_trace_component_smoke_run_plan
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_check_plan();
 
+-- The dated cohort has exactly four admitted profiles.  Keep the decimal
+-- arithmetic in integer microdollar numerators so PostgreSQL independently
+-- verifies the same one-time round-up as datedPricingCostMicros().  Cache
+-- categories are additive for Anthropic and mutually-exclusive subsets of
+-- input for OpenAI/Google; Google's cache writes are deliberately impossible.
+CREATE FUNCTION addie_fixed_trace_component_smoke_expected_cost(
+  p_profile_id TEXT, p_input INTEGER, p_output INTEGER, p_cache_read INTEGER, p_cache_write INTEGER
+) RETURNS BIGINT
+LANGUAGE plpgsql IMMUTABLE STRICT AS $$
+DECLARE
+  numerator NUMERIC;
+  denominator NUMERIC;
+BEGIN
+  IF p_input < 0 OR p_output < 0 OR p_cache_read < 0 OR p_cache_write < 0 THEN
+    RAISE EXCEPTION 'pricing usage cannot be negative';
+  END IF;
+  CASE p_profile_id
+    WHEN 'anthropic-standard-2026-09:claude-haiku-4-5' THEN
+      numerator := 100 * p_input + 500 * p_output + 10 * p_cache_read + 125 * p_cache_write; denominator := 100;
+    WHEN 'anthropic-standard-2026-09:claude-sonnet-5' THEN
+      numerator := 20 * p_input + 100 * p_output + 2 * p_cache_read + 25 * p_cache_write; denominator := 10;
+    WHEN 'openai-gpt-5.6-luna-standard-2026-09-05' THEN
+      IF p_cache_read + p_cache_write > p_input THEN RAISE EXCEPTION 'subset cache usage exceeds input'; END IF;
+      numerator := 20 * (p_input - p_cache_read - p_cache_write) + 120 * p_output + 2 * p_cache_read + 25 * p_cache_write; denominator := 100;
+    WHEN 'google-gemini-3.7-flash-through-2026-12-31' THEN
+      IF p_cache_write <> 0 OR p_cache_read > p_input THEN RAISE EXCEPTION 'Google cache usage is not admitted'; END IF;
+      numerator := 750 * (p_input - p_cache_read) + 3750 * p_output + 75 * p_cache_read; denominator := 1000;
+    ELSE RAISE EXCEPTION 'pricing profile is not admitted';
+  END CASE;
+  RETURN ceil(numerator / denominator)::BIGINT;
+END;
+$$;
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_usage_within_limits(
+  p_profile_id TEXT, p_input INTEGER, p_output INTEGER, p_cache_read INTEGER, p_cache_write INTEGER,
+  p_latency INTEGER, p_max_input INTEGER, p_max_output INTEGER, p_timeout INTEGER
+) RETURNS BOOLEAN
+LANGUAGE plpgsql IMMUTABLE STRICT AS $$
+BEGIN
+  IF p_input > p_max_input OR p_output > p_max_output OR p_latency > p_timeout THEN RETURN false; END IF;
+  IF p_profile_id IN ('anthropic-standard-2026-09:claude-haiku-4-5', 'anthropic-standard-2026-09:claude-sonnet-5') THEN
+    RETURN p_cache_read <= p_max_input AND p_cache_write <= p_max_input;
+  END IF;
+  RETURN true;
+END;
+$$;
+
 CREATE FUNCTION addie_fixed_trace_component_smoke_check_attempt() RETURNS trigger
 LANGUAGE plpgsql AS $$
 DECLARE
@@ -341,7 +388,12 @@ DECLARE
   requested_provider VARCHAR(32);
   requested_model VARCHAR(128);
   requested_effort VARCHAR(64);
+  pricing_profile VARCHAR(128);
+  max_input INTEGER;
+  max_output INTEGER;
+  timeout_limit INTEGER;
   reserved BIGINT;
+  expected_cost BIGINT;
   prior_spend BIGINT;
   reservation_limit BIGINT;
   provider_limit BIGINT;
@@ -351,9 +403,11 @@ BEGIN
   IF TG_OP = 'INSERT' AND NEW.status <> 'intent_recorded' THEN
     RAISE EXCEPTION 'a provider attempt must begin as an intent';
   END IF;
-  SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort,
+  SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort, p.pricing_profile_id,
+         p.max_input_tokens, p.max_output_tokens, p.timeout_ms,
          p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
-    INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, reserved, assignment_outcome
+    INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, pricing_profile,
+         max_input, max_output, timeout_limit, reserved, assignment_outcome
     FROM addie_fixed_trace_component_smoke_run_plan AS p
    WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
   IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
@@ -405,6 +459,21 @@ BEGIN
           OR NEW.returned_effort IS DISTINCT FROM requested_effort) THEN
     RAISE EXCEPTION 'actual cost requires admitted returned identity';
   END IF;
+  IF TG_OP = 'UPDATE' AND NEW.status = 'invalid_limits'
+     AND (NEW.returned_provider IS DISTINCT FROM requested_provider OR NEW.returned_model IS DISTINCT FROM requested_model
+          OR NEW.returned_effort IS DISTINCT FROM requested_effort) THEN
+    RAISE EXCEPTION 'observed limit cost requires admitted returned identity';
+  END IF;
+  IF TG_OP = 'UPDATE' AND (NEW.actual_cost_microdollars IS NOT NULL OR NEW.observed_cost_microdollars IS NOT NULL) THEN
+    expected_cost := addie_fixed_trace_component_smoke_expected_cost(pricing_profile, NEW.input_tokens, NEW.output_tokens,
+      NEW.cache_read_tokens, NEW.cache_write_tokens);
+    IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars <> expected_cost THEN
+      RAISE EXCEPTION 'attempt actual cost does not match admitted pricing';
+    END IF;
+    IF NEW.observed_cost_microdollars IS NOT NULL AND NEW.observed_cost_microdollars <> expected_cost THEN
+      RAISE EXCEPTION 'attempt observed cost does not match admitted pricing';
+    END IF;
+  END IF;
   IF TG_OP = 'UPDATE' AND NEW.status = 'succeeded' AND NEW.response_disposition = 'tool_continuation_required'
      AND NEW.invocation_ordinal = max_invocations THEN
     -- A continuation beyond the admitted slot cannot be dispatched.  Preserve
@@ -417,15 +486,36 @@ BEGIN
        SET status = 'halted'
      WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
   END IF;
-  IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
-    RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
+  IF TG_OP = 'UPDATE' AND NEW.status IN ('succeeded', 'provider_failed')
+     AND NOT addie_fixed_trace_component_smoke_usage_within_limits(pricing_profile, NEW.input_tokens, NEW.output_tokens,
+       NEW.cache_read_tokens, NEW.cache_write_tokens, NEW.latency_ms, max_input, max_output, timeout_limit) THEN
+    NEW.status := 'invalid_limits';
+    NEW.response_disposition := NULL;
+    NEW.observed_cost_microdollars := NEW.actual_cost_microdollars;
+    NEW.actual_cost_microdollars := NULL;
+    UPDATE addie_fixed_trace_component_smoke_authorizations
+       SET status = 'halted'
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
   END IF;
   SELECT COALESCE(sum(actual_cost_microdollars), 0) INTO prior_spend
     FROM addie_fixed_trace_component_smoke_attempts
    WHERE authorization_digest = NEW.authorization_digest AND attempt_id <> NEW.attempt_id;
-  IF prior_spend + COALESCE(NEW.actual_cost_microdollars, 0) > reservation_limit
-     OR prior_spend + COALESCE(NEW.actual_cost_microdollars, 0) > provider_limit THEN
-    RAISE EXCEPTION 'attempt cost exceeds fixed-trace aggregate limit';
+  IF NEW.actual_cost_microdollars IS NOT NULL AND (NEW.actual_cost_microdollars > reserved
+     OR prior_spend + NEW.actual_cost_microdollars > reservation_limit
+     OR prior_spend + NEW.actual_cost_microdollars > provider_limit) THEN
+    NEW.status := 'invalid_limits';
+    NEW.response_disposition := NULL;
+    NEW.observed_cost_microdollars := NEW.actual_cost_microdollars;
+    NEW.actual_cost_microdollars := NULL;
+    UPDATE addie_fixed_trace_component_smoke_authorizations
+       SET status = 'halted'
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.status NOT IN ('intent_recorded', 'succeeded') THEN
+    UPDATE addie_fixed_trace_component_smoke_authorizations
+       SET status = CASE WHEN NEW.status = 'invalid_limits' THEN 'halted' ELSE 'unknown_exposure' END,
+           unknown_exposure_at = CASE WHEN NEW.status = 'invalid_limits' THEN NULL ELSE clock_timestamp() END
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
   END IF;
   RETURN NEW;
 END;

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -34,6 +34,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_authorizations (
   unknown_exposure_at TIMESTAMPTZ,
   reservation_id VARCHAR(44) NOT NULL UNIQUE CHECK (reservation_id ~ '^reservation_[a-f0-9]{32}$'),
   CHECK (issued_at < expires_at),
+  CHECK (expires_at - issued_at <= interval '15 minutes'),
   CHECK (status = 'unknown_exposure' OR unknown_exposure_at IS NULL),
   CHECK (status <> 'unknown_exposure' OR unknown_exposure_at IS NOT NULL)
 );
@@ -69,9 +70,12 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   authorization_digest CHAR(64) NOT NULL,
   assignment_id CHAR(64) NOT NULL,
   invocation_ordinal SMALLINT NOT NULL CHECK (invocation_ordinal BETWEEN 1 AND 2),
-  status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage')),
+  status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage', 'invalid_limits', 'pricing_unavailable')),
   prepared_request_hmac CHAR(64) NOT NULL CHECK (prepared_request_hmac ~ '^[a-f0-9]{64}$'),
   response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
+  returned_provider VARCHAR(32) CHECK (returned_provider IS NULL OR length(returned_provider) BETWEEN 1 AND 32),
+  returned_model VARCHAR(128) CHECK (returned_model IS NULL OR length(returned_model) BETWEEN 1 AND 128),
+  returned_effort VARCHAR(64) CHECK (returned_effort IS NULL OR length(returned_effort) BETWEEN 1 AND 64),
   input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
   output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
   cache_read_tokens INTEGER CHECK (cache_read_tokens IS NULL OR cache_read_tokens >= 0),
@@ -83,8 +87,11 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   FOREIGN KEY (authorization_digest, assignment_id) REFERENCES addie_fixed_trace_component_smoke_run_plan(authorization_digest, assignment_id) ON DELETE RESTRICT,
   UNIQUE (authorization_digest, assignment_id, invocation_ordinal),
   CHECK ((status = 'intent_recorded') = (terminal_at IS NULL)),
+  CHECK ((returned_provider IS NULL) = (returned_model IS NULL) AND (returned_provider IS NULL) = (returned_effort IS NULL)),
   CHECK (status <> 'succeeded' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND actual_cost_microdollars IS NOT NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL)),
-  CHECK (status NOT IN ('malformed_response', 'identity_mismatch', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL))
+  CHECK (status NOT IN ('malformed_response', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
+  CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
+  CHECK (status NOT IN ('succeeded', 'provider_failed', 'malformed_response', 'identity_mismatch', 'missing_usage') OR response_hmac IS NOT NULL)
 );
 
 CREATE INDEX addie_fixed_trace_component_smoke_attempts_open_idx
@@ -95,28 +102,130 @@ CREATE INDEX addie_fixed_trace_component_smoke_attempts_open_idx
 -- deferred constraints make direct SQL writes obey the same fixed plan that
 -- the ledger derives: 168 assignments, 126 dispatch dispositions, 192 slots,
 -- and only positive per-slot reservations totaling 2,819,484 micros.
-CREATE FUNCTION addie_fixed_trace_component_smoke_check_plan() RETURNS trigger
+CREATE FUNCTION addie_fixed_trace_component_smoke_check_plan_group(p_authorization_digest CHAR(64)) RETURNS void
 LANGUAGE plpgsql AS $$
 DECLARE
   plan_count INTEGER;
   dispatch_count INTEGER;
+  local_count INTEGER;
+  pre_dispatch_count INTEGER;
   slots INTEGER;
   reserved BIGINT;
   invalid_reservation BOOLEAN;
 BEGIN
   SELECT count(*), count(*) FILTER (WHERE disposition = 'provider_dispatch'),
+         count(*) FILTER (WHERE disposition = 'local_terminal'), count(*) FILTER (WHERE disposition = 'pre_dispatch_fault'),
          COALESCE(sum(maximum_provider_invocations), 0),
          COALESCE(sum((SELECT sum(value) FROM unnest(reserved_microdollars) AS value)), 0),
          COALESCE(bool_or(EXISTS (SELECT 1 FROM unnest(reserved_microdollars) AS value WHERE value <= 0 OR value > 2819484)), false)
-    INTO plan_count, dispatch_count, slots, reserved, invalid_reservation
+   INTO plan_count, dispatch_count, local_count, pre_dispatch_count, slots, reserved, invalid_reservation
     FROM addie_fixed_trace_component_smoke_run_plan
-   WHERE authorization_digest = NEW.authorization_digest;
-  IF plan_count <> 168 OR dispatch_count <> 126 OR slots <> 192 OR reserved <> 2819484 OR invalid_reservation THEN
+   WHERE authorization_digest = p_authorization_digest;
+  IF plan_count <> 168 OR dispatch_count <> 126 OR local_count <> 21 OR pre_dispatch_count <> 21 OR slots <> 192 OR reserved <> 2819484 OR invalid_reservation THEN
     RAISE EXCEPTION 'fixed-trace component smoke plan is not the admitted exact plan';
+  END IF;
+END;
+$$;
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_check_plan() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM addie_fixed_trace_component_smoke_check_plan_group(COALESCE(NEW.authorization_digest, OLD.authorization_digest));
+  IF TG_OP = 'UPDATE' AND OLD.authorization_digest IS DISTINCT FROM NEW.authorization_digest THEN
+    PERFORM addie_fixed_trace_component_smoke_check_plan_group(OLD.authorization_digest);
   END IF;
   RETURN NULL;
 END;
 $$;
+
+-- Plan identity and limits are immutable after reservation.  Completing a
+-- non-dispatch row is the only permitted plan mutation.
+CREATE FUNCTION addie_fixed_trace_component_smoke_protect_plan() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'admitted plan rows are immutable';
+  END IF;
+  IF NEW.authorization_digest IS DISTINCT FROM OLD.authorization_digest OR NEW.assignment_id IS DISTINCT FROM OLD.assignment_id
+     OR NEW.probe_id IS DISTINCT FROM OLD.probe_id OR NEW.cell_id IS DISTINCT FROM OLD.cell_id
+     OR NEW.disposition IS DISTINCT FROM OLD.disposition OR NEW.maximum_provider_invocations IS DISTINCT FROM OLD.maximum_provider_invocations
+     OR NEW.requested_provider IS DISTINCT FROM OLD.requested_provider OR NEW.requested_model IS DISTINCT FROM OLD.requested_model
+     OR NEW.requested_effort IS DISTINCT FROM OLD.requested_effort OR NEW.pricing_profile_id IS DISTINCT FROM OLD.pricing_profile_id
+     OR NEW.max_input_tokens IS DISTINCT FROM OLD.max_input_tokens OR NEW.max_output_tokens IS DISTINCT FROM OLD.max_output_tokens
+     OR NEW.timeout_ms IS DISTINCT FROM OLD.timeout_ms OR NEW.retries IS DISTINCT FROM OLD.retries
+     OR NEW.reserved_microdollars IS DISTINCT FROM OLD.reserved_microdollars THEN
+    RAISE EXCEPTION 'admitted plan fields are immutable';
+  END IF;
+  IF OLD.non_dispatch_status IS NOT NULL OR NEW.non_dispatch_status IS NULL
+     OR NEW.non_dispatch_status <> OLD.disposition OR NEW.non_dispatch_terminal_at IS NULL THEN
+    RAISE EXCEPTION 'non-dispatch plan terminal is monotonic';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER addie_fixed_trace_component_smoke_plan_immutable
+BEFORE UPDATE OR DELETE ON addie_fixed_trace_component_smoke_run_plan
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_protect_plan();
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_protect_authorization() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'authorization rows are immutable';
+  END IF;
+  IF NEW.authorization_digest IS DISTINCT FROM OLD.authorization_digest OR NEW.signed_payload_digest IS DISTINCT FROM OLD.signed_payload_digest
+     OR NEW.signature_digest IS DISTINCT FROM OLD.signature_digest OR NEW.kid IS DISTINCT FROM OLD.kid
+     OR NEW.nonce_commitment IS DISTINCT FROM OLD.nonce_commitment OR NEW.grant_version IS DISTINCT FROM OLD.grant_version
+     OR NEW.stage_id IS DISTINCT FROM OLD.stage_id OR NEW.admission_version IS DISTINCT FROM OLD.admission_version
+     OR NEW.aggregate_admission_fingerprint IS DISTINCT FROM OLD.aggregate_admission_fingerprint
+     OR NEW.probes IS DISTINCT FROM OLD.probes OR NEW.router_cells IS DISTINCT FROM OLD.router_cells
+     OR NEW.generation_cells IS DISTINCT FROM OLD.generation_cells OR NEW.total_cells IS DISTINCT FROM OLD.total_cells
+     OR NEW.repetitions IS DISTINCT FROM OLD.repetitions OR NEW.assignments IS DISTINCT FROM OLD.assignments
+     OR NEW.provider_dispatch_assignments IS DISTINCT FROM OLD.provider_dispatch_assignments
+     OR NEW.local_terminal_assignments IS DISTINCT FROM OLD.local_terminal_assignments
+     OR NEW.pre_dispatch_fault_assignments IS DISTINCT FROM OLD.pre_dispatch_fault_assignments
+     OR NEW.maximum_planned_invocation_slots IS DISTINCT FROM OLD.maximum_planned_invocation_slots
+     OR NEW.maximum_provider_invocations IS DISTINCT FROM OLD.maximum_provider_invocations
+     OR NEW.reservation_microdollars IS DISTINCT FROM OLD.reservation_microdollars
+     OR NEW.provider_ceiling_microdollars IS DISTINCT FROM OLD.provider_ceiling_microdollars
+     OR NEW.pricing_cohort_digest IS DISTINCT FROM OLD.pricing_cohort_digest OR NEW.issued_at IS DISTINCT FROM OLD.issued_at
+     OR NEW.expires_at IS DISTINCT FROM OLD.expires_at OR NEW.consumed_at IS DISTINCT FROM OLD.consumed_at
+     OR NEW.reservation_id IS DISTINCT FROM OLD.reservation_id THEN
+    RAISE EXCEPTION 'authorization evidence is immutable';
+  END IF;
+  IF OLD.status <> 'consumed' OR NEW.status NOT IN ('halted', 'unknown_exposure') THEN
+    RAISE EXCEPTION 'authorization status is monotonic';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER addie_fixed_trace_component_smoke_authorization_immutable
+BEFORE UPDATE OR DELETE ON addie_fixed_trace_component_smoke_authorizations
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_protect_authorization();
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_protect_attempt() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'attempt rows are immutable';
+  END IF;
+  IF NEW.attempt_id IS DISTINCT FROM OLD.attempt_id OR NEW.authorization_digest IS DISTINCT FROM OLD.authorization_digest
+     OR NEW.assignment_id IS DISTINCT FROM OLD.assignment_id OR NEW.invocation_ordinal IS DISTINCT FROM OLD.invocation_ordinal
+     OR NEW.prepared_request_hmac IS DISTINCT FROM OLD.prepared_request_hmac OR NEW.intent_at IS DISTINCT FROM OLD.intent_at THEN
+    RAISE EXCEPTION 'attempt intent evidence is immutable';
+  END IF;
+  IF OLD.status <> 'intent_recorded' OR NEW.status = 'intent_recorded' OR NEW.terminal_at IS NULL THEN
+    RAISE EXCEPTION 'attempt status is monotonic';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER addie_fixed_trace_component_smoke_attempt_immutable
+BEFORE UPDATE OR DELETE ON addie_fixed_trace_component_smoke_attempts
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_protect_attempt();
 
 CREATE CONSTRAINT TRIGGER addie_fixed_trace_component_smoke_plan_exact
 AFTER INSERT OR UPDATE OR DELETE ON addie_fixed_trace_component_smoke_run_plan
@@ -133,15 +242,20 @@ DECLARE
   reservation_limit BIGINT;
   provider_limit BIGINT;
 BEGIN
-  SELECT maximum_provider_invocations, disposition, reserved_microdollars[NEW.invocation_ordinal]
+  SELECT p.maximum_provider_invocations, p.disposition, p.reserved_microdollars[NEW.invocation_ordinal]
     INTO max_invocations, disposition, reserved
-    FROM addie_fixed_trace_component_smoke_run_plan
-   WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id;
+    FROM addie_fixed_trace_component_smoke_run_plan AS p
+   WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
   IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
     RAISE EXCEPTION 'attempt is not an admitted provider-dispatch ordinal';
   END IF;
   IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
     RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
+  END IF;
+  PERFORM 1 FROM addie_fixed_trace_component_smoke_authorizations
+   WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'attempt authorization is absent';
   END IF;
   SELECT reservation_microdollars, provider_ceiling_microdollars INTO reservation_limit, provider_limit
     FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = NEW.authorization_digest;

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -57,16 +57,16 @@ CREATE TABLE addie_fixed_trace_component_smoke_run_plan (
   reserved_microdollars BIGINT[] NOT NULL CHECK (cardinality(reserved_microdollars) = maximum_provider_invocations),
   -- Assignment outcomes close the 168-entry denominator. They are distinct
   -- from provider attempt terminals and contain no provider-call evidence.
-  assignment_outcome VARCHAR(32) CHECK (assignment_outcome IS NULL OR assignment_outcome IN ('provider_completed', 'provider_failed', 'local_terminal', 'pre_dispatch_fault', 'not_executed_after_halt')),
+  assignment_outcome VARCHAR(32) CHECK (assignment_outcome IS NULL OR assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure', 'local_terminal', 'pre_dispatch_fault', 'not_executed_after_halt')),
   assignment_terminal_at TIMESTAMPTZ,
   assignment_final_invocation_ordinal SMALLINT,
   PRIMARY KEY (authorization_digest, assignment_id),
   UNIQUE (authorization_digest, probe_id, cell_id),
   CHECK ((disposition = 'provider_dispatch' AND maximum_provider_invocations > 0) OR (disposition <> 'provider_dispatch' AND maximum_provider_invocations = 0)),
   CHECK (array_position(reserved_microdollars, NULL) IS NULL),
-  CHECK (assignment_outcome IS NULL OR assignment_outcome = disposition OR assignment_outcome IN ('provider_completed', 'provider_failed', 'not_executed_after_halt')),
+  CHECK (assignment_outcome IS NULL OR assignment_outcome = disposition OR assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure', 'not_executed_after_halt')),
   CHECK ((assignment_outcome IS NULL) = (assignment_terminal_at IS NULL)),
-  CHECK ((assignment_outcome IN ('provider_completed', 'provider_failed')) = (assignment_final_invocation_ordinal IS NOT NULL)),
+  CHECK ((assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure')) = (assignment_final_invocation_ordinal IS NOT NULL)),
   CHECK (assignment_final_invocation_ordinal IS NULL OR assignment_final_invocation_ordinal BETWEEN 1 AND maximum_provider_invocations)
 );
 
@@ -75,7 +75,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   authorization_digest CHAR(64) NOT NULL,
   assignment_id CHAR(64) NOT NULL,
   invocation_ordinal SMALLINT NOT NULL CHECK (invocation_ordinal BETWEEN 1 AND 2),
-  status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage', 'invalid_limits', 'pricing_unavailable')),
+  status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage', 'invalid_limits', 'pricing_unavailable', 'unknown_exposure')),
   response_disposition VARCHAR(32) CHECK (response_disposition IS NULL OR response_disposition IN ('final_response', 'tool_continuation_required')),
   prepared_request_hmac CHAR(64) NOT NULL CHECK (prepared_request_hmac ~ '^[a-f0-9]{64}$'),
   response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
@@ -101,6 +101,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   CHECK ((status = 'succeeded') = (response_disposition IS NOT NULL)),
   CHECK (status NOT IN ('malformed_response', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
   CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
+  CHECK (status <> 'unknown_exposure' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
   CHECK (status NOT IN ('succeeded', 'provider_failed', 'malformed_response', 'identity_mismatch', 'missing_usage') OR response_hmac IS NOT NULL)
 );
 
@@ -190,13 +191,13 @@ BEGIN
     RAISE EXCEPTION 'admitted plan fields are immutable';
   END IF;
   IF OLD.assignment_outcome IS NOT NULL OR NEW.assignment_outcome IS NULL OR NEW.assignment_terminal_at IS NULL
-     OR (NEW.assignment_outcome <> OLD.disposition AND NEW.assignment_outcome NOT IN ('provider_completed', 'provider_failed', 'not_executed_after_halt')) THEN
+     OR (NEW.assignment_outcome <> OLD.disposition AND NEW.assignment_outcome NOT IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure', 'not_executed_after_halt')) THEN
     RAISE EXCEPTION 'assignment outcome is monotonic';
   END IF;
-  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed') AND OLD.disposition <> 'provider_dispatch' THEN
+  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure') AND OLD.disposition <> 'provider_dispatch' THEN
     RAISE EXCEPTION 'provider assignment outcome requires provider dispatch';
   END IF;
-  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed') THEN
+  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure') THEN
     SELECT status INTO authorization_status FROM addie_fixed_trace_component_smoke_authorizations
      WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
     SELECT count(*), bool_or(status = 'intent_recorded'), bool_or(status <> 'succeeded')
@@ -205,11 +206,15 @@ BEGIN
      WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id
        AND invocation_ordinal <= NEW.assignment_final_invocation_ordinal;
     IF terminal_count <> NEW.assignment_final_invocation_ordinal OR COALESCE(open_attempt, false)
-       OR (NEW.assignment_outcome = 'provider_completed' AND (COALESCE(failed_attempt, false) OR authorization_status <> 'consumed'
+       OR (NEW.assignment_outcome = 'provider_completed' AND (COALESCE(failed_attempt, false) OR authorization_status = 'completed'
            OR NOT EXISTS (SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = NEW.authorization_digest
                             AND assignment_id = NEW.assignment_id AND invocation_ordinal = NEW.assignment_final_invocation_ordinal
                             AND status = 'succeeded' AND response_disposition = 'final_response')))
-       OR (NEW.assignment_outcome = 'provider_failed' AND NOT COALESCE(failed_attempt, false)) THEN
+       OR (NEW.assignment_outcome = 'provider_failed' AND NOT COALESCE(failed_attempt, false))
+       OR (NEW.assignment_outcome = 'provider_unknown_exposure' AND (authorization_status <> 'unknown_exposure'
+           OR NOT EXISTS (SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = NEW.authorization_digest
+                            AND assignment_id = NEW.assignment_id AND invocation_ordinal = NEW.assignment_final_invocation_ordinal
+                            AND status = 'unknown_exposure'))) THEN
       RAISE EXCEPTION 'provider assignment outcome lacks final terminal attempt evidence';
     END IF;
   END IF;
@@ -322,6 +327,9 @@ LANGUAGE plpgsql AS $$
 DECLARE
   max_invocations SMALLINT;
   disposition VARCHAR(24);
+  requested_provider VARCHAR(32);
+  requested_model VARCHAR(128);
+  requested_effort VARCHAR(64);
   reserved BIGINT;
   prior_spend BIGINT;
   reservation_limit BIGINT;
@@ -332,8 +340,9 @@ BEGIN
   IF TG_OP = 'INSERT' AND NEW.status <> 'intent_recorded' THEN
     RAISE EXCEPTION 'a provider attempt must begin as an intent';
   END IF;
-  SELECT p.maximum_provider_invocations, p.disposition, p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
-    INTO max_invocations, disposition, reserved, assignment_outcome
+  SELECT p.maximum_provider_invocations, p.disposition, p.requested_provider, p.requested_model, p.requested_effort,
+         p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
+    INTO max_invocations, disposition, requested_provider, requested_model, requested_effort, reserved, assignment_outcome
     FROM addie_fixed_trace_component_smoke_run_plan AS p
    WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
   IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
@@ -342,16 +351,6 @@ BEGIN
   IF assignment_outcome IS NOT NULL THEN
     RAISE EXCEPTION 'provider assignment is already terminal';
   END IF;
-  IF TG_OP = 'INSERT' AND NEW.invocation_ordinal > 1 AND EXISTS (
-    SELECT 1 FROM addie_fixed_trace_component_smoke_attempts
-     WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id
-       AND invocation_ordinal < NEW.invocation_ordinal AND response_disposition = 'final_response'
-  ) THEN
-    RAISE EXCEPTION 'provider assignment was already final';
-  END IF;
-  IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
-    RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
-  END IF;
   SELECT status, reservation_microdollars, provider_ceiling_microdollars
     INTO authorization_status, reservation_limit, provider_limit
     FROM addie_fixed_trace_component_smoke_authorizations
@@ -359,8 +358,51 @@ BEGIN
   IF NOT FOUND THEN
     RAISE EXCEPTION 'attempt authorization is absent';
   END IF;
-  IF authorization_status <> 'consumed' THEN
+  IF TG_OP = 'INSERT' AND authorization_status <> 'consumed' THEN
     RAISE EXCEPTION 'attempt authorization is not dispatchable';
+  END IF;
+  IF TG_OP = 'UPDATE' AND authorization_status <> 'consumed'
+     AND NOT (authorization_status = 'unknown_exposure' AND NEW.status = 'unknown_exposure') THEN
+    RAISE EXCEPTION 'attempt authorization cannot be settled';
+  END IF;
+  IF TG_OP = 'INSERT' AND EXISTS (
+    SELECT 1 FROM addie_fixed_trace_component_smoke_attempts
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'intent_recorded'
+  ) THEN
+    RAISE EXCEPTION 'a prior provider intent remains unresolved';
+  END IF;
+  IF TG_OP = 'INSERT' AND NEW.invocation_ordinal > 1 AND NOT EXISTS (
+    SELECT 1 FROM addie_fixed_trace_component_smoke_attempts
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id
+       AND invocation_ordinal = NEW.invocation_ordinal - 1
+       AND status = 'succeeded' AND response_disposition = 'tool_continuation_required'
+  ) THEN
+    RAISE EXCEPTION 'provider invocation ordinal lacks a terminal continuation predecessor';
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.status = 'succeeded'
+     AND (NEW.returned_provider IS DISTINCT FROM requested_provider OR NEW.returned_model IS DISTINCT FROM requested_model
+          OR NEW.returned_effort IS DISTINCT FROM requested_effort) THEN
+    RAISE EXCEPTION 'succeeded attempt identity differs from admitted plan';
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.actual_cost_microdollars IS NOT NULL
+     AND (NEW.returned_provider IS DISTINCT FROM requested_provider OR NEW.returned_model IS DISTINCT FROM requested_model
+          OR NEW.returned_effort IS DISTINCT FROM requested_effort) THEN
+    RAISE EXCEPTION 'actual cost requires admitted returned identity';
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.status = 'succeeded' AND NEW.response_disposition = 'tool_continuation_required'
+     AND NEW.invocation_ordinal = max_invocations THEN
+    -- A continuation beyond the admitted slot cannot be dispatched.  Preserve
+    -- known receipt cost as observation, settle categorically, and halt.
+    NEW.status := 'invalid_limits';
+    NEW.response_disposition := NULL;
+    NEW.observed_cost_microdollars := NEW.actual_cost_microdollars;
+    NEW.actual_cost_microdollars := NULL;
+    UPDATE addie_fixed_trace_component_smoke_authorizations
+       SET status = 'halted'
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
+  END IF;
+  IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
+    RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
   END IF;
   SELECT COALESCE(sum(actual_cost_microdollars), 0) INTO prior_spend
     FROM addie_fixed_trace_component_smoke_attempts

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -1,0 +1,97 @@
+-- Private fixed-trace smoke authorization boundary.  This schema is additive
+-- and deliberately contains only digests, categorical state, and bounded
+-- usage metadata: never a bearer grant, nonce, prompt, output, provider error,
+-- tool payload, credential, or human approval text.
+
+CREATE TABLE addie_fixed_trace_component_smoke_authorizations (
+  authorization_digest CHAR(64) PRIMARY KEY CHECK (authorization_digest ~ '^[a-f0-9]{64}$'),
+  signed_payload_digest CHAR(64) NOT NULL UNIQUE CHECK (signed_payload_digest ~ '^[a-f0-9]{64}$'),
+  signature BYTEA NOT NULL CHECK (octet_length(signature) = 64),
+  kid VARCHAR(64) NOT NULL CHECK (kid ~ '^[a-z0-9][a-z0-9._-]{0,63}$'),
+  nonce_commitment CHAR(64) NOT NULL UNIQUE CHECK (nonce_commitment ~ '^[a-f0-9]{64}$'),
+  grant_version VARCHAR(96) NOT NULL CHECK (grant_version = 'addie-fixed-trace-component-smoke-signed-grant-v1'),
+  stage_id VARCHAR(32) NOT NULL CHECK (stage_id = 'stage_1_smoke'),
+  admission_version VARCHAR(96) NOT NULL CHECK (admission_version = 'addie-fixed-trace-component-smoke-admission-v2'),
+  aggregate_admission_fingerprint CHAR(64) NOT NULL CHECK (aggregate_admission_fingerprint = '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d'),
+  probes SMALLINT NOT NULL CHECK (probes = 8),
+  router_cells SMALLINT NOT NULL CHECK (router_cells = 10),
+  generation_cells SMALLINT NOT NULL CHECK (generation_cells = 11),
+  total_cells SMALLINT NOT NULL CHECK (total_cells = 21),
+  repetitions SMALLINT NOT NULL CHECK (repetitions = 1),
+  assignments SMALLINT NOT NULL CHECK (assignments = 168),
+  provider_dispatch_assignments SMALLINT NOT NULL CHECK (provider_dispatch_assignments = 126),
+  local_terminal_assignments SMALLINT NOT NULL CHECK (local_terminal_assignments = 21),
+  pre_dispatch_fault_assignments SMALLINT NOT NULL CHECK (pre_dispatch_fault_assignments = 21),
+  maximum_planned_invocation_slots SMALLINT NOT NULL CHECK (maximum_planned_invocation_slots = 256),
+  maximum_provider_invocations SMALLINT NOT NULL CHECK (maximum_provider_invocations = 192),
+  reservation_microdollars BIGINT NOT NULL CHECK (reservation_microdollars = 2819484),
+  provider_ceiling_microdollars BIGINT NOT NULL CHECK (provider_ceiling_microdollars = 5000000),
+  pricing_cohort_digest CHAR(64) NOT NULL CHECK (pricing_cohort_digest ~ '^[a-f0-9]{64}$'),
+  issued_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  status VARCHAR(32) NOT NULL CHECK (status IN ('consumed', 'halted', 'unknown_exposure')),
+  consumed_at TIMESTAMPTZ NOT NULL,
+  unknown_exposure_at TIMESTAMPTZ,
+  reservation_id VARCHAR(44) NOT NULL UNIQUE CHECK (reservation_id ~ '^reservation_[a-f0-9]{32}$'),
+  CHECK (issued_at < expires_at),
+  CHECK (status = 'unknown_exposure' OR unknown_exposure_at IS NULL),
+  CHECK (status <> 'unknown_exposure' OR unknown_exposure_at IS NOT NULL)
+);
+
+CREATE TABLE addie_fixed_trace_component_smoke_run_plan (
+  authorization_digest CHAR(64) NOT NULL REFERENCES addie_fixed_trace_component_smoke_authorizations(authorization_digest) ON DELETE RESTRICT,
+  assignment_id CHAR(64) NOT NULL CHECK (assignment_id ~ '^[a-f0-9]{64}$'),
+  probe_id VARCHAR(128) NOT NULL CHECK (length(probe_id) BETWEEN 1 AND 128),
+  cell_id VARCHAR(128) NOT NULL CHECK (length(cell_id) BETWEEN 1 AND 128),
+  disposition VARCHAR(24) NOT NULL CHECK (disposition IN ('provider_dispatch', 'local_terminal', 'pre_dispatch_fault')),
+  maximum_provider_invocations SMALLINT NOT NULL CHECK (maximum_provider_invocations BETWEEN 0 AND 2),
+  requested_provider VARCHAR(32) NOT NULL CHECK (length(requested_provider) BETWEEN 1 AND 32),
+  requested_model VARCHAR(128) NOT NULL CHECK (length(requested_model) BETWEEN 1 AND 128),
+  requested_effort VARCHAR(64) NOT NULL CHECK (length(requested_effort) BETWEEN 1 AND 64),
+  pricing_profile_id VARCHAR(128) NOT NULL CHECK (length(pricing_profile_id) BETWEEN 1 AND 128),
+  max_input_tokens INTEGER NOT NULL CHECK (max_input_tokens > 0 AND max_input_tokens <= 1000000),
+  max_output_tokens INTEGER NOT NULL CHECK (max_output_tokens > 0 AND max_output_tokens <= 1000000),
+  timeout_ms INTEGER NOT NULL CHECK (timeout_ms > 0 AND timeout_ms <= 86400000),
+  retries SMALLINT NOT NULL CHECK (retries = 0),
+  reserved_microdollars BIGINT[] NOT NULL CHECK (cardinality(reserved_microdollars) = maximum_provider_invocations),
+  non_dispatch_status VARCHAR(24) CHECK (non_dispatch_status IS NULL OR non_dispatch_status IN ('local_terminal', 'pre_dispatch_fault')),
+  non_dispatch_terminal_at TIMESTAMPTZ,
+  PRIMARY KEY (authorization_digest, assignment_id),
+  UNIQUE (authorization_digest, probe_id, cell_id),
+  CHECK ((disposition = 'provider_dispatch' AND maximum_provider_invocations > 0) OR (disposition <> 'provider_dispatch' AND maximum_provider_invocations = 0)),
+  CHECK (array_position(reserved_microdollars, NULL) IS NULL),
+  CHECK (non_dispatch_status IS NULL OR non_dispatch_status = disposition),
+  CHECK ((non_dispatch_status IS NULL) = (non_dispatch_terminal_at IS NULL))
+);
+
+CREATE TABLE addie_fixed_trace_component_smoke_attempts (
+  attempt_id VARCHAR(40) PRIMARY KEY CHECK (attempt_id ~ '^attempt_[a-f0-9]{32}$'),
+  authorization_digest CHAR(64) NOT NULL,
+  assignment_id CHAR(64) NOT NULL,
+  invocation_ordinal SMALLINT NOT NULL CHECK (invocation_ordinal BETWEEN 1 AND 2),
+  status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage')),
+  prepared_request_hmac CHAR(64) NOT NULL CHECK (prepared_request_hmac ~ '^[a-f0-9]{64}$'),
+  response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
+  input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
+  output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
+  actual_cost_microdollars BIGINT CHECK (actual_cost_microdollars IS NULL OR actual_cost_microdollars BETWEEN 0 AND 2819484),
+  latency_ms INTEGER CHECK (latency_ms IS NULL OR latency_ms BETWEEN 0 AND 86400000),
+  intent_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  terminal_at TIMESTAMPTZ,
+  FOREIGN KEY (authorization_digest, assignment_id) REFERENCES addie_fixed_trace_component_smoke_run_plan(authorization_digest, assignment_id) ON DELETE RESTRICT,
+  UNIQUE (authorization_digest, assignment_id, invocation_ordinal),
+  CHECK ((status = 'intent_recorded') = (terminal_at IS NULL)),
+  CHECK (status <> 'succeeded' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND actual_cost_microdollars IS NOT NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL)),
+  CHECK (status NOT IN ('malformed_response', 'identity_mismatch', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL))
+);
+
+CREATE INDEX addie_fixed_trace_component_smoke_attempts_open_idx
+  ON addie_fixed_trace_component_smoke_attempts (authorization_digest, status)
+  WHERE status = 'intent_recorded';
+
+COMMENT ON TABLE addie_fixed_trace_component_smoke_authorizations IS
+  'One-use signed private smoke grants, stored only as digests and categorical consumption state; no bearer data or text';
+COMMENT ON TABLE addie_fixed_trace_component_smoke_run_plan IS
+  'Exact admitted 168-entry private smoke plan, persisted before any future provider dispatch';
+COMMENT ON TABLE addie_fixed_trace_component_smoke_attempts IS
+  'Intent-before-terminal, HMAC-only provider attempt evidence; unknown exposure must halt the authorization';

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -6,7 +6,7 @@
 CREATE TABLE addie_fixed_trace_component_smoke_authorizations (
   authorization_digest CHAR(64) PRIMARY KEY CHECK (authorization_digest ~ '^[a-f0-9]{64}$'),
   signed_payload_digest CHAR(64) NOT NULL UNIQUE CHECK (signed_payload_digest ~ '^[a-f0-9]{64}$'),
-  signature BYTEA NOT NULL CHECK (octet_length(signature) = 64),
+  signature_digest CHAR(64) NOT NULL CHECK (signature_digest ~ '^[a-f0-9]{64}$'),
   kid VARCHAR(64) NOT NULL CHECK (kid ~ '^[a-z0-9][a-z0-9._-]{0,63}$'),
   nonce_commitment CHAR(64) NOT NULL UNIQUE CHECK (nonce_commitment ~ '^[a-f0-9]{64}$'),
   grant_version VARCHAR(96) NOT NULL CHECK (grant_version = 'addie-fixed-trace-component-smoke-signed-grant-v1'),
@@ -74,6 +74,8 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
   input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
   output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
+  cache_read_tokens INTEGER CHECK (cache_read_tokens IS NULL OR cache_read_tokens >= 0),
+  cache_write_tokens INTEGER CHECK (cache_write_tokens IS NULL OR cache_write_tokens >= 0),
   actual_cost_microdollars BIGINT CHECK (actual_cost_microdollars IS NULL OR actual_cost_microdollars BETWEEN 0 AND 5000000),
   latency_ms INTEGER CHECK (latency_ms IS NULL OR latency_ms BETWEEN 0 AND 86400000),
   intent_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -26,7 +26,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_authorizations (
   maximum_provider_invocations SMALLINT NOT NULL CHECK (maximum_provider_invocations = 192),
   reservation_microdollars BIGINT NOT NULL CHECK (reservation_microdollars = 2819484),
   provider_ceiling_microdollars BIGINT NOT NULL CHECK (provider_ceiling_microdollars = 5000000),
-  pricing_cohort_digest CHAR(64) NOT NULL CHECK (pricing_cohort_digest ~ '^[a-f0-9]{64}$'),
+  pricing_cohort_digest VARCHAR(71) NOT NULL CHECK (pricing_cohort_digest ~ '^sha256:[a-f0-9]{64}$'),
   issued_at TIMESTAMPTZ NOT NULL,
   expires_at TIMESTAMPTZ NOT NULL,
   status VARCHAR(32) NOT NULL CHECK (status IN ('consumed', 'halted', 'unknown_exposure')),
@@ -74,7 +74,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
   input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
   output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
-  actual_cost_microdollars BIGINT CHECK (actual_cost_microdollars IS NULL OR actual_cost_microdollars BETWEEN 0 AND 2819484),
+  actual_cost_microdollars BIGINT CHECK (actual_cost_microdollars IS NULL OR actual_cost_microdollars BETWEEN 0 AND 5000000),
   latency_ms INTEGER CHECK (latency_ms IS NULL OR latency_ms BETWEEN 0 AND 86400000),
   intent_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
   terminal_at TIMESTAMPTZ,
@@ -88,6 +88,75 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
 CREATE INDEX addie_fixed_trace_component_smoke_attempts_open_idx
   ON addie_fixed_trace_component_smoke_attempts (authorization_digest, status)
   WHERE status = 'intent_recorded';
+
+-- Check constraints cannot inspect array elements or sibling plan rows. These
+-- deferred constraints make direct SQL writes obey the same fixed plan that
+-- the ledger derives: 168 assignments, 126 dispatch dispositions, 192 slots,
+-- and only positive per-slot reservations totaling 2,819,484 micros.
+CREATE FUNCTION addie_fixed_trace_component_smoke_check_plan() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  plan_count INTEGER;
+  dispatch_count INTEGER;
+  slots INTEGER;
+  reserved BIGINT;
+  invalid_reservation BOOLEAN;
+BEGIN
+  SELECT count(*), count(*) FILTER (WHERE disposition = 'provider_dispatch'),
+         COALESCE(sum(maximum_provider_invocations), 0),
+         COALESCE(sum((SELECT sum(value) FROM unnest(reserved_microdollars) AS value)), 0),
+         COALESCE(bool_or(EXISTS (SELECT 1 FROM unnest(reserved_microdollars) AS value WHERE value <= 0 OR value > 2819484)), false)
+    INTO plan_count, dispatch_count, slots, reserved, invalid_reservation
+    FROM addie_fixed_trace_component_smoke_run_plan
+   WHERE authorization_digest = NEW.authorization_digest;
+  IF plan_count <> 168 OR dispatch_count <> 126 OR slots <> 192 OR reserved <> 2819484 OR invalid_reservation THEN
+    RAISE EXCEPTION 'fixed-trace component smoke plan is not the admitted exact plan';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE CONSTRAINT TRIGGER addie_fixed_trace_component_smoke_plan_exact
+AFTER INSERT OR UPDATE OR DELETE ON addie_fixed_trace_component_smoke_run_plan
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_check_plan();
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_check_attempt() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  max_invocations SMALLINT;
+  disposition VARCHAR(24);
+  reserved BIGINT;
+  prior_spend BIGINT;
+  reservation_limit BIGINT;
+  provider_limit BIGINT;
+BEGIN
+  SELECT maximum_provider_invocations, disposition, reserved_microdollars[NEW.invocation_ordinal]
+    INTO max_invocations, disposition, reserved
+    FROM addie_fixed_trace_component_smoke_run_plan
+   WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id;
+  IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
+    RAISE EXCEPTION 'attempt is not an admitted provider-dispatch ordinal';
+  END IF;
+  IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
+    RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
+  END IF;
+  SELECT reservation_microdollars, provider_ceiling_microdollars INTO reservation_limit, provider_limit
+    FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = NEW.authorization_digest;
+  SELECT COALESCE(sum(actual_cost_microdollars), 0) INTO prior_spend
+    FROM addie_fixed_trace_component_smoke_attempts
+   WHERE authorization_digest = NEW.authorization_digest AND attempt_id <> NEW.attempt_id;
+  IF prior_spend + COALESCE(NEW.actual_cost_microdollars, 0) > reservation_limit
+     OR prior_spend + COALESCE(NEW.actual_cost_microdollars, 0) > provider_limit THEN
+    RAISE EXCEPTION 'attempt cost exceeds fixed-trace aggregate limit';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER addie_fixed_trace_component_smoke_attempt_exact
+BEFORE INSERT OR UPDATE OF invocation_ordinal, actual_cost_microdollars ON addie_fixed_trace_component_smoke_attempts
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_check_attempt();
 
 COMMENT ON TABLE addie_fixed_trace_component_smoke_authorizations IS
   'One-use signed private smoke grants, stored only as digests and categorical consumption state; no bearer data or text';

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -351,15 +351,15 @@ BEGIN
   END IF;
   CASE p_profile_id
     WHEN 'anthropic-standard-2026-09:claude-haiku-4-5' THEN
-      numerator := 100 * p_input + 500 * p_output + 10 * p_cache_read + 125 * p_cache_write; denominator := 100;
+      numerator := 100::NUMERIC * p_input::NUMERIC + 500::NUMERIC * p_output::NUMERIC + 10::NUMERIC * p_cache_read::NUMERIC + 125::NUMERIC * p_cache_write::NUMERIC; denominator := 100;
     WHEN 'anthropic-standard-2026-09:claude-sonnet-5' THEN
-      numerator := 20 * p_input + 100 * p_output + 2 * p_cache_read + 25 * p_cache_write; denominator := 10;
+      numerator := 20::NUMERIC * p_input::NUMERIC + 100::NUMERIC * p_output::NUMERIC + 2::NUMERIC * p_cache_read::NUMERIC + 25::NUMERIC * p_cache_write::NUMERIC; denominator := 10;
     WHEN 'openai-gpt-5.6-luna-standard-2026-09-05' THEN
       IF p_cache_read + p_cache_write > p_input THEN RAISE EXCEPTION 'subset cache usage exceeds input'; END IF;
-      numerator := 20 * (p_input - p_cache_read - p_cache_write) + 120 * p_output + 2 * p_cache_read + 25 * p_cache_write; denominator := 100;
+      numerator := 20::NUMERIC * (p_input::NUMERIC - p_cache_read::NUMERIC - p_cache_write::NUMERIC) + 120::NUMERIC * p_output::NUMERIC + 2::NUMERIC * p_cache_read::NUMERIC + 25::NUMERIC * p_cache_write::NUMERIC; denominator := 100;
     WHEN 'google-gemini-3.7-flash-through-2026-12-31' THEN
       IF p_cache_write <> 0 OR p_cache_read > p_input THEN RAISE EXCEPTION 'Google cache usage is not admitted'; END IF;
-      numerator := 750 * (p_input - p_cache_read) + 3750 * p_output + 75 * p_cache_read; denominator := 1000;
+      numerator := 750::NUMERIC * (p_input::NUMERIC - p_cache_read::NUMERIC) + 3750::NUMERIC * p_output::NUMERIC + 75::NUMERIC * p_cache_read::NUMERIC; denominator := 1000;
     ELSE RAISE EXCEPTION 'pricing profile is not admitted';
   END CASE;
   RETURN ceil(numerator / denominator)::BIGINT;

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -29,7 +29,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_authorizations (
   pricing_cohort_digest VARCHAR(71) NOT NULL CHECK (pricing_cohort_digest ~ '^sha256:[a-f0-9]{64}$'),
   issued_at TIMESTAMPTZ NOT NULL,
   expires_at TIMESTAMPTZ NOT NULL,
-  status VARCHAR(32) NOT NULL CHECK (status IN ('consumed', 'halted', 'unknown_exposure')),
+  status VARCHAR(32) NOT NULL CHECK (status IN ('consumed', 'completed', 'halted', 'unknown_exposure')),
   consumed_at TIMESTAMPTZ NOT NULL,
   unknown_exposure_at TIMESTAMPTZ,
   reservation_id VARCHAR(44) NOT NULL UNIQUE CHECK (reservation_id ~ '^reservation_[a-f0-9]{32}$'),
@@ -55,14 +55,19 @@ CREATE TABLE addie_fixed_trace_component_smoke_run_plan (
   timeout_ms INTEGER NOT NULL CHECK (timeout_ms > 0 AND timeout_ms <= 86400000),
   retries SMALLINT NOT NULL CHECK (retries = 0),
   reserved_microdollars BIGINT[] NOT NULL CHECK (cardinality(reserved_microdollars) = maximum_provider_invocations),
-  non_dispatch_status VARCHAR(24) CHECK (non_dispatch_status IS NULL OR non_dispatch_status IN ('local_terminal', 'pre_dispatch_fault')),
-  non_dispatch_terminal_at TIMESTAMPTZ,
+  -- Assignment outcomes close the 168-entry denominator. They are distinct
+  -- from provider attempt terminals and contain no provider-call evidence.
+  assignment_outcome VARCHAR(32) CHECK (assignment_outcome IS NULL OR assignment_outcome IN ('provider_completed', 'provider_failed', 'local_terminal', 'pre_dispatch_fault', 'not_executed_after_halt')),
+  assignment_terminal_at TIMESTAMPTZ,
+  assignment_final_invocation_ordinal SMALLINT,
   PRIMARY KEY (authorization_digest, assignment_id),
   UNIQUE (authorization_digest, probe_id, cell_id),
   CHECK ((disposition = 'provider_dispatch' AND maximum_provider_invocations > 0) OR (disposition <> 'provider_dispatch' AND maximum_provider_invocations = 0)),
   CHECK (array_position(reserved_microdollars, NULL) IS NULL),
-  CHECK (non_dispatch_status IS NULL OR non_dispatch_status = disposition),
-  CHECK ((non_dispatch_status IS NULL) = (non_dispatch_terminal_at IS NULL))
+  CHECK (assignment_outcome IS NULL OR assignment_outcome = disposition OR assignment_outcome IN ('provider_completed', 'provider_failed', 'not_executed_after_halt')),
+  CHECK ((assignment_outcome IS NULL) = (assignment_terminal_at IS NULL)),
+  CHECK ((assignment_outcome IN ('provider_completed', 'provider_failed')) = (assignment_final_invocation_ordinal IS NOT NULL)),
+  CHECK (assignment_final_invocation_ordinal IS NULL OR assignment_final_invocation_ordinal BETWEEN 1 AND maximum_provider_invocations)
 );
 
 CREATE TABLE addie_fixed_trace_component_smoke_attempts (
@@ -71,6 +76,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   assignment_id CHAR(64) NOT NULL,
   invocation_ordinal SMALLINT NOT NULL CHECK (invocation_ordinal BETWEEN 1 AND 2),
   status VARCHAR(32) NOT NULL CHECK (status IN ('intent_recorded', 'succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage', 'invalid_limits', 'pricing_unavailable')),
+  response_disposition VARCHAR(32) CHECK (response_disposition IS NULL OR response_disposition IN ('final_response', 'tool_continuation_required')),
   prepared_request_hmac CHAR(64) NOT NULL CHECK (prepared_request_hmac ~ '^[a-f0-9]{64}$'),
   response_hmac CHAR(64) CHECK (response_hmac IS NULL OR response_hmac ~ '^[a-f0-9]{64}$'),
   returned_provider VARCHAR(32) CHECK (returned_provider IS NULL OR length(returned_provider) BETWEEN 1 AND 32),
@@ -80,7 +86,10 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
   cache_read_tokens INTEGER CHECK (cache_read_tokens IS NULL OR cache_read_tokens >= 0),
   cache_write_tokens INTEGER CHECK (cache_write_tokens IS NULL OR cache_write_tokens >= 0),
+  -- `actual` is a settled, admitted charge. `observed` retains a complete,
+  -- independently priceable receipt even when a limit violation halts it.
   actual_cost_microdollars BIGINT CHECK (actual_cost_microdollars IS NULL OR actual_cost_microdollars BETWEEN 0 AND 5000000),
+  observed_cost_microdollars BIGINT CHECK (observed_cost_microdollars IS NULL OR observed_cost_microdollars BETWEEN 0 AND 100000000),
   latency_ms INTEGER CHECK (latency_ms IS NULL OR latency_ms BETWEEN 0 AND 86400000),
   intent_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
   terminal_at TIMESTAMPTZ,
@@ -89,6 +98,7 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   CHECK ((status = 'intent_recorded') = (terminal_at IS NULL)),
   CHECK ((returned_provider IS NULL) = (returned_model IS NULL) AND (returned_provider IS NULL) = (returned_effort IS NULL)),
   CHECK (status <> 'succeeded' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND actual_cost_microdollars IS NOT NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL)),
+  CHECK ((status = 'succeeded') = (response_disposition IS NOT NULL)),
   CHECK (status NOT IN ('malformed_response', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
   CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
   CHECK (status NOT IN ('succeeded', 'provider_failed', 'malformed_response', 'identity_mismatch', 'missing_usage') OR response_hmac IS NOT NULL)
@@ -98,10 +108,27 @@ CREATE INDEX addie_fixed_trace_component_smoke_attempts_open_idx
   ON addie_fixed_trace_component_smoke_attempts (authorization_digest, status)
   WHERE status = 'intent_recorded';
 
+-- The fixed manifest is pinned as a domain-separated SHA-256 over every
+-- persisted authority field (including the deterministic assignment identity).
+-- This makes a complete, initially inserted direct-SQL plan subject to the
+-- same exact 8 x 21 authority as the TypeScript derivation, not merely the
+-- same aggregate counts. pgcrypto is installed by an earlier migration.
+CREATE FUNCTION addie_fixed_trace_component_smoke_plan_manifest_digest(p_authorization_digest CHAR(64)) RETURNS TEXT
+LANGUAGE sql STABLE AS $$
+  SELECT encode(digest(E'adcp:addie:fixed-trace-component-smoke:db-plan-manifest:v1\n' || COALESCE(string_agg(
+    concat_ws('|', assignment_id, probe_id, cell_id, disposition,
+      maximum_provider_invocations::text, requested_provider, requested_model,
+      requested_effort, pricing_profile_id, max_input_tokens::text,
+      max_output_tokens::text, timeout_ms::text, retries::text,
+      array_to_string(reserved_microdollars, ',')), E'\n' ORDER BY assignment_id), ''), 'sha256'), 'hex')
+    FROM addie_fixed_trace_component_smoke_run_plan
+   WHERE authorization_digest = p_authorization_digest;
+$$;
+
 -- Check constraints cannot inspect array elements or sibling plan rows. These
--- deferred constraints make direct SQL writes obey the same fixed plan that
--- the ledger derives: 168 assignments, 126 dispatch dispositions, 192 slots,
--- and only positive per-slot reservations totaling 2,819,484 micros.
+-- deferred constraints bind all 168 rows to the admitted exact manifest,
+-- including disposition, cell identity/provider/model/effort/profile/limits,
+-- ordinals and reservations, in addition to the aggregate invariants.
 CREATE FUNCTION addie_fixed_trace_component_smoke_check_plan_group(p_authorization_digest CHAR(64)) RETURNS void
 LANGUAGE plpgsql AS $$
 DECLARE
@@ -121,7 +148,8 @@ BEGIN
    INTO plan_count, dispatch_count, local_count, pre_dispatch_count, slots, reserved, invalid_reservation
     FROM addie_fixed_trace_component_smoke_run_plan
    WHERE authorization_digest = p_authorization_digest;
-  IF plan_count <> 168 OR dispatch_count <> 126 OR local_count <> 21 OR pre_dispatch_count <> 21 OR slots <> 192 OR reserved <> 2819484 OR invalid_reservation THEN
+  IF plan_count <> 168 OR dispatch_count <> 126 OR local_count <> 21 OR pre_dispatch_count <> 21 OR slots <> 192 OR reserved <> 2819484 OR invalid_reservation
+     OR addie_fixed_trace_component_smoke_plan_manifest_digest(p_authorization_digest) <> '89fbd437f1f7f39ed04874949c86564a0f70dacb034936341c374f74c5d7d63b' THEN
     RAISE EXCEPTION 'fixed-trace component smoke plan is not the admitted exact plan';
   END IF;
 END;
@@ -142,6 +170,11 @@ $$;
 -- non-dispatch row is the only permitted plan mutation.
 CREATE FUNCTION addie_fixed_trace_component_smoke_protect_plan() RETURNS trigger
 LANGUAGE plpgsql AS $$
+DECLARE
+  terminal_count INTEGER;
+  open_attempt BOOLEAN;
+  failed_attempt BOOLEAN;
+  authorization_status VARCHAR(32);
 BEGIN
   IF TG_OP = 'DELETE' THEN
     RAISE EXCEPTION 'admitted plan rows are immutable';
@@ -156,9 +189,37 @@ BEGIN
      OR NEW.reserved_microdollars IS DISTINCT FROM OLD.reserved_microdollars THEN
     RAISE EXCEPTION 'admitted plan fields are immutable';
   END IF;
-  IF OLD.non_dispatch_status IS NOT NULL OR NEW.non_dispatch_status IS NULL
-     OR NEW.non_dispatch_status <> OLD.disposition OR NEW.non_dispatch_terminal_at IS NULL THEN
-    RAISE EXCEPTION 'non-dispatch plan terminal is monotonic';
+  IF OLD.assignment_outcome IS NOT NULL OR NEW.assignment_outcome IS NULL OR NEW.assignment_terminal_at IS NULL
+     OR (NEW.assignment_outcome <> OLD.disposition AND NEW.assignment_outcome NOT IN ('provider_completed', 'provider_failed', 'not_executed_after_halt')) THEN
+    RAISE EXCEPTION 'assignment outcome is monotonic';
+  END IF;
+  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed') AND OLD.disposition <> 'provider_dispatch' THEN
+    RAISE EXCEPTION 'provider assignment outcome requires provider dispatch';
+  END IF;
+  IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed') THEN
+    SELECT status INTO authorization_status FROM addie_fixed_trace_component_smoke_authorizations
+     WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
+    SELECT count(*), bool_or(status = 'intent_recorded'), bool_or(status <> 'succeeded')
+      INTO terminal_count, open_attempt, failed_attempt
+      FROM addie_fixed_trace_component_smoke_attempts
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id
+       AND invocation_ordinal <= NEW.assignment_final_invocation_ordinal;
+    IF terminal_count <> NEW.assignment_final_invocation_ordinal OR COALESCE(open_attempt, false)
+       OR (NEW.assignment_outcome = 'provider_completed' AND (COALESCE(failed_attempt, false) OR authorization_status <> 'consumed'
+           OR NOT EXISTS (SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = NEW.authorization_digest
+                            AND assignment_id = NEW.assignment_id AND invocation_ordinal = NEW.assignment_final_invocation_ordinal
+                            AND status = 'succeeded' AND response_disposition = 'final_response')))
+       OR (NEW.assignment_outcome = 'provider_failed' AND NOT COALESCE(failed_attempt, false)) THEN
+      RAISE EXCEPTION 'provider assignment outcome lacks final terminal attempt evidence';
+    END IF;
+  END IF;
+  IF NEW.assignment_outcome = 'not_executed_after_halt' THEN
+    PERFORM 1 FROM addie_fixed_trace_component_smoke_authorizations
+     WHERE authorization_digest = NEW.authorization_digest AND status IN ('halted', 'unknown_exposure') FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'omission requires permanent halt'; END IF;
+    PERFORM 1 FROM addie_fixed_trace_component_smoke_attempts
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id;
+    IF FOUND THEN RAISE EXCEPTION 'omission requires an unstarted assignment'; END IF;
   END IF;
   RETURN NEW;
 END;
@@ -167,6 +228,24 @@ $$;
 CREATE TRIGGER addie_fixed_trace_component_smoke_plan_immutable
 BEFORE UPDATE OR DELETE ON addie_fixed_trace_component_smoke_run_plan
 FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_protect_plan();
+
+CREATE FUNCTION addie_fixed_trace_component_smoke_complete_assignment_denominator() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.assignment_outcome IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM addie_fixed_trace_component_smoke_run_plan
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_outcome IS NULL
+  ) THEN
+    UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'completed'
+     WHERE authorization_digest = NEW.authorization_digest AND status = 'consumed';
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER addie_fixed_trace_component_smoke_assignment_denominator_complete
+AFTER UPDATE OF assignment_outcome ON addie_fixed_trace_component_smoke_run_plan
+FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_complete_assignment_denominator();
 
 CREATE FUNCTION addie_fixed_trace_component_smoke_protect_authorization() RETURNS trigger
 LANGUAGE plpgsql AS $$
@@ -194,8 +273,14 @@ BEGIN
      OR NEW.reservation_id IS DISTINCT FROM OLD.reservation_id THEN
     RAISE EXCEPTION 'authorization evidence is immutable';
   END IF;
-  IF OLD.status <> 'consumed' OR NEW.status NOT IN ('halted', 'unknown_exposure') THEN
+  IF OLD.status <> 'consumed' OR NEW.status NOT IN ('completed', 'halted', 'unknown_exposure') THEN
     RAISE EXCEPTION 'authorization status is monotonic';
+  END IF;
+  IF NEW.status = 'completed' AND EXISTS (
+    SELECT 1 FROM addie_fixed_trace_component_smoke_run_plan
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_outcome IS NULL
+  ) THEN
+    RAISE EXCEPTION 'authorization completion requires every assignment outcome';
   END IF;
   RETURN NEW;
 END;
@@ -241,24 +326,42 @@ DECLARE
   prior_spend BIGINT;
   reservation_limit BIGINT;
   provider_limit BIGINT;
+  authorization_status VARCHAR(32);
+  assignment_outcome VARCHAR(32);
 BEGIN
-  SELECT p.maximum_provider_invocations, p.disposition, p.reserved_microdollars[NEW.invocation_ordinal]
-    INTO max_invocations, disposition, reserved
+  IF TG_OP = 'INSERT' AND NEW.status <> 'intent_recorded' THEN
+    RAISE EXCEPTION 'a provider attempt must begin as an intent';
+  END IF;
+  SELECT p.maximum_provider_invocations, p.disposition, p.reserved_microdollars[NEW.invocation_ordinal], p.assignment_outcome
+    INTO max_invocations, disposition, reserved, assignment_outcome
     FROM addie_fixed_trace_component_smoke_run_plan AS p
    WHERE p.authorization_digest = NEW.authorization_digest AND p.assignment_id = NEW.assignment_id;
   IF disposition IS DISTINCT FROM 'provider_dispatch' OR NEW.invocation_ordinal > max_invocations THEN
     RAISE EXCEPTION 'attempt is not an admitted provider-dispatch ordinal';
   END IF;
+  IF assignment_outcome IS NOT NULL THEN
+    RAISE EXCEPTION 'provider assignment is already terminal';
+  END IF;
+  IF TG_OP = 'INSERT' AND NEW.invocation_ordinal > 1 AND EXISTS (
+    SELECT 1 FROM addie_fixed_trace_component_smoke_attempts
+     WHERE authorization_digest = NEW.authorization_digest AND assignment_id = NEW.assignment_id
+       AND invocation_ordinal < NEW.invocation_ordinal AND response_disposition = 'final_response'
+  ) THEN
+    RAISE EXCEPTION 'provider assignment was already final';
+  END IF;
   IF NEW.actual_cost_microdollars IS NOT NULL AND NEW.actual_cost_microdollars > reserved THEN
     RAISE EXCEPTION 'attempt cost exceeds its ordinal reservation';
   END IF;
-  PERFORM 1 FROM addie_fixed_trace_component_smoke_authorizations
+  SELECT status, reservation_microdollars, provider_ceiling_microdollars
+    INTO authorization_status, reservation_limit, provider_limit
+    FROM addie_fixed_trace_component_smoke_authorizations
    WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'attempt authorization is absent';
   END IF;
-  SELECT reservation_microdollars, provider_ceiling_microdollars INTO reservation_limit, provider_limit
-    FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = NEW.authorization_digest;
+  IF authorization_status <> 'consumed' THEN
+    RAISE EXCEPTION 'attempt authorization is not dispatchable';
+  END IF;
   SELECT COALESCE(sum(actual_cost_microdollars), 0) INTO prior_spend
     FROM addie_fixed_trace_component_smoke_attempts
    WHERE authorization_digest = NEW.authorization_digest AND attempt_id <> NEW.attempt_id;
@@ -271,7 +374,7 @@ END;
 $$;
 
 CREATE TRIGGER addie_fixed_trace_component_smoke_attempt_exact
-BEFORE INSERT OR UPDATE OF invocation_ordinal, actual_cost_microdollars ON addie_fixed_trace_component_smoke_attempts
+BEFORE INSERT OR UPDATE ON addie_fixed_trace_component_smoke_attempts
 FOR EACH ROW EXECUTE FUNCTION addie_fixed_trace_component_smoke_check_attempt();
 
 COMMENT ON TABLE addie_fixed_trace_component_smoke_authorizations IS

--- a/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
+++ b/server/src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql
@@ -97,10 +97,18 @@ CREATE TABLE addie_fixed_trace_component_smoke_attempts (
   UNIQUE (authorization_digest, assignment_id, invocation_ordinal),
   CHECK ((status = 'intent_recorded') = (terminal_at IS NULL)),
   CHECK ((returned_provider IS NULL) = (returned_model IS NULL) AND (returned_provider IS NULL) = (returned_effort IS NULL)),
-  CHECK (status <> 'succeeded' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND actual_cost_microdollars IS NOT NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL)),
+  CHECK (actual_cost_microdollars IS NULL OR status IN ('succeeded', 'provider_failed')),
+  CHECK (observed_cost_microdollars IS NULL OR status = 'invalid_limits'),
+  CHECK (actual_cost_microdollars IS NULL OR observed_cost_microdollars IS NULL),
+  CHECK (status <> 'intent_recorded' OR (response_disposition IS NULL AND response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
+  CHECK (status NOT IN ('succeeded', 'provider_failed') OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NOT NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
   CHECK ((status = 'succeeded') = (response_disposition IS NOT NULL)),
-  CHECK (status NOT IN ('malformed_response', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
-  CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND actual_cost_microdollars IS NULL)),
+  CHECK (status NOT IN ('malformed_response', 'missing_usage') OR (input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
+  CHECK (status <> 'malformed_response' OR returned_provider IS NULL),
+  CHECK (status <> 'missing_usage' OR returned_provider IS NOT NULL),
+  CHECK (status <> 'identity_mismatch' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
+  CHECK (status <> 'invalid_limits' OR (input_tokens IS NOT NULL AND output_tokens IS NOT NULL AND cache_read_tokens IS NOT NULL AND cache_write_tokens IS NOT NULL AND actual_cost_microdollars IS NULL AND latency_ms IS NOT NULL AND response_hmac IS NOT NULL AND returned_provider IS NOT NULL)),
+  CHECK (status <> 'timeout_after_dispatch' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
   CHECK (status <> 'unknown_exposure' OR (response_hmac IS NULL AND returned_provider IS NULL AND input_tokens IS NULL AND output_tokens IS NULL AND cache_read_tokens IS NULL AND cache_write_tokens IS NULL AND actual_cost_microdollars IS NULL AND observed_cost_microdollars IS NULL AND latency_ms IS NULL)),
   CHECK (status NOT IN ('succeeded', 'provider_failed', 'malformed_response', 'identity_mismatch', 'missing_usage') OR response_hmac IS NOT NULL)
 );
@@ -197,9 +205,12 @@ BEGIN
   IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure') AND OLD.disposition <> 'provider_dispatch' THEN
     RAISE EXCEPTION 'provider assignment outcome requires provider dispatch';
   END IF;
+  -- Every assignment outcome serializes on this authorization row.  This
+  -- makes the last-two-outcomes completion transition race-safe.
+  SELECT status INTO authorization_status FROM addie_fixed_trace_component_smoke_authorizations
+   WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'assignment authorization is absent'; END IF;
   IF NEW.assignment_outcome IN ('provider_completed', 'provider_failed', 'provider_unknown_exposure') THEN
-    SELECT status INTO authorization_status FROM addie_fixed_trace_component_smoke_authorizations
-     WHERE authorization_digest = NEW.authorization_digest FOR UPDATE;
     SELECT count(*), bool_or(status = 'intent_recorded'), bool_or(status <> 'succeeded')
       INTO terminal_count, open_attempt, failed_attempt
       FROM addie_fixed_trace_component_smoke_attempts
@@ -383,6 +394,11 @@ BEGIN
      AND (NEW.returned_provider IS DISTINCT FROM requested_provider OR NEW.returned_model IS DISTINCT FROM requested_model
           OR NEW.returned_effort IS DISTINCT FROM requested_effort) THEN
     RAISE EXCEPTION 'succeeded attempt identity differs from admitted plan';
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.status = 'identity_mismatch'
+     AND NEW.returned_provider = requested_provider AND NEW.returned_model = requested_model
+     AND NEW.returned_effort = requested_effort THEN
+    RAISE EXCEPTION 'identity mismatch requires differing returned identity';
   END IF;
   IF TG_OP = 'UPDATE' AND NEW.actual_cost_microdollars IS NOT NULL
      AND (NEW.returned_provider IS DISTINCT FROM requested_provider OR NEW.returned_model IS DISTINCT FROM requested_model

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -1,8 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { Client } from 'pg';
+import { Client, Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
-import { fixedTraceComponentSmokePrivateLedgerPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
+import { PostgresFixedTraceComponentSmokePrivateLedger, fixedTraceComponentSmokePrivateLedgerPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
 
 const databaseUrl = process.env.DATABASE_URL;
 let client: Client | null = null;
@@ -23,7 +23,10 @@ async function rejects(statement: string, values: unknown[] = [], subject = clie
 }
 
 function reservationIdFor(digest: string) {
-  return `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest: digest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\\0' })).digest('hex').slice(0, 32)}`;
+  return `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest: digest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0' })).digest('hex').slice(0, 32)}`;
+}
+function reservationFor(digest: string) {
+  return { authorizationDigest: digest, reservationId: reservationIdFor(digest), entryCount: 168 as const, providerDispatchEntryCount: 126 as const, reservationMicrodollars: 2_819_484 as const };
 }
 
 async function seedExactPlan(subject = client!, alterFirstModel = false) {
@@ -106,6 +109,36 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64), generation.provider, generation.model, generation.effort]);
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'4'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64)])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('rejects mismatched identity and mismatched actual-cost settlement while each attempt is still open', async () => {
+    const first = dispatchEntry(4);
+    await insertIntent(client!, authorizationDigest, first, 'a');
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'a'.repeat(32)}`, 'a'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'a'.repeat(32)}`])).rows).toEqual([{ status: 'intent_recorded' }]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'a'.repeat(32)}`, 'a'.repeat(64), first.provider, first.model, first.effort]);
+    const second = dispatchEntry(5);
+    await insertIntent(client!, authorizationDigest, second, 'b');
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 1, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'b'.repeat(32)}`, 'b'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'b'.repeat(32)}`])).rows).toEqual([{ status: 'intent_recorded' }]);
+  });
+
+  it('idempotently recovers a committed provider failure after unknown exposure has already committed', async () => {
+    const entry = dispatchEntry(6);
+    await insertIntent(client!, authorizationDigest, entry, 'c');
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'c'.repeat(32)}`, 'c'.repeat(64), entry.provider, entry.model, entry.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [authorizationDigest]);
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      expect(await ledger.recordUnknownExposure(reservationFor(authorizationDigest))).toEqual({ status: 'recorded' });
+      expect(await ledger.recordUnknownExposure(reservationFor(authorizationDigest))).toEqual({ status: 'recorded' });
+    } finally {
+      await pool.end();
+      await client!.query('BEGIN');
+    }
+    expect((await client!.query('SELECT assignment_outcome FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, entry.assignmentId])).rows).toEqual([{ assignment_outcome: 'provider_failed' }]);
   });
 
   it('settles an admitted maximum-ordinal continuation as a halt with observed cost', async () => {

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -133,11 +133,75 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).rows).toEqual([{ status: 'intent_recorded' }]);
   });
 
+  it('derives exact profile pricing and integer rounding at the database boundary', async () => {
+    const vectors = [
+      ['anthropic-standard-2026-09:claude-haiku-4-5', 1, 0, 1, 1, 3],
+      ['anthropic-standard-2026-09:claude-sonnet-5', 1, 0, 1, 1, 5],
+      ['openai-gpt-5.6-luna-standard-2026-09-05', 2, 0, 1, 1, 1],
+      ['google-gemini-3.7-flash-through-2026-12-31', 1, 0, 1, 0, 1],
+    ] as const;
+    for (const [index, [profileId, input, output, cacheRead, cacheWrite, expectedCost]] of vectors.entries()) {
+      const entry = plan.find((candidate) => candidate.disposition === 'provider_dispatch' && candidate.pricingProfileId === profileId)!;
+      const suffix = (index + 1).toString(16);
+      const attemptId = `attempt_${suffix.repeat(32)}`;
+      await insertIntent(client!, authorizationDigest, entry, suffix);
+      await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = $6, output_tokens = $7, cache_read_tokens = $8, cache_write_tokens = $9, actual_cost_microdollars = $10, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, suffix.repeat(64), entry.provider, entry.model, entry.effort, input, output, cacheRead, cacheWrite, expectedCost + 1])).resolves.toBeInstanceOf(Error);
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = $6, output_tokens = $7, cache_read_tokens = $8, cache_write_tokens = $9, actual_cost_microdollars = $10, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, suffix.repeat(64), entry.provider, entry.model, entry.effort, input, output, cacheRead, cacheWrite, expectedCost]);
+    }
+    const entry = dispatchEntry(10);
+    await insertIntent(client!, authorizationDigest, entry, 'f');
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'invalid_limits', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, observed_cost_microdollars = NULL, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'f'.repeat(32)}`, 'f'.repeat(64), entry.provider, entry.model, entry.effort])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('application terminalization uses the locked aggregate CTE on PostgreSQL', async () => {
+    const entry = dispatchEntry(11);
+    const attemptId = `attempt_${'c'.repeat(31)}d`;
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId, assignmentId: entry.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordTerminal({ reservation: reservationFor(authorizationDigest), attemptId, status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'd'.repeat(64), returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } })).toEqual({ status: 'recorded' });
+      expect((await client!.query('SELECT status, actual_cost_microdollars FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).rows).toEqual([{ status: 'succeeded', actual_cost_microdollars: '0' }]);
+    } finally {
+      await pool.end();
+      await client!.query('BEGIN');
+    }
+  });
+
+  it.each([
+    ['provider_failed', 'unknown_exposure', "status = 'provider_failed', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0"],
+    ['malformed_response', 'unknown_exposure', "status = 'malformed_response', response_hmac = $2"],
+    ['identity_mismatch', 'unknown_exposure', "status = 'identity_mismatch', response_hmac = $2, returned_provider = 'other', returned_model = 'other', returned_effort = 'other', input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, latency_ms = 0"],
+    ['missing_usage', 'unknown_exposure', "status = 'missing_usage', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5"],
+    ['timeout_after_dispatch', 'unknown_exposure', "status = 'timeout_after_dispatch'"],
+    ['invalid_limits', 'halted', "status = 'invalid_limits', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, observed_cost_microdollars = 0, latency_ms = 0"],
+    ['pricing_unavailable', 'unknown_exposure', "status = 'pricing_unavailable'"],
+    ['unknown_exposure', 'unknown_exposure', "status = 'unknown_exposure'"],
+  ] as const)('makes direct-SQL %s terminal nondispatchable', async (status, expectedAuthorizationStatus, assignment) => {
+    const digest = await seedExactPlan(client!);
+    const entry = dispatchEntry(12);
+    const suffix = `${({ provider_failed: '1', malformed_response: '2', identity_mismatch: '3', missing_usage: '4', timeout_after_dispatch: '5', invalid_limits: '6', pricing_unavailable: '7', unknown_exposure: '8' } as Record<string, string>)[status]}`;
+    const attemptId = `attempt_${suffix.repeat(32)}`;
+    await insertIntent(client!, digest, entry, suffix);
+    const values: unknown[] = [attemptId];
+    if (assignment.includes('$2')) values.push('e'.repeat(64));
+    if (assignment.includes('$3')) values.push(entry.provider);
+    if (assignment.includes('$4')) values.push(entry.model);
+    if (assignment.includes('$5')) values.push(entry.effort);
+    await client!.query(`UPDATE addie_fixed_trace_component_smoke_attempts SET ${assignment}, terminal_at = clock_timestamp() WHERE attempt_id = $1`, values);
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [digest])).rows).toEqual([{ status: expectedAuthorizationStatus }]);
+    await expect(rejects("INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,1,'intent_recorded',$4)", [`attempt_${'f'.repeat(32)}`, digest, dispatchEntry(13).assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    if (status === 'provider_failed') {
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_failed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [digest, entry.assignmentId]);
+      expect((await client!.query('SELECT assignment_outcome FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2', [digest, entry.assignmentId])).rows).toEqual([{ assignment_outcome: 'provider_failed' }]);
+    }
+  });
+
   it('idempotently recovers a committed provider failure after unknown exposure has already committed', async () => {
     const entry = dispatchEntry(6);
     await insertIntent(client!, authorizationDigest, entry, 'c');
     await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'c'.repeat(32)}`, 'c'.repeat(64), entry.provider, entry.model, entry.effort]);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [authorizationDigest]);
     await client!.query('COMMIT');
     const pool = new Pool({ connectionString: databaseUrl });
     try {

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -28,6 +28,7 @@ function reservationIdFor(digest: string) {
 function reservationFor(digest: string) {
   return { authorizationDigest: digest, reservationId: reservationIdFor(digest), entryCount: 168 as const, providerDispatchEntryCount: 126 as const, reservationMicrodollars: 2_819_484 as const };
 }
+function uniqueAttemptId() { return `attempt_${createHash('sha256').update(randomUUID()).digest('hex').slice(0, 32)}`; }
 
 async function seedExactPlan(subject = client!, alterFirstModel = false) {
   const digest = createHash('sha256').update(randomUUID()).digest('hex');
@@ -155,18 +156,69 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
 
   it('application terminalization uses the locked aggregate CTE on PostgreSQL', async () => {
     const entry = dispatchEntry(11);
-    const attemptId = `attempt_${'c'.repeat(31)}d`;
+    const attemptId = uniqueAttemptId();
     await client!.query('COMMIT');
     const pool = new Pool({ connectionString: databaseUrl });
     try {
       const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
       expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId, assignmentId: entry.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) })).toEqual({ status: 'recorded' });
       expect(await ledger.recordTerminal({ reservation: reservationFor(authorizationDigest), attemptId, status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'd'.repeat(64), returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordProviderAssignmentTerminal({ reservation: reservationFor(authorizationDigest), assignmentId: entry.assignmentId, status: 'provider_completed', finalInvocationOrdinal: 1 })).toEqual({ status: 'recorded' });
       expect((await client!.query('SELECT status, actual_cost_microdollars FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).rows).toEqual([{ status: 'succeeded', actual_cost_microdollars: '0' }]);
+      expect((await client!.query('SELECT assignment_outcome FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, entry.assignmentId])).rows).toEqual([{ assignment_outcome: 'provider_completed' }]);
     } finally {
       await pool.end();
       await client!.query('BEGIN');
     }
+  });
+
+  it('uses target-plan then authorization order against a direct outcome writer', async () => {
+    const entry = dispatchEntry(15);
+    const attemptId = uniqueAttemptId();
+    await insertIntent(client!, authorizationDigest, entry, attemptId.slice('attempt_'.length));
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, 'a'.repeat(64), entry.provider, entry.model, entry.effort]);
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      await client!.query('BEGIN');
+      await client!.query('SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE', [authorizationDigest, entry.assignmentId]);
+      let settled = false;
+      const application = ledger.recordProviderAssignmentTerminal({ reservation: reservationFor(authorizationDigest), assignmentId: entry.assignmentId, status: 'provider_completed', finalInvocationOrdinal: 1 }).then((outcome) => { settled = true; return outcome; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(settled).toBe(false);
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, entry.assignmentId]);
+      await client!.query('COMMIT');
+      expect(await application).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
+  it('application terminalizes a known provider failure after its fail-stop transition', async () => {
+    const entry = dispatchEntry(14);
+    const attemptId = uniqueAttemptId();
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId, assignmentId: entry.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'b'.repeat(64) })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordTerminal({ reservation: reservationFor(authorizationDigest), attemptId, status: 'provider_failed', responseDisposition: null, responseHmac: 'c'.repeat(64), returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordProviderAssignmentTerminal({ reservation: reservationFor(authorizationDigest), assignmentId: entry.assignmentId, status: 'provider_failed', finalInvocationOrdinal: 1 })).toEqual({ status: 'recorded' });
+      expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure' }]);
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
+  it('settles parser-maximum Google usage as priceable invalid_limits instead of leaving an open intent', async () => {
+    const entry = plan.find((candidate) => candidate.disposition === 'provider_dispatch' && candidate.pricingProfileId === 'google-gemini-3.7-flash-through-2026-12-31')!;
+    const attemptId = uniqueAttemptId();
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId, assignmentId: entry.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'a'.repeat(64) })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordTerminal({ reservation: reservationFor(authorizationDigest), attemptId, status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'b'.repeat(64), returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort }, usage: { inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } })).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+      expect((await client!.query('SELECT status, observed_cost_microdollars FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).rows).toEqual([{ status: 'invalid_limits', observed_cost_microdollars: '3750000' }]);
+      expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'halted' }]);
+    } finally { await pool.end(); await client!.query('BEGIN'); }
   });
 
   it.each([

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -322,6 +322,43 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     } finally { await blocker.query('ROLLBACK').catch(() => undefined); await blocker.end(); await pool.end(); await client!.query('BEGIN'); }
   });
 
+  it('gates a direct intent behind complete-plan recovery before its attempt snapshot', async () => {
+    // Three transactions: holder locks the last plan row; recovery consequently
+    // owns every earlier immutable plan row; a direct SQL INSERT on one of
+    // those rows must wait and then reject after recovery marks the run unknown.
+    const ordered = [...plan].sort((left, right) => left.assignmentId.localeCompare(right.assignmentId));
+    const held = ordered.at(-1)!;
+    const inserted = ordered.find((entry) => entry.disposition === 'provider_dispatch' && entry.assignmentId < held.assignmentId)!;
+    await client!.query('COMMIT');
+    const holder = new Client({ connectionString: databaseUrl });
+    const direct = new Client({ connectionString: databaseUrl });
+    const pool = new Pool({ connectionString: databaseUrl, max: 1 });
+    await holder.connect(); await direct.connect();
+    try {
+      await holder.query('BEGIN');
+      await holder.query('SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id = $2 FOR UPDATE', [authorizationDigest, held.assignmentId]);
+      const recovery = new PostgresFixedTraceComponentSmokePrivateLedger(pool).recordUnknownExposure(reservationFor(authorizationDigest));
+      let recoverySettled = false;
+      void recovery.then(() => { recoverySettled = true; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(recoverySettled).toBe(false);
+      let directSettled = false;
+      const directInsert = insertIntent(direct, authorizationDigest, inserted, uniqueAttemptId().slice('attempt_'.length))
+        .then(() => undefined, (error: unknown) => error)
+        .then((outcome) => { directSettled = true; return outcome; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(directSettled).toBe(false);
+      await holder.query('COMMIT');
+      expect(await recovery).toEqual({ status: 'recorded' });
+      expect(await directInsert).toBeInstanceOf(Error);
+      expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure' }]);
+      expect((await client!.query('SELECT count(*)::int AS count FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ count: 0 }]);
+    } finally {
+      await holder.query('ROLLBACK').catch(() => undefined);
+      await holder.end(); await direct.end(); await pool.end(); await client!.query('BEGIN');
+    }
+  });
+
   it('application terminalizes a known provider failure after its fail-stop transition', async () => {
     const entry = dispatchEntry(14);
     const attemptId = uniqueAttemptId();

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { Client } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const databaseUrl = process.env.RUN_PRIVATE_LEDGER_POSTGRES_TEST === '1' ? process.env.DATABASE_URL : undefined;
+const migration = readFileSync(new URL('../../../src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql', import.meta.url), 'utf8');
+let client: Client | null = null;
+
+/** Requires the integration PostgreSQL service; no network or provider access. */
+describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query('BEGIN');
+    await client.query(migration);
+  });
+  afterAll(async () => { if (client) { await client.query('ROLLBACK').catch(() => undefined); await client.end().catch(() => undefined); } });
+  it('accepts the 71-character sha256 pricing cohort column contract', async () => {
+    const result = await client!.query<{ character_maximum_length: number | null }>(
+      "SELECT character_maximum_length FROM information_schema.columns WHERE table_name = 'addie_fixed_trace_component_smoke_authorizations' AND column_name = 'pricing_cohort_digest'",
+    );
+    expect(result.rows).toEqual([{ character_maximum_length: 71 }]);
+    expect(migration).toContain("pricing_cohort_digest ~ '^sha256:[a-f0-9]{64}$'");
+  });
+});

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -106,7 +106,7 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'1'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
     await insertIntent(client!, authorizationDigest, generation, '2');
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'3'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64), generation.provider, generation.model, generation.effort]);
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'4'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64)])).resolves.toBeInstanceOf(Error);
   });
@@ -116,17 +116,27 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     await insertIntent(client!, authorizationDigest, first, 'a');
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'a'.repeat(32)}`, 'a'.repeat(64)])).resolves.toBeInstanceOf(Error);
     expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'a'.repeat(32)}`])).rows).toEqual([{ status: 'intent_recorded' }]);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'a'.repeat(32)}`, 'a'.repeat(64), first.provider, first.model, first.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'a'.repeat(32)}`, 'a'.repeat(64), first.provider, first.model, first.effort]);
     const second = dispatchEntry(5);
     await insertIntent(client!, authorizationDigest, second, 'b');
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 1, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'b'.repeat(32)}`, 'b'.repeat(64)])).resolves.toBeInstanceOf(Error);
     expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'b'.repeat(32)}`])).rows).toEqual([{ status: 'intent_recorded' }]);
   });
 
+  it('rejects contradictory terminal receipt accounting evidence at the database boundary', async () => {
+    const entry = dispatchEntry(7);
+    const attemptId = `attempt_${'d'.repeat(32)}`;
+    await insertIntent(client!, authorizationDigest, entry, 'd');
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'identity_mismatch', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, 'd'.repeat(64), entry.provider, entry.model, entry.effort])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, observed_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, 'd'.repeat(64), entry.provider, entry.model, entry.effort])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = NULL, returned_provider = NULL, returned_model = NULL, returned_effort = NULL, input_tokens = NULL, output_tokens = NULL, cache_read_tokens = NULL, cache_write_tokens = NULL, actual_cost_microdollars = NULL, observed_cost_microdollars = NULL, latency_ms = NULL, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId])).resolves.toBeInstanceOf(Error);
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).rows).toEqual([{ status: 'intent_recorded' }]);
+  });
+
   it('idempotently recovers a committed provider failure after unknown exposure has already committed', async () => {
     const entry = dispatchEntry(6);
     await insertIntent(client!, authorizationDigest, entry, 'c');
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'c'.repeat(32)}`, 'c'.repeat(64), entry.provider, entry.model, entry.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'provider_failed', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'c'.repeat(32)}`, 'c'.repeat(64), entry.provider, entry.model, entry.effort]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [authorizationDigest]);
     await client!.query('COMMIT');
     const pool = new Pool({ connectionString: databaseUrl });
@@ -144,7 +154,7 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
   it('settles an admitted maximum-ordinal continuation as a halt with observed cost', async () => {
     const router = dispatchEntry();
     await insertIntent(client!, authorizationDigest, router, '5');
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'5'.repeat(32)}`, '5'.repeat(64), router.provider, router.model, router.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'5'.repeat(32)}`, '5'.repeat(64), router.provider, router.model, router.effort]);
     expect((await client!.query('SELECT status, actual_cost_microdollars, observed_cost_microdollars FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'5'.repeat(32)}`])).rows).toEqual([{ status: 'invalid_limits', actual_cost_microdollars: null, observed_cost_microdollars: '0' }]);
     expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'halted' }]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_failed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId]);
@@ -181,19 +191,19 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
     await insertIntent(client!, authorizationDigest, generation);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'e'.repeat(32)}`, '1'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'e'.repeat(32)}`, '1'.repeat(64), generation.provider, generation.model, generation.effort]);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
     await insertIntent(client!, authorizationDigest, generation, '8', 2);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'8'.repeat(32)}`, '3'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'8'.repeat(32)}`, '3'.repeat(64), generation.provider, generation.model, generation.effort]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 2 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId]);
     const router = dispatchEntry();
     await insertIntent(client!, authorizationDigest, router, '7');
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'7'.repeat(32)}`, '2'.repeat(64), router.provider, router.model, router.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'7'.repeat(32)}`, '2'.repeat(64), router.provider, router.model, router.effort]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId]);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId])).resolves.toBeInstanceOf(Error);
     const finalFirst = plan.filter((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)[1]!;
     await insertIntent(client!, authorizationDigest, finalFirst, '9');
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'9'.repeat(32)}`, '4'.repeat(64), finalFirst.provider, finalFirst.model, finalFirst.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'9'.repeat(32)}`, '4'.repeat(64), finalFirst.provider, finalFirst.model, finalFirst.effort]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, finalFirst.assignmentId]);
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'0'.repeat(32)}`, authorizationDigest, finalFirst.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1", [authorizationDigest]);
@@ -224,18 +234,37 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     } finally { await contender.end(); await client!.query('BEGIN'); }
   });
 
-  it('requires all 168 assignment outcomes before completion and then rejects every later intent', async () => {
+  it('serializes the final two assignment outcomes and transitions the denominator to completed', async () => {
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'completed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+    const finalTwo = plan.filter((entry) => entry.disposition !== 'provider_dispatch').slice(0, 2);
     let index = 0;
     for (const entry of plan) {
+      if (finalTwo.some((remaining) => remaining.assignmentId === entry.assignmentId)) continue;
       if (entry.disposition === 'provider_dispatch') {
         const token = (++index).toString(16).padStart(32, '0');
         await insertIntent(client!, authorizationDigest, entry, token);
-        await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${token}`, 'a'.repeat(64), entry.provider, entry.model, entry.effort]);
+        await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${token}`, 'a'.repeat(64), entry.provider, entry.model, entry.effort]);
         await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, entry.assignmentId]);
       } else {
         await client!.query('UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, entry.assignmentId, entry.disposition]);
       }
+    }
+    await client!.query('COMMIT');
+    const first = new Client({ connectionString: databaseUrl });
+    const second = new Client({ connectionString: databaseUrl });
+    await first.connect(); await second.connect();
+    try {
+      await first.query('BEGIN'); await second.query('BEGIN');
+      await first.query('UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, finalTwo[0]!.assignmentId, finalTwo[0]!.disposition]);
+      let settled = false;
+      const closeSecond = second.query('UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, finalTwo[1]!.assignmentId, finalTwo[1]!.disposition]).then(() => { settled = true; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(settled).toBe(false);
+      await first.query('COMMIT');
+      await closeSecond;
+      await second.query('COMMIT');
+    } finally {
+      await first.end(); await second.end(); await client!.query('BEGIN');
     }
     expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'completed' }]);
     await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,1,'intent_recorded',$4)`, [`attempt_${'f'.repeat(32)}`, authorizationDigest, dispatchEntry().assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -193,6 +193,47 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     } finally { await pool.end(); await client!.query('BEGIN'); }
   });
 
+  it('serializes application terminalization with standalone recovery after a prior terminal', async () => {
+    const prior = dispatchEntry(16);
+    const open = dispatchEntry(17);
+    const priorId = uniqueAttemptId();
+    const openId = uniqueAttemptId();
+    await insertIntent(client!, authorizationDigest, prior, priorId.slice('attempt_'.length));
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [priorId, 'a'.repeat(64), prior.provider, prior.model, prior.effort]);
+    await insertIntent(client!, authorizationDigest, open, openId.slice('attempt_'.length));
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      const [terminal, recovery] = await Promise.all([
+        ledger.recordTerminal({ reservation: reservationFor(authorizationDigest), attemptId: openId, status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'b'.repeat(64), returnedIdentity: { provider: open.provider, model: open.model, effort: open.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } }),
+        ledger.recordUnknownExposure(reservationFor(authorizationDigest)),
+      ]);
+      expect(terminal.status === 'recorded' || (terminal.status === 'refused' && (terminal.reason === 'intent_required' || terminal.reason === 'unknown_exposure'))).toBe(true);
+      expect(recovery).toEqual({ status: 'recorded' });
+      expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', open: 0 }]);
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
+  it('runs provider-intent recovery independently of a concurrent standalone recovery', async () => {
+    const open = dispatchEntry(18);
+    const target = dispatchEntry(19);
+    const openId = uniqueAttemptId();
+    await insertIntent(client!, authorizationDigest, open, openId.slice('attempt_'.length));
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      const [intent, recovery] = await Promise.all([
+        ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId: uniqueAttemptId(), assignmentId: target.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) }),
+        ledger.recordUnknownExposure(reservationFor(authorizationDigest)),
+      ]);
+      expect(intent).toEqual({ status: 'refused', reason: 'unknown_exposure' });
+      expect(recovery).toEqual({ status: 'recorded' });
+      expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', open: 0 }]);
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
   it('application terminalizes a known provider failure after its fail-stop transition', async () => {
     const entry = dispatchEntry(14);
     const attemptId = uniqueAttemptId();

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -1,25 +1,93 @@
-import { readFileSync } from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
 import { Client } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import { fixedTraceComponentSmokePrivateLedgerPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
 
-const databaseUrl = process.env.RUN_PRIVATE_LEDGER_POSTGRES_TEST === '1' ? process.env.DATABASE_URL : undefined;
-const migration = readFileSync(new URL('../../../src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql', import.meta.url), 'utf8');
+const databaseUrl = process.env.DATABASE_URL;
 let client: Client | null = null;
+let authorizationDigest = '';
+const plan = fixedTraceComponentSmokePrivateLedgerPlan()!;
+const admission = fixedTraceComponentSmokeAdmission();
 
-/** Requires the integration PostgreSQL service; no network or provider access. */
+async function rejects(statement: string, values: unknown[] = []) {
+  await client!.query('SAVEPOINT private_ledger_expected_failure');
+  try {
+    await client!.query(statement, values);
+  } catch (error) {
+    await client!.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
+    return error;
+  }
+  await client!.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
+  throw new Error('statement unexpectedly succeeded');
+}
+
+async function seedExactPlan() {
+  authorizationDigest = createHash('sha256').update(randomUUID()).digest('hex');
+  const reservationId = `reservation_${createHash('sha256').update(authorizationDigest).digest('hex').slice(0, 32)}`;
+  await client!.query(
+    `INSERT INTO addie_fixed_trace_component_smoke_authorizations
+     (authorization_digest,signed_payload_digest,signature_digest,kid,nonce_commitment,grant_version,stage_id,admission_version,aggregate_admission_fingerprint,
+      probes,router_cells,generation_cells,total_cells,repetitions,assignments,provider_dispatch_assignments,local_terminal_assignments,pre_dispatch_fault_assignments,
+      maximum_planned_invocation_slots,maximum_provider_invocations,reservation_microdollars,provider_ceiling_microdollars,pricing_cohort_digest,issued_at,expires_at,status,consumed_at,reservation_id)
+     VALUES ($1,$2,$3,'postgres-ledger-test',$4,'addie-fixed-trace-component-smoke-signed-grant-v1','stage_1_smoke','addie-fixed-trace-component-smoke-admission-v2',
+       '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d',8,10,11,21,1,168,126,21,21,256,192,2819484,5000000,$5,
+       clock_timestamp() - interval '1 minute',clock_timestamp() + interval '1 minute','consumed',clock_timestamp(),$6)`,
+    [authorizationDigest, 'b'.repeat(64), 'c'.repeat(64), 'd'.repeat(64), admission.pricing.cohortDigest, reservationId],
+  );
+  for (const entry of plan) {
+    await client!.query(
+      `INSERT INTO addie_fixed_trace_component_smoke_run_plan
+       (authorization_digest,assignment_id,probe_id,cell_id,disposition,maximum_provider_invocations,requested_provider,requested_model,requested_effort,pricing_profile_id,max_input_tokens,max_output_tokens,timeout_ms,retries,reserved_microdollars)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,0,$14)`,
+      [authorizationDigest, entry.assignmentId, entry.probeId, entry.cellId, entry.disposition, entry.maximumProviderInvocations, entry.provider, entry.model, entry.effort, entry.pricingProfileId, entry.maxInputTokens, entry.maxOutputTokens, entry.timeoutMs, entry.reservedMicrodollars],
+    );
+  }
+  await client!.query('SET CONSTRAINTS addie_fixed_trace_component_smoke_plan_exact IMMEDIATE');
+}
+
+/** Uses the build-check PostgreSQL database after normal migrations; no provider path exists. */
 describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
   beforeAll(async () => {
     client = new Client({ connectionString: databaseUrl });
     await client.connect();
     await client.query('BEGIN');
-    await client.query(migration);
+    await seedExactPlan();
   });
   afterAll(async () => { if (client) { await client.query('ROLLBACK').catch(() => undefined); await client.end().catch(() => undefined); } });
-  it('accepts the 71-character sha256 pricing cohort column contract', async () => {
+
+  it('uses the migrated 71-character pricing digest contract and bounded database TTL', async () => {
     const result = await client!.query<{ character_maximum_length: number | null }>(
       "SELECT character_maximum_length FROM information_schema.columns WHERE table_name = 'addie_fixed_trace_component_smoke_authorizations' AND column_name = 'pricing_cohort_digest'",
     );
     expect(result.rows).toEqual([{ character_maximum_length: 71 }]);
-    expect(migration).toContain("pricing_cohort_digest ~ '^sha256:[a-f0-9]{64}$'");
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET expires_at = issued_at + interval '16 minutes' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('enforces exact plan counts and immutable direct SQL state', async () => {
+    const local = plan.find((entry) => entry.disposition === 'local_terminal')!;
+    await client!.query(
+      "UPDATE addie_fixed_trace_component_smoke_run_plan SET non_dispatch_status = 'local_terminal', non_dispatch_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2",
+      [authorizationDigest, local.assignmentId],
+    );
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET requested_model = 'changed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+    await expect(rejects('DELETE FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1', [authorizationDigest])).resolves.toBeInstanceOf(Error);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1", [authorizationDigest]);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'consumed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('enforces ordinal reservation and direct attempt monotonicity', async () => {
+    const entry = plan.find((candidate) => candidate.disposition === 'provider_dispatch')!;
+    const attemptId = `attempt_${'e'.repeat(32)}`;
+    const insert = (id: string, ordinal: number, cost: number) => client!.query(
+      `INSERT INTO addie_fixed_trace_component_smoke_attempts
+       (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac,response_hmac,returned_provider,returned_model,returned_effort,input_tokens,output_tokens,cache_read_tokens,cache_write_tokens,actual_cost_microdollars,latency_ms,terminal_at)
+       VALUES ($1,$2,$3,$4,'succeeded',$5,$6,$7,$8,$9,0,0,0,0,$10,0,clock_timestamp())`,
+      [id, authorizationDigest, entry.assignmentId, ordinal, 'f'.repeat(64), '1'.repeat(64), entry.provider, entry.model, entry.effort, cost],
+    );
+    await insert(attemptId, 1, entry.reservedMicrodollars[0]!);
+    await expect(rejects('UPDATE addie_fixed_trace_component_smoke_attempts SET actual_cost_microdollars = actual_cost_microdollars + 1 WHERE attempt_id = $1', [attemptId])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'intent_recorded', terminal_at = NULL WHERE attempt_id = $1", [attemptId])).resolves.toBeInstanceOf(Error);
+    await expect(rejects('DELETE FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).resolves.toBeInstanceOf(Error);
   });
 });

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -394,6 +394,45 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     }
   });
 
+  it('blocks an application outcome at the recovery table gate before it locks its target', async () => {
+    const entry = plan.find((candidate) => candidate.disposition === 'local_terminal')!;
+    const recoveryAtPlanSet = deferred();
+    const releaseRecovery = deferred();
+    let blocked = false;
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+    const recoveryPool = {
+      connect: async () => {
+        const connection = await pool.connect();
+        const mutable = connection as unknown as { query: (sql: string, values?: readonly unknown[]) => Promise<unknown> };
+        const query = mutable.query.bind(connection);
+        mutable.query = async (sql, values) => {
+          if (!blocked && sql.startsWith('SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan')) {
+            blocked = true;
+            recoveryAtPlanSet.resolve();
+            await releaseRecovery.promise;
+          }
+          return query(sql, values);
+        };
+        return connection;
+      },
+    };
+    try {
+      const recoveryLedger = new PostgresFixedTraceComponentSmokePrivateLedger(recoveryPool as never);
+      const applicationLedger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      const recovery = recoveryLedger.recordUnknownExposure(reservationFor(authorizationDigest));
+      await recoveryAtPlanSet.promise;
+      let applicationSettled = false;
+      const application = applicationLedger.recordNonDispatchTerminal({ reservation: reservationFor(authorizationDigest), assignmentId: entry.assignmentId, status: 'local_terminal' })
+        .then((outcome) => { applicationSettled = true; return outcome; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(applicationSettled).toBe(false);
+      releaseRecovery.resolve();
+      expect(await recovery).toEqual({ status: 'recorded' });
+      expect(await application).toEqual({ status: 'refused', reason: 'unknown_exposure' });
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
   it('application terminalizes a known provider failure after its fail-stop transition', async () => {
     const entry = dispatchEntry(14);
     const attemptId = uniqueAttemptId();

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { Client } from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
 import { fixedTraceComponentSmokePrivateLedgerPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
 
@@ -10,22 +10,25 @@ let authorizationDigest = '';
 const plan = fixedTraceComponentSmokePrivateLedgerPlan()!;
 const admission = fixedTraceComponentSmokeAdmission();
 
-async function rejects(statement: string, values: unknown[] = []) {
-  await client!.query('SAVEPOINT private_ledger_expected_failure');
+async function rejects(statement: string, values: unknown[] = [], subject = client!) {
+  await subject.query('SAVEPOINT private_ledger_expected_failure');
   try {
-    await client!.query(statement, values);
+    await subject.query(statement, values);
   } catch (error) {
-    await client!.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
+    await subject.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
     return error;
   }
-  await client!.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
+  await subject.query('ROLLBACK TO SAVEPOINT private_ledger_expected_failure');
   throw new Error('statement unexpectedly succeeded');
 }
 
-async function seedExactPlan() {
-  authorizationDigest = createHash('sha256').update(randomUUID()).digest('hex');
-  const reservationId = `reservation_${createHash('sha256').update(authorizationDigest).digest('hex').slice(0, 32)}`;
-  await client!.query(
+function reservationIdFor(digest: string) {
+  return `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest: digest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\\0' })).digest('hex').slice(0, 32)}`;
+}
+
+async function seedExactPlan(subject = client!, alterFirstModel = false) {
+  const digest = createHash('sha256').update(randomUUID()).digest('hex');
+  await subject.query(
     `INSERT INTO addie_fixed_trace_component_smoke_authorizations
      (authorization_digest,signed_payload_digest,signature_digest,kid,nonce_commitment,grant_version,stage_id,admission_version,aggregate_admission_fingerprint,
       probes,router_cells,generation_cells,total_cells,repetitions,assignments,provider_dispatch_assignments,local_terminal_assignments,pre_dispatch_fault_assignments,
@@ -33,61 +36,129 @@ async function seedExactPlan() {
      VALUES ($1,$2,$3,'postgres-ledger-test',$4,'addie-fixed-trace-component-smoke-signed-grant-v1','stage_1_smoke','addie-fixed-trace-component-smoke-admission-v2',
        '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d',8,10,11,21,1,168,126,21,21,256,192,2819484,5000000,$5,
        clock_timestamp() - interval '1 minute',clock_timestamp() + interval '1 minute','consumed',clock_timestamp(),$6)`,
-    [authorizationDigest, 'b'.repeat(64), 'c'.repeat(64), 'd'.repeat(64), admission.pricing.cohortDigest, reservationId],
+    [digest, createHash('sha256').update(`${digest}:payload`).digest('hex'), createHash('sha256').update(`${digest}:signature`).digest('hex'), createHash('sha256').update(`${digest}:nonce`).digest('hex'), admission.pricing.cohortDigest, reservationIdFor(digest)],
   );
-  for (const entry of plan) {
-    await client!.query(
+  for (const [index, entry] of plan.entries()) {
+    await subject.query(
       `INSERT INTO addie_fixed_trace_component_smoke_run_plan
        (authorization_digest,assignment_id,probe_id,cell_id,disposition,maximum_provider_invocations,requested_provider,requested_model,requested_effort,pricing_profile_id,max_input_tokens,max_output_tokens,timeout_ms,retries,reserved_microdollars)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,0,$14)`,
-      [authorizationDigest, entry.assignmentId, entry.probeId, entry.cellId, entry.disposition, entry.maximumProviderInvocations, entry.provider, entry.model, entry.effort, entry.pricingProfileId, entry.maxInputTokens, entry.maxOutputTokens, entry.timeoutMs, entry.reservedMicrodollars],
+      [digest, entry.assignmentId, entry.probeId, entry.cellId, entry.disposition, entry.maximumProviderInvocations, entry.provider,
+        index === 0 && alterFirstModel ? `${entry.model}-forged` : entry.model, entry.effort, entry.pricingProfileId,
+        entry.maxInputTokens, entry.maxOutputTokens, entry.timeoutMs, entry.reservedMicrodollars],
     );
   }
-  await client!.query('SET CONSTRAINTS addie_fixed_trace_component_smoke_plan_exact IMMEDIATE');
+  return digest;
+}
+
+function dispatchEntry(offset = 0) { return plan.filter((entry) => entry.disposition === 'provider_dispatch')[offset]!; }
+async function insertIntent(subject: Client, digest: string, entry = dispatchEntry(), suffix = 'e', ordinal = 1) {
+  const token = suffix.length === 1 ? suffix.repeat(32) : suffix;
+  return subject.query(
+    `INSERT INTO addie_fixed_trace_component_smoke_attempts
+     (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac)
+     VALUES ($1,$2,$3,$4,'intent_recorded',$5)`,
+    [`attempt_${token}`, digest, entry.assignmentId, ordinal, 'f'.repeat(64)],
+  );
 }
 
 /** Uses the build-check PostgreSQL database after normal migrations; no provider path exists. */
 describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
-  beforeAll(async () => {
-    client = new Client({ connectionString: databaseUrl });
-    await client.connect();
-    await client.query('BEGIN');
-    await seedExactPlan();
-  });
-  afterAll(async () => { if (client) { await client.query('ROLLBACK').catch(() => undefined); await client.end().catch(() => undefined); } });
+  beforeAll(async () => { client = new Client({ connectionString: databaseUrl }); await client.connect(); });
+  beforeEach(async () => { await client!.query('BEGIN'); authorizationDigest = await seedExactPlan(); });
+  afterEach(async () => { await client!.query('ROLLBACK'); });
+  afterAll(async () => { await client?.end().catch(() => undefined); });
 
   it('uses the migrated 71-character pricing digest contract and bounded database TTL', async () => {
-    const result = await client!.query<{ character_maximum_length: number | null }>(
-      "SELECT character_maximum_length FROM information_schema.columns WHERE table_name = 'addie_fixed_trace_component_smoke_authorizations' AND column_name = 'pricing_cohort_digest'",
-    );
+    const result = await client!.query<{ character_maximum_length: number | null }>("SELECT character_maximum_length FROM information_schema.columns WHERE table_name = 'addie_fixed_trace_component_smoke_authorizations' AND column_name = 'pricing_cohort_digest'");
     expect(result.rows).toEqual([{ character_maximum_length: 71 }]);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET expires_at = issued_at + interval '16 minutes' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
   });
 
-  it('enforces exact plan counts and immutable direct SQL state', async () => {
-    const local = plan.find((entry) => entry.disposition === 'local_terminal')!;
-    await client!.query(
-      "UPDATE addie_fixed_trace_component_smoke_run_plan SET non_dispatch_status = 'local_terminal', non_dispatch_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2",
-      [authorizationDigest, local.assignmentId],
-    );
-    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET requested_model = 'changed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
-    await expect(rejects('DELETE FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1', [authorizationDigest])).resolves.toBeInstanceOf(Error);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1", [authorizationDigest]);
-    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'consumed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+  it('rejects an initially forged full plan despite matching aggregate cardinality', async () => {
+    await seedExactPlan(client!, true);
+    await expect(rejects('SET CONSTRAINTS addie_fixed_trace_component_smoke_plan_exact IMMEDIATE')).resolves.toBeInstanceOf(Error);
   });
 
-  it('enforces ordinal reservation and direct attempt monotonicity', async () => {
-    const entry = plan.find((candidate) => candidate.disposition === 'provider_dispatch')!;
+  it('permits only consumed intent insertion and rejects direct terminal insertion', async () => {
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac,response_hmac,returned_provider,returned_model,returned_effort,input_tokens,output_tokens,actual_cost_microdollars,latency_ms,terminal_at) VALUES ($1,$2,$3,1,'succeeded',$4,$5,$6,$7,$8,0,0,0,0,clock_timestamp())`, [`attempt_${'d'.repeat(32)}`, authorizationDigest, dispatchEntry().assignmentId, 'f'.repeat(64), '1'.repeat(64), dispatchEntry().provider, dispatchEntry().model, dispatchEntry().effort])).resolves.toBeInstanceOf(Error);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1", [authorizationDigest]);
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,1,'intent_recorded',$4)`, [`attempt_${'a'.repeat(32)}`, authorizationDigest, dispatchEntry().assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    const unknown = await seedExactPlan();
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [unknown]);
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,1,'intent_recorded',$4)`, [`attempt_${'b'.repeat(32)}`, unknown, dispatchEntry().assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('enforces ordinal reservation and immutable direct SQL state', async () => {
+    await insertIntent(client!, authorizationDigest);
     const attemptId = `attempt_${'e'.repeat(32)}`;
-    const insert = (id: string, ordinal: number, cost: number) => client!.query(
-      `INSERT INTO addie_fixed_trace_component_smoke_attempts
-       (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac,response_hmac,returned_provider,returned_model,returned_effort,input_tokens,output_tokens,cache_read_tokens,cache_write_tokens,actual_cost_microdollars,latency_ms,terminal_at)
-       VALUES ($1,$2,$3,$4,'succeeded',$5,$6,$7,$8,$9,0,0,0,0,$10,0,clock_timestamp())`,
-      [id, authorizationDigest, entry.assignmentId, ordinal, 'f'.repeat(64), '1'.repeat(64), entry.provider, entry.model, entry.effort, cost],
-    );
-    await insert(attemptId, 1, entry.reservedMicrodollars[0]!);
-    await expect(rejects('UPDATE addie_fixed_trace_component_smoke_attempts SET actual_cost_microdollars = actual_cost_microdollars + 1 WHERE attempt_id = $1', [attemptId])).resolves.toBeInstanceOf(Error);
-    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'intent_recorded', terminal_at = NULL WHERE attempt_id = $1", [attemptId])).resolves.toBeInstanceOf(Error);
+    await expect(rejects('UPDATE addie_fixed_trace_component_smoke_attempts SET actual_cost_microdollars = 99999999 WHERE attempt_id = $1', [attemptId])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'intent_recorded' WHERE attempt_id = $1", [attemptId])).resolves.toBeInstanceOf(Error);
     await expect(rejects('DELETE FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [attemptId])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET requested_model = 'changed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('keeps one assignment outcome separate from invocation attempts and closes halted omissions', async () => {
+    const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
+    await insertIntent(client!, authorizationDigest, generation);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'e'.repeat(32)}`, '1'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
+    const router = dispatchEntry();
+    await insertIntent(client!, authorizationDigest, router, '7');
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'7'.repeat(32)}`, '2'.repeat(64), router.provider, router.model, router.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId]);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId])).resolves.toBeInstanceOf(Error);
+    await insertIntent(client!, authorizationDigest, generation, '8', 2);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'8'.repeat(32)}`, '3'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 2 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId]);
+    const finalFirst = plan.filter((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)[1]!;
+    await insertIntent(client!, authorizationDigest, finalFirst, '9');
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'9'.repeat(32)}`, '4'.repeat(64), finalFirst.provider, finalFirst.model, finalFirst.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, finalFirst.assignmentId]);
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'0'.repeat(32)}`, authorizationDigest, finalFirst.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'halted' WHERE authorization_digest = $1", [authorizationDigest]);
+    const local = plan.find((entry) => entry.disposition === 'local_terminal')!;
+    const untouchedProvider = dispatchEntry(2);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, local.assignmentId]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, untouchedProvider.assignmentId]);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('serializes a concurrent intent behind unknown exposure and refuses it after the lock releases', async () => {
+    await client!.query('COMMIT');
+    const contender = new Client({ connectionString: databaseUrl });
+    await contender.connect();
+    try {
+      await client!.query('BEGIN');
+      await client!.query('SELECT 1 FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 FOR UPDATE', [authorizationDigest]);
+      let settled = false;
+      const competing = insertIntent(contender, authorizationDigest, dispatchEntry(1), '9').then(() => { settled = true; }, () => { settled = true; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(settled).toBe(false);
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [authorizationDigest]);
+      await client!.query('COMMIT');
+      await competing;
+      expect(settled).toBe(true);
+      const attempts = await contender.query('SELECT count(*)::int AS count FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest = $1', [authorizationDigest]);
+      expect(attempts.rows).toEqual([{ count: 0 }]);
+    } finally { await contender.end(); await client!.query('BEGIN'); }
+  });
+
+  it('requires all 168 assignment outcomes before completion and then rejects every later intent', async () => {
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'completed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
+    let index = 0;
+    for (const entry of plan) {
+      if (entry.disposition === 'provider_dispatch') {
+        const token = (++index).toString(16).padStart(32, '0');
+        await insertIntent(client!, authorizationDigest, entry, token);
+        await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${token}`, 'a'.repeat(64), entry.provider, entry.model, entry.effort]);
+        await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, entry.assignmentId]);
+      } else {
+        await client!.query('UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = $3, assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2', [authorizationDigest, entry.assignmentId, entry.disposition]);
+      }
+    }
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'completed' }]);
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,1,'intent_recorded',$4)`, [`attempt_${'f'.repeat(32)}`, authorizationDigest, dispatchEntry().assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
   });
 });

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -359,6 +359,41 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     }
   });
 
+  it('serializes a reverse-order multi-outcome writer before recovery locks any plan target', async () => {
+    const positioned = plan.map((entry, index) => ({ entry, index })).filter(({ entry }) => entry.disposition === 'provider_dispatch');
+    const earlier = positioned[0]!;
+    const later = positioned.at(-1)!;
+    const earlierAttempt = uniqueAttemptId();
+    const laterAttempt = uniqueAttemptId();
+    for (const [entry, attemptId] of [[earlier.entry, earlierAttempt], [later.entry, laterAttempt]] as const) {
+      await insertIntent(client!, authorizationDigest, entry, attemptId.slice('attempt_'.length));
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, cache_read_tokens = 0, cache_write_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [attemptId, 'a'.repeat(64), entry.provider, entry.model, entry.effort]);
+    }
+    await client!.query('COMMIT');
+    const writer = new Client({ connectionString: databaseUrl });
+    const pool = new Pool({ connectionString: databaseUrl, max: 1 });
+    await writer.connect();
+    try {
+      await writer.query('BEGIN');
+      // The old recovery sequence could lock `earlier` while waiting for
+      // `later`; a bounded writer lock exposes that cycle as a failure.
+      await writer.query("SET LOCAL lock_timeout = '400ms'");
+      await writer.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, later.entry.assignmentId]);
+      const recovery = new PostgresFixedTraceComponentSmokePrivateLedger(pool).recordUnknownExposure(reservationFor(authorizationDigest));
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      // Reversed physical-order target. The recovery table gate has not yet
+      // taken either row, so this cannot wait behind a recovery row lock.
+      await writer.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, earlier.entry.assignmentId]);
+      await writer.query('COMMIT');
+      expect(await recovery).toEqual({ status: 'recorded' });
+      expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure' }]);
+      expect((await client!.query('SELECT assignment_outcome FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_id IN ($2,$3) ORDER BY assignment_id', [authorizationDigest, earlier.entry.assignmentId, later.entry.assignmentId])).rows).toEqual([{ assignment_outcome: 'provider_completed' }, { assignment_outcome: 'provider_completed' }]);
+    } finally {
+      await writer.query('ROLLBACK').catch(() => undefined);
+      await writer.end(); await pool.end(); await client!.query('BEGIN');
+    }
+  });
+
   it('application terminalizes a known provider failure after its fail-stop transition', async () => {
     const entry = dispatchEntry(14);
     const attemptId = uniqueAttemptId();

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -29,6 +29,11 @@ function reservationFor(digest: string) {
   return { authorizationDigest: digest, reservationId: reservationIdFor(digest), entryCount: 168 as const, providerDispatchEntryCount: 126 as const, reservationMicrodollars: 2_819_484 as const };
 }
 function uniqueAttemptId() { return `attempt_${createHash('sha256').update(randomUUID()).digest('hex').slice(0, 32)}`; }
+function deferred() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve: () => resolve?.() };
+}
 
 async function seedExactPlan(subject = client!, alterFirstModel = false) {
   const digest = createHash('sha256').update(randomUUID()).digest('hex');
@@ -232,6 +237,89 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
       expect(recovery).toEqual({ status: 'recorded' });
       expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', open: 0 }]);
     } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
+  it('releases provider-intent target locking before standalone recovery after the precheck race', async () => {
+    const target = dispatchEntry(20);
+    const opened = dispatchEntry(21);
+    const precheckRead = deferred();
+    const releasePrecheck = deferred();
+    let blocked = false;
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+    const controlledPool = {
+      connect: async () => {
+        const connection = await pool.connect();
+        const mutable = connection as unknown as { query: (sql: string, values?: readonly unknown[]) => Promise<unknown> };
+        const query = mutable.query.bind(connection);
+        mutable.query = async (sql, values) => {
+          const output = await query(sql, values);
+          if (!blocked && sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts') && sql.includes("status = 'intent_recorded'")) {
+            blocked = true;
+            precheckRead.resolve();
+            await releasePrecheck.promise;
+          }
+          return output;
+        };
+        return connection;
+      },
+    };
+    const contender = new Client({ connectionString: databaseUrl });
+    await contender.connect();
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(controlledPool as never);
+      const pendingIntent = ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId: uniqueAttemptId(), assignmentId: target.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) });
+      await precheckRead.promise;
+      // This committed intent is deliberately injected after the initial
+      // precheck but before the target plan lock is acquired.
+      await insertIntent(contender, authorizationDigest, opened, uniqueAttemptId().slice('attempt_'.length));
+      const recovery = ledger.recordUnknownExposure(reservationFor(authorizationDigest));
+      releasePrecheck.resolve();
+      expect(await recovery).toEqual({ status: 'recorded' });
+      expect(await pendingIntent).toEqual({ status: 'refused', reason: 'unknown_exposure' });
+      expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a LEFT JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', open: 0 }]);
+    } finally { await contender.end(); await pool.end(); await client!.query('BEGIN'); }
+  });
+
+  it('reports recovery lock failure as uncertainty and never claims durable poisoning', async () => {
+    const open = dispatchEntry(22);
+    const later = dispatchEntry(23);
+    const openId = uniqueAttemptId();
+    await client!.query('COMMIT');
+    await insertIntent(client!, authorizationDigest, open, openId.slice('attempt_'.length));
+    const blocker = new Client({ connectionString: databaseUrl });
+    await blocker.connect();
+    const pool = new Pool({ connectionString: databaseUrl, max: 1 });
+    let acquisitions = 0;
+    const timeoutRecoveryPool = {
+      connect: async () => {
+        const connection = await pool.connect();
+        acquisitions += 1;
+        if (acquisitions !== 2) return connection;
+        const mutable = connection as unknown as { query: (sql: string, values?: readonly unknown[]) => Promise<unknown> };
+        const query = mutable.query.bind(connection);
+        mutable.query = async (sql, values) => {
+          const output = await query(sql, values);
+          if (sql === 'BEGIN') await query("SET LOCAL lock_timeout = '50ms'");
+          return output;
+        };
+        return connection;
+      },
+    };
+    try {
+      await blocker.query('BEGIN');
+      await blocker.query('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1 FOR UPDATE', [openId]);
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(timeoutRecoveryPool as never);
+      expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId: uniqueAttemptId(), assignmentId: later.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) })).toEqual({ status: 'refused', reason: 'persistence_uncertain' });
+      expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'consumed', open: 1 }]);
+      await blocker.query('ROLLBACK');
+      const cleanPool = new Pool({ connectionString: databaseUrl });
+      try {
+        const cleanLedger = new PostgresFixedTraceComponentSmokePrivateLedger(cleanPool);
+        expect(await cleanLedger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId: uniqueAttemptId(), assignmentId: later.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'd'.repeat(64) })).toEqual({ status: 'refused', reason: 'unknown_exposure' });
+      } finally { await cleanPool.end(); }
+      expect((await client!.query("SELECT a.status, count(*) FILTER (WHERE t.status = 'intent_recorded')::int AS open FROM addie_fixed_trace_component_smoke_authorizations a LEFT JOIN addie_fixed_trace_component_smoke_attempts t USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY a.status", [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', open: 0 }]);
+    } finally { await blocker.query('ROLLBACK').catch(() => undefined); await blocker.end(); await pool.end(); await client!.query('BEGIN'); }
   });
 
   it('application terminalizes a known provider failure after its fail-stop transition', async () => {

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -98,20 +98,66 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET requested_model = 'changed' WHERE authorization_digest = $1", [authorizationDigest])).resolves.toBeInstanceOf(Error);
   });
 
+  it('enforces contiguous ordinal sequencing and refuses a concurrent second open intent', async () => {
+    const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'1'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    await insertIntent(client!, authorizationDigest, generation, '2');
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'3'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await expect(rejects(`INSERT INTO addie_fixed_trace_component_smoke_attempts (attempt_id,authorization_digest,assignment_id,invocation_ordinal,status,prepared_request_hmac) VALUES ($1,$2,$3,2,'intent_recorded',$4)`, [`attempt_${'4'.repeat(32)}`, authorizationDigest, generation.assignmentId, 'f'.repeat(64)])).resolves.toBeInstanceOf(Error);
+    await expect(rejects("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = 'wrong', returned_model = 'wrong', returned_effort = 'wrong', input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'2'.repeat(32)}`, '2'.repeat(64)])).resolves.toBeInstanceOf(Error);
+  });
+
+  it('settles an admitted maximum-ordinal continuation as a halt with observed cost', async () => {
+    const router = dispatchEntry();
+    await insertIntent(client!, authorizationDigest, router, '5');
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'5'.repeat(32)}`, '5'.repeat(64), router.provider, router.model, router.effort]);
+    expect((await client!.query('SELECT status, actual_cost_microdollars, observed_cost_microdollars FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id = $1', [`attempt_${'5'.repeat(32)}`])).rows).toEqual([{ status: 'invalid_limits', actual_cost_microdollars: null, observed_cost_microdollars: '0' }]);
+    expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'halted' }]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_failed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId]);
+  });
+
+  it('serializes direct concurrent intents and closes a started ambiguous assignment without receipt evidence', async () => {
+    await client!.query('COMMIT');
+    const contender = new Client({ connectionString: databaseUrl });
+    await contender.connect();
+    const started = dispatchEntry();
+    try {
+      await client!.query('BEGIN');
+      await insertIntent(client!, authorizationDigest, started, '6');
+      let settled = false;
+      const competing = insertIntent(contender, authorizationDigest, dispatchEntry(1), '7').then(() => { settled = true; }, () => { settled = true; });
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(settled).toBe(false);
+      await client!.query('COMMIT');
+      await competing;
+      expect(settled).toBe(true);
+      await client!.query('BEGIN');
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_authorizations SET status = 'unknown_exposure', unknown_exposure_at = clock_timestamp() WHERE authorization_digest = $1", [authorizationDigest]);
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'unknown_exposure', terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'6'.repeat(32)}`]);
+      await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_unknown_exposure', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, started.assignmentId]);
+      expect((await client!.query('SELECT status, assignment_outcome FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_run_plan p USING (authorization_digest) WHERE a.authorization_digest = $1 AND p.assignment_id = $2', [authorizationDigest, started.assignmentId])).rows).toEqual([{ status: 'unknown_exposure', assignment_outcome: 'provider_unknown_exposure' }]);
+      for (const entry of plan.filter((entry) => entry.assignmentId !== started.assignmentId)) {
+        await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp() WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, entry.assignmentId]);
+      }
+      expect((await client!.query('SELECT status, count(*) FILTER (WHERE assignment_outcome IS NOT NULL)::int AS outcomes FROM addie_fixed_trace_component_smoke_authorizations a JOIN addie_fixed_trace_component_smoke_run_plan p USING (authorization_digest) WHERE a.authorization_digest = $1 GROUP BY status', [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure', outcomes: 168 }]);
+    } finally { await contender.end(); }
+  });
+
   it('keeps one assignment outcome separate from invocation attempts and closes halted omissions', async () => {
     const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
     await insertIntent(client!, authorizationDigest, generation);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'tool_continuation_required', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'e'.repeat(32)}`, '1'.repeat(64), generation.provider, generation.model, generation.effort]);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId])).resolves.toBeInstanceOf(Error);
+    await insertIntent(client!, authorizationDigest, generation, '8', 2);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'8'.repeat(32)}`, '3'.repeat(64), generation.provider, generation.model, generation.effort]);
+    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 2 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId]);
     const router = dispatchEntry();
     await insertIntent(client!, authorizationDigest, router, '7');
     await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'7'.repeat(32)}`, '2'.repeat(64), router.provider, router.model, router.effort]);
     await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId]);
     await expect(rejects("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 1 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, router.assignmentId])).resolves.toBeInstanceOf(Error);
-    await insertIntent(client!, authorizationDigest, generation, '8', 2);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'8'.repeat(32)}`, '3'.repeat(64), generation.provider, generation.model, generation.effort]);
-    await client!.query("UPDATE addie_fixed_trace_component_smoke_run_plan SET assignment_outcome = 'provider_completed', assignment_terminal_at = clock_timestamp(), assignment_final_invocation_ordinal = 2 WHERE authorization_digest = $1 AND assignment_id = $2", [authorizationDigest, generation.assignmentId]);
     const finalFirst = plan.filter((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)[1]!;
     await insertIntent(client!, authorizationDigest, finalFirst, '9');
     await client!.query("UPDATE addie_fixed_trace_component_smoke_attempts SET status = 'succeeded', response_disposition = 'final_response', response_hmac = $2, returned_provider = $3, returned_model = $4, returned_effort = $5, input_tokens = 0, output_tokens = 0, actual_cost_microdollars = 0, latency_ms = 0, terminal_at = clock_timestamp() WHERE attempt_id = $1", [`attempt_${'9'.repeat(32)}`, '4'.repeat(64), finalFirst.provider, finalFirst.model, finalFirst.effort]);

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -60,7 +60,7 @@ class FakeLedgerClient {
       const status = this.authorizations.get(params?.[0] as string);
       return status ? { rowCount: 1, rows: [{ status, expires_at: '2026-09-06T13:00:00.000Z' }] } : { rowCount: 0, rows: [] };
     }
-    return { rowCount: 1, rows: [] };
+    throw new Error(`unrecognised fake SQL: ${sql.slice(0, 80)}`);
   }
   release() {}
 }

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -1,0 +1,124 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
+  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
+  fixedTraceComponentSmokeSignedGrantBytes,
+  verifyFixedTraceComponentSmokeSignedGrant,
+  verifyFixedTraceComponentSmokeSignedGrantForTest,
+  type FixedTraceComponentSmokeSignedGrantPayload,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.js';
+import {
+  PostgresFixedTraceComponentSmokePrivateLedger,
+  fixedTraceComponentSmokePrivateLedgerPlan,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
+
+const NOW = new Date('2026-09-06T12:00:00.000Z');
+const keys = generateKeyPairSync('ed25519');
+const TEST_KID = 'component-smoke-test-ed25519-2026';
+
+function payload(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}): FixedTraceComponentSmokeSignedGrantPayload {
+  const admission = fixedTraceComponentSmokeAdmission();
+  if (!admission.pricing.cohortDigest || admission.pricing.reservationMicrodollars === null) throw new Error('expected pinned pricing');
+  return {
+    grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: TEST_KID,
+    issuedAt: '2026-09-06T11:00:00.000Z', expiresAt: '2026-09-06T13:00:00.000Z',
+    stageId: 'stage_1_smoke', admissionVersion: admission.version,
+    aggregateAdmissionFingerprint: admission.fingerprints.aggregateAdmission,
+    cardinality: admission.cardinality, reservationMicrodollars: admission.pricing.reservationMicrodollars,
+    providerCeilingMicrodollars: admission.pricing.providerCeilingUsd * 1_000_000,
+    pricingCohortDigest: admission.pricing.cohortDigest,
+    nonceCommitment: 'a'.repeat(64), ...overrides,
+  };
+}
+function grant(candidate = payload(), signature = sign(null, fixedTraceComponentSmokeSignedGrantBytes(candidate), keys.privateKey)) {
+  return { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload: candidate, signature: signature.toString('base64url') };
+}
+function verify(value: unknown) { return verifyFixedTraceComponentSmokeSignedGrantForTest(value, NOW, { kid: TEST_KID, publicKey: keys.publicKey }); }
+
+/** Deterministic in-process SQL fake; it has no socket, network, or provider path. */
+class FakeLedgerClient {
+  readonly calls: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  private readonly authorizations = new Map<string, string>();
+  async query(sql: string, params?: unknown[]) {
+    this.calls.push({ sql, params });
+    if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_authorizations')) {
+      const digest = params?.[0] as string;
+      if (this.authorizations.has(digest)) return { rowCount: 0, rows: [] };
+      this.authorizations.set(digest, 'consumed');
+      return { rowCount: 1, rows: [{ authorization_digest: digest }] };
+    }
+    if (sql.startsWith('SELECT status, expires_at')) {
+      const status = this.authorizations.get(params?.[0] as string);
+      return status ? { rowCount: 1, rows: [{ status, expires_at: '2026-09-06T13:00:00.000Z' }] } : { rowCount: 0, rows: [] };
+    }
+    return { rowCount: 1, rows: [] };
+  }
+  release() {}
+}
+
+describe('fixed-trace component smoke private signed authorization', () => {
+  it('verifies only an exact Ed25519 test grant; production stays unprovisioned', () => {
+    expect(verify(grant())).toMatchObject({ payload: { kid: TEST_KID, stageId: 'stage_1_smoke' } });
+    expect(verifyFixedTraceComponentSmokeSignedGrant(grant(), NOW)).toBeNull();
+    expect(verify({ ...grant(), algorithm: 'ES256' })).toBeNull();
+    expect(verify({ ...grant(), extra: true })).toBeNull();
+    expect(verify({ ...grant(), payload: { ...payload(), extra: true } })).toBeNull();
+    expect(verify(grant(payload({ kid: 'unknown-key' })))).toBeNull();
+    expect(verify(grant(payload(), Buffer.alloc(64)))).toBeNull();
+  });
+
+  it.each([
+    ['v1 admission', { admissionVersion: 'addie-fixed-trace-component-smoke-admission-v1' }],
+    ['fingerprint drift', { aggregateAdmissionFingerprint: '0'.repeat(64) }],
+    ['cardinality drift', { cardinality: { ...payload().cardinality, maximumProviderInvocations: 193 } }],
+    ['cost drift', { reservationMicrodollars: 2_819_485 }],
+    ['pricing drift', { pricingCohortDigest: '0'.repeat(64) }],
+    ['future issue', { issuedAt: '2026-09-06T12:00:00.001Z' }],
+    ['exact expiry', { expiresAt: '2026-09-06T12:00:00.000Z' }],
+  ])('rejects %s before any ledger boundary', (_name, overrides) => {
+    expect(verify(grant(payload(overrides)))).toBeNull();
+  });
+
+  it('derives the exact no-spend plan and retains no dispatch construction path', () => {
+    const plan = fixedTraceComponentSmokePrivateLedgerPlan();
+    expect(plan).toHaveLength(168);
+    expect(plan?.filter((entry) => entry.disposition === 'provider_dispatch')).toHaveLength(126);
+    expect(plan?.filter((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 1)).toHaveLength(60);
+    expect(plan?.filter((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)).toHaveLength(66);
+    expect(plan?.filter((entry) => entry.disposition !== 'provider_dispatch')).toHaveLength(42);
+    expect(plan?.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0)).toBe(192);
+    expect(plan?.reduce((sum, entry) => sum + entry.reservedMicrodollars.reduce((inner, micros) => inner + micros, 0), 0)).toBe(2_819_484);
+    expect(plan?.filter((entry) => entry.disposition !== 'provider_dispatch').every((entry) => entry.maximumProviderInvocations === 0 && entry.reservedMicrodollars.length === 0)).toBe(true);
+    const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts', import.meta.url), 'utf8');
+    expect(source).not.toContain('process.env');
+    expect(source).not.toContain('fetch(');
+    expect(source).not.toContain('adapter.invoke');
+    const migration = readFileSync(new URL('../../../src/db/migrations/582_addie_fixed_trace_component_smoke_private_ledger.sql', import.meta.url), 'utf8');
+    expect(migration).toContain('UNIQUE (authorization_digest, assignment_id, invocation_ordinal)');
+    expect(migration).toContain('invocation_ordinal BETWEEN 1 AND 2');
+    expect(migration).toContain('provider_dispatch_assignments = 126');
+    expect(migration).toContain('assignments = 168');
+  });
+
+  it('uses one checked-out-client transaction to atomically reserve the exact plan and reject a replay', async () => {
+    const approved = verify(grant());
+    if (!approved) throw new Error('expected test grant');
+    const client = new FakeLedgerClient();
+    const ledger = new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never);
+    const results = await Promise.all([ledger.reserveAndConsume(approved), ledger.reserveAndConsume(approved)]);
+    expect(results.filter((entry) => entry.status === 'reserved')).toHaveLength(1);
+    expect(results).toContainEqual({ status: 'refused', reason: 'grant_already_consumed' });
+    expect(client.calls.filter((entry) => entry.sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_run_plan'))).toHaveLength(168);
+    expect(client.calls.filter((entry) => entry.sql === 'BEGIN')).toHaveLength(2);
+    expect(client.calls.filter((entry) => entry.sql === 'COMMIT')).toHaveLength(2);
+    const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts', import.meta.url), 'utf8');
+    expect(source).not.toContain('from "../../db/client');
+    expect(source).not.toContain('grantId');
+    expect(source).not.toContain('apiKey');
+    expect(source).not.toContain('prompt:');
+    expect(source).not.toContain('output:');
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -5,6 +5,7 @@ import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed
 import {
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
+  createFixedTraceComponentSmokeOneShotGrantVerifier,
   fixedTraceComponentSmokeSignedGrantBytes,
   verifyFixedTraceComponentSmokeSignedGrant,
   verifyFixedTraceComponentSmokeSignedGrantForTest,
@@ -134,6 +135,13 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(source).not.toContain('apiKey');
     expect(source).not.toContain('prompt:');
     expect(source).not.toContain('output:');
+  });
+
+  it('keeps arbitrary injected roots and structural lookalikes fail-closed until a reviewed pin exists', () => {
+    const spki = (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url');
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki })).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki, extra: true })).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ verify: () => grant() })).toBeNull();
   });
 
   it('rejects a wrong or cross-reservation envelope before it can mutate a ledger', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -114,6 +114,11 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(migration).toContain('invocation_ordinal BETWEEN 1 AND 2');
     expect(migration).toContain('provider_dispatch_assignments = 126');
     expect(migration).toContain('assignments = 168');
+    expect(migration).toContain('signature_digest CHAR(64)');
+    expect(migration).not.toContain('signature BYTEA');
+    expect(source).toContain('pgSafeInt');
+    expect(source).toContain('cacheReadTokens');
+    expect(source).toContain("status = 'unknown_exposure'");
   });
 
   it('never turns a caller-selected test trust root into a ledger capability', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync, sign } from 'node:crypto';
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
@@ -24,7 +24,7 @@ function payload(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> 
   if (!admission.pricing.cohortDigest || admission.pricing.reservationMicrodollars === null) throw new Error('expected pinned pricing');
   return {
     grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: TEST_KID,
-    issuedAt: '2026-09-06T11:00:00.000Z', expiresAt: '2026-09-06T13:00:00.000Z',
+    issuedAt: '2026-09-06T11:55:00.000Z', expiresAt: '2026-09-06T12:05:00.000Z',
     stageId: 'stage_1_smoke', admissionVersion: admission.version,
     aggregateAdmissionFingerprint: admission.fingerprints.aggregateAdmission,
     cardinality: admission.cardinality, reservationMicrodollars: admission.pricing.reservationMicrodollars,
@@ -37,6 +37,12 @@ function grant(candidate = payload(), signature = sign(null, fixedTraceComponent
   return { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload: candidate, signature: signature.toString('base64url') };
 }
 function verify(value: unknown) { return verifyFixedTraceComponentSmokeSignedGrantForTest(value, NOW, { kid: TEST_KID, publicKey: keys.publicKey }); }
+function deterministicReservationId(authorizationDigest: string) {
+  return `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0' }), 'utf8').digest('hex').slice(0, 32)}`;
+}
+function reservation(authorizationDigest = 'a'.repeat(64), reservationId = deterministicReservationId(authorizationDigest)) {
+  return { authorizationDigest, reservationId, entryCount: 168 as const, providerDispatchEntryCount: 126 as const, reservationMicrodollars: 2_819_484 as const };
+}
 
 /** Deterministic in-process SQL fake; it has no socket, network, or provider path. */
 class FakeLedgerClient {
@@ -61,7 +67,13 @@ class FakeLedgerClient {
 
 describe('fixed-trace component smoke private signed authorization', () => {
   it('verifies only an exact Ed25519 test grant; production stays unprovisioned', () => {
-    expect(verify(grant())).toMatchObject({ payload: { kid: TEST_KID, stageId: 'stage_1_smoke' } });
+    const checked = verify(grant());
+    expect(checked).toMatchObject({ valid: true });
+    expect(checked).not.toHaveProperty('signature');
+    const mutableEnvelope = grant();
+    const verifiedBeforeMutation = verify(mutableEnvelope);
+    mutableEnvelope.signature = 'A'.repeat(86);
+    expect(verifiedBeforeMutation).toMatchObject({ valid: true });
     expect(verifyFixedTraceComponentSmokeSignedGrant(grant(), NOW)).toBeNull();
     expect(verify({ ...grant(), algorithm: 'ES256' })).toBeNull();
     expect(verify({ ...grant(), extra: true })).toBeNull();
@@ -78,6 +90,7 @@ describe('fixed-trace component smoke private signed authorization', () => {
     ['pricing drift', { pricingCohortDigest: '0'.repeat(64) }],
     ['future issue', { issuedAt: '2026-09-06T12:00:00.001Z' }],
     ['exact expiry', { expiresAt: '2026-09-06T12:00:00.000Z' }],
+    ['excess lifetime', { expiresAt: '2026-09-06T12:10:00.001Z' }],
   ])('rejects %s before any ledger boundary', (_name, overrides) => {
     expect(verify(grant(payload(overrides)))).toBeNull();
   });
@@ -103,22 +116,28 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(migration).toContain('assignments = 168');
   });
 
-  it('uses one checked-out-client transaction to atomically reserve the exact plan and reject a replay', async () => {
-    const approved = verify(grant());
-    if (!approved) throw new Error('expected test grant');
+  it('never turns a caller-selected test trust root into a ledger capability', async () => {
+    const checked = verify(grant());
+    if (!checked) throw new Error('expected test grant verification');
     const client = new FakeLedgerClient();
     const ledger = new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never);
-    const results = await Promise.all([ledger.reserveAndConsume(approved), ledger.reserveAndConsume(approved)]);
-    expect(results.filter((entry) => entry.status === 'reserved')).toHaveLength(1);
-    expect(results).toContainEqual({ status: 'refused', reason: 'grant_already_consumed' });
-    expect(client.calls.filter((entry) => entry.sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_run_plan'))).toHaveLength(168);
-    expect(client.calls.filter((entry) => entry.sql === 'BEGIN')).toHaveLength(2);
-    expect(client.calls.filter((entry) => entry.sql === 'COMMIT')).toHaveLength(2);
+    await expect(ledger.reserveAndConsume(checked as never)).resolves.toEqual({ status: 'refused', reason: 'admission_drift' });
+    expect(client.calls).toHaveLength(0);
     const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts', import.meta.url), 'utf8');
     expect(source).not.toContain('from "../../db/client');
     expect(source).not.toContain('grantId');
     expect(source).not.toContain('apiKey');
     expect(source).not.toContain('prompt:');
     expect(source).not.toContain('output:');
+  });
+
+  it('rejects a wrong or cross-reservation envelope before it can mutate a ledger', async () => {
+    const client = new FakeLedgerClient();
+    const ledger = new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never);
+    const wrong = reservation('a'.repeat(64), 'reservation_'.concat('0'.repeat(32)));
+    const cross = reservation('a'.repeat(64), deterministicReservationId('b'.repeat(64)));
+    await expect(ledger.recordUnknownExposure(wrong)).resolves.toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    await expect(ledger.recordProviderIntent({ reservation: cross, attemptId: `attempt_${'0'.repeat(32)}`, assignmentId: 'c'.repeat(64), invocationOrdinal: 1, preparedRequestHmac: 'd'.repeat(64) })).resolves.toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    expect(client.calls).toHaveLength(0);
   });
 });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -5,6 +5,7 @@ import {
   fixedTraceComponentSmokePrivateLedgerPlan,
   type FixedTraceComponentSmokePlanEntry,
 } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
+import { datedPricingCostMicros, datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 
 const digest = 'a'.repeat(64);
 const reservation = Object.freeze({
@@ -61,7 +62,7 @@ class StrictLedgerClient {
       const attempt = this.attempts.get(params![0] as string);
       return attempt ? { rowCount: 1, rows: [{ assignment_id: attempt.assignmentId, status: attempt.status, invocation_ordinal: String(attempt.ordinal), ...this.planRow() }] } : { rowCount: 0, rows: [] };
     }
-    if (sql.startsWith('SELECT COALESCE(SUM(actual_cost_microdollars)')) {
+    if (sql.startsWith('WITH locked_attempts AS')) {
       const spent = this.priorSpend ?? String([...this.attempts.values()].reduce((sum, attempt) => sum + (attempt.cost ?? 0), 0));
       return { rowCount: 1, rows: [{ spent }] };
     }
@@ -129,7 +130,6 @@ describe('private ledger state machine', () => {
     ['input', { inputTokens: dispatch.maxInputTokens + 1 }],
     ['output', { outputTokens: dispatch.maxOutputTokens + 1 }],
     ['timeout', { latencyMs: dispatch.timeoutMs + 1 }],
-    ['cache input', { inputTokens: dispatch.maxInputTokens, cacheReadTokens: 1 }],
   ])('settles %s overruns rather than leaving an open intent', async (_name, usage) => {
     const client = new StrictLedgerClient(); const subject = ledger(client);
     await subject.recordProviderIntent(intent());
@@ -137,6 +137,25 @@ describe('private ledger state machine', () => {
     expect(client.authStatus).toBe('halted');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('invalid_limits');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.observedCost).toEqual(expect.any(Number));
+  });
+
+  it('permits additive cache at the independent max-input boundary', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    expect(await subject.recordProviderIntent(intent())).toEqual({ status: 'recorded' });
+    expect(await subject.recordTerminal(terminal({
+      usage: { inputTokens: dispatch.maxInputTokens, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1, latencyMs: 0 },
+    }))).toEqual({ status: 'recorded' });
+    expect(client.authStatus).toBe('consumed');
+  });
+
+  it.each([
+    ['anthropic-standard-2026-09:claude-haiku-4-5', { inputTokens: 1, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1 }, 3],
+    ['anthropic-standard-2026-09:claude-sonnet-5', { inputTokens: 1, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1 }, 5],
+    ['openai-gpt-5.6-luna-standard-2026-09-05', { inputTokens: 2, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1 }, 1],
+    ['google-gemini-3.7-flash-through-2026-12-31', { inputTokens: 1, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 0 }, 1],
+  ])('uses exact rounded microdollar pricing for %s', (profileId, usage, expectedMicros) => {
+    const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === profileId)!;
+    expect(datedPricingCostMicros(profile, usage)).toBe(expectedMicros);
   });
 
   it('poisons an authorization with an unresolved intent and maps response failures to unknown exposure', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -173,6 +173,30 @@ describe('private ledger state machine', () => {
     expect(failed.authStatus).toBe('unknown_exposure');
   });
 
+  it('never reports durable poisoning when standalone recovery refuses', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    // This simulates an independently failed recovery transaction. The
+    // caller must receive uncertainty, not a false durable-poison result.
+    (subject as unknown as { recordUnknownExposure: () => Promise<unknown> }).recordUnknownExposure = async () =>
+      ({ status: 'refused', reason: 'persistence_uncertain' });
+    expect(await subject.recordProviderIntent(intent(`attempt_${'2'.repeat(32)}`))).toEqual({ status: 'refused', reason: 'persistence_uncertain' });
+    expect(client.authStatus).toBe('consumed');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('intent_recorded');
+  });
+
+  it('locks the target attempt then authorization before reading spend', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordTerminal(terminal())).toEqual({ status: 'recorded' });
+    const target = client.calls.findIndex(({ sql }) => sql.includes('FROM addie_fixed_trace_component_smoke_attempts a'));
+    const authorization = client.calls.findIndex(({ sql }) => sql.startsWith('SELECT status, reservation_microdollars'));
+    const spend = client.calls.findIndex(({ sql }) => sql.includes('SUM(actual_cost_microdollars)'));
+    expect(target).toBeGreaterThanOrEqual(0);
+    expect(authorization).toBeGreaterThan(target);
+    expect(spend).toBeGreaterThan(authorization);
+  });
+
   it('requires a succeeded continuation predecessor before ordinal two', async () => {
     const generation = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
     const client = new StrictLedgerClient(generation); const subject = ledger(client);

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -40,6 +40,10 @@ class StrictLedgerClient {
     if (sql.startsWith('SELECT status, reservation_microdollars')) return { rowCount: 1, rows: [{ status: this.authStatus, reservation_microdollars: '2819484', provider_ceiling_microdollars: '5000000' }] };
     if (sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations')) return { rowCount: 1, rows: [{ status: this.authStatus }] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts') && sql.includes("status = 'intent_recorded'")) return { rowCount: [...this.attempts.values()].some((attempt) => attempt.status === 'intent_recorded') ? 1 : 0, rows: [] };
+    if (sql.startsWith('SELECT status, response_disposition FROM addie_fixed_trace_component_smoke_attempts')) {
+      const attempt = [...this.attempts.values()].find((entry) => entry.assignmentId === params![1] && entry.ordinal === params![2]);
+      return attempt ? { rowCount: 1, rows: [{ status: attempt.status, response_disposition: attempt.responseDisposition }] } : { rowCount: 0, rows: [] };
+    }
     if (sql.includes('FROM addie_fixed_trace_component_smoke_run_plan') && sql.includes('FOR UPDATE') && !sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) return { rowCount: 1, rows: [this.planRow()] };
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 1, rows: [] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id')) return { rowCount: this.attempts.has(params![0] as string) ? 1 : 0, rows: [] };
@@ -65,6 +69,13 @@ class StrictLedgerClient {
       const last = [...matches].sort((left, right) => right.ordinal - left.ordinal)[0];
       return { rowCount: 1, rows: [{ count: String(matches.length), open: matches.some((attempt) => attempt.status === 'intent_recorded'), failures: matches.some((attempt) => attempt.status !== 'succeeded'), last_response_disposition: last?.responseDisposition ?? null }] };
     }
+    if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_attempts') && sql.includes("WHERE authorization_digest = $1 AND status = 'intent_recorded'")) {
+      for (const attempt of this.attempts.values()) if (attempt.status === 'intent_recorded') {
+        attempt.status = 'unknown_exposure'; attempt.responseDisposition = null; attempt.cost = null; attempt.observedCost = null; attempt.responseHmac = null; attempt.returnedProvider = null;
+      }
+      return { rowCount: 1, rows: [] };
+    }
+    if (sql.startsWith('WITH started AS (')) return { rowCount: 1, rows: [] };
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_attempts')) {
       const attempt = this.attempts.get(params![0] as string)!;
       attempt.status = params![2] as string;
@@ -124,10 +135,40 @@ describe('private ledger state machine', () => {
     await subject.recordProviderIntent(intent());
     expect(await subject.recordProviderIntent(intent(`attempt_${'2'.repeat(32)}`))).toEqual({ status: 'refused', reason: 'unknown_exposure' });
     expect(client.authStatus).toBe('unknown_exposure');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('unknown_exposure');
     const failed = new StrictLedgerClient(); const failedLedger = ledger(failed);
     await failedLedger.recordProviderIntent(intent());
     expect(await failedLedger.recordTerminal(terminal({ status: 'provider_failed' }))).toEqual({ status: 'recorded' });
     expect(failed.authStatus).toBe('unknown_exposure');
+  });
+
+  it('requires a succeeded continuation predecessor before ordinal two', async () => {
+    const generation = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+    const client = new StrictLedgerClient(generation); const subject = ledger(client);
+    const second = { ...intent(`attempt_${'2'.repeat(32)}`, 2), assignmentId: generation.assignmentId };
+    expect(await subject.recordProviderIntent(second)).toEqual({ status: 'refused', reason: 'intent_required' });
+    client.attempts.set(`attempt_${'1'.repeat(32)}`, { id: `attempt_${'1'.repeat(32)}`, assignmentId: generation.assignmentId, ordinal: 1, status: 'succeeded', responseDisposition: 'final_response', cost: 0, observedCost: null, returnedProvider: generation.provider, responseHmac: 'c'.repeat(64) });
+    expect(await subject.recordProviderIntent(second)).toEqual({ status: 'refused', reason: 'intent_required' });
+    client.attempts.get(`attempt_${'1'.repeat(32)}`)!.responseDisposition = 'tool_continuation_required';
+    expect(await subject.recordProviderIntent(second)).toEqual({ status: 'recorded' });
+  });
+
+  it('fail-stops a continuation at generation ordinal two while retaining observed usage cost', async () => {
+    const generation = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+    const client = new StrictLedgerClient(generation); const subject = ledger(client);
+    client.attempts.set(`attempt_${'1'.repeat(32)}`, { id: `attempt_${'1'.repeat(32)}`, assignmentId: generation.assignmentId, ordinal: 1, status: 'succeeded', responseDisposition: 'tool_continuation_required', cost: 0, observedCost: null, returnedProvider: generation.provider, responseHmac: 'c'.repeat(64) });
+    await subject.recordProviderIntent({ ...intent(`attempt_${'2'.repeat(32)}`, 2), assignmentId: generation.assignmentId });
+    expect(await subject.recordTerminal({ ...terminal({ attemptId: `attempt_${'2'.repeat(32)}`, responseDisposition: 'tool_continuation_required' }), returnedIdentity: { provider: generation.provider, model: generation.model, effort: generation.effort } })).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    expect(client.authStatus).toBe('halted');
+    expect(client.attempts.get(`attempt_${'2'.repeat(32)}`)).toMatchObject({ status: 'invalid_limits', cost: null, observedCost: expect.any(Number) });
+  });
+
+  it('closes an explicitly ambiguous open intent as an unknown provider assignment outcome', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
+    expect(client.authStatus).toBe('unknown_exposure');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)).toMatchObject({ status: 'unknown_exposure', responseHmac: null, cost: null });
   });
 
   it.each([
@@ -138,7 +179,9 @@ describe('private ledger state machine', () => {
   ])('preserves status-specific receipt evidence and fail-stops %s', async (status, receipt) => {
     const client = new StrictLedgerClient(); const subject = ledger(client);
     await subject.recordProviderIntent(intent());
-    expect(await subject.recordTerminal(terminal({ status, ...receipt }))).toEqual({ status: 'recorded' });
+    expect(await subject.recordTerminal(terminal({ status, ...receipt }))).toEqual(
+      status === 'identity_mismatch' ? { status: 'refused', reason: 'plan_mismatch' } : { status: 'recorded' },
+    );
     expect(client.authStatus).toBe('unknown_exposure');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.responseHmac).toBe(receipt.responseHmac);
   });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -1,0 +1,150 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  PostgresFixedTraceComponentSmokePrivateLedger,
+  fixedTraceComponentSmokePrivateLedgerPlan,
+  type FixedTraceComponentSmokePlanEntry,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
+
+const digest = 'a'.repeat(64);
+const reservation = Object.freeze({
+  authorizationDigest: digest,
+  reservationId: `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest: digest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0' })).digest('hex').slice(0, 32)}`,
+  entryCount: 168 as const,
+  providerDispatchEntryCount: 126 as const,
+  reservationMicrodollars: 2_819_484 as const,
+});
+const dispatch = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch')!;
+
+type StoredAttempt = { id: string; assignmentId: string; ordinal: number; status: string; cost: number | null; returnedProvider: string | null; responseHmac: string | null };
+
+/** Strict deterministic fake: every SQL statement is modelled or rejected. */
+class StrictLedgerClient {
+  readonly calls: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  readonly attempts = new Map<string, StoredAttempt>();
+  authStatus = 'consumed';
+  priorSpend: string | null = null;
+  constructor(private readonly entry: FixedTraceComponentSmokePlanEntry = dispatch) {}
+  private planRow() {
+    return {
+      probe_id: this.entry.probeId, cell_id: this.entry.cellId, disposition: this.entry.disposition,
+      maximum_provider_invocations: String(this.entry.maximumProviderInvocations), requested_provider: this.entry.provider,
+      requested_model: this.entry.model, requested_effort: this.entry.effort, pricing_profile_id: this.entry.pricingProfileId,
+      max_input_tokens: String(this.entry.maxInputTokens), max_output_tokens: String(this.entry.maxOutputTokens),
+      timeout_ms: String(this.entry.timeoutMs), retries: '0', reserved_microdollars: this.entry.reservedMicrodollars.map(String),
+    };
+  }
+  async query(sql: string, params?: unknown[]) {
+    this.calls.push({ sql, params });
+    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
+    if (sql.startsWith('SELECT status, reservation_microdollars')) return { rowCount: 1, rows: [{ status: this.authStatus, reservation_microdollars: '2819484', provider_ceiling_microdollars: '5000000' }] };
+    if (sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations')) return { rowCount: 1, rows: [{ status: this.authStatus }] };
+    if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts') && sql.includes("status = 'intent_recorded'")) return { rowCount: [...this.attempts.values()].some((attempt) => attempt.status === 'intent_recorded') ? 1 : 0, rows: [] };
+    if (sql.includes('FROM addie_fixed_trace_component_smoke_run_plan') && sql.includes('FOR UPDATE') && !sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) return { rowCount: 1, rows: [this.planRow()] };
+    if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id')) return { rowCount: this.attempts.has(params![0] as string) ? 1 : 0, rows: [] };
+    if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest')) {
+      return { rowCount: [...this.attempts.values()].some((attempt) => attempt.assignmentId === params![1] && attempt.ordinal === params![2]) ? 1 : 0, rows: [] };
+    }
+    if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_attempts')) {
+      this.attempts.set(params![0] as string, { id: params![0] as string, assignmentId: params![2] as string, ordinal: params![3] as number, status: 'intent_recorded', cost: null, returnedProvider: null, responseHmac: null });
+      return { rowCount: 1, rows: [] };
+    }
+    if (sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) {
+      const attempt = this.attempts.get(params![0] as string);
+      return attempt ? { rowCount: 1, rows: [{ assignment_id: attempt.assignmentId, status: attempt.status, invocation_ordinal: String(attempt.ordinal), ...this.planRow() }] } : { rowCount: 0, rows: [] };
+    }
+    if (sql.startsWith('SELECT COALESCE(SUM(actual_cost_microdollars)')) {
+      const spent = this.priorSpend ?? String([...this.attempts.values()].reduce((sum, attempt) => sum + (attempt.cost ?? 0), 0));
+      return { rowCount: 1, rows: [{ spent }] };
+    }
+    if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_attempts')) {
+      const attempt = this.attempts.get(params![0] as string)!;
+      attempt.status = params![2] as string;
+      attempt.cost = sql.includes('actual_cost_microdollars = NULL') ? null : params![7] as number | null;
+      attempt.responseHmac = (sql.includes('actual_cost_microdollars = NULL') ? params![8] : params![9]) as string | null;
+      attempt.returnedProvider = (sql.includes('actual_cost_microdollars = NULL') ? params![9] : params![10]) as string | null;
+      return { rowCount: 1, rows: [] };
+    }
+    if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_authorizations')) {
+      this.authStatus = sql.includes("SET status = 'unknown_exposure'") ? 'unknown_exposure' : params![1] as string;
+      return { rowCount: 1, rows: [] };
+    }
+    throw new Error(`unrecognised strict-fake SQL: ${sql.replace(/\s+/g, ' ').slice(0, 120)}`);
+  }
+  release() {}
+}
+
+function intent(id = `attempt_${'1'.repeat(32)}`, ordinal = 1) {
+  return { reservation, attemptId: id, assignmentId: dispatch.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac: 'b'.repeat(64) };
+}
+function terminal(overrides: Record<string, unknown> = {}) {
+  return {
+    reservation, attemptId: `attempt_${'1'.repeat(32)}`, status: 'succeeded', responseHmac: 'c'.repeat(64),
+    returnedIdentity: { provider: dispatch.provider, model: dispatch.model, effort: dispatch.effort },
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 }, ...overrides,
+  };
+}
+function ledger(client: StrictLedgerClient) { return new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never); }
+
+describe('private ledger state machine', () => {
+  it('records a provider intent and terminal using realistic pg int8 and int8[] strings', async () => {
+    const client = new StrictLedgerClient();
+    expect(await ledger(client).recordProviderIntent(intent())).toEqual({ status: 'recorded' });
+    expect(await ledger(client).recordTerminal(terminal())).toEqual({ status: 'recorded' });
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)).toMatchObject({ status: 'succeeded', returnedProvider: dispatch.provider, responseHmac: 'c'.repeat(64) });
+  });
+
+  it.each([
+    ['input', { inputTokens: dispatch.maxInputTokens + 1 }],
+    ['output', { outputTokens: dispatch.maxOutputTokens + 1 }],
+    ['timeout', { latencyMs: dispatch.timeoutMs + 1 }],
+    ['cache input', { inputTokens: dispatch.maxInputTokens, cacheReadTokens: 1 }],
+  ])('settles %s overruns rather than leaving an open intent', async (_name, usage) => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordTerminal(terminal({ usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0, ...usage } }))).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    expect(client.authStatus).toBe('halted');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('invalid_limits');
+  });
+
+  it('poisons an authorization with an unresolved intent and maps response failures to unknown exposure', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordProviderIntent(intent(`attempt_${'2'.repeat(32)}`))).toEqual({ status: 'refused', reason: 'unknown_exposure' });
+    expect(client.authStatus).toBe('unknown_exposure');
+    const failed = new StrictLedgerClient(); const failedLedger = ledger(failed);
+    await failedLedger.recordProviderIntent(intent());
+    expect(await failedLedger.recordTerminal(terminal({ status: 'provider_failed' }))).toEqual({ status: 'recorded' });
+    expect(failed.authStatus).toBe('unknown_exposure');
+  });
+
+  it.each([
+    ['timeout_after_dispatch', { usage: null, responseHmac: null, returnedIdentity: null }],
+    ['malformed_response', { usage: null, responseHmac: 'd'.repeat(64), returnedIdentity: null }],
+    ['missing_usage', { usage: null, responseHmac: 'd'.repeat(64), returnedIdentity: { provider: dispatch.provider, model: dispatch.model, effort: dispatch.effort } }],
+    ['identity_mismatch', { usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 }, responseHmac: 'd'.repeat(64), returnedIdentity: { provider: 'other', model: 'other', effort: 'other' } }],
+  ])('preserves status-specific receipt evidence and fail-stops %s', async (status, receipt) => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordTerminal(terminal({ status, ...receipt }))).toEqual({ status: 'recorded' });
+    expect(client.authStatus).toBe('unknown_exposure');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.responseHmac).toBe(receipt.responseHmac);
+  });
+
+  it('settles a pricing-profile mismatch as unknown exposure rather than zero-cost success', async () => {
+    const altered = { ...dispatch, pricingProfileId: 'missing-profile' };
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    (client as unknown as { entry: FixedTraceComponentSmokePlanEntry }).entry = altered;
+    expect(await subject.recordTerminal(terminal())).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    expect(client.authStatus).toBe('unknown_exposure');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('pricing_unavailable');
+  });
+
+  it('settles aggregate one-over accounting failures from a pg int8 SUM', async () => {
+    const client = new StrictLedgerClient(); client.priorSpend = '2819484'; const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordTerminal(terminal({ usage: { inputTokens: 1, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } }))).toEqual({ status: 'refused', reason: 'cost_exhausted' });
+    expect(client.authStatus).toBe('halted');
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -16,7 +16,7 @@ const reservation = Object.freeze({
 });
 const dispatch = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch')!;
 
-type StoredAttempt = { id: string; assignmentId: string; ordinal: number; status: string; cost: number | null; returnedProvider: string | null; responseHmac: string | null };
+type StoredAttempt = { id: string; assignmentId: string; ordinal: number; status: string; responseDisposition: string | null; cost: number | null; observedCost: number | null; returnedProvider: string | null; responseHmac: string | null };
 
 /** Strict deterministic fake: every SQL statement is modelled or rejected. */
 class StrictLedgerClient {
@@ -41,12 +41,15 @@ class StrictLedgerClient {
     if (sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations')) return { rowCount: 1, rows: [{ status: this.authStatus }] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts') && sql.includes("status = 'intent_recorded'")) return { rowCount: [...this.attempts.values()].some((attempt) => attempt.status === 'intent_recorded') ? 1 : 0, rows: [] };
     if (sql.includes('FROM addie_fixed_trace_component_smoke_run_plan') && sql.includes('FOR UPDATE') && !sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) return { rowCount: 1, rows: [this.planRow()] };
+    if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 1, rows: [] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id')) return { rowCount: this.attempts.has(params![0] as string) ? 1 : 0, rows: [] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest')) {
-      return { rowCount: [...this.attempts.values()].some((attempt) => attempt.assignmentId === params![1] && attempt.ordinal === params![2]) ? 1 : 0, rows: [] };
+      const started = [...this.attempts.values()].some((attempt) => attempt.assignmentId === params![1]
+        && (!sql.includes('invocation_ordinal') || attempt.ordinal === params![2]));
+      return { rowCount: started ? 1 : 0, rows: [] };
     }
     if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_attempts')) {
-      this.attempts.set(params![0] as string, { id: params![0] as string, assignmentId: params![2] as string, ordinal: params![3] as number, status: 'intent_recorded', cost: null, returnedProvider: null, responseHmac: null });
+      this.attempts.set(params![0] as string, { id: params![0] as string, assignmentId: params![2] as string, ordinal: params![3] as number, status: 'intent_recorded', responseDisposition: null, cost: null, observedCost: null, returnedProvider: null, responseHmac: null });
       return { rowCount: 1, rows: [] };
     }
     if (sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) {
@@ -57,12 +60,19 @@ class StrictLedgerClient {
       const spent = this.priorSpend ?? String([...this.attempts.values()].reduce((sum, attempt) => sum + (attempt.cost ?? 0), 0));
       return { rowCount: 1, rows: [{ spent }] };
     }
+    if (sql.startsWith('SELECT count(*)::bigint AS count')) {
+      const matches = [...this.attempts.values()].filter((attempt) => attempt.assignmentId === params![1] && attempt.ordinal <= params![2] as number);
+      const last = [...matches].sort((left, right) => right.ordinal - left.ordinal)[0];
+      return { rowCount: 1, rows: [{ count: String(matches.length), open: matches.some((attempt) => attempt.status === 'intent_recorded'), failures: matches.some((attempt) => attempt.status !== 'succeeded'), last_response_disposition: last?.responseDisposition ?? null }] };
+    }
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_attempts')) {
       const attempt = this.attempts.get(params![0] as string)!;
       attempt.status = params![2] as string;
-      attempt.cost = sql.includes('actual_cost_microdollars = NULL') ? null : params![7] as number | null;
-      attempt.responseHmac = (sql.includes('actual_cost_microdollars = NULL') ? params![8] : params![9]) as string | null;
-      attempt.returnedProvider = (sql.includes('actual_cost_microdollars = NULL') ? params![9] : params![10]) as string | null;
+      attempt.responseDisposition = sql.includes('actual_cost_microdollars = NULL') ? null : params![3] as string | null;
+      attempt.cost = sql.includes('actual_cost_microdollars = NULL') ? null : params![8] as number | null;
+      attempt.observedCost = sql.includes('actual_cost_microdollars = NULL') ? params![7] as number | null : null;
+      attempt.responseHmac = (sql.includes('actual_cost_microdollars = NULL') ? params![9] : params![10]) as string | null;
+      attempt.returnedProvider = (sql.includes('actual_cost_microdollars = NULL') ? params![10] : params![11]) as string | null;
       return { rowCount: 1, rows: [] };
     }
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_authorizations')) {
@@ -78,8 +88,9 @@ function intent(id = `attempt_${'1'.repeat(32)}`, ordinal = 1) {
   return { reservation, attemptId: id, assignmentId: dispatch.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac: 'b'.repeat(64) };
 }
 function terminal(overrides: Record<string, unknown> = {}) {
+  const status = overrides.status ?? 'succeeded';
   return {
-    reservation, attemptId: `attempt_${'1'.repeat(32)}`, status: 'succeeded', responseHmac: 'c'.repeat(64),
+    reservation, attemptId: `attempt_${'1'.repeat(32)}`, status, responseDisposition: status === 'succeeded' ? 'final_response' : null, responseHmac: 'c'.repeat(64),
     returnedIdentity: { provider: dispatch.provider, model: dispatch.model, effort: dispatch.effort },
     usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 }, ...overrides,
   };
@@ -105,6 +116,7 @@ describe('private ledger state machine', () => {
     expect(await subject.recordTerminal(terminal({ usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0, ...usage } }))).toEqual({ status: 'refused', reason: 'plan_mismatch' });
     expect(client.authStatus).toBe('halted');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.status).toBe('invalid_limits');
+    expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)?.observedCost).toEqual(expect.any(Number));
   });
 
   it('poisons an authorization with an unresolved intent and maps response failures to unknown exposure', async () => {
@@ -146,5 +158,25 @@ describe('private ledger state machine', () => {
     await subject.recordProviderIntent(intent());
     expect(await subject.recordTerminal(terminal({ usage: { inputTokens: 1, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } }))).toEqual({ status: 'refused', reason: 'cost_exhausted' });
     expect(client.authStatus).toBe('halted');
+  });
+
+  it('closes only an unstarted assignment as a zero-call post-halt denominator outcome', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    client.authStatus = 'halted';
+    expect(await subject.recordNotExecutedAfterHalt({ reservation, assignmentId: dispatch.assignmentId })).toEqual({ status: 'recorded' });
+    expect(await subject.recordNotExecutedAfterHalt({ reservation, assignmentId: dispatch.assignmentId, status: 'not_executed_after_halt' })).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+    const started = new StrictLedgerClient(); started.authStatus = 'unknown_exposure';
+    started.attempts.set(`attempt_${'2'.repeat(32)}`, { id: `attempt_${'2'.repeat(32)}`, assignmentId: dispatch.assignmentId, ordinal: 1, status: 'intent_recorded', responseDisposition: null, cost: null, observedCost: null, returnedProvider: null, responseHmac: null });
+    expect(await ledger(started).recordNotExecutedAfterHalt({ reservation, assignmentId: dispatch.assignmentId })).toEqual({ status: 'refused', reason: 'plan_mismatch' });
+  });
+
+  it('requires a final-response disposition before a provider assignment can close', async () => {
+    const generation = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+    const client = new StrictLedgerClient(generation); const subject = ledger(client);
+    client.attempts.set(`attempt_${'3'.repeat(32)}`, { id: `attempt_${'3'.repeat(32)}`, assignmentId: generation.assignmentId, ordinal: 1, status: 'succeeded', responseDisposition: 'tool_continuation_required', cost: 0, observedCost: null, returnedProvider: generation.provider, responseHmac: 'c'.repeat(64) });
+    const completion = { reservation, assignmentId: generation.assignmentId, status: 'provider_completed' as const, finalInvocationOrdinal: 1 };
+    expect(await subject.recordProviderAssignmentTerminal(completion)).toEqual({ status: 'refused', reason: 'intent_required' });
+    client.attempts.get(`attempt_${'3'.repeat(32)}`)!.responseDisposition = 'final_response';
+    expect(await subject.recordProviderAssignmentTerminal(completion)).toEqual({ status: 'recorded' });
   });
 });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -39,6 +39,8 @@ class StrictLedgerClient {
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
     if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
+    if (sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts')
+      || sql.startsWith('SELECT p.assignment_id FROM addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT status, reservation_microdollars')) return { rowCount: 1, rows: [{ status: this.authStatus, reservation_microdollars: '2819484', provider_ceiling_microdollars: '5000000' }] };
     if (sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations')) return { rowCount: 1, rows: [{ status: this.authStatus }] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts') && sql.includes("status = 'intent_recorded'")) return { rowCount: [...this.attempts.values()].some((attempt) => attempt.status === 'intent_recorded') ? 1 : 0, rows: [] };
@@ -62,11 +64,11 @@ class StrictLedgerClient {
       const attempt = this.attempts.get(params![0] as string);
       return attempt ? { rowCount: 1, rows: [{ assignment_id: attempt.assignmentId, status: attempt.status, invocation_ordinal: String(attempt.ordinal), ...this.planRow() }] } : { rowCount: 0, rows: [] };
     }
-    if (sql.startsWith('WITH locked_attempts AS')) {
+    if (sql.startsWith('WITH locked_attempts AS') && sql.includes('actual_cost_microdollars')) {
       const spent = this.priorSpend ?? String([...this.attempts.values()].reduce((sum, attempt) => sum + (attempt.cost ?? 0), 0));
       return { rowCount: 1, rows: [{ spent }] };
     }
-    if (sql.startsWith('SELECT count(*)::bigint AS count')) {
+    if ((sql.startsWith('WITH locked_attempts AS') && sql.includes('last_response_disposition')) || sql.startsWith('SELECT count(*)::bigint AS count')) {
       const matches = [...this.attempts.values()].filter((attempt) => attempt.assignmentId === params![1] && attempt.ordinal <= params![2] as number);
       const last = [...matches].sort((left, right) => right.ordinal - left.ordinal)[0];
       return { rowCount: 1, rows: [{ count: String(matches.length), open: matches.some((attempt) => attempt.status === 'intent_recorded'), failures: matches.some((attempt) => attempt.status !== 'succeeded'), last_response_disposition: last?.responseDisposition ?? null }] };

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -16,6 +16,7 @@ const reservation = Object.freeze({
   reservationMicrodollars: 2_819_484 as const,
 });
 const dispatch = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'provider_dispatch')!;
+const local = fixedTraceComponentSmokePrivateLedgerPlan()!.find((entry) => entry.disposition === 'local_terminal')!;
 
 type StoredAttempt = { id: string; assignmentId: string; ordinal: number; status: string; responseDisposition: string | null; cost: number | null; observedCost: number | null; returnedProvider: string | null; responseHmac: string | null };
 
@@ -39,7 +40,8 @@ class StrictLedgerClient {
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
     if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK'
-      || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN SHARE ROW EXCLUSIVE MODE') return { rowCount: 0, rows: [] };
+      || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN SHARE ROW EXCLUSIVE MODE'
+      || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN ROW EXCLUSIVE MODE') return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts')
       || sql.startsWith('SELECT p.assignment_id FROM addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT status, reservation_microdollars')) return { rowCount: 1, rows: [{ status: this.authStatus, reservation_microdollars: '2819484', provider_ceiling_microdollars: '5000000' }] };
@@ -240,6 +242,17 @@ describe('private ledger state machine', () => {
     expect(planSet).toBeGreaterThan(tableGate);
     expect(attempts).toBeGreaterThan(planSet);
     expect(authorization).toBeGreaterThan(attempts);
+  });
+
+  it('takes the plan writer gate before the target row for application outcomes', async () => {
+    const client = new StrictLedgerClient(local); const subject = ledger(client);
+    expect(await subject.recordNonDispatchTerminal({ reservation, assignmentId: local.assignmentId, status: 'local_terminal' })).toEqual({ status: 'recorded' });
+    const writerGate = client.calls.findIndex(({ sql }) => sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN ROW EXCLUSIVE MODE');
+    const target = client.calls.findIndex(({ sql }) => sql.includes('FROM addie_fixed_trace_component_smoke_run_plan') && sql.includes('FOR UPDATE'));
+    const authorization = client.calls.findIndex(({ sql }) => sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations'));
+    expect(writerGate).toBeGreaterThanOrEqual(0);
+    expect(target).toBeGreaterThan(writerGate);
+    expect(authorization).toBeGreaterThan(target);
   });
 
   it('idempotently recovers a committed known provider failure after its unknown-exposure commit response is lost', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -22,6 +22,7 @@ type StoredAttempt = { id: string; assignmentId: string; ordinal: number; status
 class StrictLedgerClient {
   readonly calls: Array<{ sql: string; params: unknown[] | undefined }> = [];
   readonly attempts = new Map<string, StoredAttempt>();
+  readonly assignmentOutcomes = new Map<string, string>();
   authStatus = 'consumed';
   priorSpend: string | null = null;
   constructor(private readonly entry: FixedTraceComponentSmokePlanEntry = dispatch) {}
@@ -75,7 +76,15 @@ class StrictLedgerClient {
       }
       return { rowCount: 1, rows: [] };
     }
-    if (sql.startsWith('WITH started AS (')) return { rowCount: 1, rows: [] };
+    if (sql.startsWith('WITH started AS (')) {
+      for (const attempt of this.attempts.values()) {
+        if (this.assignmentOutcomes.has(attempt.assignmentId)) continue;
+        this.assignmentOutcomes.set(attempt.assignmentId,
+          attempt.status === 'unknown_exposure' || attempt.responseDisposition === 'tool_continuation_required'
+            ? 'provider_unknown_exposure' : attempt.status === 'succeeded' ? 'provider_completed' : 'provider_failed');
+      }
+      return { rowCount: 1, rows: [] };
+    }
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_attempts')) {
       const attempt = this.attempts.get(params![0] as string)!;
       attempt.status = params![2] as string;
@@ -169,6 +178,17 @@ describe('private ledger state machine', () => {
     expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
     expect(client.authStatus).toBe('unknown_exposure');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)).toMatchObject({ status: 'unknown_exposure', responseHmac: null, cost: null });
+    expect(client.assignmentOutcomes.get(dispatch.assignmentId)).toBe('provider_unknown_exposure');
+  });
+
+  it('idempotently recovers a committed known provider failure after its unknown-exposure commit response is lost', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    client.authStatus = 'unknown_exposure';
+    client.attempts.set(`attempt_${'4'.repeat(32)}`, { id: `attempt_${'4'.repeat(32)}`, assignmentId: dispatch.assignmentId, ordinal: 1, status: 'provider_failed', responseDisposition: null, cost: 0, observedCost: null, returnedProvider: dispatch.provider, responseHmac: 'c'.repeat(64) });
+    expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
+    expect(client.assignmentOutcomes.get(dispatch.assignmentId)).toBe('provider_failed');
+    expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
+    expect(client.assignmentOutcomes.get(dispatch.assignmentId)).toBe('provider_failed');
   });
 
   it.each([

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -38,7 +38,8 @@ class StrictLedgerClient {
   }
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
-    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
+    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK'
+      || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN SHARE ROW EXCLUSIVE MODE') return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts')
       || sql.startsWith('SELECT p.assignment_id FROM addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT status, reservation_microdollars')) return { rowCount: 1, rows: [{ status: this.authStatus, reservation_microdollars: '2819484', provider_ceiling_microdollars: '5000000' }] };
@@ -231,10 +232,12 @@ describe('private ledger state machine', () => {
     const client = new StrictLedgerClient(); const subject = ledger(client);
     await subject.recordProviderIntent(intent());
     expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
+    const tableGate = client.calls.findIndex(({ sql }) => sql.startsWith('LOCK TABLE addie_fixed_trace_component_smoke_run_plan'));
     const planSet = client.calls.findIndex(({ sql }) => sql.startsWith('SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan'));
     const attempts = client.calls.findIndex(({ sql }, index) => index > planSet && sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts'));
     const authorization = client.calls.findIndex(({ sql }, index) => index > attempts && sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations'));
-    expect(planSet).toBeGreaterThanOrEqual(0);
+    expect(tableGate).toBeGreaterThanOrEqual(0);
+    expect(planSet).toBeGreaterThan(tableGate);
     expect(attempts).toBeGreaterThan(planSet);
     expect(authorization).toBeGreaterThan(attempts);
   });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -227,6 +227,18 @@ describe('private ledger state machine', () => {
     expect(client.assignmentOutcomes.get(dispatch.assignmentId)).toBe('provider_unknown_exposure');
   });
 
+  it('uses complete-plan, then attempts, then authorization recovery locking', async () => {
+    const client = new StrictLedgerClient(); const subject = ledger(client);
+    await subject.recordProviderIntent(intent());
+    expect(await subject.recordUnknownExposure(reservation)).toEqual({ status: 'recorded' });
+    const planSet = client.calls.findIndex(({ sql }) => sql.startsWith('SELECT assignment_id FROM addie_fixed_trace_component_smoke_run_plan'));
+    const attempts = client.calls.findIndex(({ sql }, index) => index > planSet && sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts'));
+    const authorization = client.calls.findIndex(({ sql }, index) => index > attempts && sql.startsWith('SELECT status FROM addie_fixed_trace_component_smoke_authorizations'));
+    expect(planSet).toBeGreaterThanOrEqual(0);
+    expect(attempts).toBeGreaterThan(planSet);
+    expect(authorization).toBeGreaterThan(attempts);
+  });
+
   it('idempotently recovers a committed known provider failure after its unknown-exposure commit response is lost', async () => {
     const client = new StrictLedgerClient(); const subject = ledger(client);
     client.authStatus = 'unknown_exposure';

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -64,11 +64,12 @@ class StrictLedgerClient {
       const attempt = this.attempts.get(params![0] as string);
       return attempt ? { rowCount: 1, rows: [{ assignment_id: attempt.assignmentId, status: attempt.status, invocation_ordinal: String(attempt.ordinal), ...this.planRow() }] } : { rowCount: 0, rows: [] };
     }
-    if (sql.startsWith('WITH locked_attempts AS') && sql.includes('actual_cost_microdollars')) {
+    if (sql.startsWith('WITH locked_attempts AS') && sql.includes('actual_cost_microdollars')
+      || sql.startsWith('SELECT COALESCE(SUM(actual_cost_microdollars)')) {
       const spent = this.priorSpend ?? String([...this.attempts.values()].reduce((sum, attempt) => sum + (attempt.cost ?? 0), 0));
       return { rowCount: 1, rows: [{ spent }] };
     }
-    if ((sql.startsWith('WITH locked_attempts AS') && sql.includes('last_response_disposition')) || sql.startsWith('SELECT count(*)::bigint AS count')) {
+    if (sql.startsWith('WITH assignment_attempts AS') || sql.startsWith('SELECT count(*)::bigint AS count')) {
       const matches = [...this.attempts.values()].filter((attempt) => attempt.assignmentId === params![1] && attempt.ordinal <= params![2] as number);
       const last = [...matches].sort((left, right) => right.ordinal - left.ordinal)[0];
       return { rowCount: 1, rows: [{ count: String(matches.length), open: matches.some((attempt) => attempt.status === 'intent_recorded'), failures: matches.some((attempt) => attempt.status !== 'succeeded'), last_response_disposition: last?.responseDisposition ?? null }] };


### PR DESCRIPTION
## Summary

Private authorization and PostgreSQL ledger contract only for Addie #6842. No provider adapter, route, job, cron, composition root, credential, issuer key, provider/API call, or runnable dispatch path is included.

- No-spend, default-off, non-promotable, and not runnable: `FIXED_TRACE_COMPONENT_SMOKE_CURRENT_MODULE_CAN_DISPATCH` remains permanently false.
- Production Ed25519 trust registry and the separately reviewed one-shot trust-root pin remain deliberately `null`. An injected root cannot mint a capability until a later review pins its digest.
- Ledger stores only irreversible digests/HMACs and bounded categorical accounting metadata; it retains no bearer grant, raw signature, nonce, prompt, output, provider error, payload, or credential.
- The exact SHA-256-bound 168-row plan is distinct from up to 192 ordinal-specific provider attempts: 126 provider-dispatch assignments, 21 local-terminal assignments, and 21 pre-dispatch-fault assignments.

## Audit dispositions

- Authorization and lifetime: verifier-minted opaque authority only; test syntax verification/arbitrary roots cannot mint it; signature is digest-only; verifier and database cap TTL at 15 minutes.
- Reservation and plan integrity: every mutation locks and matches derived reservation ID plus authorization digest. A deferred exact-manifest digest binds every assignment field; plan rows are immutable apart from one monotonic outcome.
- Dispatch sequencing: new intents require `consumed`, no existing open intent, and for ordinal N>1 a succeeded immediate predecessor with `tool_continuation_required`. A final ordinal-1 generation response blocks ordinal 2.
- Terminal and cost accounting: exact returned identity is required for admitted actual cost; a mismatched identity becomes unknown/pricing-unavailable instead. Per-slot reservation, input including cache, output, timeout, and serialized cumulative ceilings apply. A known over-limit response preserves observed cost but does not claim an admitted actual cost.
- Continuation/ambiguity/denominator: continuation at the maximum ordinal is categorically settled as `invalid_limits`, halts dispatch, and can close as a provider failure. Unknown-exposure recovery locks either `consumed` or already-unknown authorization idempotently, then derives started/unclosed provider outcomes without invented evidence; untouched assignments close as zero-call `not_executed_after_halt`. Every 168 assignment has one outcome; only a fully completed consumed run becomes `completed`; halted/unknown remain permanently nondispatchable.
- Direct SQL: trigger checks prevent intents after halt/unknown/completion, terminal assignment re-entry, identity-mismatched succeeded or actual-cost rows, duplicate/open/skip ordinal attempts, state rollback, and mutation/deletion of immutable plan, intent, or authorization evidence.
- Recovery lock ordering: application/direct intent INSERT uses target plan → authorization; terminal UPDATE uses target attempt → authorization and never locks a plan. Every application plan-outcome writer takes `ROW EXCLUSIVE` before its target plan row; direct `UPDATE` has the same PostgreSQL table lock. Before recovery acquires any plan row it takes `SHARE ROW EXCLUSIVE`, serializing it against those writers, then locks the complete immutable plan set in assignment order → all existing attempts in deterministic order → authorization. Complete-plan locking is the insertion gate, so no intent can appear after its attempt snapshot. `recordProviderIntent` observes unresolved work before a target or under the authorization, commits that transaction, then invokes standalone recovery. Failed recovery returns `persistence_uncertain`, never a false durable-poison result.

## Validation

- Rebased onto `origin/main` `d44a71a553476480d08a0fff76e2a606b08997c4`.
- Clean-environment focused unit tests: `env -u DEV_USER_EMAIL -u DEV_USER_ID npx vitest run --config server/vitest.config.ts tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts` — 37 passed.
- `npm run typecheck` — passed.
- Fresh disposable UTF-8 PostgreSQL 16 database: all 582 migrations applied, then `server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts` — 33 passed. This includes blocker-controlled precheck-to-committed-intent-to-standalone-recovery interleaving, a forced recovery lock-timeout regression proving no false durable poison or later dispatch, a three-transaction full-plan recovery insertion-gate/phantom regression, reverse-order multi-outcome writer versus recovery coverage, and recovery-gate-first application-outcome coverage.
- `git diff --check` — passed.
- Exceptional recovery: normal pre-commit and a direct `precommit:server-unit` previously reached the repository fixed 600-second wall-clock timeout while still advancing in this VM. The normal hook is a timeout/failure, not a pass. The latest commit uses the authorized one-time `HUSKY=0` timeout exception. Exact-head GitHub CI remains the full-suite gate.

Draft only pending exact-head GitHub CI, root inspection, and independent Sol re-review. No merge, ready-for-review transition, runtime activation, provider call, or spend.
