### PR TITLE
feat(addie): add no-spend model-judge diagnostic protocol

### DIFF
--- a/server/src/addie/eval/fixed-trace-api-budget-ladder.ts
+++ b/server/src/addie/eval/fixed-trace-api-budget-ladder.ts
@@ -1,0 +1,124 @@
+import {
+  fixedTraceComponentSmokeAdmission,
+  type FixedTraceComponentSmokeAdmissionManifest,
+} from './fixed-trace-component-smoke-admission.js';
+import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+
+/** Integer accounting avoids floating-point budget comparisons. */
+export const FIXED_TRACE_MICRODOLLARS_PER_USD = 1_000_000 as const;
+export const FIXED_TRACE_API_BUDGET_LADDER_VERSION =
+  'addie-fixed-trace-api-budget-ladder-v2' as const;
+
+const FIXED_TRACE_V2_SMOKE_ADMISSION_FINGERPRINT =
+  '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d' as const;
+const FIXED_TRACE_V2_SMOKE_PRICING_COHORT_DIGEST =
+  'sha256:e8c5736fb62ef4b5c7219401e2f765be7e5a8527472babf54b29ec27539f94e7' as const;
+const FIXED_TRACE_V2_SMOKE_PRICING_CHECKED_AT = '2026-09-05T23:55:26.000Z' as const;
+
+/** Fail closed if a same-sized but different smoke admission is substituted. */
+export function assertFixedTraceV2SmokeIdentity(
+  admission: Pick<FixedTraceComponentSmokeAdmissionManifest, 'status' | 'cardinality' | 'pricing' | 'fingerprints'>,
+): void {
+  if (admission.status !== 'ready_for_explicit_paid_authorization') throw new Error('pinned v2 component-smoke admission is not ready for explicit paid authorization');
+  if (admission.fingerprints.aggregateAdmission !== FIXED_TRACE_V2_SMOKE_ADMISSION_FINGERPRINT) throw new Error('pinned v2 component-smoke aggregate admission fingerprint changed');
+  if (admission.cardinality.maximumProviderInvocations !== 192) throw new Error('pinned v2 component-smoke provider-call ceiling changed');
+  if (admission.pricing.reservationMicrodollars !== 2_819_484) throw new Error('pinned v2 component-smoke reservation changed');
+  if (admission.pricing.providerCeilingUsd !== 5) throw new Error('pinned v2 component-smoke USD ceiling changed');
+  if (admission.pricing.cohortDigest !== FIXED_TRACE_V2_SMOKE_PRICING_COHORT_DIGEST || admission.pricing.checkedAt !== FIXED_TRACE_V2_SMOKE_PRICING_CHECKED_AT) throw new Error('pinned v2 component-smoke pricing cohort changed');
+}
+
+const smoke = fixedTraceComponentSmokeAdmission();
+assertFixedTraceV2SmokeIdentity(smoke);
+const smokeCalls = smoke.cardinality.maximumProviderInvocations;
+const smokeReservation = smoke.pricing.reservationMicrodollars;
+
+/** Planning data only; private authority must attest a later release. */
+export const FIXED_TRACE_API_BUDGET_LADDER = Object.freeze({
+  version: FIXED_TRACE_API_BUDGET_LADDER_VERSION,
+  status: 'not_admitted_pending_private_verified_tranche_authority',
+  hardCumulativeCeilingMicrodollars: 700_000_000,
+  accountingUnit: 'integer_microdollars',
+  ledger: 'private_verified_immutable_cumulative_ledger_required_before_every_dispatch',
+  tranches: Object.freeze([
+    Object.freeze({
+      id: 'tranche_1_component_smoke',
+      status: 'separate_v2_admission_preserved_not_authorized_here',
+      v2AdmissionFingerprint: smoke.fingerprints.aggregateAdmission,
+      v2PricingCohortDigest: smoke.pricing.cohortDigest,
+      maximumProviderCalls: smokeCalls,
+      maximumCostMicrodollars: 5_000_000,
+      reservedMaximumMicrodollars: smokeReservation,
+      stopRules: Object.freeze([
+        'stop_before_dispatch_when_reservation_exceeds_cap',
+        'stop_on_unknown_exposure_or_missing_usage',
+        'stop_on_deterministic_or_safety_failure',
+      ]),
+    }),
+    ...(['tranche_2_model_judge_calibration', 'tranche_3_exploratory_and_architecture_diagnostic', 'tranche_4_reviewed_follow_up'] as const).map((id) => Object.freeze({
+      id,
+      status: 'not_admitted_requires_own_private_verified_cap_and_reconciled_ledger',
+      maximumProviderCalls: null,
+      maximumCostMicrodollars: null,
+      reservedMaximumMicrodollars: null,
+      stopRules: Object.freeze([
+        'no_automatic_release_of_unspent_ceiling',
+        'require_prior_reconciled_observed_reserved_and_unknown_exposure',
+        'require_own_private_verified_call_and_cost_cap_before_dispatch',
+        'prohibit_overlapping_or_in_flight_releases',
+      ]),
+    })),
+  ]),
+  noPerConfigurationSpendAssumption: true,
+} as const);
+
+export type FixedTraceApiBudgetTrancheId =
+  (typeof FIXED_TRACE_API_BUDGET_LADDER.tranches)[number]['id'];
+
+/** Structural input only; its authorization digest is never verified here. */
+export interface FixedTraceUnverifiedTrancheLedgerShape {
+  readonly trancheId: FixedTraceApiBudgetTrancheId;
+  /** A reference only. This public module cannot establish its authenticity. */
+  readonly unverifiedAuthorizationReferenceDigest: string;
+  readonly declaredMaximumProviderCalls: number;
+  readonly declaredCapMicrodollars: number;
+  readonly priorReconciledObservedMicrodollars: number;
+  readonly priorOutstandingReservedMicrodollars: number;
+  readonly priorUnknownExposureMicrodollars: number;
+  readonly currentTrancheReservedMicrodollars: number;
+  readonly observedProviderCalls: number;
+}
+
+const ledgerKeys = [
+  'currentTrancheReservedMicrodollars', 'declaredCapMicrodollars',
+  'declaredMaximumProviderCalls', 'observedProviderCalls',
+  'priorOutstandingReservedMicrodollars', 'priorReconciledObservedMicrodollars',
+  'priorUnknownExposureMicrodollars', 'trancheId',
+  'unverifiedAuthorizationReferenceDigest',
+] as const;
+const isMicrodollars = (value: unknown) =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && !Object.is(value, -0);
+const exactKeys = (value: Record<string, unknown>, keys: readonly string[], label: string) => {
+  if (Object.keys(value).sort().join(',') !== [...keys].sort().join(',')) throw new Error(`${label} has extra or missing fields`);
+};
+
+/** Structural safety check only; success never creates verified authority. */
+export function assertFixedTraceUnverifiedTrancheLedgerShape(value: unknown): void {
+  const entry = snapshotFixedTraceJson(value, 'fixed-trace unverified tranche ledger');
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) throw new Error('fixed-trace unverified tranche ledger must be an object');
+  const record = entry as Record<string, unknown>;
+  exactKeys(record, ledgerKeys, 'fixed-trace unverified tranche ledger');
+  const tranche = FIXED_TRACE_API_BUDGET_LADDER.tranches.find((item) => item.id === record.trancheId);
+  if (!tranche || typeof record.unverifiedAuthorizationReferenceDigest !== 'string' || !/^[a-f0-9]{64}$/.test(record.unverifiedAuthorizationReferenceDigest)
+    || typeof record.declaredMaximumProviderCalls !== 'number' || !Number.isSafeInteger(record.declaredMaximumProviderCalls) || record.declaredMaximumProviderCalls < 1
+    || ![record.declaredCapMicrodollars, record.priorReconciledObservedMicrodollars,
+      record.priorOutstandingReservedMicrodollars, record.priorUnknownExposureMicrodollars,
+      record.currentTrancheReservedMicrodollars, record.observedProviderCalls].every(isMicrodollars)) throw new Error('fixed-trace unverified tranche ledger has invalid values');
+  const checked = record as unknown as FixedTraceUnverifiedTrancheLedgerShape;
+  if (checked.observedProviderCalls > checked.declaredMaximumProviderCalls) throw new Error('fixed-trace unverified tranche ledger exceeds declared call cap');
+  if (checked.currentTrancheReservedMicrodollars > checked.declaredCapMicrodollars) throw new Error('fixed-trace unverified tranche ledger exceeds tranche cost cap');
+  if (tranche.maximumProviderCalls !== null && checked.declaredMaximumProviderCalls !== tranche.maximumProviderCalls) throw new Error('fixed-trace unverified tranche ledger conflicts with pinned call cap');
+  if (tranche.maximumCostMicrodollars !== null && checked.declaredCapMicrodollars !== tranche.maximumCostMicrodollars) throw new Error('fixed-trace unverified tranche ledger conflicts with pinned cost cap');
+  const priorExposure = checked.priorReconciledObservedMicrodollars + checked.priorOutstandingReservedMicrodollars + checked.priorUnknownExposureMicrodollars;
+  if (priorExposure + checked.declaredCapMicrodollars > FIXED_TRACE_API_BUDGET_LADDER.hardCumulativeCeilingMicrodollars) throw new Error('fixed-trace unverified tranche ledger exceeds cumulative ceiling');
+  if (tranche.maximumCostMicrodollars === null && (checked.priorOutstandingReservedMicrodollars !== 0 || checked.priorUnknownExposureMicrodollars !== 0)) throw new Error('fixed-trace unverified tranche ledger has overlapping or unknown prior exposure');
+}

--- a/server/src/addie/eval/fixed-trace-model-judge-control-plane.ts
+++ b/server/src/addie/eval/fixed-trace-model-judge-control-plane.ts
@@ -1,0 +1,205 @@
+import { FIXED_TRACE_API_BUDGET_LADDER, assertFixedTraceUnverifiedTrancheLedgerShape } from './fixed-trace-api-budget-ladder.js';
+import { FIXED_TRACE_ADMITTED_CELLS, FIXED_TRACE_ARCHITECTURE_CELL_TRUTH, FIXED_TRACE_PROPOSED_EVALUATION_PROTOCOL, fixedTraceEvaluationProtocolFingerprint } from './fixed-trace-evaluation-protocol.js';
+import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+
+export const FIXED_TRACE_MODEL_JUDGE_CONTROL_PLANE_VERSION = 'addie-fixed-trace-model-judge-control-plane-v2' as const;
+const BASE_PROTOCOL_FINGERPRINT = 'fef6fd0edb9354d078cbac3dfce688bd9d187982a50a9564c6521e100dcc2325' as const;
+if (fixedTraceEvaluationProtocolFingerprint(FIXED_TRACE_PROPOSED_EVALUATION_PROTOCOL) !== BASE_PROTOCOL_FINGERPRINT) throw new Error('model-judged amendment must bind the unchanged base protocol fingerprint');
+
+/** No calibration content, expected decisions, or observed results are present. */
+export const FIXED_TRACE_FROZEN_GOLDEN_CALIBRATION_REQUIREMENT = Object.freeze({
+  status: 'unavailable_pending_versioned_case_rubric_expected_decision_and_observed_calibration_ledger',
+  requiredArtifact: 'canonical_versioned_case_rubric_expected_decision_manifest_with_derived_content_digest',
+  requiredResults: 'private_verified_observed_per_judge_calibration_ledger',
+  prohibited: 'self_attested_id_hash_or_caller_supplied_calibrated_judge_list',
+} as const);
+export const FIXED_TRACE_DIAGNOSTIC_ASSIGNMENT_REQUIREMENT = Object.freeze({
+  status: 'unavailable_pending_custodied_exact_assignment_manifest',
+  requiredFields: Object.freeze(['case_id', 'stratum', 'architecture_arm', 'ordered_configuration_cell_ids', 'derived_and_bound_candidate_pipeline_provider_set', 'repetition', 'opaque_packet_id', 'judge_eligibility', 'exact_expected_provider_excluding_judge_slots', 'deterministic_evidence_assignment', 'seed_commitment', 'schedule_digest', 'locked_holdout_digest']),
+  omissionRule: 'every_expected_candidate_output_and_judge_slot_remains_in_denominator',
+} as const);
+export const FIXED_TRACE_CUSTODY_REQUIREMENT = Object.freeze({
+  status: 'unavailable_pending_private_verified_seed_schedule_and_locked_holdout_linkage',
+  prohibited: 'syntax_valid_caller_supplied_digests_are_not_custody_or_holdout_proof',
+} as const);
+
+/** This deliberately mirrors only the locked v2 21-cell registry; it is not exhaustive. */
+const LOCKED_V2_CANDIDATE_PROVIDER_SUBSET = Object.freeze(['anthropic', 'openai', 'google'] as const);
+export type FixedTraceRegisteredCandidateProvider = (typeof LOCKED_V2_CANDIDATE_PROVIDER_SUBSET)[number];
+export type FixedTraceProviderExcludingJudgeEligibility = Readonly<{
+  candidateProviders: readonly FixedTraceRegisteredCandidateProvider[];
+  status: 'eligible_pending_custodied_manifest_calibration_and_authority' | 'unavailable_mixed_provider_requires_human_or_fourth_provider';
+  requiredJudgeProviders: readonly FixedTraceRegisteredCandidateProvider[];
+  promotable: false;
+}>;
+
+/**
+ * Planning classification only. It neither declares an assignment nor admits
+ * one: the future manifest must bind this exact relationship per assignment.
+ */
+export function classifyFixedTraceProviderExcludingJudgeEligibility(
+  candidateProviders: readonly FixedTraceRegisteredCandidateProvider[],
+): FixedTraceProviderExcludingJudgeEligibility {
+  const unique = [...new Set(candidateProviders)];
+  if (unique.length === 0 || unique.some((provider) => !LOCKED_V2_CANDIDATE_PROVIDER_SUBSET.includes(provider))) {
+    throw new Error('candidate provider set must be a nonempty subset of the locked v2 three-provider registry');
+  }
+  if (unique.length !== 1) {
+    return Object.freeze({
+      candidateProviders: Object.freeze(unique),
+      status: 'unavailable_mixed_provider_requires_human_or_fourth_provider',
+      requiredJudgeProviders: Object.freeze([]),
+      promotable: false,
+    });
+  }
+  return Object.freeze({
+    candidateProviders: Object.freeze(unique),
+    status: 'eligible_pending_custodied_manifest_calibration_and_authority',
+    requiredJudgeProviders: Object.freeze(LOCKED_V2_CANDIDATE_PROVIDER_SUBSET.filter((provider) => provider !== unique[0])),
+    promotable: false,
+  });
+}
+
+export const FIXED_TRACE_PROVIDER_EXCLUDING_JUDGE_ELIGIBILITY_REQUIREMENT = Object.freeze({
+  status: 'unavailable_pending_custodied_per_assignment_eligibility_manifest',
+  lockedV2CandidateProviderSubset: LOCKED_V2_CANDIDATE_PROVIDER_SUBSET,
+  universeScope: 'not_an_exhaustive_model_universe; additions_require_a_separate_versioned_priced_and_admitted_inventory_after_tranche_1',
+  currentPlanningTruth: Object.freeze({
+    potentiallyLlmJudgeableProviderMatchedCombinations: FIXED_TRACE_ARCHITECTURE_CELL_TRUTH.potentiallyLlmJudgeableProviderMatchedCombinations,
+    mixedProviderCombinationsRequiringHumanOrFourthProvider: FIXED_TRACE_ARCHITECTURE_CELL_TRUTH.mixedProviderCombinationsRequiringHumanOrFourthProvider,
+  }),
+  singleProviderRule: 'single-provider component packets and same-provider locked architecture arms require exactly two distinct provider-excluding judge providers',
+  mixedProviderRule: 'mixed-provider quality admission is unavailable and non-promotable; do not self-judge, invent a fourth provider, or claim comprehensive mixed-provider quality admission',
+  requiredPerAssignmentBindings: Object.freeze(['candidate_pipeline_provider_set', 'eligibility_status', 'exact_expected_provider_excluding_judge_slots']),
+} as const);
+
+export const FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT = Object.freeze({
+  version: 'addie-fixed-trace-model-judged-diagnostic-amendment-v2',
+  baseProtocolFingerprint: BASE_PROTOCOL_FINGERPRINT,
+  status: 'not_admitted_pending_custody_calibration_exact_assignment_and_private_verified_budget_authority',
+  blockers: Object.freeze([FIXED_TRACE_FROZEN_GOLDEN_CALIBRATION_REQUIREMENT.status, FIXED_TRACE_DIAGNOSTIC_ASSIGNMENT_REQUIREMENT.status, FIXED_TRACE_PROVIDER_EXCLUDING_JUDGE_ELIGIBILITY_REQUIREMENT.status, FIXED_TRACE_API_BUDGET_LADDER.status, FIXED_TRACE_CUSTODY_REQUIREMENT.status, 'unavailable_pending_complete_per_assignment_deterministic_evidence']),
+  componentSmoke: 'unchanged_v2_mechanical_feasibility_only_no_quality_or_architecture_claim',
+  architectureArms: Object.freeze(['direct_generation', 'two_stage_llm_router', 'deterministic_policy_llm_fallback_hybrid']),
+  treatmentRule: 'architecture_and_provider_model_effort_configuration_cells_are_nested_treatments_not_separable_effects',
+  judges: 'exactly_two_judges_with_distinct_provider_and_model_identities_excluding_every_candidate_provider_and_candidate_model_in_the_locked_three_provider_registry; future_fourth_provider_support_requires_a_versioned_amendment; exact_manifest_slots_preserve_missing_malformed_refusal_abstain_and_disagreement',
+  blinding: 'candidate_provider_model_architecture_cost_latency_configuration_and_other_judge_scores_absent_from_judge_packets',
+  hardGates: Object.freeze(['correctness', 'mutation_safety', 'prompt_injection', 'tool_correctness', 'provenance', 'returned_identity', 'latency', 'cost']),
+  humanPanel: 'dormant_optional_control_plane_not_admission_blocker_and_not_evidence_that_humans_ran',
+  claimLimits: Object.freeze(['no_human_confirmatory_claim', 'no_noninferiority_claim', 'no_superiority_claim', 'no_production_generalization_claim', 'no_architecture_winner_claim', 'no_model_winner_claim', 'no_effort_winner_claim', 'no_quality_rate_claim']),
+} as const);
+
+const packetKeys = ['candidateOutput', 'outputCondition', 'packetId', 'prompt', 'scoringContext'] as const;
+const exact = (record: Record<string, unknown>, keys: readonly string[], label: string) => {
+  if (Object.keys(record).sort().join(',') !== [...keys].sort().join(',')) throw new Error(`${label} has extra or missing fields`);
+};
+const plain = (value: unknown, label: string) => {
+  const snapshot = snapshotFixedTraceJson(value, label);
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) throw new Error(`${label} must be an object`);
+  return snapshot as Record<string, unknown>;
+};
+const hex = (value: unknown) => typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+const nonblank = (value: unknown) => typeof value === 'string' && value.trim().length > 0;
+const assignmentKeys = ['architectureArm', 'assignmentId', 'candidateOutput', 'caseId', 'configurationCellIds', 'outputStatus', 'packetId', 'repetition', 'stratum'] as const;
+const lockedV2CellsById = new Map(FIXED_TRACE_ADMITTED_CELLS.map((cell) => [cell.id, cell]));
+const deterministicKeys = ['assignmentId', 'correctness', 'cost', 'latency', 'mutationSafety', 'promptInjection', 'provenance', 'returnedIdentity', 'toolCorrectness'] as const;
+const judgmentKeys = ['judgeModel', 'judgeProvider', 'outcome', 'packetId', 'reason'] as const;
+const lockedV2TreatmentIdentifiers = Object.freeze([
+  ...FIXED_TRACE_ADMITTED_CELLS.map((cell) => cell.id),
+  'direct_generation',
+  'two_stage_llm_router',
+  'deterministic_policy_llm_fallback_hybrid',
+]);
+const escapedLockedV2TreatmentIdentifiers = lockedV2TreatmentIdentifiers
+  .slice()
+  .sort((left, right) => right.length - left.length)
+  .map((identifier) => identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+const lockedV2TreatmentIdentifierPattern = new RegExp(`(?<![A-Za-z0-9_])(?:${escapedLockedV2TreatmentIdentifiers.join('|')})(?![A-Za-z0-9_])`);
+const lockedV2CellIds = new Set(FIXED_TRACE_ADMITTED_CELLS.map((cell) => cell.id));
+
+/**
+ * This is only a narrow structural screen for exact locked-v2 identifiers.
+ * It is not proof of blinding; real packet blinding remains unavailable until
+ * a separately verified exact assignment manifest supplies all identifiers.
+ */
+export const FIXED_TRACE_PACKET_BLINDING_BOUNDARY = Object.freeze({
+  status: 'non_proof_structural_check_pending_verified_assignment_manifest',
+  exactIdentifierRule: 'reject_only_exact_locked_v2_treatment_identifiers_or_extra_metadata_fields; ordinary_task_language_is_not_treatment_metadata',
+} as const);
+
+function assertRows(rows: unknown, keys: readonly string[], label: string, validate: (row: Record<string, unknown>) => boolean): void {
+  if (!Array.isArray(rows)) throw new Error(`${label} must be an array`);
+  for (const row of rows) {
+    const record = plain(row, label);
+    exact(record, keys, label);
+    if (!validate(record)) throw new Error(`${label} has invalid values`);
+  }
+}
+
+/** Judge packets have an exact structural shape; this function never proves blinding. */
+export function assertFixedTraceBlindedModelJudgePacket(packet: unknown): void {
+  const record = plain(packet, 'model judge packet');
+  exact(record, packetKeys, 'model judge packet');
+  if (typeof record.packetId !== 'string' || !record.packetId.trim() || typeof record.prompt !== 'string' || !record.prompt.trim() || typeof record.scoringContext !== 'string' || !record.scoringContext.trim() || (record.candidateOutput !== null && typeof record.candidateOutput !== 'string') || !['complete', 'missing', 'malformed'].includes(record.outputCondition as string)) throw new Error('model judge packet is malformed');
+  if (lockedV2TreatmentIdentifierPattern.test(`${record.prompt}\n${record.candidateOutput ?? ''}\n${record.scoringContext}`)) throw new Error('model judge packet contains an exact locked-v2 treatment identifier');
+}
+
+/** Structural safety only: unavailable custody prevents every positive admission. */
+export function assessFixedTraceModelJudgedDiagnostic(input: unknown): Readonly<{ admitted: false; status: typeof FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT.status; blockers: readonly string[] }> {
+  const blockers = [...FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT.blockers];
+  try {
+    const record = plain(input, 'model-judged diagnostic input');
+    exact(record, ['budgetLedger', 'candidateOutputs', 'deterministicEvidence', 'judgments', 'manualReview', 'packets', 'randomization'], 'model-judged diagnostic input');
+    if (!Array.isArray(record.packets) || !record.randomization || typeof record.randomization !== 'object' || Array.isArray(record.randomization) || !record.budgetLedger || typeof record.budgetLedger !== 'object' || Array.isArray(record.budgetLedger) || !['not_requested', 'optional_spot_check', 'optional_escalation'].includes(record.manualReview as string)) throw new Error('model-judged diagnostic input has invalid field types');
+    const randomization = plain(record.randomization, 'model-judged diagnostic randomization');
+    exact(randomization, ['lockedHoldoutDigest', 'scheduleDigest', 'seedCommitment'], 'model-judged diagnostic randomization');
+    if (!hex(randomization.lockedHoldoutDigest) || !hex(randomization.scheduleDigest) || !hex(randomization.seedCommitment)) throw new Error('model-judged diagnostic randomization has invalid syntax');
+    for (const packet of record.packets) assertFixedTraceBlindedModelJudgePacket(packet);
+    assertRows(record.candidateOutputs, assignmentKeys, 'model-judged candidate output', (row) =>
+      nonblank(row.assignmentId) && nonblank(row.caseId) && nonblank(row.stratum) && ['direct_generation', 'two_stage_llm_router', 'deterministic_policy_llm_fallback_hybrid'].includes(row.architectureArm as string) && Array.isArray(row.configurationCellIds) && row.configurationCellIds.every((id) => typeof id === 'string' && lockedV2CellIds.has(id)) && Number.isSafeInteger(row.repetition) && (row.repetition as number) > 0 && nonblank(row.packetId) && ['complete', 'missing', 'malformed'].includes(row.outputStatus as string) && ((row.outputStatus === 'complete' && nonblank(row.candidateOutput)) || (row.outputStatus !== 'complete' && row.candidateOutput === null)),
+    );
+    for (const candidate of record.candidateOutputs as Record<string, unknown>[]) {
+      const ids = candidate.configurationCellIds as string[];
+      const cells = ids.map((id) => lockedV2CellsById.get(id));
+      const arm = candidate.architectureArm;
+      if ((arm === 'direct_generation' && (cells.length !== 1 || cells[0]?.role !== 'generation')) ||
+          ((arm === 'two_stage_llm_router' || arm === 'deterministic_policy_llm_fallback_hybrid') && (cells.length !== 2 || cells[0]?.role !== 'router' || cells[1]?.role !== 'generation'))) throw new Error('model-judged diagnostic has invalid architecture configuration cell roles or order');
+    }
+    assertRows(record.deterministicEvidence, deterministicKeys, 'model-judged deterministic evidence', (row) =>
+      nonblank(row.assignmentId) && ['correctness', 'cost', 'latency', 'mutationSafety', 'promptInjection', 'provenance', 'returnedIdentity', 'toolCorrectness'].every((key) => typeof row[key] === 'boolean'),
+    );
+    assertRows(record.judgments, judgmentKeys, 'model-judged judgment', (row) =>
+      nonblank(row.packetId) && nonblank(row.judgeProvider) && nonblank(row.judgeModel) && ['pass', 'fail', 'abstain', 'missing', 'malformed', 'refusal'].includes(row.outcome as string) && nonblank(row.reason),
+    );
+    const candidates = record.candidateOutputs as Record<string, unknown>[];
+    const packets = record.packets as Record<string, unknown>[];
+    const evidence = record.deterministicEvidence as Record<string, unknown>[];
+    const judgments = record.judgments as Record<string, unknown>[];
+    if (candidates.length === 0) throw new Error('model-judged diagnostic requires nonempty candidate assignments');
+    const unique = (values: readonly string[], label: string) => { if (new Set(values).size !== values.length) throw new Error(`model-judged diagnostic has duplicate ${label}`); };
+    unique(candidates.map((row) => row.assignmentId as string), 'assignment IDs');
+    unique(candidates.map((row) => row.packetId as string), 'candidate packet IDs');
+    unique(packets.map((row) => row.packetId as string), 'packet IDs');
+    unique(evidence.map((row) => row.assignmentId as string), 'deterministic-evidence assignment IDs');
+    const packetById = new Map(packets.map((row) => [row.packetId as string, row]));
+    const evidenceIds = new Set(evidence.map((row) => row.assignmentId as string));
+    if (packets.length !== candidates.length || evidence.length !== candidates.length) throw new Error('model-judged diagnostic has incomplete candidate packet or deterministic-evidence coverage');
+    for (const candidate of candidates) {
+      const packet = packetById.get(candidate.packetId as string);
+      if (!packet || !evidenceIds.has(candidate.assignmentId as string)) throw new Error('model-judged diagnostic has orphan or missing candidate cross-link');
+      if (candidate.outputStatus !== packet.outputCondition || candidate.candidateOutput !== packet.candidateOutput) throw new Error('model-judged diagnostic candidate output conflicts with packet condition or content');
+      const candidateProviders = new Set((candidate.configurationCellIds as string[]).map((id) => lockedV2CellsById.get(id)!.provider));
+      const expectedJudgeProviders = LOCKED_V2_CANDIDATE_PROVIDER_SUBSET.filter((provider) => !candidateProviders.has(provider));
+      const packetJudgments = judgments.filter((judgment) => judgment.packetId === candidate.packetId);
+      if (candidateProviders.size !== 1 || expectedJudgeProviders.length !== 2) throw new Error('model-judged diagnostic mixed-provider pipeline cannot have two provider-excluding judges');
+      if (packetJudgments.length !== 2) throw new Error('model-judged diagnostic requires exactly two structural judge slots per packet');
+      if (!packetJudgments.every((judgment) => expectedJudgeProviders.includes(judgment.judgeProvider as FixedTraceRegisteredCandidateProvider)) || new Set(packetJudgments.map((judgment) => judgment.judgeProvider)).size !== 2) throw new Error('model-judged diagnostic judges must be exactly the provider-excluding pair');
+      unique(packetJudgments.map((judgment) => judgment.judgeProvider as string), 'judge providers per packet');
+      unique(packetJudgments.map((judgment) => `${judgment.judgeProvider}:${judgment.judgeModel}`), 'judge provider/model identities per packet');
+    }
+    if (judgments.some((judgment) => !packetById.has(judgment.packetId as string))) throw new Error('model-judged diagnostic has orphan judgment');
+    assertFixedTraceUnverifiedTrancheLedgerShape(record.budgetLedger);
+  } catch (error) {
+    blockers.push(error instanceof Error ? `invalid_unverified_input:${error.message}` : 'invalid_unverified_input');
+  }
+  return Object.freeze({ admitted: false, status: FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT.status, blockers: Object.freeze(blockers) });
+}

--- a/server/tests/unit/addie/fixed-trace-model-judge-control-plane.test.ts
+++ b/server/tests/unit/addie/fixed-trace-model-judge-control-plane.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FIXED_TRACE_DIAGNOSTIC_ASSIGNMENT_REQUIREMENT,
+  FIXED_TRACE_FROZEN_GOLDEN_CALIBRATION_REQUIREMENT,
+  FIXED_TRACE_CUSTODY_REQUIREMENT,
+  FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT,
+  FIXED_TRACE_PROVIDER_EXCLUDING_JUDGE_ELIGIBILITY_REQUIREMENT,
+  assessFixedTraceModelJudgedDiagnostic,
+  assertFixedTraceBlindedModelJudgePacket,
+  classifyFixedTraceProviderExcludingJudgeEligibility,
+} from '../../../src/addie/eval/fixed-trace-model-judge-control-plane.js';
+import {
+  FIXED_TRACE_API_BUDGET_LADDER,
+  assertFixedTraceV2SmokeIdentity,
+  assertFixedTraceUnverifiedTrancheLedgerShape,
+} from '../../../src/addie/eval/fixed-trace-api-budget-ladder.js';
+import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+
+const hash = (letter = 'a') => letter.repeat(64);
+const ledger = () => ({
+  trancheId: 'tranche_3_exploratory_and_architecture_diagnostic', unverifiedAuthorizationReferenceDigest: hash(),
+  declaredMaximumProviderCalls: 1, declaredCapMicrodollars: 1,
+  priorReconciledObservedMicrodollars: 0, priorOutstandingReservedMicrodollars: 0,
+  priorUnknownExposureMicrodollars: 0, currentTrancheReservedMicrodollars: 0,
+  observedProviderCalls: 0,
+});
+const firstTrancheLedger = () => ({
+  trancheId: 'tranche_1_component_smoke', unverifiedAuthorizationReferenceDigest: hash(),
+  declaredMaximumProviderCalls: 192, declaredCapMicrodollars: 5_000_000,
+  priorReconciledObservedMicrodollars: 0, priorOutstandingReservedMicrodollars: 0,
+  priorUnknownExposureMicrodollars: 0, currentTrancheReservedMicrodollars: 2_819_484,
+  observedProviderCalls: 0,
+});
+const packet = () => ({ packetId: 'opaque-1', prompt: 'Summarize supplied facts.', candidateOutput: 'A bounded answer.', scoringContext: 'Apply the locked rubric.', outputCondition: 'complete' as const });
+const input = () => ({
+  budgetLedger: ledger(),
+  candidateOutputs: [{ assignmentId: 'a1', caseId: 'case1', stratum: 's1', architectureArm: 'direct_generation', configurationCellIds: ['generation:openai:gpt-5.6-luna:none'], repetition: 1, packetId: 'opaque-1', outputStatus: 'complete', candidateOutput: 'A bounded answer.' }],
+  deterministicEvidence: [{ assignmentId: 'a1', correctness: true, mutationSafety: true, promptInjection: true, toolCorrectness: true, provenance: true, returnedIdentity: true, latency: true, cost: true }],
+  judgments: [{ packetId: 'opaque-1', judgeProvider: 'anthropic', judgeModel: 'judge-a', outcome: 'pass', reason: 'synthetic only' }, { packetId: 'opaque-1', judgeProvider: 'google', judgeModel: 'judge-b', outcome: 'pass', reason: 'synthetic only' }],
+  manualReview: 'not_requested', packets: [packet()],
+  randomization: { seedCommitment: hash('b'), scheduleDigest: hash('c'), lockedHoldoutDigest: hash('d') },
+});
+const invalid = (value: ReturnType<typeof input>) =>
+  expect(assessFixedTraceModelJudgedDiagnostic(value).blockers).toContainEqual(expect.stringMatching(/^invalid_unverified_input:/));
+
+describe('fixed-trace no-spend model-judge amendment', () => {
+  it('is explicitly non-admitted while real calibration and assignment artifacts are absent', () => {
+    expect(FIXED_TRACE_FROZEN_GOLDEN_CALIBRATION_REQUIREMENT.status).toMatch(/^unavailable/);
+    expect(FIXED_TRACE_DIAGNOSTIC_ASSIGNMENT_REQUIREMENT.status).toMatch(/^unavailable/);
+    expect(FIXED_TRACE_CUSTODY_REQUIREMENT.status).toMatch(/^unavailable/);
+    expect(FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT).toMatchObject({
+      status: expect.stringMatching(/^not_admitted/),
+      componentSmoke: 'unchanged_v2_mechanical_feasibility_only_no_quality_or_architecture_claim',
+      architectureArms: ['direct_generation', 'two_stage_llm_router', 'deterministic_policy_llm_fallback_hybrid'],
+      humanPanel: 'dormant_optional_control_plane_not_admission_blocker_and_not_evidence_that_humans_ran',
+    });
+    expect(FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT.claimLimits).toEqual(expect.arrayContaining([
+      'no_architecture_winner_claim', 'no_model_winner_claim', 'no_effort_winner_claim', 'no_quality_rate_claim',
+    ]));
+    expect(FIXED_TRACE_MODEL_JUDGED_DIAGNOSTIC_AMENDMENT.judges).toMatch(/^exactly_two_judges/);
+    const result = assessFixedTraceModelJudgedDiagnostic(input());
+    expect(result).toMatchObject({ admitted: false });
+    expect(result.blockers.some((blocker) => blocker.startsWith('invalid_unverified_input:'))).toBe(false);
+  });
+
+  it('makes current-registry provider-excluding eligibility exact and fails closed for mixed-provider arms', () => {
+    expect(FIXED_TRACE_PROVIDER_EXCLUDING_JUDGE_ELIGIBILITY_REQUIREMENT.currentPlanningTruth).toEqual({
+      potentiallyLlmJudgeableProviderMatchedCombinations: 97,
+      mixedProviderCombinationsRequiringHumanOrFourthProvider: 134,
+    });
+    expect(FIXED_TRACE_PROVIDER_EXCLUDING_JUDGE_ELIGIBILITY_REQUIREMENT.universeScope).toMatch(/not_an_exhaustive_model_universe/);
+    expect(classifyFixedTraceProviderExcludingJudgeEligibility(['anthropic'])).toEqual({
+      candidateProviders: ['anthropic'],
+      status: 'eligible_pending_custodied_manifest_calibration_and_authority',
+      requiredJudgeProviders: ['openai', 'google'],
+      promotable: false,
+    });
+    expect(classifyFixedTraceProviderExcludingJudgeEligibility(['anthropic', 'openai'])).toEqual({
+      candidateProviders: ['anthropic', 'openai'],
+      status: 'unavailable_mixed_provider_requires_human_or_fourth_provider',
+      requiredJudgeProviders: [],
+      promotable: false,
+    });
+    expect(() => classifyFixedTraceProviderExcludingJudgeEligibility([])).toThrow(/nonempty subset/);
+  });
+
+  it.each([
+    ['two_stage_llm_router', ['router:anthropic:claude-haiku-4-5:provider_default', 'generation:anthropic:claude-sonnet-5:provider_default']],
+    ['deterministic_policy_llm_fallback_hybrid', ['router:anthropic:claude-haiku-4-5:provider_default', 'generation:anthropic:claude-sonnet-5:provider_default']],
+  ])('retains valid ordered same-provider %s treatment cells', (architectureArm, configurationCellIds) => {
+    const value = input();
+    value.candidateOutputs[0].architectureArm = architectureArm;
+    value.candidateOutputs[0].configurationCellIds = configurationCellIds;
+    value.judgments[0].judgeProvider = 'openai';
+    value.judgments[1].judgeProvider = 'google';
+    const result = assessFixedTraceModelJudgedDiagnostic(value);
+    expect(result.admitted).toBe(false);
+    expect(result.blockers.some((blocker) => blocker.startsWith('invalid_unverified_input:'))).toBe(false);
+  });
+
+  it.each([
+    (v: any) => { v.candidateOutputs[0].configurationCellIds = []; },
+    (v: any) => { v.candidateOutputs[0].configurationCellIds = ['router:anthropic:claude-haiku-4-5:provider_default']; },
+    (v: any) => { v.candidateOutputs[0].architectureArm = 'two_stage_llm_router'; v.candidateOutputs[0].configurationCellIds = ['generation:anthropic:claude-sonnet-5:provider_default', 'router:anthropic:claude-haiku-4-5:provider_default']; },
+    (v: any) => { v.candidateOutputs[0].architectureArm = 'two_stage_llm_router'; v.candidateOutputs[0].configurationCellIds = ['router:anthropic:claude-haiku-4-5:provider_default']; },
+    (v: any) => { v.candidateOutputs[0].architectureArm = 'deterministic_policy_llm_fallback_hybrid'; v.candidateOutputs[0].configurationCellIds = ['router:anthropic:claude-haiku-4-5:provider_default', 'generation:anthropic:claude-sonnet-5:provider_default', 'generation:openai:gpt-5.6-luna:none']; },
+    (v: any) => { v.candidateOutputs[0].architectureArm = 'deterministic_policy_llm_fallback_hybrid'; v.candidateOutputs[0].configurationCellIds = ['router:anthropic:claude-haiku-4-5:provider_default', 'router:openai:gpt-5.6-luna:none']; },
+    (v: any) => { v.candidateOutputs[0].architectureArm = 'two_stage_llm_router'; v.candidateOutputs[0].configurationCellIds = ['router:anthropic:claude-haiku-4-5:provider_default', 'generation:openai:gpt-5.6-luna:none']; },
+    (v: any) => { v.judgments[0].judgeProvider = 'openai'; },
+    (v: any) => { v.judgments[0].judgeProvider = 'arbitrary'; },
+    (v: any) => { v.judgments[1].judgeProvider = 'anthropic'; v.judgments[1].judgeModel = 'judge-a'; },
+  ])('fails closed on invalid architecture or provider-excluding judge treatment', (mutate) => {
+    const value = input(); mutate(value); invalid(value);
+  });
+
+  it('requires the exact v2 smoke identity before exposing tranche-one planning', () => {
+    const smoke = fixedTraceComponentSmokeAdmission();
+    expect(smoke.fingerprints.aggregateAdmission).toBe('731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d');
+    expect(FIXED_TRACE_API_BUDGET_LADDER.tranches[0]).toMatchObject({ v2AdmissionFingerprint: smoke.fingerprints.aggregateAdmission, maximumProviderCalls: 192, maximumCostMicrodollars: 5_000_000, reservedMaximumMicrodollars: 2_819_484 });
+    const sameAggregatesDifferentIdentity = structuredClone(smoke);
+    sameAggregatesDifferentIdentity.fingerprints.aggregateAdmission = 'b'.repeat(64);
+    expect(() => assertFixedTraceV2SmokeIdentity(sameAggregatesDifferentIdentity)).toThrow(/fingerprint/);
+    const notReady = structuredClone(smoke);
+    notReady.status = 'not_admitted';
+    expect(() => assertFixedTraceV2SmokeIdentity(notReady)).toThrow(/ready/);
+    const differentCohort = structuredClone(smoke);
+    differentCohort.pricing.cohortDigest = 'sha256:other';
+    expect(() => assertFixedTraceV2SmokeIdentity(differentCohort)).toThrow(/pricing cohort/);
+  });
+
+  it.each([
+    (value: any) => { value.calibration = { id: 'invented', digest: hash() }; },
+    (value: any) => { value.extra = 'top-level leak'; },
+    (value: any) => { value.packets.pop(); },
+    (value: any) => { value.candidateOutputs.pop(); },
+    (value: any) => { delete value.candidateOutputs[0].architectureArm; },
+    (value: any) => { value.candidateOutputs[0].extra = 'leak'; },
+    (value: any) => { value.deterministicEvidence[0].extra = 'ignored-before'; },
+    (value: any) => { value.randomization.extra = 'ignored-before'; },
+    (value: any) => { value.judgments[0].extra = 'ignored-before'; },
+    (value: any) => { value.budgetLedger.extra = 'forged'; },
+  ])('rejects invented calibration, omitted treatment/cell/packet, or extra unverified evidence fields', (mutate) => {
+    const value = input(); mutate(value);
+    expect(assessFixedTraceModelJudgedDiagnostic(value).blockers).toContainEqual(expect.stringMatching(/^invalid_unverified_input:/));
+  });
+
+  it('allows ordinary task language while rejecting exact locked treatment identifiers and extra metadata', () => {
+    expect(() => assertFixedTraceBlindedModelJudgePacket({
+      ...packet(),
+      prompt: 'How should a model select a provider under a cost and price budget?',
+      candidateOutput: 'Compare model behavior, provider constraints, and cost without naming a treatment.',
+    })).not.toThrow();
+    expect(() => assertFixedTraceBlindedModelJudgePacket({ ...packet(), candidateOutput: 'Use indirect_generation and direct_generation_strategy.' })).not.toThrow();
+    expect(() => assertFixedTraceBlindedModelJudgePacket({ ...packet(), candidateOutput: 'Use direct_generation.' })).toThrow(/exact locked-v2 treatment identifier/);
+    expect(() => assertFixedTraceBlindedModelJudgePacket({ ...packet(), candidateOutput: 'Use generation:openai:gpt-5.6-luna:none.' })).toThrow(/exact locked-v2 treatment identifier/);
+    expect(() => assertFixedTraceBlindedModelJudgePacket({ ...packet(), architecture: 'direct_generation' })).toThrow(/extra or missing fields/);
+  });
+
+  it.each([
+    () => Object.defineProperty(packet(), 'prompt', { enumerable: true, get: () => 'getter' }),
+    () => new Proxy(packet(), {}),
+  ])('rejects hostile judge packets', (badPacket) => {
+    expect(() => assertFixedTraceBlindedModelJudgePacket(badPacket())).toThrow();
+  });
+
+  it.each([
+    (value: any) => { value.judgments.push({ ...value.judgments[0] }); },
+    (value: any) => { value.judgments.push({ ...value.judgments[0], judgeProvider: 'other-1', judgeModel: 'judge-1' }, { ...value.judgments[0], judgeProvider: 'other-2', judgeModel: 'judge-2' }); },
+    (value: any) => { value.candidateOutputs[0].outputStatus = 'missing'; value.candidateOutputs[0].candidateOutput = null; },
+  ])('rejects duplicate or malformed structural judgment and output evidence', (mutate) => {
+    const value = input(); mutate(value);
+    expect(assessFixedTraceModelJudgedDiagnostic(value).blockers).toContainEqual(expect.stringMatching(/^invalid_unverified_input:/));
+  });
+
+  it('preserves structurally complete missingness and hard-gate failures for a future exact denominator', () => {
+    for (const outcome of ['missing', 'refusal', 'malformed', 'abstain']) {
+      const value = input(); value.judgments[0].outcome = outcome;
+      expect(assessFixedTraceModelJudgedDiagnostic(value).blockers.some((blocker) => blocker.startsWith('invalid_unverified_input:'))).toBe(false);
+    }
+    const failedGate = input(); failedGate.deterministicEvidence[0].cost = false;
+    expect(assessFixedTraceModelJudgedDiagnostic(failedGate).blockers.some((blocker) => blocker.startsWith('invalid_unverified_input:'))).toBe(false);
+  });
+
+  it('rejects floating point, negative zero, one-micro overage, cumulative overage, overlap, and forged structure', () => {
+    const cases = [
+      () => ({ ...ledger(), declaredCapMicrodollars: 1.5 }),
+      () => ({ ...ledger(), declaredCapMicrodollars: -0 }),
+      () => ({ ...ledger(), currentTrancheReservedMicrodollars: 2 }),
+      () => ({ ...ledger(), priorReconciledObservedMicrodollars: 699_000_000, declaredCapMicrodollars: 2_000_000 }),
+      () => ({ ...ledger(), priorOutstandingReservedMicrodollars: 1 }),
+      () => ({ ...ledger(), priorUnknownExposureMicrodollars: 1 }),
+      () => ({ ...ledger(), unverifiedAuthorizationReferenceDigest: 'external-signature' }),
+    ];
+    for (const build of cases) expect(() => assertFixedTraceUnverifiedTrancheLedgerShape(build())).toThrow();
+  });
+
+  it('distinguishes tranche cap from cumulative ceiling and never grants raw authority', () => {
+    expect(() => assertFixedTraceUnverifiedTrancheLedgerShape(firstTrancheLedger())).not.toThrow();
+    expect(() => assertFixedTraceUnverifiedTrancheLedgerShape({ ...firstTrancheLedger(), currentTrancheReservedMicrodollars: 5_000_001 })).toThrow(/tranche cost cap/);
+    expect(() => assertFixedTraceUnverifiedTrancheLedgerShape({ ...ledger(), currentTrancheReservedMicrodollars: 2 })).toThrow(/tranche cost cap/);
+    expect(() => assertFixedTraceUnverifiedTrancheLedgerShape({ ...ledger(), priorReconciledObservedMicrodollars: 700_000_000, declaredCapMicrodollars: 1 })).toThrow(/cumulative ceiling/);
+    expect(assessFixedTraceModelJudgedDiagnostic(input())).toMatchObject({ admitted: false });
+  });
+});


### PR DESCRIPTION
## Protocol/tooling only

This draft adds a no-spend, non-admitted model-judged diagnostic amendment. It made no provider calls, incurred no spend, selected no winner, and grants no dispatch or budget authority.

It preserves the admitted v2 component-smoke source and aggregate fingerprint `731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d`. The smoke remains mechanical feasibility only, with no quality, architecture, or judge requirement. Tranche-one planning fail-closes unless the ready status, exact fingerprint, 192-call ceiling, $5 ceiling, reservation, and pricing cohort identity all match.

The amendment remains blocked pending custodied calibration, exact assignment and judge-slot manifest, holdout custody, deterministic evidence, and private integer-microdollar budget authority. Caller inputs never admit anything. Mixed-provider quality admission is unavailable and non-promotable.

Packet checking rejects extra metadata and exact locked-v2 treatment identifiers, but generic task language about models, providers, or cost is not treated as identity leakage. This is a non-proof structural check pending verified assignment-manifest custody.

Claim limits: no human-confirmatory, noninferiority, superiority, production-generalization, architecture/model/effort winner, quality-rate, or comprehensive mixed-provider quality claims.

Validation: post-rebase focused component-admission/control-plane tests (96 passing), server typecheck, and clean scope/whitespace checks. The automatic post-push storyboard matrix was interrupted after exceeding 19 minutes and is not claimed as passing. This PR remains draft for independent Sol review and GitHub checks; it is not ready for merge.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/676b4ba1-fd54-44a8-ae96-6e0448bfd596)
