### PR TITLE
fix(ops): harden worker outage recovery

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -105,6 +105,8 @@ primary_region = 'iad'
 
 [[vm]]
   processes = ["worker"]
-  memory = "4gb"
+  # Persist the production incident remediation from PR #7282; keeping the
+  # worker resize in config prevents the next deploy from undoing it.
+  memory = "8gb"
   cpu_kind = "performance"
   cpus = 2

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -789,7 +789,7 @@ function isPendingWorkOSMembershipError(error: unknown): boolean {
  * Consecutive failed DB health probes on this machine. A single transient
  * connect timeout — common during a rolling deploy or a Managed Postgres
  * failover, when the direct endpoint briefly stops accepting connections —
- * should not page #admin-errors. We only escalate (Slack + error-level log)
+ * should not page #admin-errors. We only escalate through the explicit notifier
  * once the database has been unreachable across HEALTH_DB_ALERT_THRESHOLD
  * consecutive probes. At Fly's 15s probe interval that is ~45s of sustained
  * unreachability, which is a real outage rather than deploy-window noise.
@@ -797,6 +797,7 @@ function isPendingWorkOSMembershipError(error: unknown): boolean {
  * out of the load balancer immediately.
  */
 let consecutiveDbHealthFailures = 0;
+let dbHealthAlerted = false;
 const HEALTH_DB_ALERT_THRESHOLD = 3;
 
 /**
@@ -3086,7 +3087,14 @@ export class HTTPServer {
         // succeed even when the pool is fully occupied under load.
         await healthCheck(5000);
         checks.database = true;
+        if (dbHealthAlerted) {
+          logger.info(
+            { priorFailures: consecutiveDbHealthFailures },
+            'Database health check recovered',
+          );
+        }
         consecutiveDbHealthFailures = 0;
+        dbHealthAlerted = false;
       } catch (dbErr) {
         checks.database = false;
         const errMsg = dbErr instanceof Error ? dbErr.message : String(dbErr);
@@ -3095,12 +3103,15 @@ export class HTTPServer {
 
         // Debounce alerting: a single transient connect timeout during a
         // rolling deploy or Postgres failover is not an outage. Escalate to
-        // Slack (and error-level logs, which PostHog forwards as alerts) only
-        // after the DB has been unreachable across several consecutive probes.
-        if (consecutiveDbHealthFailures >= HEALTH_DB_ALERT_THRESHOLD) {
-          logger.error(
+        // through the explicit Slack notifier only after the DB has been
+        // unreachable across several consecutive probes. Keep the companion
+        // log below warning-level so PostHog's error hook does not send a
+        // duplicate alert through a second source.
+        if (consecutiveDbHealthFailures === HEALTH_DB_ALERT_THRESHOLD) {
+          dbHealthAlerted = true;
+          logger.warn(
             { err: dbErr, consecutiveFailures: consecutiveDbHealthFailures },
-            'Database health check failed',
+            'Database health check alert threshold reached',
           );
           notifySystemError({
             source: 'health-check',
@@ -3109,7 +3120,9 @@ export class HTTPServer {
         } else {
           logger.warn(
             { err: dbErr, consecutiveFailures: consecutiveDbHealthFailures },
-            'Database health check failed (transient, not yet alerting)',
+            consecutiveDbHealthFailures < HEALTH_DB_ALERT_THRESHOLD
+              ? 'Database health check failed (transient, not yet alerting)'
+              : 'Database health check remains unavailable',
           );
         }
       }

--- a/server/src/services/worker-watchdog.ts
+++ b/server/src/services/worker-watchdog.ts
@@ -7,12 +7,12 @@
  * `posthog.ts`), so the alert reaches Slack without any extra wiring.
  *
  * Recovery: on each failure, attempts to start any worker machines in `stopped`
- * state via the Fly Machines API. Rolling deploys can leave the worker stopped
- * because `auto_start_machines` is a fly-proxy feature and the worker has no
- * `[[services.ports]]` (see fly.toml). Without active recovery, nothing brings
- * a stopped worker back. Started machines surface as a successful probe on the
- * next tick; if start didn't help (real crashloop), failures keep climbing and
- * the alert still fires at the threshold.
+ * state via the Fly Machines API. If Fly reports a worker as `started` but it
+ * remains unreachable through the failure threshold, the watchdog acquires a
+ * Machine lease and cold-restarts one worker. The successful repair holds the
+ * lease until its TTL expires, giving staggered web replicas a shared recovery
+ * cooldown instead of cold-restarting the same worker again. Recovery is
+ * attempted only once per outage by each replica.
  *
  * Fire-once semantics: alert when the failure streak crosses the threshold, and
  * again on recovery (info level). Without these guards a flapping worker would
@@ -25,6 +25,8 @@ const logger = createLogger('worker-watchdog');
 const TICK_MS = 60_000;
 const FAILURE_THRESHOLD = 3;
 const FETCH_TIMEOUT_MS = 5_000;
+const FLY_MUTATION_TIMEOUT_MS = 15_000;
+const FLY_LEASE_TTL_SECONDS = 120;
 const FLY_API_BASE = 'https://api.machines.dev/v1';
 
 let intervalId: NodeJS.Timeout | null = null;
@@ -40,8 +42,30 @@ interface FlyMachine {
 interface RecoveryResult {
   attempted: boolean;
   started: number;
+  restarted?: number;
   stoppedWorkerCount?: number;
+  startedWorkerCount?: number;
   reason?: string;
+}
+
+interface FlyMachineLease {
+  data?: {
+    nonce?: string;
+  };
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs = FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function probeWorker(): Promise<{ ok: true } | { ok: false; reason: string }> {
@@ -50,36 +74,131 @@ async function probeWorker(): Promise<{ ok: true } | { ok: false; reason: string
     return { ok: false, reason: 'FLY_APP_NAME not set' };
   }
   const url = `http://worker.process.${appName}.internal:8080/internal/jobs`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { signal: controller.signal });
+    const res = await fetchWithTimeout(url);
     if (!res.ok) {
       return { ok: false, reason: `HTTP ${res.status}` };
     }
     return { ok: true };
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) };
-  } finally {
-    clearTimeout(timer);
   }
 }
 
-async function recoverStoppedWorkers(): Promise<RecoveryResult> {
+async function restartStartedWorker(
+  appName: string,
+  token: string,
+  machine: FlyMachine,
+): Promise<{ restarted: boolean; reason?: string }> {
+  const machineUrl = `${FLY_API_BASE}/apps/${appName}/machines/${machine.id}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  let leaseNonce: string | undefined;
+  let releaseLease = true;
+
+  try {
+    const leaseRes = await fetchWithTimeout(`${machineUrl}/lease`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        description: 'worker-watchdog recovery',
+        ttl: FLY_LEASE_TTL_SECONDS,
+      }),
+    });
+    if (leaseRes.status === 409) {
+      return { restarted: false, reason: 'Worker recovery lease already held' };
+    }
+    if (!leaseRes.ok) {
+      return {
+        restarted: false,
+        reason: `Fly Machines API lease failed: HTTP ${leaseRes.status}`,
+      };
+    }
+    const lease = (await leaseRes.json()) as FlyMachineLease;
+    leaseNonce = lease.data?.nonce;
+    if (!leaseNonce) {
+      return { restarted: false, reason: 'Fly Machines API lease response omitted nonce' };
+    }
+
+    const mutationHeaders = { ...headers, 'fly-machine-lease-nonce': leaseNonce };
+    const stopRes = await fetchWithTimeout(`${machineUrl}/stop`, {
+      method: 'POST',
+      headers: mutationHeaders,
+      body: JSON.stringify({ signal: 'SIGTERM', timeout: '10' }),
+    }, FLY_MUTATION_TIMEOUT_MS);
+    if (!stopRes.ok) {
+      return {
+        restarted: false,
+        reason: `Fly Machines API stop failed: HTTP ${stopRes.status}`,
+      };
+    }
+
+    const startRes = await fetchWithTimeout(`${machineUrl}/start`, {
+      method: 'POST',
+      headers: mutationHeaders,
+    }, FLY_MUTATION_TIMEOUT_MS);
+    if (!startRes.ok) {
+      return {
+        restarted: false,
+        reason: `Fly Machines API restart failed: HTTP ${startRes.status}`,
+      };
+    }
+
+    // Keep the lease until its TTL expires after a successful restart. Web
+    // watchdogs tick independently, so releasing immediately would let a
+    // staggered replica acquire the lease and restart the same worker again.
+    releaseLease = false;
+    logger.info(
+      { machineId: machine.id, recoveryFenceSeconds: FLY_LEASE_TTL_SECONDS },
+      'Restarted unreachable worker machine',
+    );
+    return { restarted: true };
+  } catch (err) {
+    return {
+      restarted: false,
+      reason: `Fly Machines API restart errored: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  } finally {
+    // Failed attempts release immediately so another replica can retry. A
+    // successful attempt intentionally leaves the bounded lease as a shared
+    // cross-replica recovery fence.
+    if (leaseNonce && releaseLease) {
+      try {
+        const releaseRes = await fetchWithTimeout(`${machineUrl}/lease`, {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'fly-machine-lease-nonce': leaseNonce,
+          },
+        });
+        if (!releaseRes.ok) {
+          logger.warn(
+            { machineId: machine.id, status: releaseRes.status },
+            'Fly Machines API lease release failed',
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          { machineId: machine.id, err: err instanceof Error ? err.message : String(err) },
+          'Fly Machines API lease release errored',
+        );
+      }
+    }
+  }
+}
+
+async function recoverWorkers(restartUnreachable: boolean): Promise<RecoveryResult> {
   const appName = process.env.FLY_APP_NAME;
   const token = process.env.FLY_API_TOKEN;
   if (!appName) return { attempted: false, started: 0, reason: 'FLY_APP_NAME not set' };
   if (!token) return { attempted: false, started: 0, reason: 'FLY_API_TOKEN not set' };
 
   const headers = { Authorization: `Bearer ${token}` };
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   let machines: FlyMachine[];
   try {
-    const listRes = await fetch(`${FLY_API_BASE}/apps/${appName}/machines`, {
-      headers,
-      signal: controller.signal,
-    });
+    const listRes = await fetchWithTimeout(`${FLY_API_BASE}/apps/${appName}/machines`, { headers });
     if (!listRes.ok) {
       logger.warn({ status: listRes.status }, 'Fly Machines API list failed');
       return { attempted: true, started: 0, reason: `Fly Machines API list failed: HTTP ${listRes.status}` };
@@ -92,24 +211,19 @@ async function recoverStoppedWorkers(): Promise<RecoveryResult> {
       started: 0,
       reason: `Fly Machines API list errored: ${err instanceof Error ? err.message : String(err)}`,
     };
-  } finally {
-    clearTimeout(timer);
   }
 
-  const stoppedWorkers = machines.filter(
-    (m) => m.config?.metadata?.fly_process_group === 'worker' && m.state === 'stopped',
-  );
-  if (stoppedWorkers.length === 0) {
-    return { attempted: true, started: 0, stoppedWorkerCount: 0 };
-  }
+  const workers = machines.filter((m) => m.config?.metadata?.fly_process_group === 'worker');
+  const stoppedWorkers = workers.filter((m) => m.state === 'stopped');
+  const startedWorkers = workers.filter((m) => m.state === 'started');
 
   let started = 0;
   for (const machine of stoppedWorkers) {
     try {
-      const res = await fetch(`${FLY_API_BASE}/apps/${appName}/machines/${machine.id}/start`, {
+      const res = await fetchWithTimeout(`${FLY_API_BASE}/apps/${appName}/machines/${machine.id}/start`, {
         method: 'POST',
         headers,
-      });
+      }, FLY_MUTATION_TIMEOUT_MS);
       if (res.ok) {
         started++;
         logger.info({ machineId: machine.id }, 'Started stopped worker machine');
@@ -123,7 +237,26 @@ async function recoverStoppedWorkers(): Promise<RecoveryResult> {
       );
     }
   }
-  return { attempted: true, started, stoppedWorkerCount: stoppedWorkers.length };
+
+  let restarted = 0;
+  let reason: string | undefined;
+  // A stopped worker was already repaired above. Only cold-restart a worker
+  // when Fly says it is started yet the service has missed the full threshold.
+  // Restart one machine per outage to keep the repair's blast radius bounded.
+  if (restartUnreachable && stoppedWorkers.length === 0 && startedWorkers[0]) {
+    const restart = await restartStartedWorker(appName, token, startedWorkers[0]);
+    restarted = restart.restarted ? 1 : 0;
+    reason = restart.reason;
+  }
+
+  return {
+    attempted: true,
+    started,
+    restarted,
+    stoppedWorkerCount: stoppedWorkers.length,
+    startedWorkerCount: startedWorkers.length,
+    ...(reason ? { reason } : {}),
+  };
 }
 
 async function tick(): Promise<void> {
@@ -138,7 +271,9 @@ async function tick(): Promise<void> {
   }
 
   consecutiveFailures++;
-  const recovery = await recoverStoppedWorkers();
+  const recovery = await recoverWorkers(
+    consecutiveFailures === FAILURE_THRESHOLD && !alerted,
+  );
 
   if (consecutiveFailures === FAILURE_THRESHOLD && !alerted) {
     alerted = true;
@@ -174,6 +309,7 @@ export function stopWorkerWatchdog(): void {
 export const _internals = {
   tick,
   probeWorker,
+  restartStartedWorker,
   getState: () => ({ consecutiveFailures, alerted }),
   reset: () => {
     consecutiveFailures = 0;

--- a/server/src/training-agent/seller-managed-control-jobs.ts
+++ b/server/src/training-agent/seller-managed-control-jobs.ts
@@ -10,7 +10,6 @@ import {
 import { isDatabaseInitialized, query } from '../db/client.js';
 import { decrypt, deriveKey, encrypt } from '../db/encryption.js';
 import { createLogger } from '../logger.js';
-import { notifySystemError } from '../addie/error-notifier.js';
 
 const logger = createLogger('seller-managed-control-jobs');
 const LEASE_MS = 30_000;
@@ -805,6 +804,15 @@ export function withSellerManagedIdempotencyReplay(
 
 type ExecuteJob = (job: SellerManagedControlJob) => Promise<Record<string, unknown>>;
 type NotifyJob = (job: SellerManagedControlJob) => Promise<void>;
+type NotifySystemError = (context: { source: string; errorMessage: string }) => void;
+
+const defaultNotifySystemError: NotifySystemError = context => {
+  // Lazy import keeps the durable-job module usable in isolated protocol tests
+  // that intentionally provide a minimal logger mock.
+  void import('../addie/error-notifier.js')
+    .then(({ notifySystemError }) => notifySystemError(context))
+    .catch(err => logger.warn({ err }, 'Failed to load seller-control error notifier'));
+};
 
 function structuredErrorFromResult(result: Record<string, unknown>): AdcpStructuredError | null {
   const errors = Array.isArray(result.errors) ? result.errors : [];
@@ -842,6 +850,7 @@ export class SellerManagedControlJobCoordinator {
       : new InMemorySellerManagedControlJobStore(),
     private readonly notify: NotifyJob = async () => {},
     private readonly isDatabaseReady: () => boolean = isDatabaseInitialized,
+    private readonly notifySystemError: NotifySystemError = defaultNotifySystemError,
   ) {}
 
   start(): void {
@@ -897,7 +906,7 @@ export class SellerManagedControlJobCoordinator {
           // log below error level so its hook cannot send a duplicate page.
           logger.warn(context, `${errorMessage} (alert threshold reached)`);
           const detail = err instanceof Error ? err.message : String(err);
-          notifySystemError({
+          this.notifySystemError({
             source: 'seller-managed-control-jobs',
             errorMessage: `${errorMessage} (${this.consecutiveReconciliationFailures} consecutive): ${detail}`,
           });

--- a/server/src/training-agent/seller-managed-control-jobs.ts
+++ b/server/src/training-agent/seller-managed-control-jobs.ts
@@ -10,12 +10,14 @@ import {
 import { isDatabaseInitialized, query } from '../db/client.js';
 import { decrypt, deriveKey, encrypt } from '../db/encryption.js';
 import { createLogger } from '../logger.js';
+import { notifySystemError } from '../addie/error-notifier.js';
 
 const logger = createLogger('seller-managed-control-jobs');
 const LEASE_MS = 30_000;
 const LEASE_HEARTBEAT_MS = 10_000;
 const TASK_CREATE_GRACE_MS = 2_000;
 const RECONCILE_INTERVAL_MS = 5_000;
+const RECONCILE_FAILURE_THRESHOLD = 3;
 const FRAMEWORK_WEBHOOK_GRACE_MS = 60_000;
 
 export interface SellerManagedControlJobContext extends Record<string, unknown> {
@@ -828,6 +830,9 @@ class RetryableSellerControlError extends Error {}
 export class SellerManagedControlJobCoordinator {
   private readonly workerId = `seller-control-${randomUUID()}`;
   private timer?: NodeJS.Timeout;
+  private reconciliationInFlight = false;
+  private consecutiveReconciliationFailures = 0;
+  private reconciliationAlerted = false;
 
   constructor(
     private readonly taskRegistry: TaskRegistry,
@@ -859,7 +864,50 @@ export class SellerManagedControlJobCoordinator {
       logger.debug('Deferring seller-control reconciliation until database initialization');
       return;
     }
-    void this.runAvailable().catch(err => logger.error({ err }, errorMessage));
+    // setInterval does not wait for async work. During a database outage a
+    // claim can take longer than the five-second cadence, so allowing overlap
+    // would multiply pool pressure exactly when PostgreSQL is least healthy.
+    if (this.reconciliationInFlight) {
+      logger.debug('Skipping seller-control reconciliation because the previous run is still active');
+      return;
+    }
+
+    this.reconciliationInFlight = true;
+    void this.runAvailable()
+      .then(() => {
+        if (this.reconciliationAlerted) {
+          logger.info(
+            { priorFailures: this.consecutiveReconciliationFailures },
+            'Seller-control reconciliation recovered',
+          );
+        }
+        this.consecutiveReconciliationFailures = 0;
+        this.reconciliationAlerted = false;
+      })
+      .catch(err => {
+        this.consecutiveReconciliationFailures += 1;
+        const context = {
+          err,
+          consecutiveFailures: this.consecutiveReconciliationFailures,
+          threshold: RECONCILE_FAILURE_THRESHOLD,
+        };
+        if (this.consecutiveReconciliationFailures === RECONCILE_FAILURE_THRESHOLD) {
+          this.reconciliationAlerted = true;
+          // Alert directly so delivery does not depend on PostHog. Keep the
+          // log below error level so its hook cannot send a duplicate page.
+          logger.warn(context, `${errorMessage} (alert threshold reached)`);
+          const detail = err instanceof Error ? err.message : String(err);
+          notifySystemError({
+            source: 'seller-managed-control-jobs',
+            errorMessage: `${errorMessage} (${this.consecutiveReconciliationFailures} consecutive): ${detail}`,
+          });
+        } else {
+          logger.warn(context, errorMessage);
+        }
+      })
+      .finally(() => {
+        this.reconciliationInFlight = false;
+      });
   }
 
   async enqueue(input: SellerManagedControlJobInput): Promise<SellerManagedControlJob> {

--- a/server/tests/integration/health.test.ts
+++ b/server/tests/integration/health.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { HTTPServer } from "../../src/http.js";
+import { healthCheck } from "../../src/db/client.js";
+import { logger } from "../../src/logger.js";
+import { notifySystemError } from "../../src/addie/error-notifier.js";
 import request from "supertest";
 
 // Mock config and database to prevent actual database connections.
@@ -27,6 +30,13 @@ vi.mock("../../src/db/client.js", () => ({
 vi.mock("../../src/db/migrate.js", () => ({
   runMigrations: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock("../../src/addie/error-notifier.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/addie/error-notifier.js")>(
+    "../../src/addie/error-notifier.js",
+  );
+  return { ...actual, notifySystemError: vi.fn() };
+});
 
 describe("Health Endpoint Integration", () => {
   let server: HTTPServer;
@@ -57,6 +67,35 @@ describe("Health Endpoint Integration", () => {
 
       expect(response.body.registry.mode).toBe("database");
       expect(response.body.registry.using_database).toBe(true);
+    });
+
+    it("alerts once for a sustained database outage and reports recovery", async () => {
+      const healthCheckMock = vi.mocked(healthCheck);
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+      const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+      const notifyMock = vi.mocked(notifySystemError);
+      notifyMock.mockClear();
+      healthCheckMock.mockRejectedValue(new Error("timeout expired"));
+
+      for (let i = 0; i < 5; i += 1) {
+        const response = await request(app).get("/health");
+        expect(response.status).toBe(503);
+      }
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(notifyMock).toHaveBeenCalledOnce();
+      expect(notifyMock).toHaveBeenCalledWith({
+        source: "health-check",
+        errorMessage: "Database health check failed (3 consecutive): timeout expired",
+      });
+
+      healthCheckMock.mockResolvedValue(undefined);
+      await request(app).get("/health").expect(200);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ priorFailures: 5 }),
+        "Database health check recovered",
+      );
+      vi.restoreAllMocks();
     });
   });
 });

--- a/server/tests/unit/seller-managed-control-jobs.test.ts
+++ b/server/tests/unit/seller-managed-control-jobs.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createInMemoryTaskRegistry } from '@adcp/sdk/server';
+import { logger } from '../../src/logger.js';
+import { notifySystemError } from '../../src/addie/error-notifier.js';
 import {
   InMemorySellerManagedControlJobStore,
   PostgresSellerManagedControlJobStore,
@@ -9,6 +11,13 @@ import {
   withSellerManagedTaskReplay,
   type SellerManagedControlJob,
 } from '../../src/training-agent/seller-managed-control-jobs.js';
+
+vi.mock('../../src/addie/error-notifier.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/addie/error-notifier.js')>(
+    '../../src/addie/error-notifier.js',
+  );
+  return { ...actual, notifySystemError: vi.fn() };
+});
 
 const INPUT = {
   taskId: 'smc_recovery_test',
@@ -28,6 +37,7 @@ const TASK_SCOPE = { accountId: INPUT.accountId, ownerScope: INPUT.ownerScope };
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
 
 async function registerTask(taskRegistry: ReturnType<typeof createInMemoryTaskRegistry>): Promise<void> {
@@ -61,6 +71,74 @@ describe('seller-managed control durable jobs', () => {
     databaseReady = true;
     await vi.advanceTimersByTimeAsync(5_000);
     expect(claim).toHaveBeenCalledOnce();
+    coordinator.stop();
+  });
+
+  it('does not overlap periodic reconciliation while a database claim is pending', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('NODE_ENV', 'production');
+    let resolveFirstClaim!: (value: null) => void;
+    const firstClaim = new Promise<null>(resolve => { resolveFirstClaim = resolve; });
+    const store = new PostgresSellerManagedControlJobStore();
+    const claim = vi.spyOn(store, 'claim')
+      .mockReturnValueOnce(firstClaim)
+      .mockResolvedValue(null);
+    const coordinator = new SellerManagedControlJobCoordinator(
+      createInMemoryTaskRegistry(),
+      async () => ({}),
+      store,
+      async () => {},
+      () => true,
+    );
+
+    coordinator.start();
+    expect(claim).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(claim).toHaveBeenCalledOnce();
+
+    resolveFirstClaim(null);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(claim).toHaveBeenCalledTimes(2);
+    coordinator.stop();
+  });
+
+  it('alerts once after sustained reconciliation failures and logs recovery', async () => {
+    vi.useFakeTimers();
+    vi.stubEnv('NODE_ENV', 'production');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    const notifyMock = vi.mocked(notifySystemError);
+    notifyMock.mockClear();
+    const store = new PostgresSellerManagedControlJobStore();
+    const claim = vi.spyOn(store, 'claim').mockRejectedValue(new Error('database unavailable'));
+    const coordinator = new SellerManagedControlJobCoordinator(
+      createInMemoryTaskRegistry(),
+      async () => ({}),
+      store,
+      async () => {},
+      () => true,
+    );
+
+    coordinator.start();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalledOnce();
+    expect(notifyMock).toHaveBeenCalledWith({
+      source: 'seller-managed-control-jobs',
+      errorMessage: 'Seller-control reconciliation failed (3 consecutive): database unavailable',
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalledOnce();
+
+    claim.mockResolvedValue(null);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ priorFailures: 5 }),
+      'Seller-control reconciliation recovered',
+    );
     coordinator.stop();
   });
 

--- a/server/tests/unit/seller-managed-control-jobs.test.ts
+++ b/server/tests/unit/seller-managed-control-jobs.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createInMemoryTaskRegistry } from '@adcp/sdk/server';
 import { logger } from '../../src/logger.js';
-import { notifySystemError } from '../../src/addie/error-notifier.js';
 import {
   InMemorySellerManagedControlJobStore,
   PostgresSellerManagedControlJobStore,
@@ -11,13 +10,6 @@ import {
   withSellerManagedTaskReplay,
   type SellerManagedControlJob,
 } from '../../src/training-agent/seller-managed-control-jobs.js';
-
-vi.mock('../../src/addie/error-notifier.js', async () => {
-  const actual = await vi.importActual<typeof import('../../src/addie/error-notifier.js')>(
-    '../../src/addie/error-notifier.js',
-  );
-  return { ...actual, notifySystemError: vi.fn() };
-});
 
 const INPUT = {
   taskId: 'smc_recovery_test',
@@ -108,8 +100,7 @@ describe('seller-managed control durable jobs', () => {
     vi.stubEnv('NODE_ENV', 'production');
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
     const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
-    const notifyMock = vi.mocked(notifySystemError);
-    notifyMock.mockClear();
+    const notifyMock = vi.fn();
     const store = new PostgresSellerManagedControlJobStore();
     const claim = vi.spyOn(store, 'claim').mockRejectedValue(new Error('database unavailable'));
     const coordinator = new SellerManagedControlJobCoordinator(
@@ -118,6 +109,7 @@ describe('seller-managed control durable jobs', () => {
       store,
       async () => {},
       () => true,
+      notifyMock,
     );
 
     coordinator.start();

--- a/server/tests/unit/worker-watchdog.test.ts
+++ b/server/tests/unit/worker-watchdog.test.ts
@@ -140,6 +140,80 @@ describe('worker-watchdog', () => {
       expect(startCall).toBeUndefined();
     });
 
+    it('leases and restarts a started worker after the failure threshold', async () => {
+      for (let i = 0; i < 2; i++) {
+        fetchSpy.mockRejectedValueOnce(new Error('unreachable'));
+        fetchSpy.mockResolvedValueOnce(
+          new Response(JSON.stringify([
+            { id: 'wk1', state: 'started', config: { metadata: { fly_process_group: 'worker' } } },
+          ]), { status: 200 }),
+        );
+      }
+      fetchSpy.mockRejectedValueOnce(new Error('unreachable'));
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify([
+          { id: 'wk1', state: 'started', config: { metadata: { fly_process_group: 'worker' } } },
+        ]), { status: 200 }),
+      );
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'success', data: { nonce: 'lease-1' } }), { status: 201 }),
+      );
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await _internals.tick();
+      await _internals.tick();
+      await _internals.tick();
+
+      const stopCall = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/machines/wk1/stop'));
+      const startCall = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/machines/wk1/start'));
+      const releaseCall = fetchSpy.mock.calls.find(([url, init]) =>
+        String(url).endsWith('/machines/wk1/lease') && init?.method === 'DELETE'
+      );
+      expect(stopCall).toBeDefined();
+      expect(startCall).toBeDefined();
+      expect(releaseCall).toBeUndefined();
+      expect(stopCall?.[1]).toMatchObject({
+        headers: expect.objectContaining({ 'fly-machine-lease-nonce': 'lease-1' }),
+      });
+      expect(startCall?.[1]).toMatchObject({
+        headers: expect.objectContaining({ 'fly-machine-lease-nonce': 'lease-1' }),
+      });
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ machineId: 'wk1' }),
+        'Restarted unreachable worker machine',
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ recovery: expect.objectContaining({ restarted: 1 }) }),
+        expect.any(String),
+      );
+    });
+
+    it('holds a successful restart lease as a cross-replica recovery fence', async () => {
+      const worker = {
+        id: 'wk1',
+        state: 'started',
+        config: { metadata: { fly_process_group: 'worker' } },
+      };
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'success', data: { nonce: 'lease-1' } }), { status: 201 }),
+      );
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      // A staggered replica reaches its threshold after the first restart. Fly
+      // still holds the successful replica's lease, so it receives a conflict.
+      fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 409 }));
+
+      const first = await _internals.restartStartedWorker('adcp-docs', 'test-token', worker);
+      const second = await _internals.restartStartedWorker('adcp-docs', 'test-token', worker);
+
+      expect(first).toEqual({ restarted: true });
+      expect(second).toEqual({ restarted: false, reason: 'Worker recovery lease already held' });
+      expect(fetchSpy.mock.calls.filter(([url]) => String(url).endsWith('/stop'))).toHaveLength(1);
+      expect(fetchSpy.mock.calls.filter(([url]) => String(url).endsWith('/start'))).toHaveLength(1);
+      expect(fetchSpy.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false);
+    });
+
     it('still alerts at threshold when recovery does not help', async () => {
       // Recovery on every failure tick: list returns empty (nothing to start).
       // Three probe failures, three list calls → alert fires once.


### PR DESCRIPTION
## Summary
- persist the production worker resize at 8 GB so deploys do not revert the incident remediation
- restart a Fly worker that remains unreachable while still reported as started, using a lease-backed 120-second cross-replica recovery fence
- prevent overlapping seller-control reconciliation during database outages
- debounce database and reconciliation alerts and send exactly one explicit Slack notification independent of PostHog configuration

## Validation
- `npm run build`
- `npm run typecheck`
- `npx vitest run --config server/vitest.config.ts tests/unit/worker-watchdog.test.ts tests/unit/seller-managed-control-jobs.test.ts tests/integration/health.test.ts` (27 passed)
- `git diff --check`
- independent production-safety and CI-readiness reviews: no remaining blockers

## Notes
- No changeset: this is an operational reliability fix with no protocol release-surface change.
- The full local server-unit suite has four reproducible baseline failures in untouched auth/billing tests; 8,690 tests pass and 32 skip. GitHub's required sharded suites remain the merge authority.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/59e83f43-0984-4bb0-b626-638bf95c485d)
