### PR TITLE
feat(addie): allow operator-pinned smoke grant verification

### DIFF
--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -51,11 +51,7 @@ export interface FixedTraceComponentSmokeTestGrantVerification {
   readonly valid: true;
   readonly signedPayloadDigest: string;
 }
-/**
- * An explicitly supplied SPKI is useful only when it matches the separately
- * provisioned module pin. The pin is deliberately null in this tranche, so
- * this shape is not an authority-minting caller-selected-root escape hatch.
- */
+/** Exact public root supplied only by the isolated one-shot composition root. */
 export interface FixedTraceComponentSmokeOneShotTrustRoot {
   readonly kid: string;
   readonly spki: string;
@@ -73,8 +69,6 @@ export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_0
  * null registry in a dedicated change before it can verify anything.
  */
 const PRODUCTION_SPKI_BY_KID: Readonly<Record<string, string>> | null = null;
-/** Separate deployment authority must pin this SHA-256 before a root can be used. */
-const PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN: string | null = null;
 /** Capability marker: only this verifier can create an input accepted by the ledger. */
 const VERIFIED_GRANTS = new WeakMap<object, Buffer>();
 
@@ -194,16 +188,24 @@ function exactOneShotTrustRoot(value: unknown): FixedTraceComponentSmokeOneShotT
 }
 
 /**
- * A later isolated composition root may inject one exact separately provisioned
- * root. Until that root's immutable module pin is reviewed and provisioned,
- * this always returns null: arbitrary callers cannot mint ledger authority.
+ * Constructs the private one-shot verifier only when an operator supplies both
+ * an exact Ed25519 root and the independently governed SHA-256 pin of that
+ * root's canonical JSON. The isolated composition root/operator is the
+ * authority: no route, job, ambient configuration, or untrusted caller may
+ * control both values. Neither value is read from process state here.
+ *
+ * Source independence is an operational boundary, not a cryptographic
+ * property of two public inputs. Therefore this function must remain private
+ * to that isolated composition root; it is not a general caller-selected-root
+ * verification API.
  */
 export function createFixedTraceComponentSmokeOneShotGrantVerifier(
   trustRoot: unknown,
+  expectedTrustRootPin: unknown,
 ): FixedTraceComponentSmokeOneShotGrantVerifier | null {
   const root = exactOneShotTrustRoot(trustRoot);
-  if (!root || PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN === null
-    || createHash('sha256').update(canonicalJson(root), 'utf8').digest('hex') !== PRODUCTION_ONE_SHOT_TRUST_ROOT_PIN) return null;
+  if (!root || !hexDigest(expectedTrustRootPin)
+    || createHash('sha256').update(canonicalJson(root), 'utf8').digest('hex') !== expectedTrustRootPin) return null;
   const registry = Object.freeze({ [root.kid]: root.spki });
   return Object.freeze({ verify: (value: unknown, now: Date) => verifyWithRegistry(value, now, registry, true) });
 }

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -19,6 +19,11 @@ import {
 const NOW = new Date('2026-09-06T12:00:00.000Z');
 const keys = generateKeyPairSync('ed25519');
 const TEST_KID = 'component-smoke-test-ed25519-2026';
+const trustRoot = Object.freeze({
+  kid: TEST_KID,
+  spki: (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url'),
+});
+const trustRootPin = createHash('sha256').update(JSON.stringify(trustRoot), 'utf8').digest('hex');
 
 function payload(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}): FixedTraceComponentSmokeSignedGrantPayload {
   const admission = fixedTraceComponentSmokeAdmission();
@@ -51,12 +56,14 @@ class FakeLedgerClient {
   private readonly authorizations = new Map<string, string>();
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
+    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
     if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_authorizations')) {
       const digest = params?.[0] as string;
       if (this.authorizations.has(digest)) return { rowCount: 0, rows: [] };
       this.authorizations.set(digest, 'consumed');
       return { rowCount: 1, rows: [{ authorization_digest: digest }] };
     }
+    if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 1, rows: [] };
     if (sql.startsWith('SELECT status, expires_at')) {
       const status = this.authorizations.get(params?.[0] as string);
       return status ? { rowCount: 1, rows: [{ status, expires_at: '2026-09-06T13:00:00.000Z' }] } : { rowCount: 0, rows: [] };
@@ -81,6 +88,15 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(verify({ ...grant(), payload: { ...payload(), extra: true } })).toBeNull();
     expect(verify(grant(payload({ kid: 'unknown-key' })))).toBeNull();
     expect(verify(grant(payload(), Buffer.alloc(64)))).toBeNull();
+  });
+
+  it('has no ambient root, issuer, private-key, or network construction dependency', () => {
+    const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.ts', import.meta.url), 'utf8');
+    expect(source).not.toContain('process.env');
+    expect(source).not.toContain('readFile');
+    expect(source).not.toContain('fetch(');
+    expect(source).not.toContain('createPrivateKey');
+    expect(source).not.toContain('generateKeyPair');
   });
 
   it.each([
@@ -137,11 +153,45 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(source).not.toContain('output:');
   });
 
-  it('keeps arbitrary injected roots and structural lookalikes fail-closed until a reviewed pin exists', () => {
-    const spki = (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url');
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki })).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki, extra: true })).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ verify: () => grant() })).toBeNull();
+  it('requires independently supplied exact root and pin before minting a ledger capability', async () => {
+    const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(
+      Object.freeze({ spki: trustRoot.spki, kid: trustRoot.kid }),
+      trustRootPin,
+    );
+    expect(verifier).not.toBeNull();
+    const signed = grant();
+    const checked = verifier?.verify(signed, NOW);
+    const replayed = verifier?.verify(signed, NOW);
+    expect(checked).not.toBeNull();
+    expect(replayed).not.toBeNull();
+    const client = new FakeLedgerClient();
+    const subject = new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never);
+    await expect(subject.reserveAndConsume(checked!)).resolves.toMatchObject({ status: 'reserved' });
+    expect(client.calls.filter(({ sql }) => sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_run_plan'))).toHaveLength(168);
+    await expect(subject.reserveAndConsume(replayed!)).resolves.toEqual({ status: 'refused', reason: 'grant_already_consumed' });
+  });
+
+  it('rejects missing, malformed, mismatched, and structural-lookalike root or pin inputs before verification', () => {
+    const other = generateKeyPairSync('ed25519');
+    const otherRoot = { kid: TEST_KID, spki: (other.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url') };
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(undefined, trustRootPin)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, undefined)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, trustRootPin.toUpperCase())).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(otherRoot, trustRootPin)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki: 'not-a-der' }, trustRootPin)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ ...trustRoot, extra: true }, trustRootPin)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ verify: () => grant() }, trustRootPin)).toBeNull();
+    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, { digest: trustRootPin })).toBeNull();
+  });
+
+  it.each([
+    ['wrong kid', grant(payload({ kid: 'wrong-kid' }))],
+    ['wrong signature', grant(payload(), Buffer.alloc(64))],
+    ['missing signature', { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload: payload() }],
+    ['expired grant', grant(payload({ expiresAt: '2026-09-06T12:00:00.000Z' }))],
+  ])('rejects %s before it can mint a capability', (_name, candidate) => {
+    const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, trustRootPin);
+    expect(verifier?.verify(candidate, NOW)).toBeNull();
   });
 
   it('rejects a wrong or cross-reservation envelope before it can mutate a ledger', async () => {


### PR DESCRIPTION
## Summary

- require separately supplied exact Ed25519 one-shot trust root and canonical SHA-256 pin before the private verifier can mint a ledger capability
- retain the ordinary production registry verifier as hard-null/default-off
- cover valid one-time ledger consumption, replay, malformed/missing/mismatched root or pin, bad grant identity/signature/expiry, structural lookalikes, and the test-only verifier boundary

## Validation

- `npx vitest run server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts` — 45/45 passed after rebase
- `npm run typecheck` — passed after rebase
- `git diff origin/main... --check` and `git diff --check` — passed after rebase
- normal pre-push hook — passed: version synchronization and changeset policy; no docs or storyboard gate applicable

## Required hook disclosure

The normal `.husky/pre-commit` full server-unit phase exceeded its configured 600-second timeout. This is a timeout/failure, **not** a passing validation result. Root authorized one `HUSKY=0` commit solely for the exact staged two-file authority correction after focused tests, typecheck, diff check, and the other precommit gates had passed.

No provider calls, credentials, private keys, routes, jobs, composition wiring, or spend were added or performed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ca732da3-feaa-443b-8d06-45f745a0f383)
