### PR TITLE
feat(addie): add private fake-only smoke runtime

### DIFF
--- a/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-admission.ts
@@ -38,15 +38,19 @@ import {
   fixedTraceCorpusSha256,
 } from './fixed-trace-suite.js';
 import { FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_POLICY } from './fixed-trace-component-smoke-admission-policy.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityMatchesAdmission,
+} from './fixed-trace-component-smoke-private-authority.js';
 
 /**
  * Stage 1 is admitted against this pinned instant, never an ambient clock.
  * A later paid-run coordinator must obtain a fresh admission rather than
  * treating this static review as a live authorization.
  */
-export const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF = '2026-09-06T00:00:00.000Z' as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF = FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.asOf;
 export const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION =
-  'addie-fixed-trace-component-smoke-admission-v2' as const;
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion;
 
 /** One detached, evaluator-owned source for every emitted readiness policy value. */
 const FIXED_TRACE_COMPONENT_SMOKE_READINESS = Object.freeze({
@@ -211,7 +215,7 @@ export interface FixedTraceComponentSmokeAdmissionManifest {
 
 /** Independently reviewed integrity pin; it is never an authorization artifact. */
 const FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN =
-  '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d' as const;
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint;
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -540,6 +544,11 @@ function pinnedManifest(): FixedTraceComponentSmokeAdmissionManifest {
   if (aggregate !== FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_FINGERPRINT_PIN) {
     reasons.push('component_admission_fingerprint_mismatch');
   }
+  if (!fixedTraceComponentSmokePrivateAuthorityMatchesAdmission({
+    version: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION, probes, cells, cardinality,
+    pricing: pricingManifest, privateRuntimePlan: pricing.privateRuntimePlan,
+    fingerprints: { aggregateAdmission: aggregate },
+  })) reasons.push('component_admission_fingerprint_mismatch');
   return Object.freeze({
     version: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
     asOf: FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_AS_OF,

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authority.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authority.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * The private smoke boundary's reviewed authority is deliberately a leaf
+ * module.  It has no live configuration, provider, route, storyboard, clock,
+ * or logging dependency.  The admission module independently checks its
+ * dynamic review artifact against these immutable values; this leaf is what a
+ * later private one-shot composition may safely import.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY = Object.freeze({
+  admissionVersion: 'addie-fixed-trace-component-smoke-admission-v2',
+  asOf: '2026-09-06T00:00:00.000Z',
+  aggregateAdmissionFingerprint: '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d',
+  pricingCohortDigest: 'sha256:e8c5736fb62ef4b5c7219401e2f765be7e5a8527472babf54b29ec27539f94e7',
+  reservationMicrodollars: 2_819_484,
+  providerCeilingMicrodollars: 5_000_000,
+  cardinality: Object.freeze({
+    probes: 8, routerCells: 10, generationCells: 11, totalCells: 21, repetitions: 1,
+    caseCellAssignments: 168, providerDispatchCaseCellAssignments: 126,
+    localTerminalCaseCellAssignments: 21, preDispatchFaultCaseCellAssignments: 21,
+    maximumPlannedInvocationSlots: 256, maximumProviderInvocations: 192,
+  }),
+  probes: Object.freeze([
+    Object.freeze({ id: 'component-smoke-surface-channel-chatter-v1', disposition: 'local_terminal' as const }),
+    Object.freeze({ id: 'component-smoke-knowledge-task-model-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-admin-member-records-without-slack-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-billing-invoice-confirmed-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-tool-result-prompt-injection-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-dev-tool-error-retry-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-dev-truncation-boundary-v1', disposition: 'provider_dispatch' as const }),
+    Object.freeze({ id: 'component-smoke-provider-unavailable-v1', disposition: 'pre_dispatch_fault' as const }),
+  ]),
+  cells: Object.freeze([
+    Object.freeze({ id: 'router:anthropic:claude-haiku-4-5:provider_default', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'provider_default', pricingProfileId: 'anthropic-standard-2026-09:claude-haiku-4-5', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 11126 }),
+    Object.freeze({ id: 'router:openai:gpt-5.6-luna:provider_default', provider: 'openai', model: 'gpt-5.6-luna', effort: 'provider_default', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 1384 }),
+    Object.freeze({ id: 'router:openai:gpt-5.6-luna:none', provider: 'openai', model: 'gpt-5.6-luna', effort: 'none', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 1384 }),
+    Object.freeze({ id: 'router:openai:gpt-5.6-luna:low', provider: 'openai', model: 'gpt-5.6-luna', effort: 'low', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 1384 }),
+    Object.freeze({ id: 'router:openai:gpt-5.6-luna:medium', provider: 'openai', model: 'gpt-5.6-luna', effort: 'medium', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 1384 }),
+    Object.freeze({ id: 'router:openai:gpt-5.6-luna:high', provider: 'openai', model: 'gpt-5.6-luna', effort: 'high', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 1384 }),
+    Object.freeze({ id: 'router:google:gemini-3.7-flash:provider_default', provider: 'google', model: 'gemini-3.7-flash', effort: 'provider_default', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 4197 }),
+    Object.freeze({ id: 'router:google:gemini-3.7-flash:low', provider: 'google', model: 'gemini-3.7-flash', effort: 'low', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 4197 }),
+    Object.freeze({ id: 'router:google:gemini-3.7-flash:medium', provider: 'google', model: 'gemini-3.7-flash', effort: 'medium', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 4197 }),
+    Object.freeze({ id: 'router:google:gemini-3.7-flash:high', provider: 'google', model: 'gemini-3.7-flash', effort: 'high', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 1, maxInputTokens: 4096, maxOutputTokens: 300, timeoutMs: 120000, reservationPerInvocationMicrodollars: 4197 }),
+    Object.freeze({ id: 'generation:anthropic:claude-haiku-4-5:provider_default', provider: 'anthropic', model: 'claude-haiku-4-5', effort: 'provider_default', pricingProfileId: 'anthropic-standard-2026-09:claude-haiku-4-5', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 43003 }),
+    Object.freeze({ id: 'generation:anthropic:claude-sonnet-5:provider_default', provider: 'anthropic', model: 'claude-sonnet-5', effort: 'provider_default', pricingProfileId: 'anthropic-standard-2026-09:claude-sonnet-5', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 86005 }),
+    Object.freeze({ id: 'generation:openai:gpt-5.6-luna:provider_default', provider: 'openai', model: 'gpt-5.6-luna', effort: 'provider_default', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 5176 }),
+    Object.freeze({ id: 'generation:openai:gpt-5.6-luna:none', provider: 'openai', model: 'gpt-5.6-luna', effort: 'none', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 5176 }),
+    Object.freeze({ id: 'generation:openai:gpt-5.6-luna:low', provider: 'openai', model: 'gpt-5.6-luna', effort: 'low', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 5176 }),
+    Object.freeze({ id: 'generation:openai:gpt-5.6-luna:medium', provider: 'openai', model: 'gpt-5.6-luna', effort: 'medium', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 5176 }),
+    Object.freeze({ id: 'generation:openai:gpt-5.6-luna:high', provider: 'openai', model: 'gpt-5.6-luna', effort: 'high', pricingProfileId: 'openai-gpt-5.6-luna-standard-2026-09-05', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 5176 }),
+    Object.freeze({ id: 'generation:google:gemini-3.7-flash:provider_default', provider: 'google', model: 'gemini-3.7-flash', effort: 'provider_default', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 15663 }),
+    Object.freeze({ id: 'generation:google:gemini-3.7-flash:low', provider: 'google', model: 'gemini-3.7-flash', effort: 'low', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 15663 }),
+    Object.freeze({ id: 'generation:google:gemini-3.7-flash:medium', provider: 'google', model: 'gemini-3.7-flash', effort: 'medium', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 15663 }),
+    Object.freeze({ id: 'generation:google:gemini-3.7-flash:high', provider: 'google', model: 'gemini-3.7-flash', effort: 'high', pricingProfileId: 'google-gemini-3.7-flash-through-2026-12-31', maximumProviderInvocations: 2, maxInputTokens: 16384, maxOutputTokens: 900, timeoutMs: 120000, reservationPerInvocationMicrodollars: 15663 }),
+  ]),
+});
+
+export type FixedTraceComponentSmokePrivateAuthorityPlanEntry = Readonly<{
+  assignmentId: string; probeId: string; cellId: string;
+  disposition: 'provider_dispatch' | 'local_terminal' | 'pre_dispatch_fault';
+  maximumProviderInvocations: number; provider: string; model: string; effort: string;
+  pricingProfileId: string; maxInputTokens: number; maxOutputTokens: number; timeoutMs: number;
+  retries: 0; reservedMicrodollars: readonly number[];
+}>;
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') { if (!Number.isSafeInteger(value)) throw new Error('non-canonical number'); return JSON.stringify(value); }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`).join(',')}}`;
+  }
+  throw new Error('non-canonical value');
+}
+function sha256(value: unknown): string { return createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex'); }
+
+const PRIVATE_PLAN = Object.freeze(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.probes.flatMap((probe) => (
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cells.map((cell) => Object.freeze({
+    assignmentId: sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:plan-entry:v1\0', fingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint, probeId: probe.id, cellId: cell.id }),
+    probeId: probe.id, cellId: cell.id, disposition: probe.disposition,
+    maximumProviderInvocations: probe.disposition === 'provider_dispatch' ? cell.maximumProviderInvocations : 0,
+    provider: cell.provider, model: cell.model, effort: cell.effort, pricingProfileId: cell.pricingProfileId,
+    maxInputTokens: cell.maxInputTokens, maxOutputTokens: cell.maxOutputTokens, timeoutMs: cell.timeoutMs,
+    retries: 0 as const,
+    reservedMicrodollars: Object.freeze(probe.disposition === 'provider_dispatch'
+      ? Array.from({ length: cell.maximumProviderInvocations }, () => cell.reservationPerInvocationMicrodollars) : []),
+  }))
+))) as readonly FixedTraceComponentSmokePrivateAuthorityPlanEntry[];
+
+/** The immutable 8-probe by 21-cell plan, derived only from the authority above. */
+export function fixedTraceComponentSmokePrivateAuthorityPlan(): readonly FixedTraceComponentSmokePrivateAuthorityPlanEntry[] {
+  const authority = FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY;
+  const total = PRIVATE_PLAN.reduce((sum, entry) => sum + entry.reservedMicrodollars.reduce((subtotal, value) => subtotal + value, 0), 0);
+  const dispatch = PRIVATE_PLAN.filter((entry) => entry.disposition === 'provider_dispatch');
+  if (PRIVATE_PLAN.length !== authority.cardinality.caseCellAssignments
+    || new Set(PRIVATE_PLAN.map((entry) => entry.assignmentId)).size !== PRIVATE_PLAN.length
+    || dispatch.length !== authority.cardinality.providerDispatchCaseCellAssignments
+    || dispatch.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0) !== authority.cardinality.maximumProviderInvocations
+    || total !== authority.reservationMicrodollars) throw new Error('private authority integrity failure');
+  return PRIVATE_PLAN;
+}
+
+export type FixedTraceComponentSmokePrivateAuthorityUsage = Readonly<{
+  inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number;
+}>;
+
+type Price = Readonly<{ provider: string; model: string; input: number; output: number; cacheRead: number | null; cacheWrite: number | null; readAccounting: 'additive' | 'subset' | 'unsupported'; writeAccounting: 'additive' | 'subset' | 'unsupported' }>;
+const PRICES: Readonly<Record<string, Price>> = Object.freeze({
+  'anthropic-standard-2026-09:claude-haiku-4-5': Object.freeze({ provider: 'anthropic', model: 'claude-haiku-4-5', input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25, readAccounting: 'additive', writeAccounting: 'additive' }),
+  'anthropic-standard-2026-09:claude-sonnet-5': Object.freeze({ provider: 'anthropic', model: 'claude-sonnet-5', input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5, readAccounting: 'additive', writeAccounting: 'additive' }),
+  'openai-gpt-5.6-luna-standard-2026-09-05': Object.freeze({ provider: 'openai', model: 'gpt-5.6-luna', input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25, readAccounting: 'subset', writeAccounting: 'subset' }),
+  'google-gemini-3.7-flash-through-2026-12-31': Object.freeze({ provider: 'google', model: 'gemini-3.7-flash', input: 0.75, output: 3.75, cacheRead: 0.075, cacheWrite: null, readAccounting: 'subset', writeAccounting: 'unsupported' }),
+});
+
+function fraction(rate: number): readonly [number, number] {
+  const text = String(rate); if (!/^\d+(?:\.\d+)?$/.test(text)) throw new Error('invalid price');
+  const decimals = text.split('.')[1]?.length ?? 0;
+  return [Number(text.replace('.', '')), 10 ** decimals];
+}
+/** Exact copied-free integer microdollar settlement for one canonical profile. */
+export function fixedTraceComponentSmokePrivateAuthorityCostMicros(profileId: string, usage: FixedTraceComponentSmokePrivateAuthorityUsage): number {
+  const price = PRICES[profileId];
+  if (!price || !Object.values(usage).every((value) => Number.isSafeInteger(value) && value >= 0)) throw new Error('private authority pricing unavailable');
+  const { inputTokens: input, outputTokens: output, cacheReadTokens: read, cacheWriteTokens: write } = usage;
+  if ((price.readAccounting === 'unsupported' && read !== 0) || (price.writeAccounting === 'unsupported' && write !== 0)
+    || (price.readAccounting === 'subset' && read > input)
+    || (price.writeAccounting === 'subset' && write > input - (price.readAccounting === 'subset' ? read : 0))) throw new Error('private authority cache usage invalid');
+  const categories: Array<readonly [number, number | null]> = [
+    [input - (price.readAccounting === 'subset' ? read : 0) - (price.writeAccounting === 'subset' ? write : 0), price.input],
+    [output, price.output], [read, price.cacheRead], [write, price.cacheWrite],
+  ];
+  let denominator = 1;
+  for (const [, rate] of categories) if (rate !== null) denominator = Math.max(denominator, fraction(rate)[1]);
+  const total = categories.reduce((sum, [count, rate]) => {
+    if (rate === null && count !== 0) throw new Error('private authority cache rate unavailable');
+    const [numerator, rateDenominator] = fraction(rate ?? 0);
+    const contribution = count * numerator * (denominator / rateDenominator);
+    if (!Number.isSafeInteger(contribution) || !Number.isSafeInteger(sum + contribution)) throw new Error('private authority cost range exceeded');
+    return sum + contribution;
+  }, 0);
+  return Math.ceil(total / denominator);
+}
+
+export function fixedTraceComponentSmokePrivateAuthorityIdentityMatches(profileId: string, identity: Readonly<{ provider: string; model: string }>): boolean {
+  const price = PRICES[profileId];
+  return price !== undefined && price.provider === identity.provider && price.model === identity.model;
+}
+
+export function fixedTraceComponentSmokePrivateAuthorityHasAdditiveCache(profileId: string): boolean {
+  const price = PRICES[profileId];
+  return price?.readAccounting === 'additive' || price?.writeAccounting === 'additive';
+}
+
+/**
+ * The live admission artifact remains an independent review check.  It must
+ * agree byte-for-byte in all private authority-relevant fields before it can
+ * describe this authority as admitted; it is never imported by the runtime.
+ */
+export function fixedTraceComponentSmokePrivateAuthorityMatchesAdmission(value: unknown): boolean {
+  try {
+    if (!value || typeof value !== 'object') return false;
+    const admission = value as Record<string, any>;
+    const authority = FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY;
+    if (admission.version !== authority.admissionVersion
+      || admission.fingerprints?.aggregateAdmission !== authority.aggregateAdmissionFingerprint
+      || admission.pricing?.cohortDigest !== authority.pricingCohortDigest
+      || admission.pricing?.reservationMicrodollars !== authority.reservationMicrodollars
+      || admission.pricing?.providerCeilingUsd !== authority.providerCeilingMicrodollars / 1_000_000
+      || canonicalJson(admission.cardinality) !== canonicalJson(authority.cardinality)
+      || !Array.isArray(admission.probes) || !Array.isArray(admission.cells) || !Array.isArray(admission.privateRuntimePlan)) return false;
+    if (admission.probes.length !== authority.probes.length || admission.cells.length !== authority.cells.length
+      || admission.privateRuntimePlan.length !== PRIVATE_PLAN.length) return false;
+    const probesMatch = authority.probes.every((probe, index) => admission.probes[index]?.id === probe.id
+      && admission.probes[index]?.dispatchDisposition === probe.disposition);
+    const cellsMatch = authority.cells.every((cell, index) => admission.cells[index]?.id === cell.id
+      && admission.cells[index]?.provider === cell.provider && admission.cells[index]?.model === cell.model
+      && admission.cells[index]?.effort === cell.effort && admission.cells[index]?.pricingProfileId === cell.pricingProfileId);
+    const planMatch = PRIVATE_PLAN.every((entry, index) => {
+      const candidate = admission.privateRuntimePlan[index];
+      return candidate?.probeId === entry.probeId && candidate?.cellId === entry.cellId
+        && candidate?.dispatchDisposition === entry.disposition && candidate?.maximumProviderInvocations === entry.maximumProviderInvocations
+        && candidate?.pricingProfileId === entry.pricingProfileId && candidate?.preparedRequestHmac === 'required_before_intent'
+        && candidate?.maxInputTokensPerInvocation === entry.maxInputTokens && candidate?.maxOutputTokensPerInvocation === entry.maxOutputTokens
+        && candidate?.timeoutMs === entry.timeoutMs && candidate?.sdkAutomaticRetries === 0
+        && canonicalJson(candidate?.perAttemptReservationMicrodollars) === canonicalJson(entry.reservedMicrodollars);
+    });
+    return probesMatch && cellsMatch && planMatch;
+  } catch { return false; }
+}

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -49,14 +49,6 @@ export interface FixedTraceComponentSmokeTestGrantVerification {
   readonly valid: true;
   readonly signedPayloadDigest: string;
 }
-/** Exact public root supplied only by the isolated one-shot composition root. */
-export interface FixedTraceComponentSmokeOneShotTrustRoot {
-  readonly kid: string;
-  readonly spki: string;
-}
-export interface FixedTraceComponentSmokeOneShotGrantVerifier {
-  verify(value: unknown, now: Date): FixedTraceComponentSmokeVerifiedGrant | null;
-}
 /** A one-shot smoke grant may not outlive this bounded interval. */
 export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_000;
 
@@ -66,9 +58,6 @@ export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS = 15 * 60 * 1_0
  * A later separately-reviewed private deployment must replace this module-owned
  * null registry in a dedicated change before it can verify anything.
  */
-const PRODUCTION_SPKI_BY_KID: Readonly<Record<string, string>> | null = null;
-/** Capability marker: only this verifier can create an input accepted by the ledger. */
-const VERIFIED_GRANTS = new WeakMap<object, Buffer>();
 
 function canonicalJson(value: unknown): string {
   if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
@@ -154,7 +143,7 @@ function parseGrant(value: unknown): { payload: FixedTraceComponentSmokeSignedGr
   } catch { return null; }
 }
 
-function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null, mintLedgerCapability: boolean): FixedTraceComponentSmokeVerifiedGrant | null {
+function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null): FixedTraceComponentSmokeVerifiedGrant | null {
   if (!(now instanceof Date) || !Number.isFinite(now.valueOf()) || registry === null) return null;
   const parsed = parseGrant(value);
   if (!parsed || Date.parse(parsed.payload.issuedAt) > now.valueOf() || Date.parse(parsed.payload.expiresAt) <= now.valueOf()
@@ -168,58 +157,23 @@ function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record
     const verified = Object.freeze({ signedPayloadDigest,
       grantDigest: createHash('sha256').update(parsed.signature).update(signedPayloadDigest, 'utf8').digest('hex'),
       payload: parsed.payload });
-    if (mintLedgerCapability) VERIFIED_GRANTS.set(verified, Buffer.from(parsed.signature));
     return verified;
   } catch { return null; }
 }
 
-function exactOneShotTrustRoot(value: unknown): FixedTraceComponentSmokeOneShotTrustRoot | null {
-  try {
-    const root = snapshotFixedTraceJson(value, 'private one-shot trust root') as Record<string, unknown>;
-    if (!exactKeys(root, ['kid', 'spki']) || !kid(root.kid) || typeof root.spki !== 'string' || !/^[A-Za-z0-9_-]+$/.test(root.spki)) return null;
-    const publicKey = createPublicKey({ key: Buffer.from(root.spki, 'base64url'), format: 'der', type: 'spki' });
-    return publicKey.asymmetricKeyType === 'ed25519' ? Object.freeze({ kid: root.kid, spki: root.spki }) : null;
-  } catch { return null; }
+/** Production entry point: permanently fail-closed in this unprovisioned slice. */
+export function verifyFixedTraceComponentSmokeSignedGrant(_value: unknown, _now: Date): FixedTraceComponentSmokeVerifiedGrant | null {
+  return null;
 }
 
-/**
- * Constructs the private one-shot verifier only when an operator supplies both
- * an exact Ed25519 root and the independently governed SHA-256 pin of that
- * root's canonical JSON. The isolated composition root/operator is the
- * authority: no route, job, ambient configuration, or untrusted caller may
- * control both values. Neither value is read from process state here.
- *
- * Source independence is an operational boundary, not a cryptographic
- * property of two public inputs. Therefore this function must remain private
- * to that isolated composition root; it is not a general caller-selected-root
- * verification API.
- */
-export function createFixedTraceComponentSmokeOneShotGrantVerifier(
-  trustRoot: unknown,
-  expectedTrustRootPin: unknown,
-): FixedTraceComponentSmokeOneShotGrantVerifier | null {
-  const root = exactOneShotTrustRoot(trustRoot);
-  if (!root || !hexDigest(expectedTrustRootPin)
-    || createHash('sha256').update(canonicalJson(root), 'utf8').digest('hex') !== expectedTrustRootPin) return null;
-  const registry = Object.freeze({ [root.kid]: root.spki });
-  return Object.freeze({ verify: (value: unknown, now: Date) => verifyWithRegistry(value, now, registry, true) });
+/** No caller-visible path can mint the adjacent ledger's production capability. */
+export function isFixedTraceComponentSmokeVerifiedGrant(_value: unknown): _value is FixedTraceComponentSmokeVerifiedGrant {
+  return false;
 }
 
-/** Production entry point: always fail-closed until its module-owned registry is provisioned. */
-export function verifyFixedTraceComponentSmokeSignedGrant(value: unknown, now: Date): FixedTraceComponentSmokeVerifiedGrant | null {
-  return verifyWithRegistry(value, now, PRODUCTION_SPKI_BY_KID, true);
-}
-
-/** Internal capability check used by the adjacent private ledger, never a boolean authorization API. */
-export function isFixedTraceComponentSmokeVerifiedGrant(value: unknown): value is FixedTraceComponentSmokeVerifiedGrant {
-  return typeof value === 'object' && value !== null && VERIFIED_GRANTS.has(value);
-}
-
-/** Returns only an irreversible digest; raw signatures never cross into the ledger. */
-export function fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(value: unknown): string | null {
-  if (!isFixedTraceComponentSmokeVerifiedGrant(value)) return null;
-  const signature = VERIFIED_GRANTS.get(value);
-  return signature ? createHash('sha256').update(signature).digest('hex') : null;
+/** There is consequently no signature digest for the unconstructible production path. */
+export function fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(_value: unknown): string | null {
+  return null;
 }
 
 /**
@@ -234,6 +188,6 @@ export function verifyFixedTraceComponentSmokeSignedGrantForTest(
 ): FixedTraceComponentSmokeTestGrantVerification | null {
   if (!kid(testTrustRoot.kid) || testTrustRoot.publicKey.asymmetricKeyType !== 'ed25519') return null;
   const spki = testTrustRoot.publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
-  const verified = verifyWithRegistry(value, now, Object.freeze({ [testTrustRoot.kid]: spki.toString('base64url') }), false);
+  const verified = verifyWithRegistry(value, now, Object.freeze({ [testTrustRoot.kid]: spki.toString('base64url') }));
   return verified ? Object.freeze({ valid: true as const, signedPayloadDigest: verified.signedPayloadDigest }) : null;
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-authorization.ts
@@ -1,8 +1,7 @@
 import { createHash, createPublicKey, verify, type KeyObject } from 'node:crypto';
 import {
-  FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION,
-  fixedTraceComponentSmokeAdmission,
-} from './fixed-trace-component-smoke-admission.js';
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+} from './fixed-trace-component-smoke-private-authority.js';
 import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
 
 /**
@@ -16,8 +15,7 @@ export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM = 'Ed25519' as c
 export const FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_DOMAIN =
   'adcp:addie:fixed-trace-component-smoke:private-grant:v1\0' as const;
 
-type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
-type Cardinality = Admission['cardinality'];
+type Cardinality = typeof FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality;
 
 export interface FixedTraceComponentSmokeSignedGrantPayload {
   readonly grantVersion: typeof FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION;
@@ -25,7 +23,7 @@ export interface FixedTraceComponentSmokeSignedGrantPayload {
   readonly issuedAt: string;
   readonly expiresAt: string;
   readonly stageId: 'stage_1_smoke';
-  readonly admissionVersion: typeof FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION;
+  readonly admissionVersion: typeof FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion;
   readonly aggregateAdmissionFingerprint: string;
   readonly cardinality: Cardinality;
   readonly reservationMicrodollars: number;
@@ -108,11 +106,11 @@ function exactIso(value: unknown): value is string {
 function base64url(value: unknown): value is string {
   return typeof value === 'string' && /^[A-Za-z0-9_-]{86}$/.test(value);
 }
-function exactCardinality(value: unknown, admission: Admission): value is Cardinality {
+function exactCardinality(value: unknown): value is Cardinality {
   try {
     const candidate = snapshotFixedTraceJson(value, 'signed grant cardinality') as Record<string, unknown>;
-    return exactKeys(candidate, Object.keys(admission.cardinality))
-      && canonicalJson(candidate) === canonicalJson(admission.cardinality);
+    return exactKeys(candidate, Object.keys(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality))
+      && canonicalJson(candidate) === canonicalJson(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality);
   } catch { return false; }
 }
 
@@ -125,33 +123,31 @@ export function fixedTraceComponentSmokeSignedPayloadDigest(payload: FixedTraceC
   return createHash('sha256').update(fixedTraceComponentSmokeSignedGrantBytes(payload)).digest('hex');
 }
 
-function parsePayload(value: unknown, admission: Admission): FixedTraceComponentSmokeSignedGrantPayload | null {
+function parsePayload(value: unknown): FixedTraceComponentSmokeSignedGrantPayload | null {
   try {
     const payload = snapshotFixedTraceJson(value, 'signed private grant payload') as Record<string, unknown>;
-    const pricing = admission.pricing;
-    if (pricing.cohortDigest === null || pricing.reservationMicrodollars === null) return null;
     if (!exactKeys(payload, ['admissionVersion', 'aggregateAdmissionFingerprint', 'cardinality', 'expiresAt', 'grantVersion', 'issuedAt', 'kid', 'nonceCommitment', 'pricingCohortDigest', 'providerCeilingMicrodollars', 'reservationMicrodollars', 'stageId'])) return null;
     if (payload.grantVersion !== FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION
       || !kid(payload.kid) || !exactIso(payload.issuedAt) || !exactIso(payload.expiresAt)
-      || payload.stageId !== admission.stageControls.phaseId
-      || payload.admissionVersion !== FIXED_TRACE_COMPONENT_SMOKE_ADMISSION_VERSION
-      || payload.aggregateAdmissionFingerprint !== admission.fingerprints.aggregateAdmission
-      || !exactCardinality(payload.cardinality, admission)
-      || payload.reservationMicrodollars !== pricing.reservationMicrodollars
-      || payload.providerCeilingMicrodollars !== pricing.providerCeilingUsd * 1_000_000
-      || !pricingCohortDigest(payload.pricingCohortDigest) || payload.pricingCohortDigest !== pricing.cohortDigest
+      || payload.stageId !== 'stage_1_smoke'
+      || payload.admissionVersion !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion
+      || payload.aggregateAdmissionFingerprint !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint
+      || !exactCardinality(payload.cardinality)
+      || payload.reservationMicrodollars !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars
+      || payload.providerCeilingMicrodollars !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars
+      || !pricingCohortDigest(payload.pricingCohortDigest) || payload.pricingCohortDigest !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.pricingCohortDigest
       || !hexDigest(payload.nonceCommitment)
       || Date.parse(payload.issuedAt as string) >= Date.parse(payload.expiresAt as string)) return null;
     return Object.freeze(payload) as unknown as FixedTraceComponentSmokeSignedGrantPayload;
   } catch { return null; }
 }
 
-function parseGrant(value: unknown, admission: Admission): { payload: FixedTraceComponentSmokeSignedGrantPayload; signature: Buffer } | null {
+function parseGrant(value: unknown): { payload: FixedTraceComponentSmokeSignedGrantPayload; signature: Buffer } | null {
   try {
     const grant = snapshotFixedTraceJson(value, 'signed private grant') as Record<string, unknown>;
     if (!exactKeys(grant, ['algorithm', 'payload', 'signature'])
       || grant.algorithm !== FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM || !base64url(grant.signature)) return null;
-    const payload = parsePayload(grant.payload, admission);
+    const payload = parsePayload(grant.payload);
     if (!payload) return null;
     const signature = Buffer.from(grant.signature, 'base64url');
     return signature.length === 64 ? { payload, signature } : null;
@@ -159,9 +155,8 @@ function parseGrant(value: unknown, admission: Admission): { payload: FixedTrace
 }
 
 function verifyWithRegistry(value: unknown, now: Date, registry: Readonly<Record<string, string>> | null, mintLedgerCapability: boolean): FixedTraceComponentSmokeVerifiedGrant | null {
-  const admission = fixedTraceComponentSmokeAdmission();
   if (!(now instanceof Date) || !Number.isFinite(now.valueOf()) || registry === null) return null;
-  const parsed = parseGrant(value, admission);
+  const parsed = parseGrant(value);
   if (!parsed || Date.parse(parsed.payload.issuedAt) > now.valueOf() || Date.parse(parsed.payload.expiresAt) <= now.valueOf()
     || Date.parse(parsed.payload.expiresAt) - Date.parse(parsed.payload.issuedAt) > FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_MAX_TTL_MS) return null;
   const spki = registry[parsed.payload.kid];

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -521,6 +521,21 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           AND p.assignment_outcome IS NULL`,
       [reservation.authorizationDigest],
     );
+    // This is recovery for a committed intent whose caller may never receive
+    // the acknowledgement. Finish the complete denominator in this same
+    // transaction: a later process must never need to guess which entries
+    // were already closed, nor issue individual omission writes after an
+    // ambiguous provider exposure.
+    await client.query(
+      `UPDATE addie_fixed_trace_component_smoke_run_plan AS p
+          SET assignment_outcome = 'not_executed_after_halt', assignment_terminal_at = clock_timestamp()
+        WHERE p.authorization_digest = $1 AND p.assignment_outcome IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM addie_fixed_trace_component_smoke_attempts AS a
+             WHERE a.authorization_digest = p.authorization_digest AND a.assignment_id = p.assignment_id
+          )`,
+      [reservation.authorizationDigest],
+    );
     return true;
   }
 

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -20,6 +20,14 @@ export const FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN =
   'adcp:addie:fixed-trace-component-smoke:prepared-request:v1\0' as const;
 export const FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN =
   'adcp:addie:fixed-trace-component-smoke:provider-response:v1\0' as const;
+/**
+ * Ledger transactions contain database bookkeeping only: a provider call is
+ * always outside them. These deliberately small, fixed PostgreSQL-local
+ * bounds therefore fail closed on contention/query stalls without ever
+ * bounding (or spanning) provider work.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_LEDGER_LOCK_TIMEOUT_MS = 250 as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_LEDGER_STATEMENT_TIMEOUT_MS = 1_000 as const;
 
 type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
 type Disposition = Admission['privateRuntimePlan'][number]['dispatchDisposition'];
@@ -202,6 +210,10 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
     let began = false;
     try {
       await client.query('BEGIN'); began = true;
+      // These must be the first commands in every transaction. SET LOCAL
+      // cannot escape COMMIT/ROLLBACK and neither value is caller-controlled.
+      await client.query(`SET LOCAL lock_timeout = '${FIXED_TRACE_COMPONENT_SMOKE_LEDGER_LOCK_TIMEOUT_MS}ms'`);
+      await client.query(`SET LOCAL statement_timeout = '${FIXED_TRACE_COMPONENT_SMOKE_LEDGER_STATEMENT_TIMEOUT_MS}ms'`);
       const output = await work(client);
       await client.query('COMMIT');
       return output;
@@ -640,7 +652,14 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
           || parsed.finalInvocationOrdinal > expected.maximumProviderInvocations) return result('refused', 'plan_mismatch');
         const auth = await client.query<{ status: string }>('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1 AND reservation_id = $2 FOR UPDATE', [parsed.reservation.authorizationDigest, parsed.reservation.reservationId]);
         if (auth.rowCount !== 1) return result('refused', 'grant_already_consumed');
-        if (auth.rows[0]!.status !== 'consumed' && !(auth.rows[0]!.status === 'unknown_exposure' && parsed.status === 'provider_failed')) return result('refused', auth.rows[0]!.status === 'unknown_exposure' ? 'unknown_exposure' : 'run_halted');
+        // A limit breach has already settled the attempt and permanently
+        // halted the authorization. Its provider assignment must still close
+        // as failed so the 168-entry denominator is never left open.
+        if (auth.rows[0]!.status !== 'consumed'
+          && !(auth.rows[0]!.status === 'unknown_exposure' && parsed.status === 'provider_failed')
+          && !(auth.rows[0]!.status === 'halted' && parsed.status === 'provider_failed')) {
+          return result('refused', auth.rows[0]!.status === 'unknown_exposure' ? 'unknown_exposure' : 'run_halted');
+        }
         // Target plan then authorization is the universal ordinary-mutation
         // order. This aggregate deliberately takes no peer-row locks.
         const evidence = await client.query<{ count: unknown; open: unknown; failures: unknown; last_response_disposition: unknown }>(

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-ledger.ts
@@ -1,7 +1,13 @@
 import { createHash } from 'node:crypto';
 import type { Pool, PoolClient } from 'pg';
-import { fixedTraceComponentSmokeAdmission } from './fixed-trace-component-smoke-admission.js';
-import { datedPricingCostMicros, datedPricingProfilesForFixedTrace } from './dated-pricing-cohort.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityCostMicros,
+  fixedTraceComponentSmokePrivateAuthorityHasAdditiveCache,
+  fixedTraceComponentSmokePrivateAuthorityIdentityMatches,
+  fixedTraceComponentSmokePrivateAuthorityPlan,
+  type FixedTraceComponentSmokePrivateAuthorityPlanEntry,
+} from './fixed-trace-component-smoke-private-authority.js';
 import {
   fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger,
   isFixedTraceComponentSmokeVerifiedGrant,
@@ -29,8 +35,7 @@ export const FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN =
 export const FIXED_TRACE_COMPONENT_SMOKE_LEDGER_LOCK_TIMEOUT_MS = 250 as const;
 export const FIXED_TRACE_COMPONENT_SMOKE_LEDGER_STATEMENT_TIMEOUT_MS = 1_000 as const;
 
-type Admission = ReturnType<typeof fixedTraceComponentSmokeAdmission>;
-type Disposition = Admission['privateRuntimePlan'][number]['dispatchDisposition'];
+type Disposition = FixedTraceComponentSmokePrivateAuthorityPlanEntry['disposition'];
 export type FixedTraceComponentSmokeLedgerRefusal =
   | 'grant_not_active' | 'grant_already_consumed' | 'admission_drift'
   | 'unknown_exposure' | 'run_halted' | 'duplicate_attempt_id' | 'intent_required'
@@ -43,22 +48,7 @@ export interface FixedTraceComponentSmokeReservation {
   readonly providerDispatchEntryCount: 126;
   readonly reservationMicrodollars: 2819484;
 }
-export interface FixedTraceComponentSmokePlanEntry {
-  readonly assignmentId: string;
-  readonly probeId: string;
-  readonly cellId: string;
-  readonly disposition: Disposition;
-  readonly maximumProviderInvocations: number;
-  readonly provider: string;
-  readonly model: string;
-  readonly effort: string;
-  readonly pricingProfileId: string;
-  readonly maxInputTokens: number;
-  readonly maxOutputTokens: number;
-  readonly timeoutMs: number;
-  readonly retries: 0;
-  readonly reservedMicrodollars: readonly number[];
-}
+export type FixedTraceComponentSmokePlanEntry = FixedTraceComponentSmokePrivateAuthorityPlanEntry;
 export interface FixedTraceComponentSmokeProviderIntent {
   readonly reservation: FixedTraceComponentSmokeReservation;
   readonly attemptId: string;
@@ -133,7 +123,7 @@ function safeString(value: unknown, max: number): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= max && /^[a-z0-9._:-]+$/i.test(value);
 }
 function expectedPlanEntry(assignmentId: string): FixedTraceComponentSmokePlanEntry | null {
-  return fixedTraceComponentSmokePrivateLedgerPlan()?.find((entry) => entry.assignmentId === assignmentId) ?? null;
+  return fixedTraceComponentSmokePrivateLedgerPlan().find((entry) => entry.assignmentId === assignmentId) ?? null;
 }
 function pgPlanMatches(row: Record<string, unknown>, expected: FixedTraceComponentSmokePlanEntry): boolean {
   const reservations = row.reserved_microdollars;
@@ -151,39 +141,19 @@ function pgPlanMatches(row: Record<string, unknown>, expected: FixedTraceCompone
 }
 
 /** Derives, rather than accepts, the exact 168-entry admitted plan. */
-export function fixedTraceComponentSmokePrivateLedgerPlan(): readonly FixedTraceComponentSmokePlanEntry[] | null {
-  const admission = fixedTraceComponentSmokeAdmission();
-  if (admission.status !== 'ready_for_explicit_paid_authorization'
-    || admission.fingerprints.aggregateAdmission !== '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d'
-    || admission.cardinality.caseCellAssignments !== 168
-    || admission.cardinality.providerDispatchCaseCellAssignments !== 126
-    || admission.cardinality.preDispatchFaultCaseCellAssignments !== 21
-    || admission.cardinality.maximumProviderInvocations !== 192
-    || admission.pricing.reservationMicrodollars !== 2_819_484
-    || admission.pricing.providerCeilingUsd !== 5) return null;
-  const cells = new Map(admission.cells.map((cell) => [cell.id, cell]));
-  const entries = admission.privateRuntimePlan.map((entry) => {
-    const cell = cells.get(entry.cellId);
-    if (!cell || entry.maximumProviderInvocations !== entry.perAttemptReservationMicrodollars.length || entry.sdkAutomaticRetries !== 0) return null;
-    return Object.freeze({
-      assignmentId: sha256({ domain: 'adcp:addie:fixed-trace-component-smoke:plan-entry:v1\0', fingerprint: admission.fingerprints.aggregateAdmission, probeId: entry.probeId, cellId: entry.cellId }),
-      probeId: entry.probeId, cellId: entry.cellId, disposition: entry.dispatchDisposition,
-      maximumProviderInvocations: entry.maximumProviderInvocations, provider: cell.provider, model: cell.model, effort: cell.effort,
-      pricingProfileId: entry.pricingProfileId, maxInputTokens: entry.maxInputTokensPerInvocation,
-      maxOutputTokens: entry.maxOutputTokensPerInvocation, timeoutMs: entry.timeoutMs, retries: 0 as const,
-      reservedMicrodollars: Object.freeze([...entry.perAttemptReservationMicrodollars]),
-    });
-  });
-  if (entries.some((entry) => entry === null)) return null;
-  const plan = entries as FixedTraceComponentSmokePlanEntry[];
-  const total = plan.reduce((sum, entry) => sum + entry.reservedMicrodollars.reduce((subtotal, micros) => subtotal + micros, 0), 0);
+export function fixedTraceComponentSmokePrivateLedgerPlan(): readonly FixedTraceComponentSmokePlanEntry[] {
+  const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+  const authority = FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY;
   const dispatch = plan.filter((entry) => entry.disposition === 'provider_dispatch');
-  const nonDispatchValid = plan.filter((entry) => entry.disposition !== 'provider_dispatch')
-    .every((entry) => entry.maximumProviderInvocations === 0 && entry.reservedMicrodollars.length === 0);
-  return plan.length === 168 && new Set(plan.map((entry) => entry.assignmentId)).size === 168
-    && dispatch.length === 126 && dispatch.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0) === 192
-    && total === 2_819_484 && plan.every((entry) => entry.reservedMicrodollars.every((micros) => Number.isSafeInteger(micros) && micros > 0 && micros <= 2_819_484))
-    && nonDispatchValid ? Object.freeze(plan) : null;
+  const total = plan.reduce((sum, entry) => sum + entry.reservedMicrodollars.reduce((subtotal, micros) => subtotal + micros, 0), 0);
+  if (plan.length !== authority.cardinality.caseCellAssignments
+    || dispatch.length !== authority.cardinality.providerDispatchCaseCellAssignments
+    || dispatch.reduce((sum, entry) => sum + entry.maximumProviderInvocations, 0) !== authority.cardinality.maximumProviderInvocations
+    || total !== authority.reservationMicrodollars
+    || plan.some((entry) => entry.retries !== 0 || (entry.disposition === 'provider_dispatch') !== (entry.maximumProviderInvocations > 0))) {
+    throw new Error('private ledger authority integrity failure');
+  }
+  return plan;
 }
 
 function reservationIdForAuthorizationDigest(authorizationDigest: string): string {
@@ -376,10 +346,11 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         if (ordinal === null || maxInput === null || maxOutput === null || timeout === null) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
         const reservedForOrdinal = pgSafeInt(row.reserved_microdollars[ordinal - 1], 2_819_484);
         const maximumInvocations = pgSafeInt(row.maximum_provider_invocations, 2);
-        const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === row.pricing_profile_id);
-        if (parsed.usage && (!profile || profile.provider !== row.requested_provider || profile.model !== row.requested_model)) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
+        if (parsed.usage && !fixedTraceComponentSmokePrivateAuthorityIdentityMatches(row.pricing_profile_id, {
+          provider: row.requested_provider, model: row.requested_model,
+        })) return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure');
         let spent: number | null = null;
-        try { spent = parsed.usage ? datedPricingCostMicros(profile!, parsed.usage) : null; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
+        try { spent = parsed.usage ? fixedTraceComponentSmokePrivateAuthorityCostMicros(row.pricing_profile_id, parsed.usage) : null; } catch { return this.settlePostIntentFailure(client, parsed, 'pricing_unavailable', 'unknown_exposure'); }
         if (parsed.status === 'succeeded' && parsed.responseDisposition === 'tool_continuation_required'
           && (maximumInvocations === null || ordinal === maximumInvocations)) {
           return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
@@ -387,10 +358,9 @@ export class PostgresFixedTraceComponentSmokePrivateLedger {
         // A complete receipt remains accounting evidence even if it breaches a
         // pinned input/output/timeout limit. Never replace known exposure with
         // NULL merely because this one-shot run must halt.
-        const additiveCacheOverLimit = parsed.usage !== null && profile !== undefined && (
-          (profile.cacheReadAccounting === 'additive' && parsed.usage.cacheReadTokens > maxInput)
-          || (profile.cacheWriteAccounting === 'additive' && parsed.usage.cacheWriteTokens > maxInput)
-        );
+        const additiveCacheOverLimit = parsed.usage !== null
+          && fixedTraceComponentSmokePrivateAuthorityHasAdditiveCache(row.pricing_profile_id)
+          && (parsed.usage.cacheReadTokens > maxInput || parsed.usage.cacheWriteTokens > maxInput);
         if (parsed.usage && (parsed.usage.inputTokens > maxInput || additiveCacheOverLimit
           || parsed.usage.outputTokens > maxOutput || parsed.usage.latencyMs > timeout)) return this.settlePostIntentFailure(client, parsed, 'invalid_limits', 'halted', 'plan_mismatch', spent);
         // The target attempt is locked before the authorization above. Every

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
@@ -1,107 +1,35 @@
-import { createHash, createHmac } from 'node:crypto';
 import {
-  createFixedTraceComponentSmokeOneShotGrantVerifier,
-  type FixedTraceComponentSmokeOneShotTrustRoot,
-} from './fixed-trace-component-smoke-private-authorization.js';
-import {
-  FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN,
-  FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN,
-  fixedTraceComponentSmokePrivateLedgerPlan,
-  type FixedTraceComponentSmokeLedgerRefusal,
-  type FixedTraceComponentSmokeReservation,
-} from './fixed-trace-component-smoke-private-ledger.js';
-import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+  fixedTraceComponentSmokePrivateAuthorityPlan,
+  type FixedTraceComponentSmokePrivateAuthorityPlanEntry,
+} from './fixed-trace-component-smoke-private-authority.js';
 
-/**
- * This is a deliberately private composition boundary. It has no route, job,
- * scheduler, environment, SDK, or provider construction import. A caller can
- * supply a signed grant and explicit, already-controlled dependencies, but
- * cannot supply a plan, cell, identity, limit, schedule, or retry policy.
- */
+/** This module deliberately has no provisioned production construction path. */
 export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_RUNTIME_DEFAULT_OFF = true as const;
 export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_RUNTIME_FAKE_ONLY = true as const;
 
-type Plan = NonNullable<ReturnType<typeof fixedTraceComponentSmokePrivateLedgerPlan>>;
-type PlanEntry = Plan[number];
+type PlanEntry = FixedTraceComponentSmokePrivateAuthorityPlanEntry;
 type Usage = Readonly<{ inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; latencyMs: number }>;
 type Identity = Readonly<{ provider: string; model: string; effort: string }>;
+type Receipt = Readonly<{
+  status: 'succeeded' | 'provider_failed';
+  disposition: 'final_response' | 'tool_continuation_required';
+  identity: Identity;
+  usage: Usage;
+}>;
 
-export interface FixedTraceComponentSmokeFakeProviderRequest {
-  readonly assignmentId: string;
-  readonly probeId: string;
-  readonly cellId: string;
-  readonly provider: string;
-  readonly model: string;
-  readonly effort: string;
-  readonly invocationOrdinal: number;
-  readonly maxInputTokens: number;
-  readonly maxOutputTokens: number;
-  readonly timeoutMs: number;
-  readonly sdkAutomaticRetries: 0;
-}
-
-/** A test double is the only adapter shape admitted by this runtime. */
-export interface FixedTraceComponentSmokeFakeProvider {
-  readonly fakeOnly: true;
-  readonly automaticRetries: 0;
-  invoke(request: Readonly<FixedTraceComponentSmokeFakeProviderRequest>): Promise<unknown>;
-}
-
-/** The runtime only receives operations, never a Pool or ambient DB client. */
-export interface FixedTraceComponentSmokePrivateRuntimeLedger {
-  reserveAndConsume(grant: object): Promise<unknown>;
-  recordProviderIntent(input: object): Promise<unknown>;
-  recordTerminal(input: object): Promise<unknown>;
-  recordProviderAssignmentTerminal(input: object): Promise<unknown>;
-  recordNonDispatchTerminal(input: object): Promise<unknown>;
-  recordNotExecutedAfterHalt(input: object): Promise<unknown>;
-  recordUnknownExposure(reservation: FixedTraceComponentSmokeReservation): Promise<unknown>;
-}
-
-export interface FixedTraceComponentSmokePrivateRuntimeDependencies {
-  readonly trustRoot: FixedTraceComponentSmokeOneShotTrustRoot;
-  readonly trustRootPin: string;
-  /** The opaque signed envelope is verified only when run starts. */
-  readonly signedGrant: unknown;
-  /** Copied at construction and used only for domain-separated evidence HMACs. */
-  readonly evidenceHmacKey: Buffer;
-  readonly trustedNow: () => Date;
-  readonly ledger: FixedTraceComponentSmokePrivateRuntimeLedger;
-  readonly fakeProvider: FixedTraceComponentSmokeFakeProvider;
-}
+/**
+ * A JSON-only test/simulation script. JSON.parse produces the internal copy;
+ * this module never reads caller objects, invokes caller code, or dispatches.
+ */
+export type FixedTraceComponentSmokePrivateSimulationScript = string;
 
 export type FixedTraceComponentSmokePrivateRuntimeResult = Readonly<{
   status: 'completed' | 'halted' | 'refused';
-  reason?: FixedTraceComponentSmokeLedgerRefusal | 'invalid_grant' | 'private_composition_invalid' | 'persistence_uncertain';
+  reason?: 'invalid_simulation_script';
   assignmentDispositions: number;
   providerInvocations: number;
 }>;
 
-type Recorded = Readonly<{ status: 'recorded' }>;
-type Refused = Readonly<{ status: 'refused'; reason: string }>;
-
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'number') {
-    if (!Number.isSafeInteger(value)) throw new Error('evidence JSON permits only safe integers');
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
-  if (typeof value === 'object') {
-    const record = value as Record<string, unknown>;
-    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
-  }
-  throw new Error('non-JSON evidence value');
-}
-function digestAttempt(reservation: FixedTraceComponentSmokeReservation, entry: PlanEntry, ordinal: number): string {
-  return `attempt_${createHash('sha256').update(canonicalJson({
-    domain: 'adcp:addie:fixed-trace-component-smoke:private-runtime-attempt:v1\0', reservationId: reservation.reservationId,
-    assignmentId: entry.assignmentId, invocationOrdinal: ordinal,
-  }), 'utf8').digest('hex').slice(0, 32)}`;
-}
-function hmac(key: Buffer, domain: string, value: unknown): string {
-  return createHmac('sha256', key).update(domain, 'utf8').update(canonicalJson(snapshotFixedTraceJson(value, 'private runtime evidence')), 'utf8').digest('hex');
-}
 function exactKeys(value: object, keys: readonly string[]): boolean {
   const actual = Object.keys(value).sort();
   return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
@@ -118,152 +46,74 @@ function safeIdentity(value: unknown): Identity | null {
   return [identity.provider, identity.model, identity.effort].every((part) => typeof part === 'string' && part.length > 0 && part.length <= 128 && /^[a-z0-9._:-]+$/i.test(part))
     ? Object.freeze(identity) as Identity : null;
 }
-function parseRecorded(value: unknown): Recorded | Refused | null {
-  try {
-    const result = snapshotFixedTraceJson(value, 'private runtime ledger result') as Record<string, unknown>;
-    if (exactKeys(result, ['status']) && result.status === 'recorded') return Object.freeze({ status: 'recorded' });
-    if (exactKeys(result, ['reason', 'status']) && result.status === 'refused' && typeof result.reason === 'string') return Object.freeze({ status: 'refused', reason: result.reason });
-  } catch { /* fail closed */ }
-  return null;
+function parseReceipt(value: unknown): Receipt | null {
+  if (!value || typeof value !== 'object' || !exactKeys(value, ['disposition', 'identity', 'status', 'usage'])) return null;
+  const receipt = value as Record<string, unknown>;
+  const identity = safeIdentity(receipt.identity); const usage = safeUsage(receipt.usage);
+  return identity && usage
+    && (receipt.status === 'succeeded' || receipt.status === 'provider_failed')
+    && (receipt.disposition === 'final_response' || receipt.disposition === 'tool_continuation_required')
+    ? Object.freeze({ status: receipt.status, disposition: receipt.disposition, identity, usage }) : null;
 }
-function parseReservation(value: unknown, authorizationDigest: string): Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Refused | null {
+function scriptResponses(script: FixedTraceComponentSmokePrivateSimulationScript | undefined, plan: readonly PlanEntry[]): Map<string, Receipt> | null {
   try {
-    const result = snapshotFixedTraceJson(value, 'private runtime reservation result') as Record<string, unknown>;
-    if (exactKeys(result, ['reason', 'status']) && result.status === 'refused' && typeof result.reason === 'string') return Object.freeze({ status: 'refused', reason: result.reason });
-    if (!exactKeys(result, ['reservation', 'status']) || result.status !== 'reserved' || !result.reservation || typeof result.reservation !== 'object') return null;
-    const reservation = result.reservation as Record<string, unknown>;
-    const expectedReservationId = `reservation_${createHash('sha256').update(canonicalJson({
-      domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0', authorizationDigest,
-    }), 'utf8').digest('hex').slice(0, 32)}`;
-    return exactKeys(reservation, ['authorizationDigest', 'entryCount', 'providerDispatchEntryCount', 'reservationId', 'reservationMicrodollars'])
-      && typeof reservation.authorizationDigest === 'string' && /^[a-f0-9]{64}$/.test(reservation.authorizationDigest)
-      && typeof reservation.reservationId === 'string' && /^reservation_[a-f0-9]{32}$/.test(reservation.reservationId)
-      && reservation.authorizationDigest === authorizationDigest && reservation.reservationId === expectedReservationId
-      && reservation.entryCount === 168 && reservation.providerDispatchEntryCount === 126 && reservation.reservationMicrodollars === 2_819_484
-      ? Object.freeze({ status: 'reserved' as const, reservation: Object.freeze(reservation) as unknown as FixedTraceComponentSmokeReservation }) : null;
+    if (script === undefined) return new Map();
+    if (typeof script !== 'string' || script.length > 1_000_000) return null;
+    const copied = JSON.parse(script) as Record<string, unknown>;
+    if (!exactKeys(copied, ['responses']) || !copied.responses || typeof copied.responses !== 'object' || Array.isArray(copied.responses)) return null;
+    const expected = new Set(plan.filter((entry) => entry.disposition === 'provider_dispatch')
+      .flatMap((entry) => Array.from({ length: entry.maximumProviderInvocations }, (_, index) => `${entry.assignmentId}:${index + 1}`)));
+    const parsed = new Map<string, Receipt>();
+    for (const [key, value] of Object.entries(copied.responses as Record<string, unknown>)) {
+      if (!expected.has(key)) return null;
+      const receipt = parseReceipt(value); if (!receipt) return null;
+      parsed.set(key, receipt);
+    }
+    return parsed;
   } catch { return null; }
 }
-function providerReceipt(value: unknown): { usage: Usage | null; identity: Identity | null; disposition: 'final_response' | 'tool_continuation_required' | null; status: 'succeeded' | 'provider_failed' | null; structurallyValid: boolean } {
-  try {
-    const receipt = snapshotFixedTraceJson(value, 'fake provider receipt') as Record<string, unknown>;
-    if (!exactKeys(receipt, ['disposition', 'identity', 'status', 'usage'])) return { usage: null, identity: null, disposition: null, status: null, structurallyValid: false };
-    const usage = safeUsage(receipt.usage); const identity = safeIdentity(receipt.identity);
-    const disposition = receipt.disposition === 'final_response' || receipt.disposition === 'tool_continuation_required' ? receipt.disposition : null;
-    const status = receipt.status === 'succeeded' || receipt.status === 'provider_failed' ? receipt.status : null;
-    return { usage, identity, disposition, status, structurallyValid: usage !== null && identity !== null && disposition !== null && status !== null };
-  } catch { return { usage: null, identity: null, disposition: null, status: null, structurallyValid: false }; }
+function defaultReceipt(entry: PlanEntry, ordinal: number): Receipt {
+  return Object.freeze({
+    status: 'succeeded',
+    disposition: entry.maximumProviderInvocations === 2 && ordinal === 1 ? 'tool_continuation_required' : 'final_response',
+    identity: Object.freeze({ provider: entry.provider, model: entry.model, effort: entry.effort }),
+    usage: Object.freeze({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 }),
+  });
 }
 
 /**
- * The returned object has no arguments: no production entry point can feed it
- * a mutable execution request. The only dispatch capability is this explicit,
- * fake-only dependency graph.
+ * Production remains unconstructible until a separately reviewed custody
+ * boundary can issue a non-forgeable capability. This function accepts no
+ * dependencies, authority material, provider adapter, or executable callback.
  */
-export function createFixedTraceComponentSmokePrivateRuntime(
-  dependencies: FixedTraceComponentSmokePrivateRuntimeDependencies,
-): Readonly<{ run(): Promise<FixedTraceComponentSmokePrivateRuntimeResult> }> | null {
-  const plan = fixedTraceComponentSmokePrivateLedgerPlan();
-  const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(dependencies.trustRoot, dependencies.trustRootPin);
-  if (!plan || !verifier || !Buffer.isBuffer(dependencies.evidenceHmacKey) || dependencies.evidenceHmacKey.length < 16
-    || typeof dependencies.trustedNow !== 'function' || !dependencies.ledger || dependencies.fakeProvider?.fakeOnly !== true
-    || dependencies.fakeProvider.automaticRetries !== 0 || typeof dependencies.fakeProvider.invoke !== 'function') return null;
-  const evidenceHmacKey = Buffer.from(dependencies.evidenceHmacKey);
+export function createFixedTraceComponentSmokePrivateRuntime(): null { return null; }
 
-  return Object.freeze({ run: async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
-    let now: Date;
-    try { now = dependencies.trustedNow(); } catch { return { status: 'refused', reason: 'private_composition_invalid', assignmentDispositions: 0, providerInvocations: 0 }; }
-    const grant = verifier.verify(dependencies.signedGrant, now);
-    if (!grant) return { status: 'refused', reason: 'invalid_grant', assignmentDispositions: 0, providerInvocations: 0 };
-    let reserved: Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Refused | null = null;
-    try { reserved = parseReservation(await dependencies.ledger.reserveAndConsume(grant), grant.grantDigest); } catch { /* fail closed */ }
-    if (!reserved) return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: 0, providerInvocations: 0 };
-    if (reserved.status === 'refused') return { status: 'refused', reason: reserved.reason as FixedTraceComponentSmokeLedgerRefusal, assignmentDispositions: 0, providerInvocations: 0 };
-    const reservation = reserved.reservation;
-
-    const finished = new Set<string>();
-    // recordUnknownExposure atomically assigns a terminal denominator outcome
-    // to every started assignment while it closes open intents. Keep that
-    // exact set locally so post-halt omission writes address only unstarted
-    // assignments.
-    const started = new Set<string>();
-    let invocations = 0;
-    const haltRemainder = async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
-      for (const entry of plan) {
-        if (finished.has(entry.assignmentId)) continue;
-        let closed: Recorded | Refused | null = null;
-        try { closed = parseRecorded(await dependencies.ledger.recordNotExecutedAfterHalt({ reservation, assignmentId: entry.assignmentId })); } catch { /* fail closed */ }
-        if (!closed || closed.status !== 'recorded') return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: finished.size, providerInvocations: invocations };
-        finished.add(entry.assignmentId);
+/**
+ * Pure deterministic simulation only. It records no intent, HMAC, receipt,
+ * grant, or provider action; production code cannot use it to authorize or
+ * dispatch a model call.
+ */
+export function simulateFixedTraceComponentSmokePrivateRuntime(
+  script?: FixedTraceComponentSmokePrivateSimulationScript,
+): FixedTraceComponentSmokePrivateRuntimeResult {
+  const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+  const responses = scriptResponses(script, plan);
+  if (!responses) return Object.freeze({ status: 'refused', reason: 'invalid_simulation_script', assignmentDispositions: 0, providerInvocations: 0 });
+  let invocations = 0;
+  for (const entry of plan) {
+    if (entry.disposition !== 'provider_dispatch') continue;
+    for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
+      const receipt = responses.get(`${entry.assignmentId}:${ordinal}`) ?? defaultReceipt(entry, ordinal);
+      invocations += 1;
+      if (receipt.identity.provider !== entry.provider || receipt.identity.model !== entry.model || receipt.identity.effort !== entry.effort
+        || receipt.status !== 'succeeded'
+        || (receipt.disposition === 'tool_continuation_required' && ordinal === entry.maximumProviderInvocations)) {
+        return Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
       }
-      return { status: 'halted', assignmentDispositions: finished.size, providerInvocations: invocations };
-    };
-    const forceUnknownAndHalt = async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
-      let poisoned: Recorded | Refused | null = null;
-      try { poisoned = parseRecorded(await dependencies.ledger.recordUnknownExposure(reservation!)); } catch { /* fail closed */ }
-      if (!poisoned || poisoned.status !== 'recorded') return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: finished.size, providerInvocations: invocations };
-      for (const assignmentId of started) finished.add(assignmentId);
-      return haltRemainder();
-    };
-
-    for (const entry of plan) {
-      if (entry.disposition !== 'provider_dispatch') {
-        let recorded: Recorded | Refused | null = null;
-        try { recorded = parseRecorded(await dependencies.ledger.recordNonDispatchTerminal({ reservation, assignmentId: entry.assignmentId, status: entry.disposition })); } catch { /* fail closed */ }
-        if (!recorded || recorded.status !== 'recorded') return forceUnknownAndHalt();
-        finished.add(entry.assignmentId);
-        continue;
-      }
-      for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
-        const request = Object.freeze({ assignmentId: entry.assignmentId, probeId: entry.probeId, cellId: entry.cellId,
-          provider: entry.provider, model: entry.model, effort: entry.effort, invocationOrdinal: ordinal,
-          maxInputTokens: entry.maxInputTokens, maxOutputTokens: entry.maxOutputTokens, timeoutMs: entry.timeoutMs,
-          sdkAutomaticRetries: 0 as const });
-        let preparedRequestHmac: string;
-        try { preparedRequestHmac = hmac(evidenceHmacKey, FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN, request); } catch { return forceUnknownAndHalt(); }
-        const attemptId = digestAttempt(reservation, entry, ordinal);
-        let intended: Recorded | Refused | null = null;
-        try { intended = parseRecorded(await dependencies.ledger.recordProviderIntent({ reservation, attemptId, assignmentId: entry.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac })); } catch { /* fail closed */ }
-        if (!intended || intended.status !== 'recorded') return forceUnknownAndHalt();
-        started.add(entry.assignmentId);
-
-        let rawResponse: unknown;
-        let thrown = false;
-        try { rawResponse = await dependencies.fakeProvider.invoke(request); invocations += 1; } catch { invocations += 1; thrown = true; }
-        const receipt = thrown ? null : providerReceipt(rawResponse);
-        let responseHmac: string | null = null;
-        // Bind the exact fake-provider response to its one committed intent;
-        // identical output on two assignments is still distinct evidence.
-        if (!thrown) try { responseHmac = hmac(evidenceHmacKey, FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN, { attemptId, response: rawResponse }); } catch { return forceUnknownAndHalt(); }
-        const identityMatches = receipt?.identity?.provider === entry.provider && receipt.identity.model === entry.model && receipt.identity.effort === entry.effort;
-        const terminal = thrown
-          ? { reservation, attemptId, status: 'timeout_after_dispatch' as const, responseDisposition: null, usage: null, returnedIdentity: null, responseHmac: null }
-          : !receipt!.identity || !receipt!.usage || !receipt!.disposition || !receipt!.status
-            ? receipt!.identity && receipt!.status ? { reservation, attemptId, status: 'missing_usage' as const, responseDisposition: null, usage: null, returnedIdentity: receipt!.identity, responseHmac }
-              : { reservation, attemptId, status: 'malformed_response' as const, responseDisposition: null, usage: null, returnedIdentity: null, responseHmac }
-            : !identityMatches
-              ? { reservation, attemptId, status: 'identity_mismatch' as const, responseDisposition: null, usage: receipt!.usage, returnedIdentity: receipt!.identity, responseHmac }
-              : { reservation, attemptId, status: receipt!.status, responseDisposition: receipt!.status === 'succeeded' ? receipt!.disposition : null, usage: receipt!.usage, returnedIdentity: receipt!.identity, responseHmac };
-        let settled: Recorded | Refused | null = null;
-        try { settled = parseRecorded(await dependencies.ledger.recordTerminal(terminal)); } catch { /* unresolved intent: fail closed */ }
-        if (!settled || settled.status !== 'recorded') return forceUnknownAndHalt();
-        // The ledger independently enforces this too, but the composition
-        // boundary must never advance after a continuation has exhausted the
-        // frozen assignment's final ordinal.
-        if (terminal.status === 'succeeded' && terminal.responseDisposition === 'tool_continuation_required'
-          && ordinal === entry.maximumProviderInvocations) return forceUnknownAndHalt();
-        if (terminal.status !== 'succeeded' || terminal.responseDisposition === 'final_response') {
-          let assignment: Recorded | Refused | null = null;
-          try { assignment = parseRecorded(await dependencies.ledger.recordProviderAssignmentTerminal({ reservation, assignmentId: entry.assignmentId, status: terminal.status === 'succeeded' ? 'provider_completed' : 'provider_failed', finalInvocationOrdinal: ordinal })); } catch { /* fail closed */ }
-          if (!assignment || assignment.status !== 'recorded') return forceUnknownAndHalt();
-          finished.add(entry.assignmentId);
-          started.delete(entry.assignmentId);
-          if (terminal.status !== 'succeeded') return haltRemainder();
-          break;
-        }
-      }
+      if (receipt.disposition === 'final_response') break;
     }
-    return finished.size === 168 && invocations <= 192
-      ? { status: 'completed', assignmentDispositions: 168, providerInvocations: invocations }
-      : forceUnknownAndHalt();
-  } });
+  }
+  return invocations === 192
+    ? Object.freeze({ status: 'completed', assignmentDispositions: 168, providerInvocations: invocations })
+    : Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
@@ -1,0 +1,269 @@
+import { createHash, createHmac } from 'node:crypto';
+import {
+  createFixedTraceComponentSmokeOneShotGrantVerifier,
+  type FixedTraceComponentSmokeOneShotTrustRoot,
+} from './fixed-trace-component-smoke-private-authorization.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN,
+  FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN,
+  fixedTraceComponentSmokePrivateLedgerPlan,
+  type FixedTraceComponentSmokeLedgerRefusal,
+  type FixedTraceComponentSmokeReservation,
+} from './fixed-trace-component-smoke-private-ledger.js';
+import { snapshotFixedTraceJson } from './fixed-trace-safe-snapshot.js';
+
+/**
+ * This is a deliberately private composition boundary. It has no route, job,
+ * scheduler, environment, SDK, or provider construction import. A caller can
+ * supply a signed grant and explicit, already-controlled dependencies, but
+ * cannot supply a plan, cell, identity, limit, schedule, or retry policy.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_RUNTIME_DEFAULT_OFF = true as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_RUNTIME_FAKE_ONLY = true as const;
+
+type Plan = NonNullable<ReturnType<typeof fixedTraceComponentSmokePrivateLedgerPlan>>;
+type PlanEntry = Plan[number];
+type Usage = Readonly<{ inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; latencyMs: number }>;
+type Identity = Readonly<{ provider: string; model: string; effort: string }>;
+
+export interface FixedTraceComponentSmokeFakeProviderRequest {
+  readonly assignmentId: string;
+  readonly probeId: string;
+  readonly cellId: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly invocationOrdinal: number;
+  readonly maxInputTokens: number;
+  readonly maxOutputTokens: number;
+  readonly timeoutMs: number;
+  readonly sdkAutomaticRetries: 0;
+}
+
+/** A test double is the only adapter shape admitted by this runtime. */
+export interface FixedTraceComponentSmokeFakeProvider {
+  readonly fakeOnly: true;
+  readonly automaticRetries: 0;
+  invoke(request: Readonly<FixedTraceComponentSmokeFakeProviderRequest>): Promise<unknown>;
+}
+
+/** The runtime only receives operations, never a Pool or ambient DB client. */
+export interface FixedTraceComponentSmokePrivateRuntimeLedger {
+  reserveAndConsume(grant: object): Promise<unknown>;
+  recordProviderIntent(input: object): Promise<unknown>;
+  recordTerminal(input: object): Promise<unknown>;
+  recordProviderAssignmentTerminal(input: object): Promise<unknown>;
+  recordNonDispatchTerminal(input: object): Promise<unknown>;
+  recordNotExecutedAfterHalt(input: object): Promise<unknown>;
+  recordUnknownExposure(reservation: FixedTraceComponentSmokeReservation): Promise<unknown>;
+}
+
+export interface FixedTraceComponentSmokePrivateRuntimeDependencies {
+  readonly trustRoot: FixedTraceComponentSmokeOneShotTrustRoot;
+  readonly trustRootPin: string;
+  /** The opaque signed envelope is verified only when run starts. */
+  readonly signedGrant: unknown;
+  /** Copied at construction and used only for domain-separated evidence HMACs. */
+  readonly evidenceHmacKey: Buffer;
+  readonly trustedNow: () => Date;
+  readonly ledger: FixedTraceComponentSmokePrivateRuntimeLedger;
+  readonly fakeProvider: FixedTraceComponentSmokeFakeProvider;
+}
+
+export type FixedTraceComponentSmokePrivateRuntimeResult = Readonly<{
+  status: 'completed' | 'halted' | 'refused';
+  reason?: FixedTraceComponentSmokeLedgerRefusal | 'invalid_grant' | 'private_composition_invalid' | 'persistence_uncertain';
+  assignmentDispositions: number;
+  providerInvocations: number;
+}>;
+
+type Recorded = Readonly<{ status: 'recorded' }>;
+type Refused = Readonly<{ status: 'refused'; reason: string }>;
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new Error('evidence JSON permits only safe integers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
+  }
+  throw new Error('non-JSON evidence value');
+}
+function digestAttempt(reservation: FixedTraceComponentSmokeReservation, entry: PlanEntry, ordinal: number): string {
+  return `attempt_${createHash('sha256').update(canonicalJson({
+    domain: 'adcp:addie:fixed-trace-component-smoke:private-runtime-attempt:v1\0', reservationId: reservation.reservationId,
+    assignmentId: entry.assignmentId, invocationOrdinal: ordinal,
+  }), 'utf8').digest('hex').slice(0, 32)}`;
+}
+function hmac(key: Buffer, domain: string, value: unknown): string {
+  return createHmac('sha256', key).update(domain, 'utf8').update(canonicalJson(snapshotFixedTraceJson(value, 'private runtime evidence')), 'utf8').digest('hex');
+}
+function exactKeys(value: object, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
+}
+function safeUsage(value: unknown): Usage | null {
+  if (!value || typeof value !== 'object' || !exactKeys(value, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])) return null;
+  const usage = value as Record<string, unknown>;
+  return Object.values(usage).every((part) => Number.isSafeInteger(part) && (part as number) >= 0 && (part as number) <= 1_000_000)
+    ? Object.freeze(usage) as Usage : null;
+}
+function safeIdentity(value: unknown): Identity | null {
+  if (!value || typeof value !== 'object' || !exactKeys(value, ['effort', 'model', 'provider'])) return null;
+  const identity = value as Record<string, unknown>;
+  return [identity.provider, identity.model, identity.effort].every((part) => typeof part === 'string' && part.length > 0 && part.length <= 128 && /^[a-z0-9._:-]+$/i.test(part))
+    ? Object.freeze(identity) as Identity : null;
+}
+function parseRecorded(value: unknown): Recorded | Refused | null {
+  try {
+    const result = snapshotFixedTraceJson(value, 'private runtime ledger result') as Record<string, unknown>;
+    if (exactKeys(result, ['status']) && result.status === 'recorded') return Object.freeze({ status: 'recorded' });
+    if (exactKeys(result, ['reason', 'status']) && result.status === 'refused' && typeof result.reason === 'string') return Object.freeze({ status: 'refused', reason: result.reason });
+  } catch { /* fail closed */ }
+  return null;
+}
+function parseReservation(value: unknown, authorizationDigest: string): Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Refused | null {
+  try {
+    const result = snapshotFixedTraceJson(value, 'private runtime reservation result') as Record<string, unknown>;
+    if (exactKeys(result, ['reason', 'status']) && result.status === 'refused' && typeof result.reason === 'string') return Object.freeze({ status: 'refused', reason: result.reason });
+    if (!exactKeys(result, ['reservation', 'status']) || result.status !== 'reserved' || !result.reservation || typeof result.reservation !== 'object') return null;
+    const reservation = result.reservation as Record<string, unknown>;
+    const expectedReservationId = `reservation_${createHash('sha256').update(canonicalJson({
+      domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0', authorizationDigest,
+    }), 'utf8').digest('hex').slice(0, 32)}`;
+    return exactKeys(reservation, ['authorizationDigest', 'entryCount', 'providerDispatchEntryCount', 'reservationId', 'reservationMicrodollars'])
+      && typeof reservation.authorizationDigest === 'string' && /^[a-f0-9]{64}$/.test(reservation.authorizationDigest)
+      && typeof reservation.reservationId === 'string' && /^reservation_[a-f0-9]{32}$/.test(reservation.reservationId)
+      && reservation.authorizationDigest === authorizationDigest && reservation.reservationId === expectedReservationId
+      && reservation.entryCount === 168 && reservation.providerDispatchEntryCount === 126 && reservation.reservationMicrodollars === 2_819_484
+      ? Object.freeze({ status: 'reserved' as const, reservation: Object.freeze(reservation) as unknown as FixedTraceComponentSmokeReservation }) : null;
+  } catch { return null; }
+}
+function providerReceipt(value: unknown): { usage: Usage | null; identity: Identity | null; disposition: 'final_response' | 'tool_continuation_required' | null; status: 'succeeded' | 'provider_failed' | null; structurallyValid: boolean } {
+  try {
+    const receipt = snapshotFixedTraceJson(value, 'fake provider receipt') as Record<string, unknown>;
+    if (!exactKeys(receipt, ['disposition', 'identity', 'status', 'usage'])) return { usage: null, identity: null, disposition: null, status: null, structurallyValid: false };
+    const usage = safeUsage(receipt.usage); const identity = safeIdentity(receipt.identity);
+    const disposition = receipt.disposition === 'final_response' || receipt.disposition === 'tool_continuation_required' ? receipt.disposition : null;
+    const status = receipt.status === 'succeeded' || receipt.status === 'provider_failed' ? receipt.status : null;
+    return { usage, identity, disposition, status, structurallyValid: usage !== null && identity !== null && disposition !== null && status !== null };
+  } catch { return { usage: null, identity: null, disposition: null, status: null, structurallyValid: false }; }
+}
+
+/**
+ * The returned object has no arguments: no production entry point can feed it
+ * a mutable execution request. The only dispatch capability is this explicit,
+ * fake-only dependency graph.
+ */
+export function createFixedTraceComponentSmokePrivateRuntime(
+  dependencies: FixedTraceComponentSmokePrivateRuntimeDependencies,
+): Readonly<{ run(): Promise<FixedTraceComponentSmokePrivateRuntimeResult> }> | null {
+  const plan = fixedTraceComponentSmokePrivateLedgerPlan();
+  const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(dependencies.trustRoot, dependencies.trustRootPin);
+  if (!plan || !verifier || !Buffer.isBuffer(dependencies.evidenceHmacKey) || dependencies.evidenceHmacKey.length < 16
+    || typeof dependencies.trustedNow !== 'function' || !dependencies.ledger || dependencies.fakeProvider?.fakeOnly !== true
+    || dependencies.fakeProvider.automaticRetries !== 0 || typeof dependencies.fakeProvider.invoke !== 'function') return null;
+  const evidenceHmacKey = Buffer.from(dependencies.evidenceHmacKey);
+
+  return Object.freeze({ run: async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
+    let now: Date;
+    try { now = dependencies.trustedNow(); } catch { return { status: 'refused', reason: 'private_composition_invalid', assignmentDispositions: 0, providerInvocations: 0 }; }
+    const grant = verifier.verify(dependencies.signedGrant, now);
+    if (!grant) return { status: 'refused', reason: 'invalid_grant', assignmentDispositions: 0, providerInvocations: 0 };
+    let reserved: Readonly<{ status: 'reserved'; reservation: FixedTraceComponentSmokeReservation }> | Refused | null = null;
+    try { reserved = parseReservation(await dependencies.ledger.reserveAndConsume(grant), grant.grantDigest); } catch { /* fail closed */ }
+    if (!reserved) return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: 0, providerInvocations: 0 };
+    if (reserved.status === 'refused') return { status: 'refused', reason: reserved.reason as FixedTraceComponentSmokeLedgerRefusal, assignmentDispositions: 0, providerInvocations: 0 };
+    const reservation = reserved.reservation;
+
+    const finished = new Set<string>();
+    // recordUnknownExposure atomically assigns a terminal denominator outcome
+    // to every started assignment while it closes open intents. Keep that
+    // exact set locally so post-halt omission writes address only unstarted
+    // assignments.
+    const started = new Set<string>();
+    let invocations = 0;
+    const haltRemainder = async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
+      for (const entry of plan) {
+        if (finished.has(entry.assignmentId)) continue;
+        let closed: Recorded | Refused | null = null;
+        try { closed = parseRecorded(await dependencies.ledger.recordNotExecutedAfterHalt({ reservation, assignmentId: entry.assignmentId })); } catch { /* fail closed */ }
+        if (!closed || closed.status !== 'recorded') return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: finished.size, providerInvocations: invocations };
+        finished.add(entry.assignmentId);
+      }
+      return { status: 'halted', assignmentDispositions: finished.size, providerInvocations: invocations };
+    };
+    const forceUnknownAndHalt = async (): Promise<FixedTraceComponentSmokePrivateRuntimeResult> => {
+      let poisoned: Recorded | Refused | null = null;
+      try { poisoned = parseRecorded(await dependencies.ledger.recordUnknownExposure(reservation!)); } catch { /* fail closed */ }
+      if (!poisoned || poisoned.status !== 'recorded') return { status: 'refused', reason: 'persistence_uncertain', assignmentDispositions: finished.size, providerInvocations: invocations };
+      for (const assignmentId of started) finished.add(assignmentId);
+      return haltRemainder();
+    };
+
+    for (const entry of plan) {
+      if (entry.disposition !== 'provider_dispatch') {
+        let recorded: Recorded | Refused | null = null;
+        try { recorded = parseRecorded(await dependencies.ledger.recordNonDispatchTerminal({ reservation, assignmentId: entry.assignmentId, status: entry.disposition })); } catch { /* fail closed */ }
+        if (!recorded || recorded.status !== 'recorded') return forceUnknownAndHalt();
+        finished.add(entry.assignmentId);
+        continue;
+      }
+      for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
+        const request = Object.freeze({ assignmentId: entry.assignmentId, probeId: entry.probeId, cellId: entry.cellId,
+          provider: entry.provider, model: entry.model, effort: entry.effort, invocationOrdinal: ordinal,
+          maxInputTokens: entry.maxInputTokens, maxOutputTokens: entry.maxOutputTokens, timeoutMs: entry.timeoutMs,
+          sdkAutomaticRetries: 0 as const });
+        let preparedRequestHmac: string;
+        try { preparedRequestHmac = hmac(evidenceHmacKey, FIXED_TRACE_COMPONENT_SMOKE_PREPARED_REQUEST_HMAC_DOMAIN, request); } catch { return forceUnknownAndHalt(); }
+        const attemptId = digestAttempt(reservation, entry, ordinal);
+        let intended: Recorded | Refused | null = null;
+        try { intended = parseRecorded(await dependencies.ledger.recordProviderIntent({ reservation, attemptId, assignmentId: entry.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac })); } catch { /* fail closed */ }
+        if (!intended || intended.status !== 'recorded') return forceUnknownAndHalt();
+        started.add(entry.assignmentId);
+
+        let rawResponse: unknown;
+        let thrown = false;
+        try { rawResponse = await dependencies.fakeProvider.invoke(request); invocations += 1; } catch { invocations += 1; thrown = true; }
+        const receipt = thrown ? null : providerReceipt(rawResponse);
+        let responseHmac: string | null = null;
+        // Bind the exact fake-provider response to its one committed intent;
+        // identical output on two assignments is still distinct evidence.
+        if (!thrown) try { responseHmac = hmac(evidenceHmacKey, FIXED_TRACE_COMPONENT_SMOKE_RESPONSE_HMAC_DOMAIN, { attemptId, response: rawResponse }); } catch { return forceUnknownAndHalt(); }
+        const identityMatches = receipt?.identity?.provider === entry.provider && receipt.identity.model === entry.model && receipt.identity.effort === entry.effort;
+        const terminal = thrown
+          ? { reservation, attemptId, status: 'timeout_after_dispatch' as const, responseDisposition: null, usage: null, returnedIdentity: null, responseHmac: null }
+          : !receipt!.identity || !receipt!.usage || !receipt!.disposition || !receipt!.status
+            ? receipt!.identity && receipt!.status ? { reservation, attemptId, status: 'missing_usage' as const, responseDisposition: null, usage: null, returnedIdentity: receipt!.identity, responseHmac }
+              : { reservation, attemptId, status: 'malformed_response' as const, responseDisposition: null, usage: null, returnedIdentity: null, responseHmac }
+            : !identityMatches
+              ? { reservation, attemptId, status: 'identity_mismatch' as const, responseDisposition: null, usage: receipt!.usage, returnedIdentity: receipt!.identity, responseHmac }
+              : { reservation, attemptId, status: receipt!.status, responseDisposition: receipt!.status === 'succeeded' ? receipt!.disposition : null, usage: receipt!.usage, returnedIdentity: receipt!.identity, responseHmac };
+        let settled: Recorded | Refused | null = null;
+        try { settled = parseRecorded(await dependencies.ledger.recordTerminal(terminal)); } catch { /* unresolved intent: fail closed */ }
+        if (!settled || settled.status !== 'recorded') return forceUnknownAndHalt();
+        // The ledger independently enforces this too, but the composition
+        // boundary must never advance after a continuation has exhausted the
+        // frozen assignment's final ordinal.
+        if (terminal.status === 'succeeded' && terminal.responseDisposition === 'tool_continuation_required'
+          && ordinal === entry.maximumProviderInvocations) return forceUnknownAndHalt();
+        if (terminal.status !== 'succeeded' || terminal.responseDisposition === 'final_response') {
+          let assignment: Recorded | Refused | null = null;
+          try { assignment = parseRecorded(await dependencies.ledger.recordProviderAssignmentTerminal({ reservation, assignmentId: entry.assignmentId, status: terminal.status === 'succeeded' ? 'provider_completed' : 'provider_failed', finalInvocationOrdinal: ordinal })); } catch { /* fail closed */ }
+          if (!assignment || assignment.status !== 'recorded') return forceUnknownAndHalt();
+          finished.add(entry.assignmentId);
+          started.delete(entry.assignmentId);
+          if (terminal.status !== 'succeeded') return haltRemainder();
+          break;
+        }
+      }
+    }
+    return finished.size === 168 && invocations <= 192
+      ? { status: 'completed', assignmentDispositions: 168, providerInvocations: invocations }
+      : forceUnknownAndHalt();
+  } });
+}

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-runtime.ts
@@ -1,4 +1,8 @@
 import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityCostMicros,
+  fixedTraceComponentSmokePrivateAuthorityHasAdditiveCache,
+  fixedTraceComponentSmokePrivateAuthorityIdentityMatches,
   fixedTraceComponentSmokePrivateAuthorityPlan,
   type FixedTraceComponentSmokePrivateAuthorityPlanEntry,
 } from './fixed-trace-component-smoke-private-authority.js';
@@ -100,20 +104,41 @@ export function simulateFixedTraceComponentSmokePrivateRuntime(
   const responses = scriptResponses(script, plan);
   if (!responses) return Object.freeze({ status: 'refused', reason: 'invalid_simulation_script', assignmentDispositions: 0, providerInvocations: 0 });
   let invocations = 0;
+  let spentMicrodollars = 0;
   for (const entry of plan) {
     if (entry.disposition !== 'provider_dispatch') continue;
     for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
       const receipt = responses.get(`${entry.assignmentId}:${ordinal}`) ?? defaultReceipt(entry, ordinal);
       invocations += 1;
       if (receipt.identity.provider !== entry.provider || receipt.identity.model !== entry.model || receipt.identity.effort !== entry.effort
+        || !fixedTraceComponentSmokePrivateAuthorityIdentityMatches(entry.pricingProfileId, receipt.identity)
         || receipt.status !== 'succeeded'
         || (receipt.disposition === 'tool_continuation_required' && ordinal === entry.maximumProviderInvocations)) {
         return Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
       }
+      let costMicrodollars: number;
+      try {
+        const additiveCacheOverLimit = fixedTraceComponentSmokePrivateAuthorityHasAdditiveCache(entry.pricingProfileId)
+          && (receipt.usage.cacheReadTokens > entry.maxInputTokens || receipt.usage.cacheWriteTokens > entry.maxInputTokens);
+        if (receipt.usage.inputTokens > entry.maxInputTokens || additiveCacheOverLimit
+          || receipt.usage.outputTokens > entry.maxOutputTokens || receipt.usage.latencyMs > entry.timeoutMs) {
+          return Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
+        }
+        costMicrodollars = fixedTraceComponentSmokePrivateAuthorityCostMicros(entry.pricingProfileId, receipt.usage);
+      } catch {
+        return Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
+      }
+      const reservedForOrdinal = entry.reservedMicrodollars[ordinal - 1];
+      if (reservedForOrdinal === undefined || costMicrodollars > reservedForOrdinal
+        || spentMicrodollars + costMicrodollars > FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars
+        || spentMicrodollars + costMicrodollars > FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars) {
+        return Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
+      }
+      spentMicrodollars += costMicrodollars;
       if (receipt.disposition === 'final_response') break;
     }
   }
-  return invocations === 192
+  return invocations <= FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality.maximumProviderInvocations
     ? Object.freeze({ status: 'completed', assignmentDispositions: 168, providerInvocations: invocations })
     : Object.freeze({ status: 'halted', assignmentDispositions: 168, providerInvocations: invocations });
 }

--- a/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
+++ b/server/tests/integration/addie/fixed-trace-component-smoke-private-ledger-migration.test.ts
@@ -177,6 +177,34 @@ describe.skipIf(!databaseUrl)('private ledger migration on PostgreSQL', () => {
     }
   });
 
+  it('atomically terminalizes all 168 assignments when a committed intent acknowledgement is lost', async () => {
+    const entry = dispatchEntry(12);
+    const attemptId = uniqueAttemptId();
+    await client!.query('COMMIT');
+    const pool = new Pool({ connectionString: databaseUrl });
+    try {
+      const ledger = new PostgresFixedTraceComponentSmokePrivateLedger(pool);
+      // The durable write succeeds, but the caller deliberately discards its
+      // acknowledgement as though the response was lost before dispatch.
+      expect(await ledger.recordProviderIntent({ reservation: reservationFor(authorizationDigest), attemptId, assignmentId: entry.assignmentId, invocationOrdinal: 1, preparedRequestHmac: 'c'.repeat(64) })).toEqual({ status: 'recorded' });
+      expect(await ledger.recordUnknownExposure(reservationFor(authorizationDigest))).toEqual({ status: 'recorded' });
+      expect((await client!.query(
+        `SELECT assignment_outcome, count(*)::int AS count
+           FROM addie_fixed_trace_component_smoke_run_plan
+          WHERE authorization_digest = $1 GROUP BY assignment_outcome ORDER BY assignment_outcome`,
+        [authorizationDigest],
+      )).rows).toEqual([
+        { assignment_outcome: 'not_executed_after_halt', count: 167 },
+        { assignment_outcome: 'provider_unknown_exposure', count: 1 },
+      ]);
+      expect((await client!.query(
+        'SELECT count(*)::int AS count FROM addie_fixed_trace_component_smoke_run_plan WHERE authorization_digest = $1 AND assignment_outcome IS NULL',
+        [authorizationDigest],
+      )).rows).toEqual([{ count: 0 }]);
+      expect((await client!.query('SELECT status FROM addie_fixed_trace_component_smoke_authorizations WHERE authorization_digest = $1', [authorizationDigest])).rows).toEqual([{ status: 'unknown_exposure' }]);
+    } finally { await pool.end(); await client!.query('BEGIN'); }
+  });
+
   it('uses target-plan then authorization order against a direct outcome writer', async () => {
     const entry = dispatchEntry(15);
     const attemptId = uniqueAttemptId();

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -5,8 +5,9 @@ import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '../../../src/addi
 import {
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
-  createFixedTraceComponentSmokeOneShotGrantVerifier,
+  fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger,
   fixedTraceComponentSmokeSignedGrantBytes,
+  isFixedTraceComponentSmokeVerifiedGrant,
   verifyFixedTraceComponentSmokeSignedGrant,
   verifyFixedTraceComponentSmokeSignedGrantForTest,
   type FixedTraceComponentSmokeSignedGrantPayload,
@@ -19,11 +20,6 @@ import {
 const NOW = new Date('2026-09-06T12:00:00.000Z');
 const keys = generateKeyPairSync('ed25519');
 const TEST_KID = 'component-smoke-test-ed25519-2026';
-const trustRoot = Object.freeze({
-  kid: TEST_KID,
-  spki: (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url'),
-});
-const trustRootPin = createHash('sha256').update(JSON.stringify(trustRoot), 'utf8').digest('hex');
 
 function payload(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}): FixedTraceComponentSmokeSignedGrantPayload {
   return {
@@ -96,6 +92,15 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(source).not.toContain('fetch(');
     expect(source).not.toContain('createPrivateKey');
     expect(source).not.toContain('generateKeyPair');
+    expect(source).not.toContain('createFixedTraceComponentSmokeOneShotGrantVerifier');
+    expect(source).not.toContain('WeakMap');
+  });
+
+  it('keeps test crypto verification data-only and unable to authorize the ledger', () => {
+    const checked = verify(grant());
+    expect(checked).toMatchObject({ valid: true });
+    expect(isFixedTraceComponentSmokeVerifiedGrant(checked)).toBe(false);
+    expect(fixedTraceComponentSmokeVerifiedGrantSignatureDigestForLedger(checked)).toBeNull();
   });
 
   it.each([
@@ -152,45 +157,13 @@ describe('fixed-trace component smoke private signed authorization', () => {
     expect(source).not.toContain('output:');
   });
 
-  it('requires independently supplied exact root and pin before minting a ledger capability', async () => {
-    const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(
-      Object.freeze({ spki: trustRoot.spki, kid: trustRoot.kid }),
-      trustRootPin,
-    );
-    expect(verifier).not.toBeNull();
-    const signed = grant();
-    const checked = verifier?.verify(signed, NOW);
-    const replayed = verifier?.verify(signed, NOW);
-    expect(checked).not.toBeNull();
-    expect(replayed).not.toBeNull();
-    const client = new FakeLedgerClient();
-    const subject = new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never);
-    await expect(subject.reserveAndConsume(checked!)).resolves.toMatchObject({ status: 'reserved' });
-    expect(client.calls.filter(({ sql }) => sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_run_plan'))).toHaveLength(168);
-    await expect(subject.reserveAndConsume(replayed!)).resolves.toEqual({ status: 'refused', reason: 'grant_already_consumed' });
-  });
-
-  it('rejects missing, malformed, mismatched, and structural-lookalike root or pin inputs before verification', () => {
-    const other = generateKeyPairSync('ed25519');
-    const otherRoot = { kid: TEST_KID, spki: (other.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url') };
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(undefined, trustRootPin)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, undefined)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, trustRootPin.toUpperCase())).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(otherRoot, trustRootPin)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ kid: TEST_KID, spki: 'not-a-der' }, trustRootPin)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ ...trustRoot, extra: true }, trustRootPin)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier({ verify: () => grant() }, trustRootPin)).toBeNull();
-    expect(createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, { digest: trustRootPin })).toBeNull();
-  });
-
   it.each([
     ['wrong kid', grant(payload({ kid: 'wrong-kid' }))],
     ['wrong signature', grant(payload(), Buffer.alloc(64))],
     ['missing signature', { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload: payload() }],
     ['expired grant', grant(payload({ expiresAt: '2026-09-06T12:00:00.000Z' }))],
   ])('rejects %s before it can mint a capability', (_name, candidate) => {
-    const verifier = createFixedTraceComponentSmokeOneShotGrantVerifier(trustRoot, trustRootPin);
-    expect(verifier?.verify(candidate, NOW)).toBeNull();
+    expect(verify(candidate)).toBeNull();
   });
 
   it('rejects a wrong or cross-reservation envelope before it can mutate a ledger', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -56,7 +56,7 @@ class FakeLedgerClient {
   private readonly authorizations = new Map<string, string>();
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
-    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
+    if (sql === 'BEGIN' || sql === "SET LOCAL lock_timeout = '250ms'" || sql === "SET LOCAL statement_timeout = '1000ms'" || sql === 'COMMIT' || sql === 'ROLLBACK') return { rowCount: 0, rows: [] };
     if (sql.startsWith('INSERT INTO addie_fixed_trace_component_smoke_authorizations')) {
       const digest = params?.[0] as string;
       if (this.authorizations.has(digest)) return { rowCount: 0, rows: [] };

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-authorization.test.ts
@@ -1,7 +1,7 @@
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 import {
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
@@ -26,16 +26,15 @@ const trustRoot = Object.freeze({
 const trustRootPin = createHash('sha256').update(JSON.stringify(trustRoot), 'utf8').digest('hex');
 
 function payload(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}): FixedTraceComponentSmokeSignedGrantPayload {
-  const admission = fixedTraceComponentSmokeAdmission();
-  if (!admission.pricing.cohortDigest || admission.pricing.reservationMicrodollars === null) throw new Error('expected pinned pricing');
   return {
     grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: TEST_KID,
     issuedAt: '2026-09-06T11:55:00.000Z', expiresAt: '2026-09-06T12:05:00.000Z',
-    stageId: 'stage_1_smoke', admissionVersion: admission.version,
-    aggregateAdmissionFingerprint: admission.fingerprints.aggregateAdmission,
-    cardinality: admission.cardinality, reservationMicrodollars: admission.pricing.reservationMicrodollars,
-    providerCeilingMicrodollars: admission.pricing.providerCeilingUsd * 1_000_000,
-    pricingCohortDigest: admission.pricing.cohortDigest,
+    stageId: 'stage_1_smoke', admissionVersion: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion,
+    aggregateAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint,
+    cardinality: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality,
+    reservationMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars,
+    providerCeilingMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars,
+    pricingCohortDigest: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.pricingCohortDigest,
     nonceCommitment: 'a'.repeat(64), ...overrides,
   };
 }

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -39,7 +39,7 @@ class StrictLedgerClient {
   }
   async query(sql: string, params?: unknown[]) {
     this.calls.push({ sql, params });
-    if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK'
+    if (sql === 'BEGIN' || sql === "SET LOCAL lock_timeout = '250ms'" || sql === "SET LOCAL statement_timeout = '1000ms'" || sql === 'COMMIT' || sql === 'ROLLBACK'
       || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN SHARE ROW EXCLUSIVE MODE'
       || sql === 'LOCK TABLE addie_fixed_trace_component_smoke_run_plan IN ROW EXCLUSIVE MODE') return { rowCount: 0, rows: [] };
     if (sql.startsWith('SELECT attempt_id FROM addie_fixed_trace_component_smoke_attempts')
@@ -125,6 +125,22 @@ function terminal(overrides: Record<string, unknown> = {}) {
 function ledger(client: StrictLedgerClient) { return new PostgresFixedTraceComponentSmokePrivateLedger({ connect: async () => client } as never); }
 
 describe('private ledger state machine', () => {
+  it('sets bounded DB-only local timeouts immediately after BEGIN and fails closed before ledger work on timeout', async () => {
+    const client = new StrictLedgerClient();
+    const originalQuery = client.query.bind(client);
+    client.query = async (sql: string, params?: unknown[]) => {
+      if (sql === "SET LOCAL statement_timeout = '1000ms'") {
+        client.calls.push({ sql, params });
+        throw new Error('statement timeout');
+      }
+      return originalQuery(sql, params);
+    };
+    expect(await ledger(client).recordProviderIntent(intent())).toEqual({ status: 'refused', reason: 'persistence_uncertain' });
+    expect(client.calls.map(({ sql }) => sql)).toEqual([
+      'BEGIN', "SET LOCAL lock_timeout = '250ms'", "SET LOCAL statement_timeout = '1000ms'", 'ROLLBACK',
+    ]);
+  });
+
   it('records a provider intent and terminal using realistic pg int8 and int8[] strings', async () => {
     const client = new StrictLedgerClient();
     expect(await ledger(client).recordProviderIntent(intent())).toEqual({ status: 'recorded' });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -25,6 +25,7 @@ class StrictLedgerClient {
   readonly calls: Array<{ sql: string; params: unknown[] | undefined }> = [];
   readonly attempts = new Map<string, StoredAttempt>();
   readonly assignmentOutcomes = new Map<string, string>();
+  recoveryClosedRemainder = false;
   authStatus = 'consumed';
   priorSpend: string | null = null;
   constructor(private readonly entry: FixedTraceComponentSmokePlanEntry = dispatch) {}
@@ -52,6 +53,10 @@ class StrictLedgerClient {
       return attempt ? { rowCount: 1, rows: [{ status: attempt.status, response_disposition: attempt.responseDisposition }] } : { rowCount: 0, rows: [] };
     }
     if (sql.includes('FROM addie_fixed_trace_component_smoke_run_plan') && sql.includes('FOR UPDATE') && !sql.includes('FROM addie_fixed_trace_component_smoke_attempts a')) return { rowCount: 1, rows: [this.planRow()] };
+    if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_run_plan AS p') && sql.includes("'not_executed_after_halt'")) {
+      this.recoveryClosedRemainder = true;
+      return { rowCount: 167, rows: [] };
+    }
     if (sql.startsWith('UPDATE addie_fixed_trace_component_smoke_run_plan')) return { rowCount: 1, rows: [] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE attempt_id')) return { rowCount: this.attempts.has(params![0] as string) ? 1 : 0, rows: [] };
     if (sql.startsWith('SELECT 1 FROM addie_fixed_trace_component_smoke_attempts WHERE authorization_digest')) {
@@ -243,6 +248,7 @@ describe('private ledger state machine', () => {
     expect(client.authStatus).toBe('unknown_exposure');
     expect(client.attempts.get(`attempt_${'1'.repeat(32)}`)).toMatchObject({ status: 'unknown_exposure', responseHmac: null, cost: null });
     expect(client.assignmentOutcomes.get(dispatch.assignmentId)).toBe('provider_unknown_exposure');
+    expect(client.recoveryClosedRemainder).toBe(true);
   });
 
   it('uses complete-plan, then attempts, then authorization recovery locking', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-ledger-state.test.ts
@@ -5,7 +5,7 @@ import {
   fixedTraceComponentSmokePrivateLedgerPlan,
   type FixedTraceComponentSmokePlanEntry,
 } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
-import { datedPricingCostMicros, datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
+import { fixedTraceComponentSmokePrivateAuthorityCostMicros } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 
 const digest = 'a'.repeat(64);
 const reservation = Object.freeze({
@@ -176,8 +176,7 @@ describe('private ledger state machine', () => {
     ['openai-gpt-5.6-luna-standard-2026-09-05', { inputTokens: 2, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 1 }, 1],
     ['google-gemini-3.7-flash-through-2026-12-31', { inputTokens: 1, outputTokens: 0, cacheReadTokens: 1, cacheWriteTokens: 0 }, 1],
   ])('uses exact rounded microdollar pricing for %s', (profileId, usage, expectedMicros) => {
-    const profile = datedPricingProfilesForFixedTrace().find((candidate) => candidate.profileId === profileId)!;
-    expect(datedPricingCostMicros(profile, usage)).toBe(expectedMicros);
+    expect(fixedTraceComponentSmokePrivateAuthorityCostMicros(profileId, usage)).toBe(expectedMicros);
   });
 
   it('poisons an authorization with an unresolved intent and maps response failures to unknown exposure', async () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
@@ -1,7 +1,11 @@
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY, fixedTraceComponentSmokePrivateAuthorityPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityCostMicros,
+  fixedTraceComponentSmokePrivateAuthorityPlan,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 import {
   createFixedTraceComponentSmokePrivateRuntime,
   simulateFixedTraceComponentSmokePrivateRuntime,
@@ -10,6 +14,8 @@ import {
 const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
 const dispatch = plan.find((entry) => entry.disposition === 'provider_dispatch')!;
 const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
+const anthropic = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.provider === 'anthropic')!;
+const google = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.provider === 'google')!;
 
 function receipt(entry = dispatch, overrides: Record<string, unknown> = {}) {
   return {
@@ -20,6 +26,30 @@ function receipt(entry = dispatch, overrides: Record<string, unknown> = {}) {
   };
 }
 function scriptFor(key: string, value: unknown) { return JSON.stringify({ responses: { [key]: value } }); }
+function firstInvocationPosition(entry: typeof dispatch) {
+  return plan.slice(0, plan.indexOf(entry) + 1).reduce((total, candidate) => (
+    total + (candidate.disposition === 'provider_dispatch' ? 1 : 0)
+  ), 0);
+}
+function maximumUsage(entry: typeof dispatch) {
+  return {
+    inputTokens: entry.maxInputTokens, outputTokens: entry.maxOutputTokens, latencyMs: entry.timeoutMs,
+    cacheReadTokens: entry.provider === 'anthropic' ? entry.maxInputTokens : 0,
+    cacheWriteTokens: entry.provider === 'anthropic' || entry.provider === 'openai' ? entry.maxInputTokens : 0,
+  };
+}
+function fullReservationScript() {
+  const responses: Record<string, unknown> = {};
+  for (const entry of plan) if (entry.disposition === 'provider_dispatch') {
+    for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
+      responses[`${entry.assignmentId}:${ordinal}`] = receipt(entry, {
+        disposition: ordinal === 1 && entry.maximumProviderInvocations === 2 ? 'tool_continuation_required' : 'final_response',
+        usage: maximumUsage(entry),
+      });
+    }
+  }
+  return JSON.stringify({ responses });
+}
 
 describe('private fake-only component smoke runtime', () => {
   it('has no production construction path or runtime dependency injection', () => {
@@ -31,9 +61,9 @@ describe('private fake-only component smoke runtime', () => {
     expect(simulateFixedTraceComponentSmokePrivateRuntime()).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
   });
 
-  it('models the frozen second ordinal only after its scripted first continuation', () => {
+  it('allows an eligible first-ordinal final response to complete below the invocation ceiling', () => {
     const first = `${generation.assignmentId}:1`;
-    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(first, receipt(generation, { disposition: 'final_response' })))).toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 191 });
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(first, receipt(generation, { disposition: 'final_response' })))).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 191 });
     expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(first, receipt(generation, { disposition: 'tool_continuation_required' })))).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
   });
 
@@ -43,6 +73,30 @@ describe('private fake-only component smoke runtime', () => {
     ['final continuation ordinal', receipt(dispatch, { disposition: 'tool_continuation_required' })],
   ])('halts the simulated denominator after %s', (_name, value) => {
     expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(`${dispatch.assignmentId}:1`, value))).toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
+  });
+
+  it.each([
+    ['input token limit', dispatch, { ...maximumUsage(dispatch), inputTokens: dispatch.maxInputTokens + 1 }],
+    ['output token limit', dispatch, { ...maximumUsage(dispatch), outputTokens: dispatch.maxOutputTokens + 1 }],
+    ['latency limit', dispatch, { ...maximumUsage(dispatch), latencyMs: dispatch.timeoutMs + 1 }],
+    ['additive cache and per-attempt cost limit', anthropic, { ...maximumUsage(anthropic), cacheReadTokens: anthropic.maxInputTokens + 1 }],
+    ['unsupported cache accounting', google, { ...maximumUsage(google), cacheWriteTokens: 1 }],
+  ])('halts rather than falsely complete on a scripted %s breach', (_name, entry, usage) => {
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(`${entry.assignmentId}:1`, receipt(entry, { usage })))).toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: firstInvocationPosition(entry) });
+  });
+
+  it('settles the exact immutable reservation boundary with integer authority pricing', () => {
+    const expected = plan.filter((entry) => entry.disposition === 'provider_dispatch').reduce((total, entry) => (
+      total + entry.reservedMicrodollars.reduce((entryTotal, reservation) => entryTotal + reservation, 0)
+    ), 0);
+    const priced = plan.filter((entry) => entry.disposition === 'provider_dispatch').reduce((total, entry) => (
+      total + entry.reservedMicrodollars.reduce((entryTotal) => entryTotal
+        + fixedTraceComponentSmokePrivateAuthorityCostMicros(entry.pricingProfileId, maximumUsage(entry)), 0)
+    ), 0);
+    expect(expected).toBe(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars);
+    expect(priced).toBe(expected);
+    expect(expected).toBeLessThanOrEqual(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars);
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(fullReservationScript())).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
   });
 
   it('deep-copies and rejects executable, malformed, or unadmitted simulation data without running it', () => {

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
@@ -1,7 +1,8 @@
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 import {
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
   FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
@@ -18,13 +19,15 @@ const rootPin = createHash('sha256').update(JSON.stringify(root), 'utf8').digest
 const plan = fixedTraceComponentSmokePrivateLedgerPlan()!;
 
 function signedGrant(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}) {
-  const admission = fixedTraceComponentSmokeAdmission();
   const payload: FixedTraceComponentSmokeSignedGrantPayload = {
     grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: root.kid,
     issuedAt: '2026-09-06T11:55:00.000Z', expiresAt: '2026-09-06T12:05:00.000Z', stageId: 'stage_1_smoke',
-    admissionVersion: admission.version, aggregateAdmissionFingerprint: admission.fingerprints.aggregateAdmission,
-    cardinality: admission.cardinality, reservationMicrodollars: 2_819_484, providerCeilingMicrodollars: 5_000_000,
-    pricingCohortDigest: admission.pricing.cohortDigest!, nonceCommitment: 'a'.repeat(64), ...overrides,
+    admissionVersion: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion,
+    aggregateAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint,
+    cardinality: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality,
+    reservationMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars,
+    providerCeilingMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars,
+    pricingCohortDigest: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.pricingCohortDigest, nonceCommitment: 'a'.repeat(64), ...overrides,
   };
   return { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload, signature: sign(null, fixedTraceComponentSmokeSignedGrantBytes(payload), keys.privateKey).toString('base64url') };
 }
@@ -131,5 +134,53 @@ describe('private fake-only component smoke runtime', () => {
     expect(source).not.toContain('from \'../../db/client'); expect(source).not.toContain('prompt:'); expect(source).not.toContain('apiKey');
     expect(createFixedTraceComponentSmokePrivateRuntime({} as never)).toBeNull();
     expect(createFixedTraceComponentSmokePrivateRuntime).toBeTypeOf('function');
+  });
+
+  it('keeps every private runtime graph leaf clear of live configuration, provider, and storyboard imports', () => {
+    const leaves = [
+      '../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts',
+      '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts',
+      '../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.ts',
+      '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.ts',
+    ].map((path) => readFileSync(new URL(path, import.meta.url), 'utf8'));
+    for (const source of leaves) {
+      expect(source).not.toContain('process.env');
+      expect(source).not.toContain('createLogger');
+      expect(source).not.toContain('console.');
+      expect(source).not.toContain('fetch(');
+      expect(source).not.toMatch(/from ['"][^'"]*(?:dated-pricing-cohort|fixed-trace-component-smoke-admission|config\/models|model-providers|storyboard)[^'"]*['"]/);
+    }
+  });
+
+  it('imports the complete private runtime graph in fresh processes without model/provider env authority or side effects', () => {
+    const runtimeUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts', import.meta.url).href;
+    const ledgerUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts', import.meta.url).href;
+    const authorityUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-authority.ts', import.meta.url).href;
+    const source = `import '${runtimeUrl}'; import { fixedTraceComponentSmokePrivateLedgerPlan } from '${ledgerUrl}'; import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '${authorityUrl}'; const plan = fixedTraceComponentSmokePrivateLedgerPlan(); process.stdout.write(JSON.stringify({ fingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint, reservation: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars, plan }));`;
+    const run = (environment: Record<string, string>) => spawnSync(process.execPath, [
+      '--import', 'tsx', '--input-type=module', '--eval', source,
+    ], {
+      cwd: process.cwd(), encoding: 'utf8', timeout: 30_000,
+      env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test', ...environment },
+    });
+    const baseline = run({});
+    const overridden = run({
+      CLAUDE_MODEL_FAST: 'unreviewed-fast', CLAUDE_MODEL_PRIMARY: 'unreviewed-primary',
+      OPENAI_API_KEY: 'not-a-real-key', ANTHROPIC_API_KEY: 'not-a-real-key', GEMINI_API_KEY: 'not-a-real-key',
+      OPENAI_MODEL: 'unreviewed-openai', GEMINI_MODEL_FAST: 'unreviewed-google',
+    });
+    for (const child of [baseline, overridden]) {
+      expect(child.status, child.stderr).toBe(0);
+      expect(child.stderr).toBe('');
+      expect(child.stdout).not.toContain('Loaded test kit');
+      expect(child.stdout).not.toContain('\n');
+    }
+    expect(overridden.stdout).toBe(baseline.stdout);
+    const output = JSON.parse(baseline.stdout) as { fingerprint: string; reservation: number; plan: unknown[] };
+    expect(output).toMatchObject({
+      fingerprint: '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d',
+      reservation: 2_819_484,
+    });
+    expect(output.plan).toHaveLength(168);
   });
 });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
@@ -1,0 +1,135 @@
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { fixedTraceComponentSmokeAdmission } from '../../../src/addie/eval/fixed-trace-component-smoke-admission.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
+  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
+  fixedTraceComponentSmokeSignedGrantBytes,
+  type FixedTraceComponentSmokeSignedGrantPayload,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.js';
+import { fixedTraceComponentSmokePrivateLedgerPlan, type FixedTraceComponentSmokeReservation } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
+import { createFixedTraceComponentSmokePrivateRuntime, type FixedTraceComponentSmokeFakeProviderRequest } from '../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.js';
+
+const NOW = new Date('2026-09-06T12:00:00.000Z');
+const keys = generateKeyPairSync('ed25519');
+const root = Object.freeze({ kid: 'component-smoke-runtime-test', spki: (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url') });
+const rootPin = createHash('sha256').update(JSON.stringify(root), 'utf8').digest('hex');
+const plan = fixedTraceComponentSmokePrivateLedgerPlan()!;
+
+function signedGrant(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}) {
+  const admission = fixedTraceComponentSmokeAdmission();
+  const payload: FixedTraceComponentSmokeSignedGrantPayload = {
+    grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: root.kid,
+    issuedAt: '2026-09-06T11:55:00.000Z', expiresAt: '2026-09-06T12:05:00.000Z', stageId: 'stage_1_smoke',
+    admissionVersion: admission.version, aggregateAdmissionFingerprint: admission.fingerprints.aggregateAdmission,
+    cardinality: admission.cardinality, reservationMicrodollars: 2_819_484, providerCeilingMicrodollars: 5_000_000,
+    pricingCohortDigest: admission.pricing.cohortDigest!, nonceCommitment: 'a'.repeat(64), ...overrides,
+  };
+  return { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload, signature: sign(null, fixedTraceComponentSmokeSignedGrantBytes(payload), keys.privateKey).toString('base64url') };
+}
+
+function reservationFor(authorizationDigest: string): FixedTraceComponentSmokeReservation {
+  return Object.freeze({ authorizationDigest,
+    reservationId: `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0' }), 'utf8').digest('hex').slice(0, 32)}`,
+    entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 });
+}
+
+class FakeLedger {
+  readonly calls: string[] = [];
+  readonly intents: Array<Record<string, unknown>> = [];
+  readonly terminals: Array<Record<string, unknown>> = [];
+  readonly assignmentTerminals: Array<Record<string, unknown>> = [];
+  readonly nonDispatch: Array<Record<string, unknown>> = [];
+  readonly omitted: Array<Record<string, unknown>> = [];
+  reserveCalls = 0;
+  failIntent = false;
+  failTerminal = false;
+  terminalRefusal: string | null = null;
+  async reserveAndConsume(grant: object) { this.reserveCalls += 1; return this.reserveCalls === 1 ? { status: 'reserved', reservation: reservationFor((grant as { grantDigest: string }).grantDigest) } : { status: 'refused', reason: 'grant_already_consumed' }; }
+  async recordProviderIntent(value: object) { this.calls.push('intent'); this.intents.push(value as Record<string, unknown>); return this.failIntent ? { status: 'refused', reason: 'persistence_uncertain' } : { status: 'recorded' }; }
+  async recordTerminal(value: object) { this.calls.push('terminal'); this.terminals.push(value as Record<string, unknown>); return this.failTerminal || this.terminalRefusal ? { status: 'refused', reason: this.terminalRefusal ?? 'persistence_uncertain' } : { status: 'recorded' }; }
+  async recordProviderAssignmentTerminal(value: object) { this.calls.push('assignment'); this.assignmentTerminals.push(value as Record<string, unknown>); return { status: 'recorded' }; }
+  async recordNonDispatchTerminal(value: object) { this.calls.push('local'); this.nonDispatch.push(value as Record<string, unknown>); return { status: 'recorded' }; }
+  async recordNotExecutedAfterHalt(value: object) { this.calls.push('omitted'); this.omitted.push(value as Record<string, unknown>); return { status: 'recorded' }; }
+  async recordUnknownExposure() { this.calls.push('unknown'); return { status: 'recorded' }; }
+}
+
+function runtime(ledger: FakeLedger, fakeProvider: { invoke(request: Readonly<FixedTraceComponentSmokeFakeProviderRequest>): Promise<unknown> }, grant = signedGrant(), pin = rootPin) {
+  return createFixedTraceComponentSmokePrivateRuntime({ trustRoot: root, trustRootPin: pin, signedGrant: grant, evidenceHmacKey: Buffer.alloc(32, 7), trustedNow: () => NOW, ledger, fakeProvider: { fakeOnly: true, automaticRetries: 0, ...fakeProvider } });
+}
+function receipt(request: FixedTraceComponentSmokeFakeProviderRequest, disposition: 'final_response' | 'tool_continuation_required' = 'final_response') {
+  return { status: 'succeeded', disposition, identity: { provider: request.provider, model: request.model, effort: request.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } };
+}
+
+describe('private fake-only component smoke runtime', () => {
+  it('runs only the frozen 8-by-21 plan, commits intent before each fake call, and reaches the exact maximum', async () => {
+    const ledger = new FakeLedger(); const seen: FixedTraceComponentSmokeFakeProviderRequest[] = [];
+    const subject = runtime(ledger, { async invoke(request) { seen.push(request); return receipt(request, request.invocationOrdinal === 1 && plan.find((entry) => entry.assignmentId === request.assignmentId)!.maximumProviderInvocations === 2 ? 'tool_continuation_required' : 'final_response'); } });
+    const result = await subject!.run();
+    expect(result).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
+    expect(seen).toHaveLength(192); expect(ledger.intents).toHaveLength(192); expect(ledger.terminals).toHaveLength(192);
+    expect(ledger.assignmentTerminals).toHaveLength(126); expect(ledger.nonDispatch).toHaveLength(42);
+    expect(ledger.calls.every((call, index) => call !== 'terminal' || ledger.calls[index - 1] === 'intent')).toBe(true);
+    expect(new Set(ledger.intents.map((entry) => entry.preparedRequestHmac))).toHaveLength(192);
+    expect(new Set(ledger.terminals.map((entry) => entry.responseHmac))).toHaveLength(192);
+    expect(seen.every((request) => request.sdkAutomaticRetries === 0)).toBe(true);
+  });
+
+  it('requires an exact operator root/pin and consumes a verified grant through the ledger once', async () => {
+    const ledger = new FakeLedger();
+    expect(runtime(ledger, { async invoke(request) { return receipt(request); } }, signedGrant(), '0'.repeat(64))).toBeNull();
+    const invalid = runtime(ledger, { async invoke(request) { return receipt(request); } }, { ...signedGrant(), signature: 'A'.repeat(86) });
+    await expect(invalid!.run()).resolves.toMatchObject({ status: 'refused', reason: 'invalid_grant', providerInvocations: 0 });
+    const oneShot = runtime(ledger, { async invoke(request) { return receipt(request); } })!;
+    await oneShot.run();
+    await expect(oneShot.run()).resolves.toMatchObject({ status: 'refused', reason: 'grant_already_consumed', providerInvocations: 0 });
+    expect(ledger.reserveCalls).toBe(2);
+  });
+
+  it.each([
+    ['provider throw', async () => { throw new Error('private fake failure'); }, 'timeout_after_dispatch'],
+    ['malformed response', async () => ({ wrong: true }), 'malformed_response'],
+    ['missing usage', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), usage: null }), 'missing_usage'],
+    ['identity mismatch', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), identity: { provider: 'other', model: request.model, effort: request.effort } }), 'identity_mismatch'],
+    ['provider failure', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), status: 'provider_failed', disposition: 'final_response' }), 'provider_failed'],
+  ])('halts and terminalizes the denominator after %s without another provider call', async (_name, invoke, expectedStatus) => {
+    const ledger = new FakeLedger(); let calls = 0;
+    const subject = runtime(ledger, { async invoke(request) { calls += 1; return invoke(request); } })!;
+    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
+    expect(calls).toBe(1); expect(ledger.terminals[0]?.status).toBe(expectedStatus);
+    expect(ledger.assignmentTerminals).toHaveLength(1);
+    expect(ledger.assignmentTerminals.length + ledger.nonDispatch.length + ledger.omitted.length).toBe(168);
+  });
+
+  it('does not call a fake provider after an uncertain intent or terminal write', async () => {
+    for (const field of ['failIntent', 'failTerminal'] as const) {
+      const ledger = new FakeLedger(); ledger[field] = true; let calls = 0;
+      const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request); } })!;
+      await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: field === 'failIntent' ? 0 : 1 });
+      expect(calls).toBe(field === 'failIntent' ? 0 : 1); expect(ledger.calls).toContain('unknown');
+    }
+  });
+
+  it.each(['plan_mismatch', 'cost_exhausted'])('stops after a ledger %s settlement refusal', async (reason) => {
+    const ledger = new FakeLedger(); ledger.terminalRefusal = reason; let calls = 0;
+    const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request); } })!;
+    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
+    expect(calls).toBe(1); expect(ledger.calls).toContain('unknown');
+  });
+
+  it('never advances past a duplicate/final continuation ordinal', async () => {
+    const ledger = new FakeLedger(); let calls = 0;
+    const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request, 'tool_continuation_required'); } })!;
+    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
+    expect(calls).toBe(1); expect(ledger.calls).toContain('unknown');
+  });
+
+  it('has no ambient wiring, no caller execution controls, and no raw secret or provider data persistence/logging surface', () => {
+    const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts', import.meta.url), 'utf8');
+    expect(source).not.toContain('process.env'); expect(source).not.toContain('fetch('); expect(source).not.toContain('console.');
+    expect(source).not.toContain('from \'../../db/client'); expect(source).not.toContain('prompt:'); expect(source).not.toContain('apiKey');
+    expect(createFixedTraceComponentSmokePrivateRuntime({} as never)).toBeNull();
+    expect(createFixedTraceComponentSmokePrivateRuntime).toBeTypeOf('function');
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-runtime.test.ts
@@ -1,186 +1,92 @@
-import { createHash, generateKeyPairSync, sign } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
+import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY, fixedTraceComponentSmokePrivateAuthorityPlan } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 import {
-  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM,
-  FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION,
-  fixedTraceComponentSmokeSignedGrantBytes,
-  type FixedTraceComponentSmokeSignedGrantPayload,
-} from '../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.js';
-import { fixedTraceComponentSmokePrivateLedgerPlan, type FixedTraceComponentSmokeReservation } from '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.js';
-import { createFixedTraceComponentSmokePrivateRuntime, type FixedTraceComponentSmokeFakeProviderRequest } from '../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.js';
+  createFixedTraceComponentSmokePrivateRuntime,
+  simulateFixedTraceComponentSmokePrivateRuntime,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.js';
 
-const NOW = new Date('2026-09-06T12:00:00.000Z');
-const keys = generateKeyPairSync('ed25519');
-const root = Object.freeze({ kid: 'component-smoke-runtime-test', spki: (keys.publicKey.export({ format: 'der', type: 'spki' }) as Buffer).toString('base64url') });
-const rootPin = createHash('sha256').update(JSON.stringify(root), 'utf8').digest('hex');
-const plan = fixedTraceComponentSmokePrivateLedgerPlan()!;
+const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+const dispatch = plan.find((entry) => entry.disposition === 'provider_dispatch')!;
+const generation = plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.maximumProviderInvocations === 2)!;
 
-function signedGrant(overrides: Partial<FixedTraceComponentSmokeSignedGrantPayload> = {}) {
-  const payload: FixedTraceComponentSmokeSignedGrantPayload = {
-    grantVersion: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_VERSION, kid: root.kid,
-    issuedAt: '2026-09-06T11:55:00.000Z', expiresAt: '2026-09-06T12:05:00.000Z', stageId: 'stage_1_smoke',
-    admissionVersion: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.admissionVersion,
-    aggregateAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint,
-    cardinality: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.cardinality,
-    reservationMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars,
-    providerCeilingMicrodollars: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.providerCeilingMicrodollars,
-    pricingCohortDigest: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.pricingCohortDigest, nonceCommitment: 'a'.repeat(64), ...overrides,
+function receipt(entry = dispatch, overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'succeeded', disposition: 'final_response',
+    identity: { provider: entry.provider, model: entry.model, effort: entry.effort },
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 },
+    ...overrides,
   };
-  return { algorithm: FIXED_TRACE_COMPONENT_SMOKE_SIGNED_GRANT_ALGORITHM, payload, signature: sign(null, fixedTraceComponentSmokeSignedGrantBytes(payload), keys.privateKey).toString('base64url') };
 }
-
-function reservationFor(authorizationDigest: string): FixedTraceComponentSmokeReservation {
-  return Object.freeze({ authorizationDigest,
-    reservationId: `reservation_${createHash('sha256').update(JSON.stringify({ authorizationDigest, domain: 'adcp:addie:fixed-trace-component-smoke:reservation:v1\0' }), 'utf8').digest('hex').slice(0, 32)}`,
-    entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 });
-}
-
-class FakeLedger {
-  readonly calls: string[] = [];
-  readonly intents: Array<Record<string, unknown>> = [];
-  readonly terminals: Array<Record<string, unknown>> = [];
-  readonly assignmentTerminals: Array<Record<string, unknown>> = [];
-  readonly nonDispatch: Array<Record<string, unknown>> = [];
-  readonly omitted: Array<Record<string, unknown>> = [];
-  reserveCalls = 0;
-  failIntent = false;
-  failTerminal = false;
-  terminalRefusal: string | null = null;
-  async reserveAndConsume(grant: object) { this.reserveCalls += 1; return this.reserveCalls === 1 ? { status: 'reserved', reservation: reservationFor((grant as { grantDigest: string }).grantDigest) } : { status: 'refused', reason: 'grant_already_consumed' }; }
-  async recordProviderIntent(value: object) { this.calls.push('intent'); this.intents.push(value as Record<string, unknown>); return this.failIntent ? { status: 'refused', reason: 'persistence_uncertain' } : { status: 'recorded' }; }
-  async recordTerminal(value: object) { this.calls.push('terminal'); this.terminals.push(value as Record<string, unknown>); return this.failTerminal || this.terminalRefusal ? { status: 'refused', reason: this.terminalRefusal ?? 'persistence_uncertain' } : { status: 'recorded' }; }
-  async recordProviderAssignmentTerminal(value: object) { this.calls.push('assignment'); this.assignmentTerminals.push(value as Record<string, unknown>); return { status: 'recorded' }; }
-  async recordNonDispatchTerminal(value: object) { this.calls.push('local'); this.nonDispatch.push(value as Record<string, unknown>); return { status: 'recorded' }; }
-  async recordNotExecutedAfterHalt(value: object) { this.calls.push('omitted'); this.omitted.push(value as Record<string, unknown>); return { status: 'recorded' }; }
-  async recordUnknownExposure() { this.calls.push('unknown'); return { status: 'recorded' }; }
-}
-
-function runtime(ledger: FakeLedger, fakeProvider: { invoke(request: Readonly<FixedTraceComponentSmokeFakeProviderRequest>): Promise<unknown> }, grant = signedGrant(), pin = rootPin) {
-  return createFixedTraceComponentSmokePrivateRuntime({ trustRoot: root, trustRootPin: pin, signedGrant: grant, evidenceHmacKey: Buffer.alloc(32, 7), trustedNow: () => NOW, ledger, fakeProvider: { fakeOnly: true, automaticRetries: 0, ...fakeProvider } });
-}
-function receipt(request: FixedTraceComponentSmokeFakeProviderRequest, disposition: 'final_response' | 'tool_continuation_required' = 'final_response') {
-  return { status: 'succeeded', disposition, identity: { provider: request.provider, model: request.model, effort: request.effort }, usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 0 } };
-}
+function scriptFor(key: string, value: unknown) { return JSON.stringify({ responses: { [key]: value } }); }
 
 describe('private fake-only component smoke runtime', () => {
-  it('runs only the frozen 8-by-21 plan, commits intent before each fake call, and reaches the exact maximum', async () => {
-    const ledger = new FakeLedger(); const seen: FixedTraceComponentSmokeFakeProviderRequest[] = [];
-    const subject = runtime(ledger, { async invoke(request) { seen.push(request); return receipt(request, request.invocationOrdinal === 1 && plan.find((entry) => entry.assignmentId === request.assignmentId)!.maximumProviderInvocations === 2 ? 'tool_continuation_required' : 'final_response'); } });
-    const result = await subject!.run();
-    expect(result).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
-    expect(seen).toHaveLength(192); expect(ledger.intents).toHaveLength(192); expect(ledger.terminals).toHaveLength(192);
-    expect(ledger.assignmentTerminals).toHaveLength(126); expect(ledger.nonDispatch).toHaveLength(42);
-    expect(ledger.calls.every((call, index) => call !== 'terminal' || ledger.calls[index - 1] === 'intent')).toBe(true);
-    expect(new Set(ledger.intents.map((entry) => entry.preparedRequestHmac))).toHaveLength(192);
-    expect(new Set(ledger.terminals.map((entry) => entry.responseHmac))).toHaveLength(192);
-    expect(seen.every((request) => request.sdkAutomaticRetries === 0)).toBe(true);
+  it('has no production construction path or runtime dependency injection', () => {
+    expect(createFixedTraceComponentSmokePrivateRuntime()).toBeNull();
+    expect((createFixedTraceComponentSmokePrivateRuntime as (...value: unknown[]) => unknown)({}, {}, {}, {})).toBeNull();
   });
 
-  it('requires an exact operator root/pin and consumes a verified grant through the ledger once', async () => {
-    const ledger = new FakeLedger();
-    expect(runtime(ledger, { async invoke(request) { return receipt(request); } }, signedGrant(), '0'.repeat(64))).toBeNull();
-    const invalid = runtime(ledger, { async invoke(request) { return receipt(request); } }, { ...signedGrant(), signature: 'A'.repeat(86) });
-    await expect(invalid!.run()).resolves.toMatchObject({ status: 'refused', reason: 'invalid_grant', providerInvocations: 0 });
-    const oneShot = runtime(ledger, { async invoke(request) { return receipt(request); } })!;
-    await oneShot.run();
-    await expect(oneShot.run()).resolves.toMatchObject({ status: 'refused', reason: 'grant_already_consumed', providerInvocations: 0 });
-    expect(ledger.reserveCalls).toBe(2);
+  it('simulates only the frozen 8-by-21 plan and exact 192 maximum without dispatch', () => {
+    expect(simulateFixedTraceComponentSmokePrivateRuntime()).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
+  });
+
+  it('models the frozen second ordinal only after its scripted first continuation', () => {
+    const first = `${generation.assignmentId}:1`;
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(first, receipt(generation, { disposition: 'final_response' })))).toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 191 });
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(first, receipt(generation, { disposition: 'tool_continuation_required' })))).toEqual({ status: 'completed', assignmentDispositions: 168, providerInvocations: 192 });
   });
 
   it.each([
-    ['provider throw', async () => { throw new Error('private fake failure'); }, 'timeout_after_dispatch'],
-    ['malformed response', async () => ({ wrong: true }), 'malformed_response'],
-    ['missing usage', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), usage: null }), 'missing_usage'],
-    ['identity mismatch', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), identity: { provider: 'other', model: request.model, effort: request.effort } }), 'identity_mismatch'],
-    ['provider failure', async (request: FixedTraceComponentSmokeFakeProviderRequest) => ({ ...receipt(request), status: 'provider_failed', disposition: 'final_response' }), 'provider_failed'],
-  ])('halts and terminalizes the denominator after %s without another provider call', async (_name, invoke, expectedStatus) => {
-    const ledger = new FakeLedger(); let calls = 0;
-    const subject = runtime(ledger, { async invoke(request) { calls += 1; return invoke(request); } })!;
-    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
-    expect(calls).toBe(1); expect(ledger.terminals[0]?.status).toBe(expectedStatus);
-    expect(ledger.assignmentTerminals).toHaveLength(1);
-    expect(ledger.assignmentTerminals.length + ledger.nonDispatch.length + ledger.omitted.length).toBe(168);
+    ['identity mismatch', receipt(dispatch, { identity: { provider: 'other', model: dispatch.model, effort: dispatch.effort } })],
+    ['provider failure', receipt(dispatch, { status: 'provider_failed' })],
+    ['final continuation ordinal', receipt(dispatch, { disposition: 'tool_continuation_required' })],
+  ])('halts the simulated denominator after %s', (_name, value) => {
+    expect(simulateFixedTraceComponentSmokePrivateRuntime(scriptFor(`${dispatch.assignmentId}:1`, value))).toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
   });
 
-  it('does not call a fake provider after an uncertain intent or terminal write', async () => {
-    for (const field of ['failIntent', 'failTerminal'] as const) {
-      const ledger = new FakeLedger(); ledger[field] = true; let calls = 0;
-      const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request); } })!;
-      await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: field === 'failIntent' ? 0 : 1 });
-      expect(calls).toBe(field === 'failIntent' ? 0 : 1); expect(ledger.calls).toContain('unknown');
-    }
+  it('deep-copies and rejects executable, malformed, or unadmitted simulation data without running it', () => {
+    let invoked = false;
+    const executable = { responses: { [`${dispatch.assignmentId}:1`]: () => { invoked = true; return receipt(); } } };
+    for (const script of [
+      executable,
+      { responses: { [`${dispatch.assignmentId}:3`]: receipt() } },
+      { responses: { [`${dispatch.assignmentId}:1`]: { wrong: true } } },
+      { trustRoot: 'caller-selected' },
+      '{not-json',
+      JSON.stringify({ responses: { [`${dispatch.assignmentId}:3`]: receipt() } }),
+      JSON.stringify({ responses: { [`${dispatch.assignmentId}:1`]: { wrong: true } } }),
+    ]) expect(simulateFixedTraceComponentSmokePrivateRuntime(script as never)).toEqual({ status: 'refused', reason: 'invalid_simulation_script', assignmentDispositions: 0, providerInvocations: 0 });
+    expect(invoked).toBe(false);
   });
 
-  it.each(['plan_mismatch', 'cost_exhausted'])('stops after a ledger %s settlement refusal', async (reason) => {
-    const ledger = new FakeLedger(); ledger.terminalRefusal = reason; let calls = 0;
-    const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request); } })!;
-    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
-    expect(calls).toBe(1); expect(ledger.calls).toContain('unknown');
-  });
-
-  it('never advances past a duplicate/final continuation ordinal', async () => {
-    const ledger = new FakeLedger(); let calls = 0;
-    const subject = runtime(ledger, { async invoke(request) { calls += 1; return receipt(request, 'tool_continuation_required'); } })!;
-    await expect(subject.run()).resolves.toEqual({ status: 'halted', assignmentDispositions: 168, providerInvocations: 1 });
-    expect(calls).toBe(1); expect(ledger.calls).toContain('unknown');
-  });
-
-  it('has no ambient wiring, no caller execution controls, and no raw secret or provider data persistence/logging surface', () => {
+  it('contains no dispatch, persistence, authorization input, provider callback, or ambient configuration surface', () => {
     const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts', import.meta.url), 'utf8');
-    expect(source).not.toContain('process.env'); expect(source).not.toContain('fetch('); expect(source).not.toContain('console.');
-    expect(source).not.toContain('from \'../../db/client'); expect(source).not.toContain('prompt:'); expect(source).not.toContain('apiKey');
-    expect(createFixedTraceComponentSmokePrivateRuntime({} as never)).toBeNull();
-    expect(createFixedTraceComponentSmokePrivateRuntime).toBeTypeOf('function');
-  });
-
-  it('keeps every private runtime graph leaf clear of live configuration, provider, and storyboard imports', () => {
-    const leaves = [
-      '../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts',
-      '../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts',
-      '../../../src/addie/eval/fixed-trace-component-smoke-private-authorization.ts',
-      '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.ts',
-    ].map((path) => readFileSync(new URL(path, import.meta.url), 'utf8'));
-    for (const source of leaves) {
-      expect(source).not.toContain('process.env');
-      expect(source).not.toContain('createLogger');
-      expect(source).not.toContain('console.');
-      expect(source).not.toContain('fetch(');
-      expect(source).not.toMatch(/from ['"][^'"]*(?:dated-pricing-cohort|fixed-trace-component-smoke-admission|config\/models|model-providers|storyboard)[^'"]*['"]/);
+    for (const forbidden of ['process.env', 'fetch(', 'console.', 'fakeProvider', '.invoke(', 'trustRoot', 'signedGrant', 'evidenceHmacKey', 'recordProviderIntent', 'recordTerminal']) {
+      expect(source).not.toContain(forbidden);
     }
+    expect(source).not.toMatch(/from ['"][^'"]*(?:dated-pricing-cohort|fixed-trace-component-smoke-admission|config\/models|model-providers|storyboard)[^'"]*['"]/);
   });
 
   it('imports the complete private runtime graph in fresh processes without model/provider env authority or side effects', () => {
     const runtimeUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-runtime.ts', import.meta.url).href;
-    const ledgerUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-ledger.ts', import.meta.url).href;
     const authorityUrl = new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-authority.ts', import.meta.url).href;
-    const source = `import '${runtimeUrl}'; import { fixedTraceComponentSmokePrivateLedgerPlan } from '${ledgerUrl}'; import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '${authorityUrl}'; const plan = fixedTraceComponentSmokePrivateLedgerPlan(); process.stdout.write(JSON.stringify({ fingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint, reservation: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars, plan }));`;
-    const run = (environment: Record<string, string>) => spawnSync(process.execPath, [
-      '--import', 'tsx', '--input-type=module', '--eval', source,
-    ], {
-      cwd: process.cwd(), encoding: 'utf8', timeout: 30_000,
-      env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test', ...environment },
+    const source = `import { simulateFixedTraceComponentSmokePrivateRuntime } from '${runtimeUrl}'; import { FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY } from '${authorityUrl}'; process.stdout.write(JSON.stringify({ fingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint, reservation: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.reservationMicrodollars, result: simulateFixedTraceComponentSmokePrivateRuntime() }));`;
+    const run = (environment: Record<string, string>) => spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', source], {
+      cwd: process.cwd(), encoding: 'utf8', timeout: 30_000, env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test', ...environment },
     });
     const baseline = run({});
     const overridden = run({
-      CLAUDE_MODEL_FAST: 'unreviewed-fast', CLAUDE_MODEL_PRIMARY: 'unreviewed-primary',
-      OPENAI_API_KEY: 'not-a-real-key', ANTHROPIC_API_KEY: 'not-a-real-key', GEMINI_API_KEY: 'not-a-real-key',
-      OPENAI_MODEL: 'unreviewed-openai', GEMINI_MODEL_FAST: 'unreviewed-google',
+      CLAUDE_MODEL_FAST: 'unreviewed-fast', CLAUDE_MODEL_PRIMARY: 'unreviewed-primary', OPENAI_API_KEY: 'not-a-real-key',
+      ANTHROPIC_API_KEY: 'not-a-real-key', GEMINI_API_KEY: 'not-a-real-key', OPENAI_MODEL: 'unreviewed-openai', GEMINI_MODEL_FAST: 'unreviewed-google',
     });
     for (const child of [baseline, overridden]) {
-      expect(child.status, child.stderr).toBe(0);
-      expect(child.stderr).toBe('');
-      expect(child.stdout).not.toContain('Loaded test kit');
-      expect(child.stdout).not.toContain('\n');
+      expect(child.status, child.stderr).toBe(0); expect(child.stderr).toBe(''); expect(child.stdout).not.toContain('Loaded test kit'); expect(child.stdout).not.toContain('\n');
     }
     expect(overridden.stdout).toBe(baseline.stdout);
-    const output = JSON.parse(baseline.stdout) as { fingerprint: string; reservation: number; plan: unknown[] };
-    expect(output).toMatchObject({
-      fingerprint: '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d',
-      reservation: 2_819_484,
+    expect(JSON.parse(baseline.stdout)).toEqual({
+      fingerprint: '731930c18475672a0ec6b44c9ff91fa89d30c441e34af32b536a28258271077d', reservation: 2_819_484,
+      result: { status: 'completed', assignmentDispositions: 168, providerInvocations: 192 },
     });
-    expect(output.plan).toHaveLength(168);
   });
 });


### PR DESCRIPTION
## Summary

Adds a pure immutable component-smoke authority leaf, a fail-closed ledger state machine, and a non-dispatching simulator for the frozen 8-probe x 21-cell plan. Production runtime construction and production grant verification are deliberately hard-null/unprovisioned: they accept no caller-selected trust root, grant, ledger, adapter, callback, or execution dependency. The simulator accepts JSON text only, performs no authorization or persistence, executes no caller code, and enforces the frozen usage and cost ceilings.

The ledger transaction boundary sets fixed PostgreSQL-local bounds immediately after BEGIN: `lock_timeout=250ms` and `statement_timeout=1000ms`. Unknown-exposure recovery atomically closes the complete 168-entry denominator, including a committed intent whose acknowledgement was lost.

## Validation at current head

- Fresh local PostgreSQL 15.18 database: all 566 migrations through 582 applied.
- `fixed-trace-component-smoke-private-ledger-migration.test.ts`: 34/34 passed, including concurrency and lost-intent-acknowledgement recovery coverage.
- Focused runtime/authority/ledger tests: 60/60 passed after the hardened JSON-only and accounting redesign.
- Fresh-process full private import-graph regression passes with overridden provider/model environment values, preserves the exact 168-entry plan and $2.819484 reservation, and emits no unrelated output.
- Migration validation: 3/3 passed; typecheck and diff checks passed.
- Exact-head GitHub CI is green and independent Sol review approved the current head.

## Hook exception and provider-call disclosure

The normal commit hook was rerun with `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEV_USER_EMAIL`, `DEV_USER_ID`, and `ADMIN_API_KEY` explicitly unset for each correction. Preliminary phases passed; the full server-unit phase then hit its fixed 600-second guard (exit 143) without an assertion-failure summary. These remain hook timeouts, not test passes. Root authorized narrowly scoped `HUSKY=0` commits for the exact unchanged seven-file import-graph correction, five-file runtime/recovery hardening correction, and four-file simulation-limit/authorization correction; normal pre-push checks passed after each.

Before that environment diagnosis, standalone test commands inherited provider/dev variables. Both exact base and corrected worktrees reproduced the same six failures under that environment and both passed with those variables unset (96 passed, 29 intentionally skipped). The inherited `ANTHROPIC_API_KEY` activated a test block labeled for real Claude calls; accidental harness overhead was $0.075672. It is excluded from evaluation spend. No evaluation dispatch has occurred; new evaluation spend remains $0.

An intermediate integration rerun against a reused temporary database produced four duplicate static attempt-ID fixture failures (29/33); the tests commit fixture rows. The database was recreated, all migrations were rerun, and the required clean runs passed first at 33/33 and then at 34/34 after the recovery regression was added.

Ready for final repository review; merge remains gated on Ladon and a post-review feedback audit.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ca732da3-feaa-443b-8d06-45f745a0f383)
