### PR TITLE
feat(addie): add private smoke live composition

### DIFF
--- a/server/src/addie/eval/fixed-trace-component-smoke-private-live.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-live.ts
@@ -1,6 +1,3 @@
-import { createHash } from 'node:crypto';
-import type { ModelRequest, ModelReasoningEffort } from '../model-providers/model-provider.js';
-import { ADDIE_REQUEST_TOOL_REPLAY_ASSEMBLY_POLICY_VERSION } from '../request-tool-replay-binding.js';
 import {
   fixedTraceComponentSmokeAdmission,
   isFixedTraceComponentSmokeAdmissionManifest,
@@ -11,287 +8,196 @@ import {
   fixedTraceComponentSmokePrivateAuthorityPlan,
   type FixedTraceComponentSmokePrivateAuthorityPlanEntry,
 } from './fixed-trace-component-smoke-private-authority.js';
-import type { FixedTraceComponentSmokeVerifiedGrant } from './fixed-trace-component-smoke-private-authorization.js';
-import {
-  PostgresFixedTraceComponentSmokePrivateLedger,
-  type FixedTraceComponentSmokeReservation,
-  type FixedTraceComponentSmokeTerminal,
-} from './fixed-trace-component-smoke-private-ledger.js';
-import { FIXED_TRACE_COMPONENT_SMOKE_PROBES } from './fixed-trace-smoke-overlays.js';
 
 /**
- * This is intentionally an unprovisioned composition boundary.  There is no
- * exported production constructor, credential input, root input, route, job,
- * or ambient activation switch in this module.
+ * Stage 1 has no live construction path. This module is deliberately a pure,
+ * declarative preflight contract until custody, a trust root, exact request
+ * replay, and provider-continuation bindings are separately provisioned.
  */
 export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF = true as const;
-export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES = 0 as const;
 
-type PlanEntry = FixedTraceComponentSmokePrivateAuthorityPlanEntry;
-type Provider = 'anthropic' | 'openai' | 'google';
-type Usage = NonNullable<FixedTraceComponentSmokeTerminal['usage']>;
-type Identity = NonNullable<FixedTraceComponentSmokeTerminal['returnedIdentity']>;
-
-export type FixedTraceComponentSmokeInertProviderReceipt = Readonly<{
-  readonly status: 'succeeded' | 'provider_failed' | 'timeout_after_dispatch' | 'malformed_response' | 'identity_mismatch' | 'missing_usage';
-  readonly responseDisposition: 'final_response' | 'tool_continuation_required' | null;
-  readonly responseHmac: string | null;
-  readonly returnedIdentity: Identity | null;
-  readonly usage: Usage | null;
+type ProviderPlanEntry = FixedTraceComponentSmokePrivateAuthorityPlanEntry & Readonly<{
+  readonly disposition: 'provider_dispatch';
 }>;
 
-/** A JSON-only fixture. It contains no callback, credential, request, or raw provider response. */
-export type FixedTraceComponentSmokeInertProviderFixtures = Readonly<Record<string, FixedTraceComponentSmokeInertProviderReceipt>>;
+export type FixedTraceComponentSmokePrivateLiveSlot = Readonly<{
+  /** A non-secret declarative key; it is not a request HMAC. */
+  readonly slotKey: string;
+  readonly admissionFingerprint: string;
+  readonly assignmentId: string;
+  readonly probeId: string;
+  readonly cellId: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly invocationOrdinal: number;
+  readonly requestReplayBinding: 'unprovisioned_exact_request_tool_replay_binding';
+  readonly semanticRequestFingerprint: null;
+  readonly providerContinuationBinding: 'not_applicable' | 'unprovisioned_exact_provider_continuation_binding';
+}>;
 
-/** Test-only structural mirror of the durable ledger calls used by the coordinator. */
-export type FixedTraceComponentSmokePrivateLiveTestLedger = Pick<PostgresFixedTraceComponentSmokePrivateLedger,
-  'reserveAndConsume' | 'recordProviderIntent' | 'recordTerminal' | 'recordUnknownExposure'
-  | 'recordNonDispatchTerminal' | 'recordProviderAssignmentTerminal'>;
+export type FixedTraceComponentSmokePrivateLiveInspection = Readonly<{
+  readonly status: 'not_provisioned' | 'refused';
+  readonly reason:
+    | 'exact_request_tool_replay_binding_unprovisioned'
+    | 'exact_provider_continuation_binding_unprovisioned'
+    | 'invalid_json_declaration'
+    | 'unknown_or_mismatched_slot_declaration';
+  readonly slot: FixedTraceComponentSmokePrivateLiveSlot | null;
+}>;
 
-interface LiveRunCapability { readonly __privateLiveRunCapability: never }
-interface ProviderTransport {
-  invoke(request: Readonly<ModelRequest>, options: Readonly<{
-    readonly signal: AbortSignal;
-    readonly timeoutMs: number;
-    readonly maxRetries: 0;
-  }>): Promise<FixedTraceComponentSmokeInertProviderReceipt>;
-}
+const DECLARATION_FIELDS = Object.freeze([
+  'admissionFingerprint',
+  'assignmentId',
+  'cellId',
+  'effort',
+  'invocationOrdinal',
+  'model',
+  'probeId',
+  'provider',
+  'slotKey',
+]);
 
-interface PrivateProviderAdapter {
-  invoke(capability: LiveRunCapability, entry: PlanEntry, request: Readonly<ModelRequest>): Promise<FixedTraceComponentSmokeInertProviderReceipt>;
-}
-
-const liveRunCapabilities = new WeakSet<object>();
-
-function issueLiveRunCapability(): LiveRunCapability {
-  const capability = Object.freeze({}) as LiveRunCapability;
-  liveRunCapabilities.add(capability);
-  return capability;
-}
-function hasLiveRunCapability(value: unknown): value is LiveRunCapability {
-  return typeof value === 'object' && value !== null && liveRunCapabilities.has(value);
-}
-function isProvider(value: string): value is Provider {
-  return value === 'anthropic' || value === 'openai' || value === 'google';
-}
-function exactKeys(value: object, keys: readonly string[]): boolean {
-  const actual = Object.keys(value).sort(); const expected = [...keys].sort();
-  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
-}
-function deepFreeze<T>(value: T): T {
-  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
-  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
-  return Object.freeze(value);
-}
-function safeReceipt(value: unknown): value is FixedTraceComponentSmokeInertProviderReceipt {
-  if (!value || typeof value !== 'object' || !exactKeys(value, ['responseDisposition', 'responseHmac', 'returnedIdentity', 'status', 'usage'])) return false;
-  const receipt = value as Record<string, unknown>;
-  const statuses = new Set(['succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage']);
-  if (typeof receipt.status !== 'string' || !statuses.has(receipt.status)
-    || (receipt.responseHmac !== null && (typeof receipt.responseHmac !== 'string' || !/^[a-f0-9]{64}$/.test(receipt.responseHmac)))) return false;
-  if (receipt.status === 'succeeded' && receipt.responseDisposition !== 'final_response' && receipt.responseDisposition !== 'tool_continuation_required') return false;
-  if (receipt.status !== 'succeeded' && receipt.responseDisposition !== null) return false;
-  const identity = receipt.returnedIdentity;
-  const usage = receipt.usage;
-  const validIdentity = identity !== null && typeof identity === 'object' && exactKeys(identity, ['effort', 'model', 'provider'])
-    && Object.values(identity).every((part) => typeof part === 'string' && /^[a-z0-9._:-]{1,128}$/i.test(part));
-  const validUsage = usage !== null && typeof usage === 'object' && exactKeys(usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])
-    && Object.values(usage).every((part) => Number.isSafeInteger(part) && (part as number) >= 0 && (part as number) <= 1_000_000);
-  if ((receipt.status === 'succeeded' || receipt.status === 'provider_failed' || receipt.status === 'identity_mismatch') && (!validIdentity || !validUsage)) return false;
-  if (receipt.status === 'missing_usage' && !validIdentity) return false;
-  if ((receipt.status === 'malformed_response' || receipt.status === 'missing_usage') && usage !== null) return false;
-  if (receipt.status === 'timeout_after_dispatch' && (receipt.responseHmac !== null || identity !== null || usage !== null)) return false;
-  if (receipt.status !== 'timeout_after_dispatch' && receipt.responseHmac === null) return false;
-  return true;
+function slotKey(entry: ProviderPlanEntry, invocationOrdinal: number): string {
+  // This durable fixture key is intentionally transparent, not a MAC or a
+  // substitute for the still-unprovisioned exact replay binding.
+  return JSON.stringify([
+    FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint,
+    entry.assignmentId,
+    entry.probeId,
+    entry.cellId,
+    entry.provider,
+    entry.model,
+    entry.effort,
+    invocationOrdinal,
+  ]);
 }
 
-/** The only adapter implementation is capability-gated at invocation time. */
-class CapabilityGatedProviderAdapter implements PrivateProviderAdapter {
-  constructor(private readonly provider: Provider, private readonly transport: ProviderTransport) {}
+function isProviderPlanEntry(entry: FixedTraceComponentSmokePrivateAuthorityPlanEntry): entry is ProviderPlanEntry {
+  return entry.disposition === 'provider_dispatch';
+}
 
-  async invoke(capability: LiveRunCapability, entry: PlanEntry, request: Readonly<ModelRequest>): Promise<FixedTraceComponentSmokeInertProviderReceipt> {
-    if (!hasLiveRunCapability(capability) || entry.provider !== this.provider || request.model !== entry.model
-      || request.maxOutputTokens !== entry.maxOutputTokens || request.reasoning?.effort !== entry.effort) {
-      throw new Error('private component-smoke adapter refused an unbound invocation');
-    }
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), entry.timeoutMs);
-    try {
-      const receipt = await this.transport.invoke(request, Object.freeze({
-        signal: controller.signal, timeoutMs: entry.timeoutMs, maxRetries: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES,
-      }));
-      if (!safeReceipt(receipt)) throw new Error('private component-smoke adapter received malformed categorical receipt');
-      return deepFreeze(structuredClone(receipt));
-    } finally {
-      clearTimeout(timer);
-    }
+function deriveSlots(): readonly FixedTraceComponentSmokePrivateLiveSlot[] {
+  const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+  const entries = plan.filter(isProviderPlanEntry);
+  const slots = entries.flatMap((entry) => Array.from(
+    { length: entry.maximumProviderInvocations },
+    (_, index) => {
+      const invocationOrdinal = index + 1;
+      return Object.freeze({
+        slotKey: slotKey(entry, invocationOrdinal),
+        admissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint,
+        assignmentId: entry.assignmentId,
+        probeId: entry.probeId,
+        cellId: entry.cellId,
+        provider: entry.provider,
+        model: entry.model,
+        effort: entry.effort,
+        invocationOrdinal,
+        requestReplayBinding: 'unprovisioned_exact_request_tool_replay_binding' as const,
+        semanticRequestFingerprint: null,
+        providerContinuationBinding: invocationOrdinal === 1
+          ? 'not_applicable' as const
+          : 'unprovisioned_exact_provider_continuation_binding' as const,
+      });
+    },
+  ));
+  const authority = FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY;
+  if (plan.length !== authority.cardinality.caseCellAssignments
+    || entries.length !== authority.cardinality.providerDispatchCaseCellAssignments
+    || slots.length !== authority.cardinality.maximumProviderInvocations
+    || new Set(slots.map((slot) => slot.slotKey)).size !== slots.length) {
+    throw new Error('private component-smoke preflight integrity failure');
   }
+  return Object.freeze(slots);
 }
 
-function assertPinnedComposition(): readonly PlanEntry[] {
+const SLOTS = deriveSlots();
+
+/** Returns immutable accounting slots only; it cannot prepare or dispatch a request. */
+export function fixedTraceComponentSmokePrivateLiveSlots(): readonly FixedTraceComponentSmokePrivateLiveSlot[] {
+  return SLOTS;
+}
+
+/**
+ * Returns the pinned plan's explicit provisioning gap. An admitted manifest
+ * is necessary but cannot stand in for a captured request replay fingerprint,
+ * keyed request MAC, or provider continuation state.
+ */
+export function fixedTraceComponentSmokePrivateLivePreflight(): FixedTraceComponentSmokePrivateLiveInspection {
   const admission = fixedTraceComponentSmokeAdmission();
   if (!isFixedTraceComponentSmokeAdmissionManifest(admission)
     || !fixedTraceComponentSmokePrivateAuthorityMatchesAdmission(admission)
     || admission.fingerprints.aggregateAdmission !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint
-    || admission.fingerprints.requestAssemblyPolicyVersion !== ADDIE_REQUEST_TOOL_REPLAY_ASSEMBLY_POLICY_VERSION
     || admission.cardinality.caseCellAssignments !== 168
     || admission.cardinality.maximumProviderInvocations !== 192
     || admission.pricing.reservationMicrodollars !== 2_819_484) {
-    throw new Error('private component-smoke admission pin drift');
-  }
-  return fixedTraceComponentSmokePrivateAuthorityPlan();
-}
-
-function requestFor(entry: PlanEntry): Readonly<ModelRequest> {
-  const probe = FIXED_TRACE_COMPONENT_SMOKE_PROBES.find((candidate) => candidate.id === entry.probeId);
-  if (!probe || !isProvider(entry.provider)) throw new Error('private component-smoke request plan drift');
-  const tools = probe.toolDescriptors.map((tool) => ({
-    name: tool.definition.name as string,
-    description: tool.definition.description as string,
-    inputSchema: structuredClone(tool.definition.input_schema) as ModelRequest['tools'][number]['inputSchema'],
-  }));
-  const request: ModelRequest = {
-    model: entry.model,
-    system: [{ text: 'Fixed-trace private component-smoke synthetic request.' }],
-    messages: [
-      ...probe.visibleFacts.threadContext.map((message) => ({ role: message.user === 'member' ? 'user' as const : 'assistant' as const, content: [{ type: 'text' as const, text: message.text }] })),
-      { role: 'user' as const, content: [{ type: 'text' as const, text: probe.visibleFacts.message }] },
-    ],
-    tools,
-    reasoning: { effort: entry.effort as ModelReasoningEffort },
-    maxOutputTokens: entry.maxOutputTokens,
-    requestMetadata: { fixedTraceAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint },
-  };
-  return deepFreeze(request);
-}
-function fixtureKey(request: Readonly<ModelRequest>): string {
-  return `${request.requestMetadata?.fixedTraceAdmissionFingerprint}:${request.model}:${request.reasoning?.effort ?? 'provider_default'}`;
-}
-function attemptId(reservation: FixedTraceComponentSmokeReservation, entry: PlanEntry, ordinal: number): string {
-  return `attempt_${createHash('sha256').update(JSON.stringify({ domain: 'adcp:addie:fixed-trace-component-smoke:live-attempt:v1\\0', reservationId: reservation.reservationId, assignmentId: entry.assignmentId, ordinal })).digest('hex').slice(0, 32)}`;
-}
-
-/**
- * This private coordinator is deliberately unconstructible in production in
- * this PR. A later exact trust-root provisioning change can be reviewed for a
- * module-local construction path; no caller can supply one today.
- */
-class PrivateLiveCoordinator {
-  constructor(
-    private readonly capability: LiveRunCapability,
-    private readonly ledger: PostgresFixedTraceComponentSmokePrivateLedger,
-    private readonly adapters: ReadonlyMap<Provider, PrivateProviderAdapter>,
-    private readonly preparedRequestHmac: (request: Readonly<ModelRequest>) => string,
-    private readonly grant: FixedTraceComponentSmokeVerifiedGrant,
-  ) {}
-
-  private async closeAmbiguity(reservation: FixedTraceComponentSmokeReservation): Promise<void> {
-    await this.ledger.recordUnknownExposure(reservation);
-  }
-
-  async run(): Promise<Readonly<{ status: 'completed' | 'halted'; providerInvocations: number }>> {
-    const plan = assertPinnedComposition();
-    const reserved = await this.ledger.reserveAndConsume(this.grant);
-    if (reserved.status !== 'reserved') return Object.freeze({ status: 'halted', providerInvocations: 0 });
-    let providerInvocations = 0;
-    for (const entry of plan) {
-      if (entry.disposition !== 'provider_dispatch') {
-        const terminal = await this.ledger.recordNonDispatchTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId, status: entry.disposition });
-        if (terminal.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-        continue;
-      }
-      const adapter = isProvider(entry.provider) ? this.adapters.get(entry.provider) : undefined;
-      if (!adapter) { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-      const request = requestFor(entry);
-      let finalOrdinal = 0;
-      for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
-        const hmac = this.preparedRequestHmac(request);
-        if (!/^[a-f0-9]{64}$/.test(hmac)) { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-        const intent = await this.ledger.recordProviderIntent({ reservation: reserved.reservation, attemptId: attemptId(reserved.reservation, entry, ordinal), assignmentId: entry.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac: hmac });
-        if (intent.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-        let receipt: FixedTraceComponentSmokeInertProviderReceipt;
-        try { receipt = await adapter.invoke(this.capability, entry, request); providerInvocations += 1; }
-        catch { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-        const terminal = await this.ledger.recordTerminal({ reservation: reserved.reservation, attemptId: attemptId(reserved.reservation, entry, ordinal), ...receipt });
-        if (terminal.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-        finalOrdinal = ordinal;
-        if (receipt.status !== 'succeeded') {
-          const outcome = await this.ledger.recordProviderAssignmentTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId,
-            status: 'provider_failed', finalInvocationOrdinal: finalOrdinal });
-          if (outcome.status !== 'recorded') await this.closeAmbiguity(reserved.reservation);
-          await this.closeAmbiguity(reserved.reservation);
-          return Object.freeze({ status: 'halted', providerInvocations });
-        }
-        if (receipt.responseDisposition === 'final_response') break;
-      }
-      const outcome = await this.ledger.recordProviderAssignmentTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId,
-        status: 'provider_completed', finalInvocationOrdinal: finalOrdinal });
-      if (outcome.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
-    }
-    return Object.freeze({ status: 'completed', providerInvocations });
-  }
-}
-
-/** Production remains unprovisioned until an exact, separately reviewed trust-root change. */
-export function createFixedTraceComponentSmokePrivateLiveCoordinator(): null { return null; }
-
-/**
- * Test-only execution harness. Its sole transport is the inert JSON fixture
- * map below; it has no SDK construction, provider endpoint, credential, or
- * production grant verification path. The real coordinator remains private.
- */
-export function createFixedTraceComponentSmokePrivateLiveCoordinatorForTest(input: Readonly<{
-  readonly ledger: FixedTraceComponentSmokePrivateLiveTestLedger;
-  readonly grant: FixedTraceComponentSmokeVerifiedGrant;
-  readonly fixtures: FixedTraceComponentSmokeInertProviderFixtures;
-}>) {
-  const copied = structuredClone(input.fixtures) as FixedTraceComponentSmokeInertProviderFixtures;
-  if (Object.values(copied).some((receipt) => !safeReceipt(receipt))) throw new Error('invalid inert provider fixture');
-  const capability = issueLiveRunCapability();
-  const adapters = new Map<Provider, PrivateProviderAdapter>();
-  for (const provider of ['anthropic', 'openai', 'google'] as const) {
-    adapters.set(provider, new CapabilityGatedProviderAdapter(provider, {
-      async invoke(request) {
-        const receipt = copied[fixtureKey(request)];
-        if (!receipt) throw new Error('missing inert provider fixture');
-        return receipt;
-      },
-    }));
-  }
-  const coordinator = new PrivateLiveCoordinator(capability, input.ledger as PostgresFixedTraceComponentSmokePrivateLedger, adapters,
-    (request) => createHash('sha256').update(JSON.stringify(request)).digest('hex'), input.grant);
-  return Object.freeze({ runForTest: () => coordinator.run() });
-}
-
-/**
- * Test-only inert adapter fixture harness. It cannot accept a transport or a
- * credential, and it never creates a coordinator, grant, ledger, or request
- * dispatcher. The capability stays module-private even to this harness.
- */
-export function createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures: FixedTraceComponentSmokeInertProviderFixtures) {
-  const copied = structuredClone(fixtures) as FixedTraceComponentSmokeInertProviderFixtures;
-  if (Object.values(copied).some((receipt) => !safeReceipt(receipt))) throw new Error('invalid inert provider fixture');
-  const capability = issueLiveRunCapability();
-  const adapters = new Map<Provider, PrivateProviderAdapter>();
-  for (const provider of ['anthropic', 'openai', 'google'] as const) {
-    adapters.set(provider, new CapabilityGatedProviderAdapter(provider, {
-      async invoke(request) {
-        const receipt = copied[fixtureKey(request)];
-        if (!receipt) throw new Error('missing inert provider fixture');
-        return receipt;
-      },
-    }));
+    return Object.freeze({ status: 'refused', reason: 'unknown_or_mismatched_slot_declaration', slot: null });
   }
   return Object.freeze({
-    requestForTest(assignmentId: string): Readonly<ModelRequest> {
-      const entry = assertPinnedComposition().find((candidate) => candidate.assignmentId === assignmentId);
-      if (!entry || entry.disposition !== 'provider_dispatch') throw new Error('unadmitted provider assignment');
-      return requestFor(entry);
-    },
-    async invokeForTest(assignmentId: string): Promise<FixedTraceComponentSmokeInertProviderReceipt> {
-      const entry = assertPinnedComposition().find((candidate) => candidate.assignmentId === assignmentId);
-      if (!entry || entry.disposition !== 'provider_dispatch' || !isProvider(entry.provider)) throw new Error('unadmitted provider assignment');
-      return adapters.get(entry.provider)!.invoke(capability, entry, requestFor(entry));
-    },
+    status: 'not_provisioned',
+    reason: 'exact_request_tool_replay_binding_unprovisioned',
+    slot: null,
   });
+}
+
+function hasExactDeclarationKeys(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value).sort();
+  return keys.length === DECLARATION_FIELDS.length
+    && keys.every((key, index) => key === DECLARATION_FIELDS[index]);
+}
+
+/**
+ * Inspect one JSON-text slot declaration. Object inputs are rejected before
+ * property access, so this contract never invokes caller getters or callbacks.
+ * It accepts no request, receipt, credential, grant, or persistence handle.
+ */
+export function inspectFixedTraceComponentSmokePrivateLiveSlotJson(jsonText: unknown): FixedTraceComponentSmokePrivateLiveInspection {
+  if (typeof jsonText !== 'string' || jsonText.length > 16_384) {
+    return Object.freeze({ status: 'refused', reason: 'invalid_json_declaration', slot: null });
+  }
+  let declaration: unknown;
+  try {
+    declaration = JSON.parse(jsonText);
+  } catch {
+    return Object.freeze({ status: 'refused', reason: 'invalid_json_declaration', slot: null });
+  }
+  if (!declaration || typeof declaration !== 'object' || Array.isArray(declaration)) {
+    return Object.freeze({ status: 'refused', reason: 'invalid_json_declaration', slot: null });
+  }
+  const candidate = declaration as Record<string, unknown>;
+  if (!hasExactDeclarationKeys(candidate)
+    || typeof candidate.slotKey !== 'string'
+    || typeof candidate.admissionFingerprint !== 'string'
+    || typeof candidate.assignmentId !== 'string'
+    || typeof candidate.probeId !== 'string'
+    || typeof candidate.cellId !== 'string'
+    || typeof candidate.provider !== 'string'
+    || typeof candidate.model !== 'string'
+    || typeof candidate.effort !== 'string'
+    || !Number.isSafeInteger(candidate.invocationOrdinal)) {
+    return Object.freeze({ status: 'refused', reason: 'invalid_json_declaration', slot: null });
+  }
+  const slot = SLOTS.find((known) => known.slotKey === candidate.slotKey
+    && known.admissionFingerprint === candidate.admissionFingerprint
+    && known.assignmentId === candidate.assignmentId
+    && known.probeId === candidate.probeId
+    && known.cellId === candidate.cellId
+    && known.provider === candidate.provider
+    && known.model === candidate.model
+    && known.effort === candidate.effort
+    && known.invocationOrdinal === candidate.invocationOrdinal) ?? null;
+  if (!slot) return Object.freeze({ status: 'refused', reason: 'unknown_or_mismatched_slot_declaration', slot: null });
+  return Object.freeze({
+    status: 'not_provisioned',
+    reason: slot.invocationOrdinal === 1
+      ? 'exact_request_tool_replay_binding_unprovisioned'
+      : 'exact_provider_continuation_binding_unprovisioned',
+    slot,
+  });
+}
+
+/** Production remains hard-null pending a separately reviewed custody and provider-access slice. */
+export function createFixedTraceComponentSmokePrivateLiveCoordinator(): null {
+  return null;
 }

--- a/server/src/addie/eval/fixed-trace-component-smoke-private-live.ts
+++ b/server/src/addie/eval/fixed-trace-component-smoke-private-live.ts
@@ -1,0 +1,297 @@
+import { createHash } from 'node:crypto';
+import type { ModelRequest, ModelReasoningEffort } from '../model-providers/model-provider.js';
+import { ADDIE_REQUEST_TOOL_REPLAY_ASSEMBLY_POLICY_VERSION } from '../request-tool-replay-binding.js';
+import {
+  fixedTraceComponentSmokeAdmission,
+  isFixedTraceComponentSmokeAdmissionManifest,
+} from './fixed-trace-component-smoke-admission.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityMatchesAdmission,
+  fixedTraceComponentSmokePrivateAuthorityPlan,
+  type FixedTraceComponentSmokePrivateAuthorityPlanEntry,
+} from './fixed-trace-component-smoke-private-authority.js';
+import type { FixedTraceComponentSmokeVerifiedGrant } from './fixed-trace-component-smoke-private-authorization.js';
+import {
+  PostgresFixedTraceComponentSmokePrivateLedger,
+  type FixedTraceComponentSmokeReservation,
+  type FixedTraceComponentSmokeTerminal,
+} from './fixed-trace-component-smoke-private-ledger.js';
+import { FIXED_TRACE_COMPONENT_SMOKE_PROBES } from './fixed-trace-smoke-overlays.js';
+
+/**
+ * This is intentionally an unprovisioned composition boundary.  There is no
+ * exported production constructor, credential input, root input, route, job,
+ * or ambient activation switch in this module.
+ */
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF = true as const;
+export const FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES = 0 as const;
+
+type PlanEntry = FixedTraceComponentSmokePrivateAuthorityPlanEntry;
+type Provider = 'anthropic' | 'openai' | 'google';
+type Usage = NonNullable<FixedTraceComponentSmokeTerminal['usage']>;
+type Identity = NonNullable<FixedTraceComponentSmokeTerminal['returnedIdentity']>;
+
+export type FixedTraceComponentSmokeInertProviderReceipt = Readonly<{
+  readonly status: 'succeeded' | 'provider_failed' | 'timeout_after_dispatch' | 'malformed_response' | 'identity_mismatch' | 'missing_usage';
+  readonly responseDisposition: 'final_response' | 'tool_continuation_required' | null;
+  readonly responseHmac: string | null;
+  readonly returnedIdentity: Identity | null;
+  readonly usage: Usage | null;
+}>;
+
+/** A JSON-only fixture. It contains no callback, credential, request, or raw provider response. */
+export type FixedTraceComponentSmokeInertProviderFixtures = Readonly<Record<string, FixedTraceComponentSmokeInertProviderReceipt>>;
+
+/** Test-only structural mirror of the durable ledger calls used by the coordinator. */
+export type FixedTraceComponentSmokePrivateLiveTestLedger = Pick<PostgresFixedTraceComponentSmokePrivateLedger,
+  'reserveAndConsume' | 'recordProviderIntent' | 'recordTerminal' | 'recordUnknownExposure'
+  | 'recordNonDispatchTerminal' | 'recordProviderAssignmentTerminal'>;
+
+interface LiveRunCapability { readonly __privateLiveRunCapability: never }
+interface ProviderTransport {
+  invoke(request: Readonly<ModelRequest>, options: Readonly<{
+    readonly signal: AbortSignal;
+    readonly timeoutMs: number;
+    readonly maxRetries: 0;
+  }>): Promise<FixedTraceComponentSmokeInertProviderReceipt>;
+}
+
+interface PrivateProviderAdapter {
+  invoke(capability: LiveRunCapability, entry: PlanEntry, request: Readonly<ModelRequest>): Promise<FixedTraceComponentSmokeInertProviderReceipt>;
+}
+
+const liveRunCapabilities = new WeakSet<object>();
+
+function issueLiveRunCapability(): LiveRunCapability {
+  const capability = Object.freeze({}) as LiveRunCapability;
+  liveRunCapabilities.add(capability);
+  return capability;
+}
+function hasLiveRunCapability(value: unknown): value is LiveRunCapability {
+  return typeof value === 'object' && value !== null && liveRunCapabilities.has(value);
+}
+function isProvider(value: string): value is Provider {
+  return value === 'anthropic' || value === 'openai' || value === 'google';
+}
+function exactKeys(value: object, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort(); const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+function safeReceipt(value: unknown): value is FixedTraceComponentSmokeInertProviderReceipt {
+  if (!value || typeof value !== 'object' || !exactKeys(value, ['responseDisposition', 'responseHmac', 'returnedIdentity', 'status', 'usage'])) return false;
+  const receipt = value as Record<string, unknown>;
+  const statuses = new Set(['succeeded', 'provider_failed', 'timeout_after_dispatch', 'malformed_response', 'identity_mismatch', 'missing_usage']);
+  if (typeof receipt.status !== 'string' || !statuses.has(receipt.status)
+    || (receipt.responseHmac !== null && (typeof receipt.responseHmac !== 'string' || !/^[a-f0-9]{64}$/.test(receipt.responseHmac)))) return false;
+  if (receipt.status === 'succeeded' && receipt.responseDisposition !== 'final_response' && receipt.responseDisposition !== 'tool_continuation_required') return false;
+  if (receipt.status !== 'succeeded' && receipt.responseDisposition !== null) return false;
+  const identity = receipt.returnedIdentity;
+  const usage = receipt.usage;
+  const validIdentity = identity !== null && typeof identity === 'object' && exactKeys(identity, ['effort', 'model', 'provider'])
+    && Object.values(identity).every((part) => typeof part === 'string' && /^[a-z0-9._:-]{1,128}$/i.test(part));
+  const validUsage = usage !== null && typeof usage === 'object' && exactKeys(usage, ['cacheReadTokens', 'cacheWriteTokens', 'inputTokens', 'latencyMs', 'outputTokens'])
+    && Object.values(usage).every((part) => Number.isSafeInteger(part) && (part as number) >= 0 && (part as number) <= 1_000_000);
+  if ((receipt.status === 'succeeded' || receipt.status === 'provider_failed' || receipt.status === 'identity_mismatch') && (!validIdentity || !validUsage)) return false;
+  if (receipt.status === 'missing_usage' && !validIdentity) return false;
+  if ((receipt.status === 'malformed_response' || receipt.status === 'missing_usage') && usage !== null) return false;
+  if (receipt.status === 'timeout_after_dispatch' && (receipt.responseHmac !== null || identity !== null || usage !== null)) return false;
+  if (receipt.status !== 'timeout_after_dispatch' && receipt.responseHmac === null) return false;
+  return true;
+}
+
+/** The only adapter implementation is capability-gated at invocation time. */
+class CapabilityGatedProviderAdapter implements PrivateProviderAdapter {
+  constructor(private readonly provider: Provider, private readonly transport: ProviderTransport) {}
+
+  async invoke(capability: LiveRunCapability, entry: PlanEntry, request: Readonly<ModelRequest>): Promise<FixedTraceComponentSmokeInertProviderReceipt> {
+    if (!hasLiveRunCapability(capability) || entry.provider !== this.provider || request.model !== entry.model
+      || request.maxOutputTokens !== entry.maxOutputTokens || request.reasoning?.effort !== entry.effort) {
+      throw new Error('private component-smoke adapter refused an unbound invocation');
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), entry.timeoutMs);
+    try {
+      const receipt = await this.transport.invoke(request, Object.freeze({
+        signal: controller.signal, timeoutMs: entry.timeoutMs, maxRetries: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES,
+      }));
+      if (!safeReceipt(receipt)) throw new Error('private component-smoke adapter received malformed categorical receipt');
+      return deepFreeze(structuredClone(receipt));
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function assertPinnedComposition(): readonly PlanEntry[] {
+  const admission = fixedTraceComponentSmokeAdmission();
+  if (!isFixedTraceComponentSmokeAdmissionManifest(admission)
+    || !fixedTraceComponentSmokePrivateAuthorityMatchesAdmission(admission)
+    || admission.fingerprints.aggregateAdmission !== FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint
+    || admission.fingerprints.requestAssemblyPolicyVersion !== ADDIE_REQUEST_TOOL_REPLAY_ASSEMBLY_POLICY_VERSION
+    || admission.cardinality.caseCellAssignments !== 168
+    || admission.cardinality.maximumProviderInvocations !== 192
+    || admission.pricing.reservationMicrodollars !== 2_819_484) {
+    throw new Error('private component-smoke admission pin drift');
+  }
+  return fixedTraceComponentSmokePrivateAuthorityPlan();
+}
+
+function requestFor(entry: PlanEntry): Readonly<ModelRequest> {
+  const probe = FIXED_TRACE_COMPONENT_SMOKE_PROBES.find((candidate) => candidate.id === entry.probeId);
+  if (!probe || !isProvider(entry.provider)) throw new Error('private component-smoke request plan drift');
+  const tools = probe.toolDescriptors.map((tool) => ({
+    name: tool.definition.name as string,
+    description: tool.definition.description as string,
+    inputSchema: structuredClone(tool.definition.input_schema) as ModelRequest['tools'][number]['inputSchema'],
+  }));
+  const request: ModelRequest = {
+    model: entry.model,
+    system: [{ text: 'Fixed-trace private component-smoke synthetic request.' }],
+    messages: [
+      ...probe.visibleFacts.threadContext.map((message) => ({ role: message.user === 'member' ? 'user' as const : 'assistant' as const, content: [{ type: 'text' as const, text: message.text }] })),
+      { role: 'user' as const, content: [{ type: 'text' as const, text: probe.visibleFacts.message }] },
+    ],
+    tools,
+    reasoning: { effort: entry.effort as ModelReasoningEffort },
+    maxOutputTokens: entry.maxOutputTokens,
+    requestMetadata: { fixedTraceAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint },
+  };
+  return deepFreeze(request);
+}
+function fixtureKey(request: Readonly<ModelRequest>): string {
+  return `${request.requestMetadata?.fixedTraceAdmissionFingerprint}:${request.model}:${request.reasoning?.effort ?? 'provider_default'}`;
+}
+function attemptId(reservation: FixedTraceComponentSmokeReservation, entry: PlanEntry, ordinal: number): string {
+  return `attempt_${createHash('sha256').update(JSON.stringify({ domain: 'adcp:addie:fixed-trace-component-smoke:live-attempt:v1\\0', reservationId: reservation.reservationId, assignmentId: entry.assignmentId, ordinal })).digest('hex').slice(0, 32)}`;
+}
+
+/**
+ * This private coordinator is deliberately unconstructible in production in
+ * this PR. A later exact trust-root provisioning change can be reviewed for a
+ * module-local construction path; no caller can supply one today.
+ */
+class PrivateLiveCoordinator {
+  constructor(
+    private readonly capability: LiveRunCapability,
+    private readonly ledger: PostgresFixedTraceComponentSmokePrivateLedger,
+    private readonly adapters: ReadonlyMap<Provider, PrivateProviderAdapter>,
+    private readonly preparedRequestHmac: (request: Readonly<ModelRequest>) => string,
+    private readonly grant: FixedTraceComponentSmokeVerifiedGrant,
+  ) {}
+
+  private async closeAmbiguity(reservation: FixedTraceComponentSmokeReservation): Promise<void> {
+    await this.ledger.recordUnknownExposure(reservation);
+  }
+
+  async run(): Promise<Readonly<{ status: 'completed' | 'halted'; providerInvocations: number }>> {
+    const plan = assertPinnedComposition();
+    const reserved = await this.ledger.reserveAndConsume(this.grant);
+    if (reserved.status !== 'reserved') return Object.freeze({ status: 'halted', providerInvocations: 0 });
+    let providerInvocations = 0;
+    for (const entry of plan) {
+      if (entry.disposition !== 'provider_dispatch') {
+        const terminal = await this.ledger.recordNonDispatchTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId, status: entry.disposition });
+        if (terminal.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+        continue;
+      }
+      const adapter = isProvider(entry.provider) ? this.adapters.get(entry.provider) : undefined;
+      if (!adapter) { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+      const request = requestFor(entry);
+      let finalOrdinal = 0;
+      for (let ordinal = 1; ordinal <= entry.maximumProviderInvocations; ordinal += 1) {
+        const hmac = this.preparedRequestHmac(request);
+        if (!/^[a-f0-9]{64}$/.test(hmac)) { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+        const intent = await this.ledger.recordProviderIntent({ reservation: reserved.reservation, attemptId: attemptId(reserved.reservation, entry, ordinal), assignmentId: entry.assignmentId, invocationOrdinal: ordinal, preparedRequestHmac: hmac });
+        if (intent.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+        let receipt: FixedTraceComponentSmokeInertProviderReceipt;
+        try { receipt = await adapter.invoke(this.capability, entry, request); providerInvocations += 1; }
+        catch { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+        const terminal = await this.ledger.recordTerminal({ reservation: reserved.reservation, attemptId: attemptId(reserved.reservation, entry, ordinal), ...receipt });
+        if (terminal.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+        finalOrdinal = ordinal;
+        if (receipt.status !== 'succeeded') {
+          const outcome = await this.ledger.recordProviderAssignmentTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId,
+            status: 'provider_failed', finalInvocationOrdinal: finalOrdinal });
+          if (outcome.status !== 'recorded') await this.closeAmbiguity(reserved.reservation);
+          await this.closeAmbiguity(reserved.reservation);
+          return Object.freeze({ status: 'halted', providerInvocations });
+        }
+        if (receipt.responseDisposition === 'final_response') break;
+      }
+      const outcome = await this.ledger.recordProviderAssignmentTerminal({ reservation: reserved.reservation, assignmentId: entry.assignmentId,
+        status: 'provider_completed', finalInvocationOrdinal: finalOrdinal });
+      if (outcome.status !== 'recorded') { await this.closeAmbiguity(reserved.reservation); return Object.freeze({ status: 'halted', providerInvocations }); }
+    }
+    return Object.freeze({ status: 'completed', providerInvocations });
+  }
+}
+
+/** Production remains unprovisioned until an exact, separately reviewed trust-root change. */
+export function createFixedTraceComponentSmokePrivateLiveCoordinator(): null { return null; }
+
+/**
+ * Test-only execution harness. Its sole transport is the inert JSON fixture
+ * map below; it has no SDK construction, provider endpoint, credential, or
+ * production grant verification path. The real coordinator remains private.
+ */
+export function createFixedTraceComponentSmokePrivateLiveCoordinatorForTest(input: Readonly<{
+  readonly ledger: FixedTraceComponentSmokePrivateLiveTestLedger;
+  readonly grant: FixedTraceComponentSmokeVerifiedGrant;
+  readonly fixtures: FixedTraceComponentSmokeInertProviderFixtures;
+}>) {
+  const copied = structuredClone(input.fixtures) as FixedTraceComponentSmokeInertProviderFixtures;
+  if (Object.values(copied).some((receipt) => !safeReceipt(receipt))) throw new Error('invalid inert provider fixture');
+  const capability = issueLiveRunCapability();
+  const adapters = new Map<Provider, PrivateProviderAdapter>();
+  for (const provider of ['anthropic', 'openai', 'google'] as const) {
+    adapters.set(provider, new CapabilityGatedProviderAdapter(provider, {
+      async invoke(request) {
+        const receipt = copied[fixtureKey(request)];
+        if (!receipt) throw new Error('missing inert provider fixture');
+        return receipt;
+      },
+    }));
+  }
+  const coordinator = new PrivateLiveCoordinator(capability, input.ledger as PostgresFixedTraceComponentSmokePrivateLedger, adapters,
+    (request) => createHash('sha256').update(JSON.stringify(request)).digest('hex'), input.grant);
+  return Object.freeze({ runForTest: () => coordinator.run() });
+}
+
+/**
+ * Test-only inert adapter fixture harness. It cannot accept a transport or a
+ * credential, and it never creates a coordinator, grant, ledger, or request
+ * dispatcher. The capability stays module-private even to this harness.
+ */
+export function createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures: FixedTraceComponentSmokeInertProviderFixtures) {
+  const copied = structuredClone(fixtures) as FixedTraceComponentSmokeInertProviderFixtures;
+  if (Object.values(copied).some((receipt) => !safeReceipt(receipt))) throw new Error('invalid inert provider fixture');
+  const capability = issueLiveRunCapability();
+  const adapters = new Map<Provider, PrivateProviderAdapter>();
+  for (const provider of ['anthropic', 'openai', 'google'] as const) {
+    adapters.set(provider, new CapabilityGatedProviderAdapter(provider, {
+      async invoke(request) {
+        const receipt = copied[fixtureKey(request)];
+        if (!receipt) throw new Error('missing inert provider fixture');
+        return receipt;
+      },
+    }));
+  }
+  return Object.freeze({
+    requestForTest(assignmentId: string): Readonly<ModelRequest> {
+      const entry = assertPinnedComposition().find((candidate) => candidate.assignmentId === assignmentId);
+      if (!entry || entry.disposition !== 'provider_dispatch') throw new Error('unadmitted provider assignment');
+      return requestFor(entry);
+    },
+    async invokeForTest(assignmentId: string): Promise<FixedTraceComponentSmokeInertProviderReceipt> {
+      const entry = assertPinnedComposition().find((candidate) => candidate.assignmentId === assignmentId);
+      if (!entry || entry.disposition !== 'provider_dispatch' || !isProvider(entry.provider)) throw new Error('unadmitted provider assignment');
+      return adapters.get(entry.provider)!.invoke(capability, entry, requestFor(entry));
+    },
+  });
+}

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-live.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-live.test.ts
@@ -6,153 +6,103 @@ import {
 } from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
 import {
   FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF,
-  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES,
-  createFixedTraceComponentSmokeInertAdapterFixturesForTest,
   createFixedTraceComponentSmokePrivateLiveCoordinator,
-  createFixedTraceComponentSmokePrivateLiveCoordinatorForTest,
-  type FixedTraceComponentSmokeInertProviderReceipt,
+  fixedTraceComponentSmokePrivateLivePreflight,
+  fixedTraceComponentSmokePrivateLiveSlots,
+  inspectFixedTraceComponentSmokePrivateLiveSlotJson,
 } from '../../../src/addie/eval/fixed-trace-component-smoke-private-live.js';
 
-const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
-const one = (provider: 'anthropic' | 'openai' | 'google') => plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.provider === provider)!;
-const fixtureKey = (entry: typeof plan[number]) => `${FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint}:${entry.model}:${entry.effort}`;
+const slots = fixedTraceComponentSmokePrivateLiveSlots();
+const declaration = (slot = slots[0]) => JSON.stringify({
+  slotKey: slot.slotKey,
+  admissionFingerprint: slot.admissionFingerprint,
+  assignmentId: slot.assignmentId,
+  probeId: slot.probeId,
+  cellId: slot.cellId,
+  provider: slot.provider,
+  model: slot.model,
+  effort: slot.effort,
+  invocationOrdinal: slot.invocationOrdinal,
+});
 
-function receipt(entry = one('anthropic'), overrides: Partial<FixedTraceComponentSmokeInertProviderReceipt> = {}): FixedTraceComponentSmokeInertProviderReceipt {
-  return {
-    status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'a'.repeat(64),
-    returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort },
-    usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 1 },
-    ...overrides,
-  };
-}
-function fixtures(overrides: Record<string, FixedTraceComponentSmokeInertProviderReceipt> = {}) {
-  return Object.fromEntries(['anthropic', 'openai', 'google'].map((provider) => {
-    const entry = one(provider as 'anthropic' | 'openai' | 'google');
-    const key = fixtureKey(entry);
-    return [key, overrides[key] ?? receipt(entry)];
-  }));
-}
-function allFixtures() {
-  return Object.fromEntries(plan.filter((entry) => entry.disposition === 'provider_dispatch').map((entry) => [
-    fixtureKey(entry),
-    receipt(entry),
-  ]));
-}
-function coordinatorLedger() {
-  const calls: string[] = [];
-  let consumed = false;
-  const reservation = { reservationId: `reservation_${'b'.repeat(32)}`, authorizationDigest: 'c'.repeat(64), entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 } as const;
-  return {
-    calls,
-    ledger: {
-      reserveAndConsume: async () => {
-        calls.push('reserve');
-        if (consumed) return { status: 'refused' as const, reason: 'grant_already_consumed' as const };
-        consumed = true;
-        return { status: 'reserved' as const, reservation };
-      },
-      recordProviderIntent: async (value: { attemptId: string }) => { calls.push(`intent:${value.attemptId}`); return { status: 'recorded' as const }; },
-      recordTerminal: async (value: { attemptId: string }) => { calls.push(`terminal:${value.attemptId}`); return { status: 'recorded' as const }; },
-      recordUnknownExposure: async () => { calls.push('unknown'); return { status: 'recorded' as const }; },
-      recordNonDispatchTerminal: async () => { calls.push('non-dispatch'); return { status: 'recorded' as const }; },
-      recordProviderAssignmentTerminal: async () => { calls.push('assignment'); return { status: 'recorded' as const }; },
-    },
-  };
-}
-function testGrant() {
-  return { grantDigest: 'd'.repeat(64), signedPayloadDigest: 'e'.repeat(64), payload: {} } as never;
-}
-
-describe('private live component-smoke composition', () => {
-  it('leaves the production coordinator hard-null and uses no ambient enablement', () => {
+describe('private live component-smoke preflight contract', () => {
+  it('leaves production hard-null and default-off without an execution export', () => {
     expect(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF).toBe(true);
-    expect(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES).toBe(0);
     expect(createFixedTraceComponentSmokePrivateLiveCoordinator()).toBeNull();
-    expect((createFixedTraceComponentSmokePrivateLiveCoordinator as (...args: unknown[]) => unknown)({}, {}, {}, {})).toBeNull();
+    expect((createFixedTraceComponentSmokePrivateLiveCoordinator as (...args: unknown[]) => unknown)({}, {}, {})).toBeNull();
   });
 
-  it.each(['anthropic', 'openai', 'google'] as const)('builds a frozen admitted %s request only from the immutable plan', (provider) => {
-    const entry = one(provider);
-    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
-    const request = harness.requestForTest(entry.assignmentId);
-    expect(request).toMatchObject({ model: entry.model, maxOutputTokens: entry.maxOutputTokens, reasoning: { effort: entry.effort } });
-    expect(request.requestMetadata).toEqual({ fixedTraceAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint });
-    expect(Object.isFrozen(request)).toBe(true);
-    expect(request.tools.map((tool) => tool.name)).toEqual(
-      expect.any(Array),
-    );
+  it('derives exactly 192 unique provider accounting slots from the immutable 168-assignment authority', () => {
+    const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+    expect(plan).toHaveLength(168);
+    expect(slots).toHaveLength(192);
+    expect(new Set(slots.map((slot) => slot.slotKey))).toHaveLength(192);
+    expect(new Set(slots.map((slot) => slot.assignmentId))).toHaveLength(126);
+    expect(slots.every((slot) => slot.admissionFingerprint === FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint)).toBe(true);
+    expect(Object.isFrozen(slots)).toBe(true);
+    expect(slots.every(Object.isFrozen)).toBe(true);
   });
 
-  it.each(['anthropic', 'openai', 'google'] as const)('accepts a pure inert %s response fixture with exact identity and usage shape', async (provider) => {
-    const entry = one(provider);
-    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
-    await expect(harness.invokeForTest(entry.assignmentId)).resolves.toEqual(receipt(entry));
+  it('binds every declarative fixture key to fingerprint, assignment, probe, cell, provider, model, effort, and ordinal', () => {
+    for (const slot of slots) {
+      const inspected = inspectFixedTraceComponentSmokePrivateLiveSlotJson(declaration(slot));
+      expect(inspected).toMatchObject({ status: 'not_provisioned', slot });
+      expect(inspected.slot?.slotKey).toBe(slot.slotKey);
+    }
   });
 
-  it('categorizes timeout and identity-drift receipts without recording a raw provider error or response', async () => {
-    const entry = one('openai');
-    const key = fixtureKey(entry);
-    const timeout = receipt(entry, { status: 'timeout_after_dispatch', responseDisposition: null, responseHmac: null, returnedIdentity: null, usage: null });
-    await expect(createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: timeout })).invokeForTest(entry.assignmentId)).resolves.toEqual(timeout);
-    const mismatchedIdentity = receipt(entry, { returnedIdentity: { provider: 'other', model: entry.model, effort: entry.effort } });
-    await expect(createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: mismatchedIdentity })).invokeForTest(entry.assignmentId)).resolves.toEqual(mismatchedIdentity);
+  it('refuses a declaration if any exact slot dimension is changed', () => {
+    const slot = slots.find((candidate) => candidate.invocationOrdinal === 2)!;
+    const dimensions = ['admissionFingerprint', 'assignmentId', 'probeId', 'cellId', 'provider', 'model', 'effort', 'invocationOrdinal'] as const;
+    for (const dimension of dimensions) {
+      const parsed = JSON.parse(declaration(slot)) as Record<string, unknown>;
+      parsed[dimension] = dimension === 'invocationOrdinal' ? 1 : `wrong-${dimension}`;
+      expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson(JSON.stringify(parsed))).toEqual({
+        status: 'refused', reason: 'unknown_or_mismatched_slot_declaration', slot: null,
+      });
+    }
   });
 
-  it('refuses absent, malformed, and missing-usage fixture receipts before a transport exists', async () => {
-    const entry = one('openai');
-    const key = fixtureKey(entry);
-    expect(() => createFixedTraceComponentSmokeInertAdapterFixturesForTest({ [key]: { bad: true } } as never)).toThrow('invalid inert provider fixture');
-    expect(() => createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: receipt(entry, { usage: null }) }))).toThrow('invalid inert provider fixture');
-    const absent = createFixedTraceComponentSmokeInertAdapterFixturesForTest({});
-    await expect(absent.invokeForTest(entry.assignmentId)).rejects.toThrow('missing inert provider fixture');
+  it('refuses object inputs before access and only accepts exact JSON-text declarations', () => {
+    const getter = Object.defineProperty({}, 'toString', { get: () => { throw new Error('getter executed'); } });
+    expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson(getter)).toEqual({
+      status: 'refused', reason: 'invalid_json_declaration', slot: null,
+    });
+    expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson('{"assignmentId":"only"}')).toEqual({
+      status: 'refused', reason: 'invalid_json_declaration', slot: null,
+    });
+    expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson('{not json')).toEqual({
+      status: 'refused', reason: 'invalid_json_declaration', slot: null,
+    });
   });
 
-  it('has no production provider construction, generic dispatch, root, credential, persistence, or raw-output surface', () => {
+  it('makes first-call replay and second-call continuation gaps explicit instead of fabricating requests', () => {
+    const first = slots.find((slot) => slot.invocationOrdinal === 1)!;
+    const continuation = slots.find((slot) => slot.invocationOrdinal === 2)!;
+    expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson(declaration(first))).toMatchObject({
+      status: 'not_provisioned', reason: 'exact_request_tool_replay_binding_unprovisioned',
+      slot: { semanticRequestFingerprint: null, providerContinuationBinding: 'not_applicable' },
+    });
+    expect(inspectFixedTraceComponentSmokePrivateLiveSlotJson(declaration(continuation))).toMatchObject({
+      status: 'not_provisioned', reason: 'exact_provider_continuation_binding_unprovisioned',
+      slot: { semanticRequestFingerprint: null, providerContinuationBinding: 'unprovisioned_exact_provider_continuation_binding' },
+    });
+  });
+
+  it('never treats the admission pin or its policy version as a replay binding', () => {
+    expect(fixedTraceComponentSmokePrivateLivePreflight()).toEqual({
+      status: 'not_provisioned', reason: 'exact_request_tool_replay_binding_unprovisioned', slot: null,
+    });
+  });
+
+  it('has no provider, credential, persistence, adapter, callback, or raw request/response surface', () => {
     const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-live.ts', import.meta.url), 'utf8');
-    for (const forbidden of ['process.env', 'fetch(', 'console.', 'new OpenAI', 'new Anthropic', 'new GoogleGenAI', 'apiKey', 'trustRoot', 'privateKey', 'from "../config/models', 'from \'../config/models']) {
-      expect(source).not.toContain(forbidden);
-    }
-    expect(source).toContain('WeakSet');
-    expect(source).toContain('recordProviderIntent');
-    expect(source).toContain('recordUnknownExposure');
-    expect(source).toContain('maxRetries: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES');
-    expect(source).toContain('new AbortController()');
-    expect(source).toContain('fixedTraceComponentSmokePrivateAuthorityMatchesAdmission');
-  });
-
-  it('cannot mutate the authority plan through the composition request path', () => {
-    const entry = one('google');
-    const before = JSON.stringify(fixedTraceComponentSmokePrivateAuthorityPlan());
-    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
-    const request = harness.requestForTest(entry.assignmentId);
-    expect(() => { (request as { model: string }).model = 'other'; }).toThrow();
-    expect(JSON.stringify(fixedTraceComponentSmokePrivateAuthorityPlan())).toBe(before);
-    expect(() => harness.requestForTest('0'.repeat(64))).toThrow('unadmitted provider assignment');
-  });
-
-  it('commits every intent before its inert response, closes the 168-entry plan, and is one-shot', async () => {
-    const { ledger, calls } = coordinatorLedger();
-    const harness = createFixedTraceComponentSmokePrivateLiveCoordinatorForTest({ ledger, grant: testGrant(), fixtures: allFixtures() });
-    await expect(harness.runForTest()).resolves.toEqual({ status: 'completed', providerInvocations: 126 });
-    expect(calls.filter((call) => call.startsWith('intent:'))).toHaveLength(126);
-    expect(calls.filter((call) => call.startsWith('terminal:'))).toHaveLength(126);
-    expect(calls.filter((call) => call === 'assignment')).toHaveLength(126);
-    expect(calls.filter((call) => call === 'non-dispatch')).toHaveLength(42);
-    for (const [index, call] of calls.entries()) if (call.startsWith('terminal:')) {
-      expect(calls.slice(0, index)).toContain(`intent:${call.slice('terminal:'.length)}`);
-    }
-    await expect(harness.runForTest()).resolves.toEqual({ status: 'halted', providerInvocations: 0 });
-  });
-
-  it('halts after a post-intent fixture fault and atomically requests ambiguity closure instead of retrying', async () => {
-    const { ledger, calls } = coordinatorLedger();
-    const first = plan.find((entry) => entry.disposition === 'provider_dispatch')!;
-    const harness = createFixedTraceComponentSmokePrivateLiveCoordinatorForTest({ ledger, grant: testGrant(), fixtures: {
-      [fixtureKey(first)]: receipt(first),
-    } });
-    await expect(harness.runForTest()).resolves.toEqual({ status: 'halted', providerInvocations: 1 });
-    expect(calls.filter((call) => call.startsWith('intent:'))).toHaveLength(2);
-    expect(calls.filter((call) => call.startsWith('terminal:'))).toHaveLength(1);
-    expect(calls.filter((call) => call === 'unknown')).toHaveLength(1);
+    for (const forbidden of [
+      'process.env', 'fetch(', 'console.', 'new OpenAI', 'new Anthropic', 'new GoogleGenAI', 'apiKey', 'trustRoot', 'privateKey',
+      'PostgresFixedTraceComponentSmokePrivateLedger', 'recordProviderIntent', 'recordUnknownExposure', 'structuredClone', 'ModelRequest',
+      'ForTest', 'requestFor', 'responseHmac', 'preparedRequestHmac', 'invoke(', 'transport',
+    ]) expect(source).not.toContain(forbidden);
+    expect(source).not.toContain("from '../config/models");
+    expect(source).toContain('JSON.parse(jsonText)');
   });
 });

--- a/server/tests/unit/addie/fixed-trace-component-smoke-private-live.test.ts
+++ b/server/tests/unit/addie/fixed-trace-component-smoke-private-live.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY,
+  fixedTraceComponentSmokePrivateAuthorityPlan,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-authority.js';
+import {
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF,
+  FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES,
+  createFixedTraceComponentSmokeInertAdapterFixturesForTest,
+  createFixedTraceComponentSmokePrivateLiveCoordinator,
+  createFixedTraceComponentSmokePrivateLiveCoordinatorForTest,
+  type FixedTraceComponentSmokeInertProviderReceipt,
+} from '../../../src/addie/eval/fixed-trace-component-smoke-private-live.js';
+
+const plan = fixedTraceComponentSmokePrivateAuthorityPlan();
+const one = (provider: 'anthropic' | 'openai' | 'google') => plan.find((entry) => entry.disposition === 'provider_dispatch' && entry.provider === provider)!;
+const fixtureKey = (entry: typeof plan[number]) => `${FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint}:${entry.model}:${entry.effort}`;
+
+function receipt(entry = one('anthropic'), overrides: Partial<FixedTraceComponentSmokeInertProviderReceipt> = {}): FixedTraceComponentSmokeInertProviderReceipt {
+  return {
+    status: 'succeeded', responseDisposition: 'final_response', responseHmac: 'a'.repeat(64),
+    returnedIdentity: { provider: entry.provider, model: entry.model, effort: entry.effort },
+    usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, latencyMs: 1 },
+    ...overrides,
+  };
+}
+function fixtures(overrides: Record<string, FixedTraceComponentSmokeInertProviderReceipt> = {}) {
+  return Object.fromEntries(['anthropic', 'openai', 'google'].map((provider) => {
+    const entry = one(provider as 'anthropic' | 'openai' | 'google');
+    const key = fixtureKey(entry);
+    return [key, overrides[key] ?? receipt(entry)];
+  }));
+}
+function allFixtures() {
+  return Object.fromEntries(plan.filter((entry) => entry.disposition === 'provider_dispatch').map((entry) => [
+    fixtureKey(entry),
+    receipt(entry),
+  ]));
+}
+function coordinatorLedger() {
+  const calls: string[] = [];
+  let consumed = false;
+  const reservation = { reservationId: `reservation_${'b'.repeat(32)}`, authorizationDigest: 'c'.repeat(64), entryCount: 168, providerDispatchEntryCount: 126, reservationMicrodollars: 2_819_484 } as const;
+  return {
+    calls,
+    ledger: {
+      reserveAndConsume: async () => {
+        calls.push('reserve');
+        if (consumed) return { status: 'refused' as const, reason: 'grant_already_consumed' as const };
+        consumed = true;
+        return { status: 'reserved' as const, reservation };
+      },
+      recordProviderIntent: async (value: { attemptId: string }) => { calls.push(`intent:${value.attemptId}`); return { status: 'recorded' as const }; },
+      recordTerminal: async (value: { attemptId: string }) => { calls.push(`terminal:${value.attemptId}`); return { status: 'recorded' as const }; },
+      recordUnknownExposure: async () => { calls.push('unknown'); return { status: 'recorded' as const }; },
+      recordNonDispatchTerminal: async () => { calls.push('non-dispatch'); return { status: 'recorded' as const }; },
+      recordProviderAssignmentTerminal: async () => { calls.push('assignment'); return { status: 'recorded' as const }; },
+    },
+  };
+}
+function testGrant() {
+  return { grantDigest: 'd'.repeat(64), signedPayloadDigest: 'e'.repeat(64), payload: {} } as never;
+}
+
+describe('private live component-smoke composition', () => {
+  it('leaves the production coordinator hard-null and uses no ambient enablement', () => {
+    expect(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_DEFAULT_OFF).toBe(true);
+    expect(FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES).toBe(0);
+    expect(createFixedTraceComponentSmokePrivateLiveCoordinator()).toBeNull();
+    expect((createFixedTraceComponentSmokePrivateLiveCoordinator as (...args: unknown[]) => unknown)({}, {}, {}, {})).toBeNull();
+  });
+
+  it.each(['anthropic', 'openai', 'google'] as const)('builds a frozen admitted %s request only from the immutable plan', (provider) => {
+    const entry = one(provider);
+    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
+    const request = harness.requestForTest(entry.assignmentId);
+    expect(request).toMatchObject({ model: entry.model, maxOutputTokens: entry.maxOutputTokens, reasoning: { effort: entry.effort } });
+    expect(request.requestMetadata).toEqual({ fixedTraceAdmissionFingerprint: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_AUTHORITY.aggregateAdmissionFingerprint });
+    expect(Object.isFrozen(request)).toBe(true);
+    expect(request.tools.map((tool) => tool.name)).toEqual(
+      expect.any(Array),
+    );
+  });
+
+  it.each(['anthropic', 'openai', 'google'] as const)('accepts a pure inert %s response fixture with exact identity and usage shape', async (provider) => {
+    const entry = one(provider);
+    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
+    await expect(harness.invokeForTest(entry.assignmentId)).resolves.toEqual(receipt(entry));
+  });
+
+  it('categorizes timeout and identity-drift receipts without recording a raw provider error or response', async () => {
+    const entry = one('openai');
+    const key = fixtureKey(entry);
+    const timeout = receipt(entry, { status: 'timeout_after_dispatch', responseDisposition: null, responseHmac: null, returnedIdentity: null, usage: null });
+    await expect(createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: timeout })).invokeForTest(entry.assignmentId)).resolves.toEqual(timeout);
+    const mismatchedIdentity = receipt(entry, { returnedIdentity: { provider: 'other', model: entry.model, effort: entry.effort } });
+    await expect(createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: mismatchedIdentity })).invokeForTest(entry.assignmentId)).resolves.toEqual(mismatchedIdentity);
+  });
+
+  it('refuses absent, malformed, and missing-usage fixture receipts before a transport exists', async () => {
+    const entry = one('openai');
+    const key = fixtureKey(entry);
+    expect(() => createFixedTraceComponentSmokeInertAdapterFixturesForTest({ [key]: { bad: true } } as never)).toThrow('invalid inert provider fixture');
+    expect(() => createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures({ [key]: receipt(entry, { usage: null }) }))).toThrow('invalid inert provider fixture');
+    const absent = createFixedTraceComponentSmokeInertAdapterFixturesForTest({});
+    await expect(absent.invokeForTest(entry.assignmentId)).rejects.toThrow('missing inert provider fixture');
+  });
+
+  it('has no production provider construction, generic dispatch, root, credential, persistence, or raw-output surface', () => {
+    const source = readFileSync(new URL('../../../src/addie/eval/fixed-trace-component-smoke-private-live.ts', import.meta.url), 'utf8');
+    for (const forbidden of ['process.env', 'fetch(', 'console.', 'new OpenAI', 'new Anthropic', 'new GoogleGenAI', 'apiKey', 'trustRoot', 'privateKey', 'from "../config/models', 'from \'../config/models']) {
+      expect(source).not.toContain(forbidden);
+    }
+    expect(source).toContain('WeakSet');
+    expect(source).toContain('recordProviderIntent');
+    expect(source).toContain('recordUnknownExposure');
+    expect(source).toContain('maxRetries: FIXED_TRACE_COMPONENT_SMOKE_PRIVATE_LIVE_SDK_RETRIES');
+    expect(source).toContain('new AbortController()');
+    expect(source).toContain('fixedTraceComponentSmokePrivateAuthorityMatchesAdmission');
+  });
+
+  it('cannot mutate the authority plan through the composition request path', () => {
+    const entry = one('google');
+    const before = JSON.stringify(fixedTraceComponentSmokePrivateAuthorityPlan());
+    const harness = createFixedTraceComponentSmokeInertAdapterFixturesForTest(fixtures());
+    const request = harness.requestForTest(entry.assignmentId);
+    expect(() => { (request as { model: string }).model = 'other'; }).toThrow();
+    expect(JSON.stringify(fixedTraceComponentSmokePrivateAuthorityPlan())).toBe(before);
+    expect(() => harness.requestForTest('0'.repeat(64))).toThrow('unadmitted provider assignment');
+  });
+
+  it('commits every intent before its inert response, closes the 168-entry plan, and is one-shot', async () => {
+    const { ledger, calls } = coordinatorLedger();
+    const harness = createFixedTraceComponentSmokePrivateLiveCoordinatorForTest({ ledger, grant: testGrant(), fixtures: allFixtures() });
+    await expect(harness.runForTest()).resolves.toEqual({ status: 'completed', providerInvocations: 126 });
+    expect(calls.filter((call) => call.startsWith('intent:'))).toHaveLength(126);
+    expect(calls.filter((call) => call.startsWith('terminal:'))).toHaveLength(126);
+    expect(calls.filter((call) => call === 'assignment')).toHaveLength(126);
+    expect(calls.filter((call) => call === 'non-dispatch')).toHaveLength(42);
+    for (const [index, call] of calls.entries()) if (call.startsWith('terminal:')) {
+      expect(calls.slice(0, index)).toContain(`intent:${call.slice('terminal:'.length)}`);
+    }
+    await expect(harness.runForTest()).resolves.toEqual({ status: 'halted', providerInvocations: 0 });
+  });
+
+  it('halts after a post-intent fixture fault and atomically requests ambiguity closure instead of retrying', async () => {
+    const { ledger, calls } = coordinatorLedger();
+    const first = plan.find((entry) => entry.disposition === 'provider_dispatch')!;
+    const harness = createFixedTraceComponentSmokePrivateLiveCoordinatorForTest({ ledger, grant: testGrant(), fixtures: {
+      [fixtureKey(first)]: receipt(first),
+    } });
+    await expect(harness.runForTest()).resolves.toEqual({ status: 'halted', providerInvocations: 1 });
+    expect(calls.filter((call) => call.startsWith('intent:'))).toHaveLength(2);
+    expect(calls.filter((call) => call.startsWith('terminal:'))).toHaveLength(1);
+    expect(calls.filter((call) => call === 'unknown')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the prior pre-live composition wiring with a pure JSON-text declarative contract for the frozen stage-1 authority. This is not a live coordinator.

- It derives 192 unique, non-secret provider accounting-slot declarations from the immutable 8-probe / 21-cell / 168-assignment authority.
- Every slot fail-closes as `not_provisioned`: ordinal 1 requires the exact reviewed request-tool replay binding and semantic request fingerprint; ordinal 2 additionally requires exact provider continuation binding.
- Production remains hard-null and default-off. The module exposes no provider transport, adapter, coordinator execution, authority/grant path, ledger handle, generic dispatcher, route, job, cron, or ambient enablement.
- The transparent slot key binds the pinned admission fingerprint, assignment, probe, cell, provider, model, effort, and ordinal. It is explicitly not an HMAC or substitute for future keyed custody.

## Safety and scope

- Provider calls: 0. New evaluation spend: $0.
- No provider/API call, credential, grant, private key, nonce, raw prompt, raw response, or provider error body was created, stored, logged, or used.
- The public trust-root registry and actual dispatch remain unprovisioned. They require a separate reviewed custody/transport/provisioning slice; raw outputs for later judging likewise require a separately reviewed encrypted-artifact slice.
- The PR remains draft and is not ready for live use.

## Validation

- Sanitized dedicated corrected-contract tests: 8/8 passed.
- Sanitized aggregate focused authority/runtime/authorization/ledger tests: 68/68 passed.
- `npm run typecheck`, migration validation (3/3), and diff checks passed.
- Fresh PostgreSQL 15 database: all 566 migrations through 582 applied; private-ledger migration integration: 34/34 passed.
- The initial fresh-PostgreSQL attempt stopped at migration 156 because this VM lacked the `pg_trgm` contrib prerequisite. After installing that prerequisite, a recreated fresh database completed the clean migration/integration rerun.
- The normal sanitized commit hook passed its preliminary phases but its full server-unit phase reached the repository fixed 600-second timeout. Root then authorized exactly one `HUSKY=0` commit only for the unchanged two-file staged correction in commit `dce6dce29b4d8933b8cdf908e37d90c121d29038`; no other bypass was used.

No protocol release surface changed, so no changeset is required.

Related to #6842.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e8ba8ee5-db0b-4751-aa60-f7ea6d7cd14d)
