### PR TITLE
fix(addie): enable Sonnet full-pack diagnostic

### DIFF
--- a/server/src/addie/eval/fixed-trace-architecture-diagnostic.ts
+++ b/server/src/addie/eval/fixed-trace-architecture-diagnostic.ts
@@ -18,6 +18,16 @@ export const FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_PACK_VERSION =
 export const FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_PILOT_VERSION =
   'addie-fixed-trace-architecture-diagnostic-pilot-v1' as const;
 
+/**
+ * Evaluator-only identities. Each declaration fixes both suite membership and
+ * the reviewed candidate-control cell; modes are never caller-selectable
+ * aliases for arbitrary pack/control combinations.
+ */
+export type FixedTraceArchitectureDiagnosticMode =
+  | 'synthetic_pack_v1'
+  | 'synthetic_pilot_v1'
+  | 'synthetic_sonnet_full_pack_v1';
+
 export type FixedTraceArchitectureDiagnosticStratum =
   | 'local_terminal_eligible'
   | 'matched_hybrid_fallback_near_miss'
@@ -189,7 +199,7 @@ export const FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_PILOT_DIGEST = sha256({
 
 /** The cohort-level mapping identity used in the architecture fingerprint. */
 export function fixedTraceArchitectureDiagnosticMappingBinding(
-  mode: 'synthetic_pack_v1' | 'synthetic_pilot_v1',
+  mode: FixedTraceArchitectureDiagnosticMode,
 ): Readonly<{ packDigest: string; pilotDigest: string | null }> {
   return freeze({
     packDigest: FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_PACK_DIGEST,
@@ -403,7 +413,7 @@ export function assertFixedTraceArchitectureDiagnosticPilotSuite(suite: unknown)
 
 /** Evaluator-side observation binding; never part of candidate-visible tools or prompts. */
 export function fixedTraceArchitectureDiagnosticCaseProvenance(
-  mode: 'synthetic_pack_v1' | 'synthetic_pilot_v1',
+  mode: FixedTraceArchitectureDiagnosticMode,
   traceId: string,
 ): Readonly<{
   packDigest: string;

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -55,6 +55,7 @@ import {
   fixedTraceArchitectureDiagnosticMappingBinding,
   fixedTraceArchitectureDiagnosticPilotStageControls,
   fixedTraceArchitectureDiagnosticStageControls,
+  type FixedTraceArchitectureDiagnosticMode,
   type FixedTraceArchitectureDiagnosticStageControl,
 } from './fixed-trace-architecture-diagnostic.js';
 import {
@@ -124,7 +125,7 @@ export interface FixedTraceRunnerConfig {
    * capability: it accepts only the declared synthetic architecture pack and
    * the inert common receipt environment.
    */
-  architectureDiagnosticMode?: 'synthetic_pack_v1' | 'synthetic_pilot_v1';
+  architectureDiagnosticMode?: FixedTraceArchitectureDiagnosticMode;
   /** One-based repetition identifier; runs are never silently pooled. */
   repetition?: number;
   router: FixedTraceProviderStageConfig;
@@ -143,7 +144,7 @@ interface FixedTraceExecutionIdentity {
   traceSuiteSha256: string;
   toolSchemaSha256: string;
   architectureConfigSha256: string;
-  architectureDiagnosticMode: 'synthetic_pack_v1' | 'synthetic_pilot_v1' | null;
+  architectureDiagnosticMode: FixedTraceArchitectureDiagnosticMode | null;
   runProvenanceSha256: string;
 }
 
@@ -344,6 +345,7 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
     config.architectureDiagnosticMode !== undefined
     && config.architectureDiagnosticMode !== 'synthetic_pack_v1'
     && config.architectureDiagnosticMode !== 'synthetic_pilot_v1'
+    && config.architectureDiagnosticMode !== 'synthetic_sonnet_full_pack_v1'
   ) {
     throw new Error('Fixed trace architecture diagnostic mode is invalid');
   }
@@ -361,6 +363,12 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       if (!stageMatches(config.generation, haiku.generation)
         || (!stageMatches(config.router, haiku.router) && !stageMatches(config.router, luna.router))) {
         throw new Error('Fixed trace architecture diagnostic pack differs from builder-owned exact stage controls');
+      }
+    } else if (config.architectureDiagnosticMode === 'synthetic_sonnet_full_pack_v1') {
+      assertFixedTraceArchitectureDiagnosticSuite(config.traceSuite);
+      const pilot = fixedTraceArchitectureDiagnosticPilotStageControls();
+      if (!stageMatches(config.router, pilot.router) || !stageMatches(config.generation, pilot.generation)) {
+        throw new Error('Fixed trace Sonnet full-pack diagnostic differs from reviewed candidate controls');
       }
     } else {
       assertFixedTraceArchitectureDiagnosticPilotSuite(config.traceSuite);
@@ -1505,6 +1513,24 @@ export async function runFixedTraceArchitectureDiagnosticSuite(
   const observations = await runFixedTraceSuite(config);
   if (observations.length !== 24) {
     throw new Error('Fixed trace architecture diagnostic runner did not preserve the complete denominator');
+  }
+  return observations;
+}
+
+/**
+ * Exact 24-case execution identity for the reviewed Sonnet 5 generation and
+ * Haiku 4.5 router cell. This reuses the pilot's controls without broadening
+ * either the legacy pack or the three-case pilot declaration.
+ */
+export async function runFixedTraceArchitectureDiagnosticSonnetFullPack(
+  config: FixedTraceRunnerConfig,
+): Promise<FixedTraceObservation[]> {
+  if (config.architectureDiagnosticMode !== 'synthetic_sonnet_full_pack_v1') {
+    throw new Error('Fixed trace Sonnet full-pack diagnostic requires synthetic_sonnet_full_pack_v1 mode');
+  }
+  const observations = await runFixedTraceSuite(config);
+  if (observations.length !== 24) {
+    throw new Error('Fixed trace Sonnet full-pack diagnostic did not preserve the complete denominator');
   }
   return observations;
 }

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -351,7 +351,7 @@ export interface FixedTraceRunMetadata {
   /** Hash of the immutable architecture/configuration cohort contract. */
   architectureConfigSha256: string;
   /** Set only by an exact synthetic architecture diagnostic declaration. */
-  architectureDiagnosticMode?: 'synthetic_pack_v1' | 'synthetic_pilot_v1' | null;
+  architectureDiagnosticMode?: 'synthetic_pack_v1' | 'synthetic_pilot_v1' | 'synthetic_sonnet_full_pack_v1' | null;
   /** Evaluator-only pack/pilot and cluster binding for architecture diagnostics. */
   architectureDiagnostic: {
     packDigest: string;
@@ -3258,7 +3258,11 @@ function assertFixedTraceDiagnosticObservationProvenance(
     }
     return;
   }
-  if (mode !== 'synthetic_pack_v1' && mode !== 'synthetic_pilot_v1') {
+  if (
+    mode !== 'synthetic_pack_v1'
+    && mode !== 'synthetic_pilot_v1'
+    && mode !== 'synthetic_sonnet_full_pack_v1'
+  ) {
     throw new Error('Fixed trace diagnostic observation mode is invalid');
   }
   let expected: NonNullable<FixedTraceRunMetadata['architectureDiagnostic']>;

--- a/server/tests/unit/addie/fixed-trace-architecture-diagnostic-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-architecture-diagnostic-runner.test.ts
@@ -8,6 +8,7 @@ import {
 import { fixedTraceCommonToolDefinitions, fixedTraceHybridPolicy } from '../../../src/addie/eval/fixed-trace-architecture.js';
 import {
   runFixedTraceArchitectureDiagnosticPilot,
+  runFixedTraceArchitectureDiagnosticSonnetFullPack,
   runFixedTraceArchitectureDiagnosticSuite,
   type FixedTraceRunnerConfig,
 } from '../../../src/addie/eval/fixed-trace-runner.js';
@@ -46,8 +47,15 @@ class SyntheticProvider implements ModelProvider {
     readonly id: 'anthropic' | 'openai' = 'anthropic',
   ) {}
 
+  private beforeDispatchMutation: (() => void) | undefined;
+
+  mutateBeforeDispatch(mutation: () => void): void {
+    this.beforeDispatchMutation = mutation;
+  }
+
   async *respond(request: ModelRequest, options: ModelRespondOptions = {}): AsyncIterable<NormalizedModelEvent> {
     const prepared = this.prepare(request);
+    this.beforeDispatchMutation?.();
     await options.beforeDispatch?.(prepared);
     this.requests.push(structuredClone(request));
     const response: ModelResponse = {
@@ -61,6 +69,21 @@ class SyntheticProvider implements ModelProvider {
     yield { type: 'text_delta', index: 0, text: (response.content[0] as { text: string }).text };
     yield { type: 'response_complete', response };
   }
+}
+
+function sonnetFullPackConfig(
+  architectureArm: FixedTraceRunnerConfig['architectureArm'],
+  router: ModelProvider,
+  generation: ModelProvider,
+): FixedTraceRunnerConfig {
+  const controls = fixedTraceArchitectureDiagnosticPilotStageControls();
+  return {
+    ...config(architectureArm, router, generation),
+    runId: `architecture-sonnet-full-pack-${architectureArm}`,
+    architectureDiagnosticMode: 'synthetic_sonnet_full_pack_v1',
+    router: { ...controls.router, provider: router },
+    generation: { ...controls.generation, provider: generation },
+  };
 }
 
 function config(
@@ -83,6 +106,108 @@ function config(
 }
 
 describe('fixed-trace architecture synthetic runner', () => {
+  it('runs the exact full pack in the distinct reviewed Sonnet/Haiku identity for every non-oracle arm', async () => {
+    const directRouter = new SyntheticProvider('router');
+    const directGeneration = new SyntheticProvider('generation');
+    const direct = await runFixedTraceArchitectureDiagnosticSonnetFullPack(
+      sonnetFullPackConfig('direct_generation', directRouter, directGeneration),
+    );
+    const routedRouter = new SyntheticProvider('router');
+    const routedGeneration = new SyntheticProvider('generation');
+    const routed = await runFixedTraceArchitectureDiagnosticSonnetFullPack(
+      sonnetFullPackConfig('two_stage_llm_router', routedRouter, routedGeneration),
+    );
+    const hybridRouter = new SyntheticProvider('router');
+    const hybridGeneration = new SyntheticProvider('generation');
+    const hybrid = await runFixedTraceArchitectureDiagnosticSonnetFullPack(
+      sonnetFullPackConfig('deterministic_policy_llm_fallback_hybrid', hybridRouter, hybridGeneration),
+    );
+
+    expect(direct).toHaveLength(24);
+    expect(routed).toHaveLength(24);
+    expect(hybrid).toHaveLength(24);
+    expect(directRouter.requests).toHaveLength(0);
+    expect(directGeneration.requests).toHaveLength(24);
+    expect(routedRouter.requests).toHaveLength(24);
+    expect(routedGeneration.requests).toHaveLength(24);
+    expect(hybridRouter.requests).toHaveLength(16);
+    expect(hybridGeneration.requests).toHaveLength(16);
+    expect(hybrid.filter((observation) => observation.terminalStage === 'surface')).toHaveLength(8);
+    for (const observation of [...direct, ...routed, ...hybrid]) {
+      expect(observation.metadata).toMatchObject({
+        architectureDiagnosticMode: 'synthetic_sonnet_full_pack_v1',
+        routerControl: { requestedModel: 'claude-haiku-4-5', maxIterations: 1 },
+        generationControl: { requestedModel: 'claude-sonnet-5', maxIterations: 2 },
+        architectureDiagnostic: { pilotDigest: null },
+      });
+    }
+  });
+
+  it.each([
+    ['subset suite', (value: FixedTraceRunnerConfig) => {
+      value.traceSuite = FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_SUITE.slice(0, 23);
+      value.traceSuiteSha256 = fixedTraceSuiteSha256(value.traceSuite);
+    }, 'differs from the predeclared synthetic pack'],
+    ['reordered suite', (value: FixedTraceRunnerConfig) => {
+      value.traceSuite = [...FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_SUITE].reverse();
+      value.traceSuiteSha256 = fixedTraceSuiteSha256(value.traceSuite);
+    }, 'differs from the predeclared synthetic pack'],
+    ['Sonnet generator model', (value: FixedTraceRunnerConfig) => {
+      value.generation = { ...value.generation, model: 'claude-haiku-4-5' };
+    }, 'differs from reviewed candidate controls'],
+    ['Sonnet generator stage control', (value: FixedTraceRunnerConfig) => {
+      value.generation = { ...value.generation, maxIterations: 3 };
+    }, 'differs from reviewed candidate controls'],
+    ['Haiku router model', (value: FixedTraceRunnerConfig) => {
+      value.router = { ...value.router, model: 'claude-sonnet-5' };
+    }, 'differs from reviewed candidate controls'],
+    ['Haiku router stage control', (value: FixedTraceRunnerConfig) => {
+      value.router = { ...value.router, maxOutputTokens: value.router.maxOutputTokens + 1 };
+    }, 'differs from reviewed candidate controls'],
+    ['tool provenance', (value: FixedTraceRunnerConfig) => {
+      value.toolDefinitionProvenance = 'fixture_local';
+    }, 'requires the evaluator-owned common tool universe'],
+    ['legacy pack mode', (value: FixedTraceRunnerConfig) => {
+      value.architectureDiagnosticMode = 'synthetic_pack_v1';
+    }, 'requires synthetic_sonnet_full_pack_v1 mode'],
+  ] as const)('rejects %s before dispatch', async (_name, mutate, error) => {
+    const router = new SyntheticProvider('router');
+    const generation = new SyntheticProvider('generation');
+    const hostile = sonnetFullPackConfig('direct_generation', router, generation);
+    mutate(hostile);
+    await expect(runFixedTraceArchitectureDiagnosticSonnetFullPack(hostile)).rejects.toThrow(error);
+    expect(router.requests).toHaveLength(0);
+    expect(generation.requests).toHaveLength(0);
+  });
+
+  it.each([
+    ['suite', (value: FixedTraceRunnerConfig) => {
+      value.traceSuite = [...FIXED_TRACE_ARCHITECTURE_DIAGNOSTIC_SUITE].reverse();
+      value.traceSuiteSha256 = fixedTraceSuiteSha256(value.traceSuite);
+    }],
+    ['stage controls', (value: FixedTraceRunnerConfig) => {
+      value.generation = { ...value.generation, maxIterations: 3 };
+    }],
+    ['tool provenance', (value: FixedTraceRunnerConfig) => {
+      value.toolDefinitionProvenance = 'fixture_local';
+    }],
+    ['mode', (value: FixedTraceRunnerConfig) => {
+      value.architectureDiagnosticMode = 'synthetic_pilot_v1';
+    }],
+    ['run provenance identity', (value: FixedTraceRunnerConfig) => {
+      value.runId = 'architecture-sonnet-full-pack-mutated';
+    }],
+  ] as const)('aborts a post-preflight %s mutation before provider dispatch', async (_name, mutate) => {
+    const router = new SyntheticProvider('router');
+    const generation = new SyntheticProvider('generation');
+    const hostile = sonnetFullPackConfig('direct_generation', router, generation);
+    generation.mutateBeforeDispatch(() => mutate(hostile));
+    await expect(runFixedTraceArchitectureDiagnosticSonnetFullPack(hostile))
+      .rejects.toThrow('execution identity');
+    expect(router.requests).toHaveLength(0);
+    expect(generation.requests).toHaveLength(0);
+  });
+
   it('executes comparable arms on one exact pack without enabling production authority', async () => {
     const directRouter = new SyntheticProvider('router');
     const directGeneration = new SyntheticProvider('generation');


### PR DESCRIPTION
## Summary
- add the exact 24-case `synthetic_sonnet_full_pack_v1` execution identity
- bind it to the reviewed Haiku 4.5 router and Sonnet 5 generation pilot controls
- preserve legacy full-pack and three-case pilot identities while testing pre-dispatch tamper rejection

## Testing
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-architecture-diagnostic.test.ts server/tests/unit/addie/fixed-trace-architecture-diagnostic-runner.test.ts --reporter=dot`
- `npm run typecheck`
- precommit: root unit/lint portions passed; server-unit phase exceeded its 600-second local hook timeout without a test failure, so required GitHub CI is authoritative

## Risk
Evaluator-only fixed identity; no provider construction, credentials, production configuration, or rollout behavior changed.

Conductor workspace: [6842 full-pack Sonnet eval enablement](conductor://workspace?id=989b84b7-7f54-492e-9d3d-d289acef01b4)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/989b84b7-7f54-492e-9d3d-d289acef01b4)
