### PR TITLE
feat(addie): add Google three-turn admission mode

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -118,6 +118,11 @@ export interface FixedTraceProviderStageConfig {
  * independently pinned below.
  */
 export const FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE = 'direct_model_screen_admission_v1' as const;
+/**
+ * A separately governed experiment for the four admitted Gemini cells.  It
+ * deliberately does not widen the original two-turn admission contract.
+ */
+export const FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE = 'direct_model_screen_google_three_turn_v1' as const;
 export type FixedTraceDirectModelScreenGenerationCellId =
   | 'generation:anthropic:claude-sonnet-5:provider_default'
   | 'generation:anthropic:claude-haiku-4-5:provider_default'
@@ -125,10 +130,18 @@ export type FixedTraceDirectModelScreenGenerationCellId =
   | 'generation:google:gemini-3.7-flash:low'
   | 'generation:google:gemini-3.7-flash:medium'
   | 'generation:google:gemini-3.7-flash:high';
-export interface FixedTraceDirectModelScreenConfig {
+export type FixedTraceGoogleThreeTurnGenerationCellId =
+  | 'generation:google:gemini-3.7-flash:provider_default'
+  | 'generation:google:gemini-3.7-flash:low'
+  | 'generation:google:gemini-3.7-flash:medium'
+  | 'generation:google:gemini-3.7-flash:high';
+export type FixedTraceDirectModelScreenConfig = {
   readonly mode: typeof FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE;
   readonly generationCellId: FixedTraceDirectModelScreenGenerationCellId;
-}
+} | {
+  readonly mode: typeof FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE;
+  readonly generationCellId: FixedTraceGoogleThreeTurnGenerationCellId;
+};
 
 export interface FixedTraceRunnerConfig {
   runId: string;
@@ -190,12 +203,18 @@ const directModelScreenGenerationCellIds = new Set<FixedTraceDirectModelScreenGe
   'generation:google:gemini-3.7-flash:medium',
   'generation:google:gemini-3.7-flash:high',
 ]);
+const directModelScreenGoogleThreeTurnGenerationCellIds = new Set<FixedTraceGoogleThreeTurnGenerationCellId>([
+  'generation:google:gemini-3.7-flash:provider_default',
+  'generation:google:gemini-3.7-flash:low',
+  'generation:google:gemini-3.7-flash:medium',
+  'generation:google:gemini-3.7-flash:high',
+]);
 
 function isDirectModelScreen(config: FixedTraceRunnerConfig): config is FixedTraceRunnerConfig & {
   directModelScreen: FixedTraceDirectModelScreenConfig;
   router: null;
 } {
-  return config.directModelScreen?.mode === FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE;
+  return config.directModelScreen !== undefined;
 }
 
 const boundTraceExecutionIdentities = new WeakMap<FixedTraceRunnerConfig, FixedTraceExecutionIdentity>();
@@ -497,7 +516,7 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || !Object.prototype.hasOwnProperty.call(screen, 'generationCellId')) {
       throw new Error('Fixed trace direct-model screen config must contain only mode and generationCellId');
     }
-    if (screen.mode !== FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE) {
+    if (screen.mode !== FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE && screen.mode !== FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE) {
       throw new Error('Fixed trace direct-model screen mode is invalid');
     }
     if (architectureArm.id !== 'direct_generation') {
@@ -509,7 +528,10 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
     if (config.toolDefinitionProvenance !== 'evaluator_owned_common_tool_universe') {
       throw new Error('Fixed trace direct-model screen requires the evaluator-owned common tool universe');
     }
-    if (!directModelScreenGenerationCellIds.has(screen.generationCellId)) {
+    const googleThreeTurn = screen.mode === FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE;
+    if (!(googleThreeTurn
+      ? directModelScreenGoogleThreeTurnGenerationCellIds.has(screen.generationCellId as FixedTraceGoogleThreeTurnGenerationCellId)
+      : directModelScreenGenerationCellIds.has(screen.generationCellId))) {
       throw new Error('Fixed trace direct-model screen generation cell is unsupported');
     }
     const cell = FIXED_TRACE_ADMITTED_CELLS.find((candidate) => candidate.id === screen.generationCellId);
@@ -520,7 +542,8 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || cell.pricingProfileId !== config.generation.pricing.profileId
       || config.generation.maxOutputTokens !== 900
       || config.generation.timeoutMs !== 120_000
-      || config.generation.maxIterations !== 2
+      || config.generation.maxIterations !== (googleThreeTurn ? 3 : 2)
+      || (googleThreeTurn && (config.repetition ?? 1) !== 1)
       || config.generation.transportRetries !== 0
       || config.generation.samplingMode !== 'provider_no_sampling_control'
       || config.generation.temperature !== null) {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -360,7 +360,7 @@ export interface FixedTraceRunMetadata {
   /** Set only by an exact synthetic architecture diagnostic declaration. */
   architectureDiagnosticMode?: 'synthetic_pack_v1' | 'synthetic_pilot_v1' | 'synthetic_sonnet_full_pack_v1' | null;
   /** Set only by the exact source-pinned direct model-screen declaration. */
-  directModelScreenMode?: 'direct_model_screen_admission_v1' | null;
+  directModelScreenMode?: 'direct_model_screen_admission_v1' | 'direct_model_screen_google_three_turn_v1' | null;
   /** Evaluator-only pack/pilot and cluster binding for architecture diagnostics. */
   architectureDiagnostic: {
     packDigest: string;
@@ -2662,6 +2662,12 @@ const directModelScreenGenerationCells = new Set([
   'google:gemini-3.7-flash:medium',
   'google:gemini-3.7-flash:high',
 ]);
+const directModelScreenGoogleThreeTurnGenerationCells = new Set([
+  'google:gemini-3.7-flash:provider_default',
+  'google:gemini-3.7-flash:low',
+  'google:gemini-3.7-flash:medium',
+  'google:gemini-3.7-flash:high',
+]);
 
 /** Rebind untrusted direct-screen metadata to the sole evaluator-owned pack. */
 function directModelScreenMetadataFailures(
@@ -2670,6 +2676,7 @@ function directModelScreenMetadataFailures(
   tools: ReadonlyArray<FixedTraceToolObservation>,
 ): string[] {
   const failures: string[] = [];
+  const googleThreeTurn = metadata.directModelScreenMode === 'direct_model_screen_google_three_turn_v1';
   const canonicalTrace = FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE.find(
     (candidate) => candidate.id === trace.id,
   );
@@ -2682,10 +2689,11 @@ function directModelScreenMetadataFailures(
   const control = metadata.generationControl;
   const tuple = `${control.requestedProvider}:${control.requestedModel}:${control.reasoningEffort}`;
   if (
-    !directModelScreenGenerationCells.has(tuple)
+    !(googleThreeTurn ? directModelScreenGoogleThreeTurnGenerationCells : directModelScreenGenerationCells).has(tuple)
     || control.configuredMaxOutputTokens !== 900
     || control.timeoutMs !== 120_000
-    || control.maxIterations !== 2
+    || control.maxIterations !== (googleThreeTurn ? 3 : 2)
+    || (googleThreeTurn && metadata.repetition !== 1)
     || control.transportRetries !== 0
     || control.samplingMode !== 'provider_no_sampling_control'
     || control.temperature !== null
@@ -2974,7 +2982,7 @@ function metadataFailures(
   }
   if (typeof metadata.providerDegradationInjectionEnabled !== 'boolean') failures.push('provider_degradation_policy_invalid');
   const directModelScreenMode = metadata.directModelScreenMode ?? null;
-  if (directModelScreenMode !== null && directModelScreenMode !== 'direct_model_screen_admission_v1') {
+  if (directModelScreenMode !== null && directModelScreenMode !== 'direct_model_screen_admission_v1' && directModelScreenMode !== 'direct_model_screen_google_three_turn_v1') {
     failures.push('direct_model_screen_mode_invalid');
   }
   failures.push(...cohortControlFailures('router', metadata.routerControl));

--- a/server/tests/unit/addie/fixed-trace-direct-model-screen.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-model-screen.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE,
   FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE_SHA256,
+  FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE,
   FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE,
   FIXED_TRACE_DIRECT_MODEL_SCREEN_TRACE_IDS,
   runFixedTraceDirectModelScreen,
   type FixedTraceDirectModelScreenGenerationCellId,
+  type FixedTraceGoogleThreeTurnGenerationCellId,
   type FixedTraceProviderStageConfig,
   type FixedTraceRunnerConfig,
 } from '../../../src/addie/eval/fixed-trace-runner.js';
@@ -59,6 +61,7 @@ class ScreenProvider implements ModelProvider {
   constructor(
     readonly id: ModelProviderId,
     private readonly returnedModel?: string | readonly string[],
+    private readonly toolCallsBeforeStop = 1,
   ) {}
 
   async *respond(request: ModelRequest, options: ModelRespondOptions = {}): AsyncIterable<NormalizedModelEvent> {
@@ -69,17 +72,23 @@ class ScreenProvider implements ModelProvider {
     if (typeof traceId !== 'string') throw new Error('screen request is missing its trace identity');
     const attempt = (this.requestsByTrace.get(traceId) ?? 0) + 1;
     this.requestsByTrace.set(traceId, attempt);
+    const toolCalls = [
+      { name: 'search_docs', input: { query: 'official overview' } },
+      { name: 'get_doc', input: { doc_id: 'synthetic-overview' } },
+      { name: 'search_repos', input: { query: 'fixed trace evaluation' } },
+    ] as const;
+    const toolCall = toolCalls[attempt - 1];
     const response: ModelResponse = {
       provider: this.id,
       model: Array.isArray(this.returnedModel)
         ? this.returnedModel[attempt - 1] ?? request.model
         : this.returnedModel ?? request.model,
       id: `screen-${this.requests.length}`,
-      content: attempt === 1
-        ? [{ type: 'tool_call', id: `screen-search-${traceId}`, name: 'search_docs', input: { query: 'official overview' } }]
+      content: attempt <= this.toolCallsBeforeStop
+        ? [{ type: 'tool_call', id: `screen-tool-${attempt}-${traceId}`, name: toolCall!.name, input: toolCall!.input }]
         : [{ type: 'text', text: 'Synthetic direct model screen response about typed tasks.' }],
-      finishReason: attempt === 1 ? 'tool_calls' : 'stop',
-      providerFinishReason: attempt === 1 ? 'tool_calls' : 'stop',
+      finishReason: attempt <= this.toolCallsBeforeStop ? 'tool_calls' : 'stop',
+      providerFinishReason: attempt <= this.toolCallsBeforeStop ? 'tool_calls' : 'stop',
       usage: { inputTokens: 10, outputTokens: 5 },
     };
     yield { type: 'response_start', provider: response.provider, model: response.model, id: response.id };
@@ -128,6 +137,16 @@ function config(
   };
 }
 
+function googleThreeTurnConfig(
+  cellId: FixedTraceGoogleThreeTurnGenerationCellId,
+  provider = new ScreenProvider('google'),
+): FixedTraceRunnerConfig {
+  const value = config(cellId, provider);
+  value.generation.maxIterations = 3;
+  value.directModelScreen = { mode: FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE, generationCellId: cellId };
+  return value;
+}
+
 describe('fixed-trace direct model screen', () => {
   it('pins only the reviewed two-probe admission pack', () => {
     expect(FIXED_TRACE_DIRECT_MODEL_SCREEN_TRACE_IDS).toEqual([
@@ -152,6 +171,57 @@ describe('fixed-trace direct model screen', () => {
     expect(observations.every((observation) => observation.metadata.routerControl.status === 'not_run')).toBe(true);
     expect(observations.every((observation) => observation.metadata.directModelScreenMode === FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE)).toBe(true);
     expect(summarizeFixedTraceRun(observations, FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE).summary.observed).toBe(2);
+  });
+
+  it.each(CELLS.slice(2))('admits the separately versioned three-turn Google mode for %s', async (cellId) => {
+    const provider = new ScreenProvider('google');
+    const observations = await runFixedTraceDirectModelScreen(googleThreeTurnConfig(cellId, provider));
+    expect(observations).toHaveLength(2);
+    expect(observations.every((observation) => observation.metadata.directModelScreenMode === FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE)).toBe(true);
+    for (const observation of observations) {
+      expect(gradeFixedTrace(FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE.find((trace) => trace.id === observation.traceId)!, observation).failures)
+        .not.toContain('direct_model_screen_generation_control_invalid');
+    }
+  });
+
+  it.each([
+    ['the old iteration limit', (observation: Awaited<ReturnType<typeof runFixedTraceDirectModelScreen>>[number]) => {
+      observation.metadata.generationControl.maxIterations = 2;
+    }],
+    ['more than one repetition', (observation: Awaited<ReturnType<typeof runFixedTraceDirectModelScreen>>[number]) => {
+      observation.metadata.repetition = 2;
+    }],
+  ] as const)('fails closed when serialized three-turn metadata is forged to %s', async (_name, mutate) => {
+    const [observation] = await runFixedTraceDirectModelScreen(googleThreeTurnConfig(CELLS[2]));
+    const forged = structuredClone(observation);
+    mutate(forged);
+    forged.metadata.architectureConfigSha256 = fixedTraceArchitectureConfigSha256FromMetadata(forged.metadata);
+
+    expect(gradeFixedTrace(FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE[0]!, forged).failures)
+      .toContain('direct_model_screen_generation_control_invalid');
+  });
+
+  it('keeps the three-turn iteration limit distinct from an ordinary terminal stop', async () => {
+    const exhausted = await runFixedTraceDirectModelScreen(googleThreeTurnConfig(
+      CELLS[2],
+      new ScreenProvider('google', undefined, 3),
+    ));
+    expect(exhausted.map((observation) => ({
+      status: observation.terminalStatus,
+      boundary: observation.boundaryReason,
+    }))).toEqual([
+      { status: 'malformed', boundary: 'iteration_limit_exceeded' },
+      { status: 'malformed', boundary: 'iteration_limit_exceeded' },
+    ]);
+
+    const stopped = await runFixedTraceDirectModelScreen(googleThreeTurnConfig(CELLS[2]));
+    expect(stopped.map((observation) => ({
+      status: observation.terminalStatus,
+      boundary: observation.boundaryReason,
+    }))).toEqual([
+      { status: 'complete', boundary: null },
+      { status: 'complete', boundary: null },
+    ]);
   });
 
   it('delivers the canonical source-pinned fixture results through the reviewed common tool surface', async () => {
@@ -302,5 +372,33 @@ describe('fixed-trace direct model screen', () => {
     await expect(runFixedTraceDirectModelScreen(hostile)).rejects.toThrow(error);
     expect(provider.prepare).not.toHaveBeenCalled();
     expect(provider.requests).toHaveLength(0);
+  });
+
+  it.each([
+    ['two turns', (value: FixedTraceRunnerConfig) => { value.generation.maxIterations = 2; }],
+    ['four turns', (value: FixedTraceRunnerConfig) => { value.generation.maxIterations = 4; }],
+    ['repetition drift', (value: FixedTraceRunnerConfig) => { value.repetition = 2; }],
+    ['Anthropic cell', (value: FixedTraceRunnerConfig) => { value.directModelScreen = { mode: FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE, generationCellId: CELLS[0] }; }],
+    ['router-role cell', (value: FixedTraceRunnerConfig) => { value.directModelScreen = { mode: FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE, generationCellId: 'router:google:gemini-3.7-flash:provider_default' as FixedTraceGoogleThreeTurnGenerationCellId }; }],
+    ['provider mismatch', (value: FixedTraceRunnerConfig) => { value.generation = { ...value.generation, provider: new ScreenProvider('anthropic') }; }],
+    ['model mismatch', (value: FixedTraceRunnerConfig) => { value.generation = { ...value.generation, model: 'claude-haiku-4-5' }; }],
+    ['router supplied', (value: FixedTraceRunnerConfig) => { value.router = stage(CELLS[2], new ScreenProvider('google')); }],
+    ['probe suite drift', (value: FixedTraceRunnerConfig) => { value.traceSuite = value.traceSuite.slice(0, 1); value.traceSuiteSha256 = fixedTraceSuiteSha256(value.traceSuite); }],
+    ['token cap drift', (value: FixedTraceRunnerConfig) => { value.generation.maxOutputTokens = 901; }],
+    ['retry drift', (value: FixedTraceRunnerConfig) => { value.generation.transportRetries = 1; }],
+  ] as const)('rejects %s under the Google-only three-turn mode before preparation', async (_name, mutate) => {
+    const provider = new ScreenProvider('google');
+    const hostile = googleThreeTurnConfig(CELLS[2], provider);
+    mutate(hostile);
+    await expect(runFixedTraceDirectModelScreen(hostile)).rejects.toThrow();
+    expect(provider.prepare).not.toHaveBeenCalled();
+  });
+
+  it('rejects three turns under the immutable v1 mode before preparation', async () => {
+    const provider = new ScreenProvider('google');
+    const hostile = config(CELLS[2], provider);
+    hostile.generation.maxIterations = 3;
+    await expect(runFixedTraceDirectModelScreen(hostile)).rejects.toThrow('generation stage differs from its admitted cell');
+    expect(provider.prepare).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Supports #6842

Adds the separately versioned `direct_model_screen_google_three_turn_v1` admission mode for exactly the four approved Gemini 3.7 Flash generation cells. The existing two-turn admission mode remains unchanged.

- pins direct-only, two-probe, 900-token, zero-retry control values
- enforces three iterations in runner preflight and deterministic grading
- covers allowed cells, rejected drifts, and iteration-limit versus terminal-stop evidence

Validation:
- `timeout 120 npx vitest run server/tests/unit/addie/fixed-trace-direct-model-screen.test.ts` (45 passed)
- `timeout 120 npm run test:addie-fixed-traces` (75 passed)
- `npm run typecheck`
- `npm run test:test-dynamic-imports`