### PR TITLE
feat(addie): add direct full-suite model comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
     "docs:json-field-audit": "node scripts/docs-json-field-audit.cjs",
     "eval:addie-router-providers": "tsx --import dotenv/config server/tests/manual/provider-router-eval.ts",
     "eval:addie-fixed-traces": "tsx --import dotenv/config server/tests/manual/fixed-trace-provider-eval.ts",
-    "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts"
+    "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts",
+    "eval:addie-fixed-traces-direct-full-suite": "tsx --import dotenv/config server/tests/manual/fixed-trace-direct-full-suite-eval.ts"
   },
   "dependencies": {
     "@adcp/sdk": "14.0.0-rc.32",

--- a/server/src/addie/eval/fixed-trace-architecture.ts
+++ b/server/src/addie/eval/fixed-trace-architecture.ts
@@ -463,10 +463,11 @@ export function assertFixedTraceCommonToolUniverseAdmission(
 export interface FixedTraceToolUniverseProvenance {
   source:
     | 'fixture_local_routed_replay'
+    | 'fixture_local_direct_full_suite'
     | 'evaluator_owned_production_definitions_simulated_receipts'
     | 'evaluator_owned_common_tool_universe'
     | 'fixture_oracle';
-  intentNarrowing: 'llm_router' | 'production_quick_match_or_llm_router' | 'not_applied' | 'fixture_oracle';
+  intentNarrowing: 'llm_router' | 'production_quick_match_or_llm_router' | 'direct_full_suite_fixture_contract' | 'not_applied' | 'fixture_oracle';
   bounded: boolean;
   deployable: boolean;
   toolNames: readonly string[] | null;

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -202,6 +202,14 @@ export function fixedTraceResponseUsesPricingPolicy(
 interface Reservation {
   readonly usd: number;
   active: boolean;
+  /** Set only when an exclusive diagnostic pre-reserved the whole run. */
+  readonly wholeRun: WholeRunReservation | null;
+}
+
+interface WholeRunReservation {
+  readonly usd: number;
+  remainingUsd: number;
+  active: boolean;
 }
 
 interface BudgetedProviderBinding {
@@ -343,6 +351,7 @@ export class FixedTraceBudget {
   private budgetRejectedCalls = 0;
   private admissionClosed = false;
   private exposureUnknown = false;
+  private wholeRunReservation: WholeRunReservation | null = null;
 
   constructor(readonly softMaxUsd: number) {
     if (!Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
@@ -378,13 +387,26 @@ export class FixedTraceBudget {
     // cache write whose replacement rate exceeds ordinary input).
     const inputTokens = requestBytes(prepared);
     const usd = datedPricingReservationCostUsd(pricing, inputTokens, maxOutputTokens);
+    const wholeRun = this.wholeRunReservation;
+    if (wholeRun !== null) {
+      if (!wholeRun.active || usd - wholeRun.remainingUsd > Number.EPSILON * Math.max(1, wholeRun.usd)) {
+        this.admissionClosed = true;
+        this.budgetRejectedCalls++;
+        throw new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared);
+      }
+      // The complete diagnostic was admitted before its selector/output were
+      // consumed. Individual calls consume that escrow rather than reserving
+      // it again, so a fully admitted run cannot self-reject mid-cell.
+      wholeRun.remainingUsd = Math.max(0, wholeRun.remainingUsd - usd);
+      return { usd, active: true, wholeRun };
+    }
     if (this.accountedSpendUsd + this.reservedUsd + usd > this.softMaxUsd) {
       this.admissionClosed = true;
       this.budgetRejectedCalls++;
       throw new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared);
     }
     this.reservedUsd += usd;
-    return { usd, active: true };
+    return { usd, active: true, wholeRun: null };
   }
 
   markDispatched(reservation: Reservation): void {
@@ -398,17 +420,23 @@ export class FixedTraceBudget {
     pricing: FixedTraceBudgetPricing,
   ): void {
     const actualUsd = fixedTraceEstimatedCostUsd(usage, pricing);
-    this.release(reservation);
+    this.settle(reservation);
     this.accountedSpendUsd += actualUsd;
     this.completedCalls++;
   }
 
   cancel(reservation: Reservation): void {
-    this.release(reservation);
+    this.requireActive(reservation);
+    reservation.active = false;
+    if (reservation.wholeRun !== null) {
+      reservation.wholeRun.remainingUsd += reservation.usd;
+    } else {
+      this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
+    }
   }
 
   markExposureUnknown(reservation: Reservation): void {
-    this.release(reservation);
+    this.settle(reservation);
     this.exposureUnknown = true;
   }
 
@@ -429,11 +457,34 @@ export class FixedTraceBudget {
     });
   }
 
+  /** Reserve the exact reviewed ceiling for one exclusive diagnostic run. */
+  claimWholeRunReservation(usd: number): WholeRunReservation {
+    if (!Number.isFinite(usd) || usd <= 0) {
+      throw new RangeError('Fixed trace whole-run reservation must be positive');
+    }
+    if (this.wholeRunReservation !== null || this.accountedSpendUsd + this.reservedUsd + usd > this.softMaxUsd) {
+      throw new RangeError('Fixed trace soft budget is below the required whole-run reservation');
+    }
+    const reservation: WholeRunReservation = { usd, remainingUsd: usd, active: true };
+    this.wholeRunReservation = reservation;
+    this.reservedUsd += usd;
+    return reservation;
+  }
+
+  releaseWholeRunReservation(reservation: WholeRunReservation): void {
+    if (this.wholeRunReservation !== reservation || !reservation.active) {
+      throw new Error('Fixed trace whole-run reservation is inactive');
+    }
+    reservation.active = false;
+    this.reservedUsd = Math.max(0, this.reservedUsd - reservation.remainingUsd);
+    reservation.remainingUsd = 0;
+  }
+
   private requireActive(reservation: Reservation): void {
     if (!reservation.active) throw new Error('Fixed trace budget reservation is inactive');
   }
 
-  private release(reservation: Reservation): void {
+  private settle(reservation: Reservation): void {
     this.requireActive(reservation);
     reservation.active = false;
     this.reservedUsd = Math.max(0, this.reservedUsd - reservation.usd);
@@ -536,7 +587,14 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
           // approval, settlement, and the outward event.
           const response = deepFreeze(structuredClone(event.response));
           if (fixedTraceResponseUsesPricingPolicy(this.#responsePricingPolicy, response)) {
-            this.#budget.complete(reservation, response.usage, this.#pricing);
+            try {
+              this.#budget.complete(reservation, response.usage, this.#pricing);
+            } catch {
+              // Preserve the frozen returned provider/model for downstream
+              // evidence while closing admission: a malformed or absent usage
+              // block means this dispatch cannot be settled at any rate.
+              this.#budget.markExposureUnknown(reservation);
+            }
           } else {
             // Do not settle an unapproved returned identity at the requested
             // model's rate. The response remains visible to the runner, which
@@ -629,6 +687,8 @@ export function isTrustedBudgetedFixedTraceProvider(
 
 export interface FixedTraceBudgetDiagnosticLease {
   providerFor(provider: ModelProvider): BudgetedFixedTraceProvider;
+  /** Return unspent whole-run escrow after every admitted call has settled. */
+  releaseWholeRunReservation(): void;
 }
 
 /**
@@ -641,6 +701,7 @@ export function claimFixedTraceBudgetDiagnosticLease(
   budget: FixedTraceBudget,
   providers: readonly ModelProvider[],
   verifyClones?: (lease: FixedTraceBudgetDiagnosticLease) => void,
+  wholeRunReservationUsd?: number,
 ): FixedTraceBudgetDiagnosticLease {
   const snapshot = budget.snapshot();
   if (
@@ -672,11 +733,18 @@ export function claimFixedTraceBudgetDiagnosticLease(
       lease,
     ));
   }
+  let wholeRunReservation: WholeRunReservation | null = null;
   const diagnosticLease = Object.freeze({
     providerFor(provider: ModelProvider): BudgetedFixedTraceProvider {
       const clone = clones.get(provider);
       if (!clone) throw new Error('Fixed trace diagnostic provider is missing from its exclusive lease');
       return clone;
+    },
+    releaseWholeRunReservation(): void {
+      if (wholeRunReservation !== null) {
+        budget.releaseWholeRunReservation(wholeRunReservation);
+        wholeRunReservation = null;
+      }
     },
   });
   for (const [source, clone] of clones) {
@@ -698,6 +766,9 @@ export function claimFixedTraceBudgetDiagnosticLease(
   // callback has no asynchronous boundary and runs before the lease becomes
   // visible to the shared ledger.
   verifyClones?.(diagnosticLease);
+  if (wholeRunReservationUsd !== undefined) {
+    wholeRunReservation = budget.claimWholeRunReservation(wholeRunReservationUsd);
+  }
   // Cloning has no asynchronous boundary. Complete it before publishing the
   // lease so a malformed wrapper cannot leave an otherwise pristine ledger
   // permanently claimed.

--- a/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
@@ -46,7 +46,8 @@ export interface FixedTraceDirectFullSuiteJudgment {
   readonly finishReason: ModelFinishReason | null;
   readonly providerFinishReason: string | null;
   readonly promptSha256: string;
-  readonly providerRequestSha256: string;
+  /** Hash of the exact invocation admitted at the SDK dispatch boundary. */
+  readonly providerRequestSha256: string | null;
   readonly promptConfigVersion: string;
   readonly judgeConfigSha256: string;
   readonly pricingProfileId: string;
@@ -204,6 +205,33 @@ function verdict(value: string): { pass: boolean; finding: string } | null {
   } catch { return null; }
 }
 
+/**
+ * Validate the one invocation the adapter is about to hand to its SDK.  Do
+ * not call `prepare()` here: adapters prepare inside `respond()` immediately
+ * before dispatch, and that value is the only request artifact may attest to.
+ */
+function assertJudgeDispatchInvocation(
+  prepared: import('../model-providers/model-provider.js').PreparedModelInvocation,
+  request: ModelRequest,
+  plan: FixedTraceDirectFullSuiteJudgePlan,
+): void {
+  if (
+    prepared.provider !== plan.provider
+    || prepared.model !== plan.model
+    || sha256(prepared.requestMetadata) !== sha256(request.requestMetadata)
+  ) throw new Error('Fixed trace direct full-suite judge dispatch invocation differs from immutable identity/config');
+  if (
+    request.model !== plan.model
+    || request.maxOutputTokens !== plan.maxOutputTokens
+    || request.reasoning !== undefined
+    || sha256(request.outputSchema) !== plan.outputSchemaSha256
+    || sha256({ promptConfigVersion: plan.promptConfigVersion, system: request.system.map((block) => block.text).join('') }) !== plan.promptSha256
+  ) throw new Error('Fixed trace direct full-suite judge request differs from immutable plan');
+  if (Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8') > FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES) {
+    throw new Error('Fixed trace direct full-suite judge dispatch request exceeds prepared request byte ceiling');
+  }
+}
+
 /** Execute exactly the supplied provider-excluding judge slots for one blinded packet. */
 export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<{
   trace: FixedTraceCase;
@@ -229,33 +257,25 @@ export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<
       maxOutputTokens: stage.maxOutputTokens,
       requestMetadata: { purpose: 'fixed_trace_blinded_judge', trace_id: input.trace.id },
     };
-    const prepared = stage.provider.prepare(request);
-    const audit = Object.freeze({
-      ...judgePlan,
-      providerRequestSha256: sha256(prepared.providerRequest),
-    });
-    if (Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8') > FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES) {
-      results.push(Object.freeze({
-        traceId: input.trace.id, judgeProvider, judgeModel: stage.model, status: 'missing', finding: null,
-        latencyMs: 0, estimatedCostUsd: null, requestedProvider: stage.provider.id, requestedModel: stage.model,
-        requestedReasoningEffort: stage.reasoningEffort, returnedProvider: null, returnedModel: null, returnedReasoningEffort: null,
-        usage: null, finishReason: null, providerFinishReason: null,
-        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
-        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
-        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
-        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched: false, exposure: 'not_dispatched',
-      }));
-      continue;
-    }
     const controller = new AbortController();
     const startedAt = Date.now();
     let dispatched = false;
     let timedOut = false;
+    let providerRequestSha256: string | null = null;
     const captured: CapturedJudgeResponse = { started: null, terminal: null };
     const timeout = setTimeout(() => { timedOut = true; controller.abort(); }, stage.timeoutMs);
     try {
       const response = await collectModelResponse(observeJudgeResponse(
-        stage.provider.respond(request, { signal: controller.signal, beforeDispatch: () => { dispatched = true; } }),
+        stage.provider.respond(request, {
+          signal: controller.signal,
+          beforeDispatch: (prepared) => {
+            // Preserve evidence even when admission rejects this boundary
+            // invocation; it was observed but never sent to the SDK.
+            providerRequestSha256 = sha256(prepared.providerRequest);
+            assertJudgeDispatchInvocation(prepared, request, judgePlan);
+            dispatched = true;
+          },
+        }),
         captured,
       ), stage.provider.id);
       const usage = snapshotUsage(response.usage);
@@ -270,10 +290,10 @@ export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<
         requestedModel: stage.model, requestedReasoningEffort: stage.reasoningEffort,
         returnedProvider: response.provider, returnedModel: response.model, returnedReasoningEffort: null,
         usage, finishReason: response.finishReason, providerFinishReason: response.providerFinishReason,
-        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
-        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
-        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
-        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched, exposure: settled ? 'settled' : 'unknown',
+        promptSha256: judgePlan.promptSha256, providerRequestSha256,
+        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: judgePlan.judgeConfigSha256,
+        pricingProfileId: judgePlan.pricingProfileId, pricingProfileSha256: judgePlan.pricingProfileSha256,
+        pricingSource: judgePlan.pricingSource, pricingPolicy: judgePlan.pricingPolicy, dispatched, exposure: settled ? 'settled' : 'unknown',
       }));
     } catch (error) {
       if (error instanceof InvalidModelEventStreamError && (captured.terminal !== null || captured.started !== null)) {
@@ -286,10 +306,10 @@ export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<
           returnedProvider: returned?.provider ?? null, returnedModel: returned?.model ?? null, returnedReasoningEffort: null,
           usage: response ? snapshotUsage(response.usage) : null,
           finishReason: response?.finishReason ?? null, providerFinishReason: response?.providerFinishReason ?? null,
-          promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
-          promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
-          pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
-          pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched, exposure: 'unknown',
+          promptSha256: judgePlan.promptSha256, providerRequestSha256,
+          promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: judgePlan.judgeConfigSha256,
+          pricingProfileId: judgePlan.pricingProfileId, pricingProfileSha256: judgePlan.pricingProfileSha256,
+          pricingSource: judgePlan.pricingSource, pricingPolicy: judgePlan.pricingPolicy, dispatched, exposure: 'unknown',
         }));
         continue;
       }
@@ -301,10 +321,10 @@ export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<
         requestedProvider: stage.provider.id, requestedModel: stage.model,
         requestedReasoningEffort: stage.reasoningEffort, returnedProvider: null, returnedModel: null, returnedReasoningEffort: null,
         usage: null, finishReason: null, providerFinishReason: null,
-        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
-        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
-        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
-        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched,
+        promptSha256: judgePlan.promptSha256, providerRequestSha256,
+        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: judgePlan.judgeConfigSha256,
+        pricingProfileId: judgePlan.pricingProfileId, pricingProfileSha256: judgePlan.pricingProfileSha256,
+        pricingSource: judgePlan.pricingSource, pricingPolicy: judgePlan.pricingPolicy, dispatched,
         exposure: dispatched ? 'unknown' : 'not_dispatched',
       }));
     } finally { clearTimeout(timeout); }

--- a/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
@@ -1,0 +1,338 @@
+import { createHash } from 'node:crypto';
+import { collectModelResponse, InvalidModelEventStreamError } from '../model-providers/events.js';
+import type { ModelFinishReason, ModelOutputSchema, ModelProvider, ModelProviderId, ModelReasoningEffort, ModelRequest, ModelResponse, ModelUsage } from '../model-providers/model-provider.js';
+import { datedPricingProfileIdentity, datedPricingProfilesForFixedTrace } from './dated-pricing-cohort.js';
+import { fixedTraceEstimatedCostUsd, fixedTraceResponsePricingPolicy } from './fixed-trace-budget.js';
+import { assertFixedTraceBlindedModelJudgePacket } from './fixed-trace-model-judge-control-plane.js';
+import { FIXED_TRACE_JUDGE_PROMPT_VERSION } from './fixed-trace-judge.js';
+import type { FixedTraceCompletedJudgeSummary } from './fixed-trace-judge.js';
+import type { FixedTraceProviderStageConfig } from './fixed-trace-runner.js';
+import type { FixedTraceCase, FixedTraceObservation } from './fixed-trace-suite.js';
+
+export const FIXED_TRACE_DIRECT_FULL_SUITE_JUDGE_OUTPUT_SCHEMA: ModelOutputSchema = Object.freeze({
+  name: 'addie_fixed_trace_blinded_judgment_v2',
+  description: 'A blinded fixed-trace judgment.',
+  strict: true,
+  schema: {
+    type: 'object', additionalProperties: false,
+    required: ['pass', 'finding'] as string[],
+    properties: {
+      pass: { type: 'boolean' },
+      finding: { type: 'string', maxLength: 240 },
+    },
+  },
+  });
+
+/** Whole-cell admission counts each blinded judge request at this hard ceiling. */
+export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES = 65_536;
+
+export interface FixedTraceDirectFullSuiteJudgment {
+  readonly traceId: string;
+  readonly judgeProvider: ModelProviderId;
+  readonly judgeModel: string;
+  readonly status: 'pass' | 'fail' | 'missing' | 'malformed' | 'timeout_after_dispatch' | 'unknown_exposure' | 'not_dispatched_budget';
+  readonly finding: string | null;
+  readonly latencyMs: number;
+  readonly estimatedCostUsd: number | null;
+  readonly requestedProvider: ModelProviderId;
+  readonly requestedModel: string;
+  readonly requestedReasoningEffort: ModelReasoningEffort;
+  readonly returnedProvider: ModelProviderId | null;
+  readonly returnedModel: string | null;
+  /** The normalized provider response has no effort field; never fabricate one. */
+  readonly returnedReasoningEffort: null;
+  /** All four categories are normalized to explicit non-negative integers. */
+  readonly usage: ModelUsage | null;
+  readonly finishReason: ModelFinishReason | null;
+  readonly providerFinishReason: string | null;
+  readonly promptSha256: string;
+  readonly providerRequestSha256: string;
+  readonly promptConfigVersion: string;
+  readonly judgeConfigSha256: string;
+  readonly pricingProfileId: string;
+  readonly pricingProfileSha256: string;
+  readonly pricingSource: string;
+  readonly pricingPolicy: Readonly<{
+    expectedProvider: ModelProviderId;
+    expectedModel: string;
+    modelResolutionPolicy: string;
+  }>;
+  readonly dispatched: boolean;
+  /** Settlement classification independent of verdict parsing. */
+  readonly exposure: 'settled' | 'unknown' | 'not_dispatched';
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value), 'utf8').digest('hex');
+}
+
+function snapshotUsage(usage: unknown): ModelUsage | null {
+  if (!usage || typeof usage !== 'object') return null;
+  const record = usage as Record<string, unknown>;
+  // Input/output are required normalized adapter evidence. Cache categories
+  // are normalized to zero only when the adapter does not expose them.
+  const inputTokens = record.inputTokens;
+  const outputTokens = record.outputTokens;
+  const cacheReadTokens = record.cacheReadTokens ?? 0;
+  const cacheWriteTokens = record.cacheWriteTokens ?? 0;
+  if (![inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens].every((entry) => Number.isSafeInteger(entry) && (entry as number) >= 0)) return null;
+  return Object.freeze({
+    inputTokens: inputTokens as number, outputTokens: outputTokens as number,
+    cacheReadTokens: cacheReadTokens as number, cacheWriteTokens: cacheWriteTokens as number,
+  });
+}
+
+function judgeModel(provider: ModelProviderId): string {
+  return provider === 'anthropic' ? 'claude-haiku-4-5'
+    : provider === 'google' ? 'gemini-3.7-flash'
+      : 'gpt-5.6-luna';
+}
+
+function judgePrompt(): string {
+  return `${FIXED_TRACE_JUDGE_PROMPT_VERSION}: Judge the candidate output only against the supplied task and scoring context. Return the required JSON; do not infer any candidate identity.`;
+}
+
+export interface FixedTraceDirectFullSuiteJudgePlan {
+  readonly provider: ModelProviderId;
+  readonly model: string;
+  readonly reasoningEffort: 'provider_default';
+  readonly maxOutputTokens: 300;
+  readonly timeoutMs: 30_000;
+  readonly maxIterations: 1;
+  readonly transportRetries: 0;
+  readonly samplingMode: 'provider_no_sampling_control';
+  readonly temperature: null;
+  readonly promptConfigVersion: string;
+  readonly promptSha256: string;
+  readonly outputSchemaSha256: string;
+  readonly judgeConfigSha256: string;
+  readonly pricingProfileId: string;
+  readonly pricingProfileSha256: string;
+  readonly pricingSource: string;
+  readonly pricingPolicy: Readonly<{
+    expectedProvider: ModelProviderId;
+    expectedModel: string;
+    modelResolutionPolicy: string;
+  }>;
+}
+
+/** Immutable judge controls used both in the outer plan and every judgment. */
+export function fixedTraceDirectFullSuiteJudgePlan(provider: ModelProviderId): FixedTraceDirectFullSuiteJudgePlan {
+  const model = judgeModel(provider);
+  const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider && entry.model === model);
+  if (!pricing) throw new Error('Fixed trace direct full-suite judge pricing is unavailable');
+  const policy = fixedTraceResponsePricingPolicy(provider, model, pricing);
+  const base = {
+    provider, model, reasoningEffort: 'provider_default' as const,
+    maxOutputTokens: 300 as const, timeoutMs: 30_000 as const, maxIterations: 1 as const,
+    transportRetries: 0 as const, samplingMode: 'provider_no_sampling_control' as const, temperature: null,
+    promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION,
+    promptSha256: sha256({ promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, system: judgePrompt() }),
+    outputSchemaSha256: sha256(FIXED_TRACE_DIRECT_FULL_SUITE_JUDGE_OUTPUT_SCHEMA),
+    pricingProfileId: pricing.profileId, pricingProfileSha256: datedPricingProfileIdentity(pricing).digest,
+    pricingSource: pricing.source,
+    pricingPolicy: Object.freeze({ expectedProvider: policy.expectedProvider, expectedModel: policy.expectedModel, modelResolutionPolicy: policy.modelResolutionPolicy }),
+  };
+  return Object.freeze({ ...base, judgeConfigSha256: sha256(base) });
+}
+
+function stageFor(provider: ModelProvider): FixedTraceProviderStageConfig {
+  const plan = fixedTraceDirectFullSuiteJudgePlan(provider.id);
+  const model = plan.model;
+  const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider.id && entry.model === model);
+  if (!pricing) throw new Error('Fixed trace direct full-suite judge pricing is unavailable');
+  return Object.freeze({
+    provider, model, reasoningEffort: plan.reasoningEffort, maxOutputTokens: plan.maxOutputTokens,
+    timeoutMs: plan.timeoutMs, maxIterations: plan.maxIterations, transportRetries: plan.transportRetries,
+    samplingMode: plan.samplingMode, temperature: plan.temperature, pricing,
+  });
+}
+
+function packet(trace: FixedTraceCase, observation: FixedTraceObservation) {
+  const outputCondition = observation.terminalStatus === 'complete' && observation.output.trim()
+    ? 'complete' as const
+    : ['malformed', 'truncated', 'empty'].includes(observation.terminalStatus)
+      ? 'malformed' as const
+      : 'missing' as const;
+  const result = {
+    packetId: createHash('sha256').update(`${observation.metadata.runId}\0${trace.id}`, 'utf8').digest('hex'),
+    prompt: trace.request.message,
+    candidateOutput: outputCondition === 'complete' ? observation.output : null,
+    outputCondition,
+    scoringContext: JSON.stringify({
+      requiredTextAny: trace.expectation.requiredTextAny ?? [],
+      bannedText: trace.expectation.bannedText ?? [],
+      maxWords: trace.expectation.maxWords ?? null,
+      expectedTerminal: trace.expectation.terminalStatuses,
+    }),
+  };
+  assertFixedTraceBlindedModelJudgePacket(result);
+  return result;
+}
+
+function text(response: ModelResponse): string {
+  return response.content.filter((entry) => entry.type === 'text').map((entry) => entry.text).join('');
+}
+
+interface CapturedJudgeResponse {
+  started: Readonly<{ provider: ModelProviderId; model: string }> | null;
+  terminal: ModelResponse | null;
+}
+
+/** Observe the unmodified stream before the normal collector validates it. */
+async function* observeJudgeResponse(
+  events: AsyncIterable<import('../model-providers/model-provider.js').NormalizedModelEvent>,
+  captured: CapturedJudgeResponse,
+): AsyncIterable<import('../model-providers/model-provider.js').NormalizedModelEvent> {
+  for await (const event of events) {
+    if (event.type === 'response_start') {
+      captured.started = Object.freeze({ provider: event.provider, model: event.model });
+    } else if (event.type === 'response_complete') {
+      captured.terminal = Object.freeze(structuredClone(event.response));
+    }
+    yield event;
+  }
+}
+
+function verdict(value: string): { pass: boolean; finding: string } | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const record = parsed as Record<string, unknown>;
+    if (Object.keys(record).length !== 2 || typeof record.pass !== 'boolean' || typeof record.finding !== 'string' || record.finding.length > 240) return null;
+    return { pass: record.pass, finding: record.finding };
+  } catch { return null; }
+}
+
+/** Execute exactly the supplied provider-excluding judge slots for one blinded packet. */
+export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<{
+  trace: FixedTraceCase;
+  observation: FixedTraceObservation;
+  judges: Readonly<Record<ModelProviderId, ModelProvider>>;
+  requiredJudgeProviders: readonly ModelProviderId[];
+}>): Promise<readonly FixedTraceDirectFullSuiteJudgment[]> {
+  if (input.requiredJudgeProviders.length !== 2 || new Set(input.requiredJudgeProviders).size !== 2) {
+    throw new Error('Fixed trace direct full-suite comparison requires exactly two distinct judge providers');
+  }
+  const blinded = packet(input.trace, input.observation);
+  const results: FixedTraceDirectFullSuiteJudgment[] = [];
+  for (const judgeProvider of input.requiredJudgeProviders) {
+    const provider = input.judges[judgeProvider];
+    if (!provider || provider.id !== judgeProvider) throw new Error('Fixed trace direct full-suite judge provider identity drift');
+    const stage = stageFor(provider);
+    const judgePlan = fixedTraceDirectFullSuiteJudgePlan(judgeProvider);
+    const request: ModelRequest = {
+      model: stage.model,
+      system: [{ text: judgePrompt() }],
+      messages: [{ role: 'user', content: [{ type: 'text', text: JSON.stringify(blinded) }] }],
+      tools: [], outputSchema: FIXED_TRACE_DIRECT_FULL_SUITE_JUDGE_OUTPUT_SCHEMA,
+      maxOutputTokens: stage.maxOutputTokens,
+      requestMetadata: { purpose: 'fixed_trace_blinded_judge', trace_id: input.trace.id },
+    };
+    const prepared = stage.provider.prepare(request);
+    const audit = Object.freeze({
+      ...judgePlan,
+      providerRequestSha256: sha256(prepared.providerRequest),
+    });
+    if (Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8') > FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES) {
+      results.push(Object.freeze({
+        traceId: input.trace.id, judgeProvider, judgeModel: stage.model, status: 'missing', finding: null,
+        latencyMs: 0, estimatedCostUsd: null, requestedProvider: stage.provider.id, requestedModel: stage.model,
+        requestedReasoningEffort: stage.reasoningEffort, returnedProvider: null, returnedModel: null, returnedReasoningEffort: null,
+        usage: null, finishReason: null, providerFinishReason: null,
+        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
+        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
+        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
+        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched: false, exposure: 'not_dispatched',
+      }));
+      continue;
+    }
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    let dispatched = false;
+    let timedOut = false;
+    const captured: CapturedJudgeResponse = { started: null, terminal: null };
+    const timeout = setTimeout(() => { timedOut = true; controller.abort(); }, stage.timeoutMs);
+    try {
+      const response = await collectModelResponse(observeJudgeResponse(
+        stage.provider.respond(request, { signal: controller.signal, beforeDispatch: () => { dispatched = true; } }),
+        captured,
+      ), stage.provider.id);
+      const usage = snapshotUsage(response.usage);
+      const parsed = response.finishReason === 'stop' ? verdict(text(response)) : null;
+      const identityExact = response.provider === stage.provider.id && response.model === stage.model;
+      const settled = dispatched && identityExact && usage !== null;
+      results.push(Object.freeze({
+        traceId: input.trace.id, judgeProvider, judgeModel: stage.model,
+        status: !settled ? 'unknown_exposure' : !parsed ? 'malformed' : parsed.pass ? 'pass' : 'fail',
+        finding: parsed?.finding ?? null, latencyMs: Date.now() - startedAt,
+        estimatedCostUsd: settled ? fixedTraceEstimatedCostUsd(usage, stage.pricing) : null, requestedProvider: stage.provider.id,
+        requestedModel: stage.model, requestedReasoningEffort: stage.reasoningEffort,
+        returnedProvider: response.provider, returnedModel: response.model, returnedReasoningEffort: null,
+        usage, finishReason: response.finishReason, providerFinishReason: response.providerFinishReason,
+        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
+        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
+        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
+        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched, exposure: settled ? 'settled' : 'unknown',
+      }));
+    } catch (error) {
+      if (error instanceof InvalidModelEventStreamError && (captured.terminal !== null || captured.started !== null)) {
+        const response = captured.terminal;
+        const returned = response ?? captured.started;
+        results.push(Object.freeze({
+          traceId: input.trace.id, judgeProvider, judgeModel: stage.model, status: 'unknown_exposure', finding: null,
+          latencyMs: Date.now() - startedAt, estimatedCostUsd: null,
+          requestedProvider: stage.provider.id, requestedModel: stage.model, requestedReasoningEffort: stage.reasoningEffort,
+          returnedProvider: returned?.provider ?? null, returnedModel: returned?.model ?? null, returnedReasoningEffort: null,
+          usage: response ? snapshotUsage(response.usage) : null,
+          finishReason: response?.finishReason ?? null, providerFinishReason: response?.providerFinishReason ?? null,
+          promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
+          promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
+          pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
+          pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched, exposure: 'unknown',
+        }));
+        continue;
+      }
+      const budget = error instanceof Error && error.name === 'FixedTraceBudgetAdmissionError';
+      results.push(Object.freeze({
+        traceId: input.trace.id, judgeProvider, judgeModel: stage.model,
+        status: budget ? 'not_dispatched_budget' : dispatched && timedOut ? 'timeout_after_dispatch' : dispatched ? 'unknown_exposure' : 'missing',
+        finding: null, latencyMs: Date.now() - startedAt, estimatedCostUsd: null,
+        requestedProvider: stage.provider.id, requestedModel: stage.model,
+        requestedReasoningEffort: stage.reasoningEffort, returnedProvider: null, returnedModel: null, returnedReasoningEffort: null,
+        usage: null, finishReason: null, providerFinishReason: null,
+        promptSha256: audit.promptSha256, providerRequestSha256: audit.providerRequestSha256,
+        promptConfigVersion: FIXED_TRACE_JUDGE_PROMPT_VERSION, judgeConfigSha256: audit.judgeConfigSha256,
+        pricingProfileId: audit.pricingProfileId, pricingProfileSha256: audit.pricingProfileSha256,
+        pricingSource: audit.pricingSource, pricingPolicy: audit.pricingPolicy, dispatched,
+        exposure: dispatched ? 'unknown' : 'not_dispatched',
+      }));
+    } finally { clearTimeout(timeout); }
+  }
+  return Object.freeze(results);
+}
+
+export function summarizeFixedTraceDirectFullSuiteJudgments(
+  judgments: readonly FixedTraceDirectFullSuiteJudgment[],
+  expectedCases: number,
+): FixedTraceCompletedJudgeSummary {
+  const expectedJudgments = expectedCases * 2;
+  const judged = judgments.filter((judgment) => judgment.status === 'pass' || judgment.status === 'fail');
+  const grouped = new Map<string, FixedTraceDirectFullSuiteJudgment[]>();
+  for (const judgment of judgments) grouped.set(judgment.traceId, [...(grouped.get(judgment.traceId) ?? []), judgment]);
+  const consensus = [...grouped.values()].filter((group) => group.length === 2 && group.every((entry) => entry.status === 'pass' || entry.status === 'fail'));
+  const consensusPasses = consensus.filter((group) => group.every((entry) => entry.status === 'pass')).length;
+  const disagreements = consensus.filter((group) => group[0]!.status !== group[1]!.status).length;
+  const costs = judgments.map((judgment) => judgment.estimatedCostUsd);
+  const latencies = judgments.map((judgment) => judgment.latencyMs).filter((latency) => Number.isFinite(latency) && latency >= 0).sort((left, right) => left - right);
+  return Object.freeze({
+    status: 'completed_diagnostic', expectedCases, expectedJudgments, observedJudgments: judgments.length,
+    judgedJudgments: judged.length, expectedRecordCountObserved: judgments.length === expectedJudgments,
+    judgmentCoverageRate: expectedJudgments === 0 ? null : judged.length / expectedJudgments,
+    consensusPassRate: expectedCases === 0 ? null : consensusPasses / expectedCases,
+    disagreementRate: expectedCases === 0 ? null : disagreements / expectedCases,
+    latencyP95Ms: latencies.length === expectedJudgments ? latencies[Math.max(0, Math.ceil(latencies.length * .95) - 1)]! : null,
+    totalEstimatedCostUsd: costs.some((cost) => cost === null) ? null : costs.reduce<number>((total, cost) => total + (cost ?? 0), 0),
+    comparisonEligible: false,
+  });
+}

--- a/server/src/addie/eval/fixed-trace-direct-full-suite.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite.ts
@@ -1,0 +1,490 @@
+import { createHash } from 'node:crypto';
+import { closeSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import type { ModelProvider, ModelProviderId, ModelReasoningEffort } from '../model-providers/model-provider.js';
+import {
+  FixedTraceBudget,
+  type FixedTraceBudgetDiagnosticLease,
+  claimFixedTraceBudgetDiagnosticLease,
+  fixedTraceResponsePricingPolicy,
+  isTrustedBudgetedFixedTraceProvider,
+} from './fixed-trace-budget.js';
+import { FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES, fixedTraceDirectFullSuiteJudgePlan, judgeFixedTraceDirectFullSuiteObservation, summarizeFixedTraceDirectFullSuiteJudgments, type FixedTraceDirectFullSuiteJudgment } from './fixed-trace-direct-full-suite-judge.js';
+import { datedPricingProfileIdentity, datedPricingProfilesForFixedTrace, datedPricingReservationCostUsd, type DatedPricingProfile } from './dated-pricing-cohort.js';
+import {
+  FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE,
+  FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES,
+  runFixedTraceDirectFullSuiteComparison,
+  type FixedTraceDirectModelScreenGenerationCellId,
+  type FixedTraceProviderStageConfig,
+  type FixedTraceRunnerConfig,
+} from './fixed-trace-runner.js';
+import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from './fixed-trace-tool-loop.js';
+import { FIXED_TRACE_SUITE, FIXED_TRACE_SUITE_VERSION, fixedTraceSuiteSha256, summarizeFixedTraceRun } from './fixed-trace-suite.js';
+import { canonicalFixedTraceToolDefinitions } from './fixed-trace-tools.js';
+
+export const FIXED_TRACE_DIRECT_FULL_SUITE_CELLS = Object.freeze([
+  'generation:anthropic:claude-sonnet-5:provider_default',
+  'generation:anthropic:claude-haiku-4-5:provider_default',
+  'generation:google:gemini-3.7-flash:provider_default',
+  'generation:google:gemini-3.7-flash:low',
+  'generation:google:gemini-3.7-flash:medium',
+  'generation:google:gemini-3.7-flash:high',
+] as const satisfies readonly FixedTraceDirectModelScreenGenerationCellId[]);
+export type FixedTraceDirectFullSuiteCellId = (typeof FIXED_TRACE_DIRECT_FULL_SUITE_CELLS)[number];
+
+export const FIXED_TRACE_DIRECT_FULL_SUITE_JUDGES = Object.freeze({
+  anthropic: Object.freeze(['google', 'openai'] as const),
+  google: Object.freeze(['anthropic', 'openai'] as const),
+  openai: Object.freeze([] as const),
+});
+
+export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_GENERATION_DISPATCHES = FIXED_TRACE_SUITE.length * MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS;
+export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_DISPATCHES = FIXED_TRACE_SUITE.length * 2;
+
+const CELL = /^generation:(anthropic|google):([^:]+):(provider_default|low|medium|high)$/;
+
+/** Session-scoped Addie credentials take precedence without exposing them. */
+export function fixedTraceDirectFullSuiteAnthropicApiKey(environment: Readonly<Record<string, string | undefined>>): string | undefined {
+  return environment.ADDIE_ANTHROPIC_API_KEY || environment.ANTHROPIC_API_KEY;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+export function fixedTraceDirectFullSuiteCell(cellId: string): {
+  readonly id: FixedTraceDirectFullSuiteCellId;
+  readonly provider: 'anthropic' | 'google';
+  readonly model: 'claude-sonnet-5' | 'claude-haiku-4-5' | 'gemini-3.7-flash';
+  readonly effort: ModelReasoningEffort;
+  readonly judgeProviders: readonly ModelProviderId[];
+} {
+  if (!(FIXED_TRACE_DIRECT_FULL_SUITE_CELLS as readonly string[]).includes(cellId)) {
+    throw new Error('Fixed trace direct full-suite comparison cell is unsupported');
+  }
+  const match = CELL.exec(cellId);
+  if (!match || (match[1] !== 'anthropic' && match[1] !== 'google')) throw new Error('Fixed trace direct full-suite comparison cell is malformed');
+  const provider = match[1];
+  const model = match[2];
+  const effort = match[3] as ModelReasoningEffort;
+  return Object.freeze({
+    id: cellId as FixedTraceDirectFullSuiteCellId,
+    provider,
+    model: model as 'claude-sonnet-5' | 'claude-haiku-4-5' | 'gemini-3.7-flash',
+    effort,
+    judgeProviders: FIXED_TRACE_DIRECT_FULL_SUITE_JUDGES[provider],
+  });
+}
+
+export function fixedTraceDirectFullSuiteStage(
+  cellId: FixedTraceDirectFullSuiteCellId,
+  provider: ModelProvider,
+): FixedTraceProviderStageConfig {
+  const cell = fixedTraceDirectFullSuiteCell(cellId);
+  const pricing = datedPricingProfilesForFixedTrace().find((candidate) => (
+    candidate.provider === cell.provider && candidate.model === cell.model
+  ));
+  if (!pricing || provider.id !== cell.provider) throw new Error('Fixed trace direct full-suite provider or pricing identity drift');
+  fixedTraceResponsePricingPolicy(cell.provider, cell.model, pricing);
+  return Object.freeze({
+    provider, model: cell.model, reasoningEffort: cell.effort, maxOutputTokens: 900,
+    timeoutMs: 120_000, maxIterations: 12, transportRetries: 0,
+    samplingMode: 'provider_no_sampling_control', temperature: null, pricing,
+  });
+}
+
+/**
+ * A whole-cell upper bound using the exact current pricing cohort. Every
+ * candidate request is hard-bounded before provider dispatch, and every judge
+ * packet has an independent bound, so all possible calls are admitted before
+ * the one-shot selector or artifact names are consumed.
+ */
+export interface FixedTraceDirectFullSuiteCostComponent {
+  readonly role: 'candidate' | 'judge';
+  readonly provider: ModelProviderId;
+  readonly model: string;
+  readonly reasoningEffort: ModelReasoningEffort;
+  readonly dispatches: number;
+  /** Admission deliberately treats every request byte as one input token. */
+  readonly inputByteUpperBound: number;
+  readonly inputTokenUpperBound: number;
+  readonly maxOutputTokens: number;
+  readonly pricingProfileId: string;
+  readonly pricingProfileSha256: string;
+  readonly pricingPolicy: Readonly<{
+    expectedProvider: ModelProviderId;
+    expectedModel: string;
+    modelResolutionPolicy: string;
+  }>;
+  readonly reservationPerDispatchUsd: number;
+  readonly reservationUsd: number;
+  /** Exact additive/subset buckets used by the shared reservation function. */
+  readonly pricingBuckets: readonly Readonly<{
+    category: 'input' | 'output' | 'cache_read' | 'cache_write';
+    accounting: 'additive' | 'subset' | 'not_applicable';
+    tokens: number;
+    usdPerMillionTokens: number;
+    usd: number;
+  }>[];
+}
+
+export interface FixedTraceDirectFullSuiteCostCeiling {
+  readonly candidateMaxDispatches: number;
+  readonly judgeMaxDispatches: number;
+  readonly candidatePreparedRequestBytes: number;
+  readonly judgePreparedRequestBytes: number;
+  readonly candidatePricingProfileId: string;
+  readonly judgePricingProfileIds: readonly string[];
+  readonly candidateReservationUsd: number;
+  readonly judgeReservationUsd: number;
+  readonly totalUsd: number;
+  /** Exact minimum soft cap accepted for the complete one-shot cell. */
+  readonly requiredSoftMaxUsd: number;
+  readonly components: readonly FixedTraceDirectFullSuiteCostComponent[];
+}
+
+function reservationComponent(input: Readonly<{
+  role: 'candidate' | 'judge';
+  provider: ModelProviderId;
+  model: string;
+  reasoningEffort: ModelReasoningEffort;
+  dispatches: number;
+  inputByteUpperBound: number;
+  maxOutputTokens: number;
+  profile: DatedPricingProfile;
+}>): FixedTraceDirectFullSuiteCostComponent {
+  const policy = fixedTraceResponsePricingPolicy(input.provider, input.model, input.profile);
+  const tokens = input.inputByteUpperBound;
+  const selectedSubset = [
+    { category: 'input' as const, rate: input.profile.inputUsdPerMillionTokens },
+    ...(input.profile.cacheReadAccounting === 'subset' && input.profile.cacheReadUsdPerMillionTokens !== null
+      ? [{ category: 'cache_read' as const, rate: input.profile.cacheReadUsdPerMillionTokens }] : []),
+    ...(input.profile.cacheWriteAccounting === 'subset' && input.profile.cacheWriteUsdPerMillionTokens !== null
+      ? [{ category: 'cache_write' as const, rate: input.profile.cacheWriteUsdPerMillionTokens }] : []),
+  ].reduce((highest, bucket) => bucket.rate > highest.rate ? bucket : highest);
+  const pricingBuckets = [
+    { category: selectedSubset.category, accounting: selectedSubset.category === 'input' ? 'not_applicable' as const : 'subset' as const, tokens, usdPerMillionTokens: selectedSubset.rate, usd: tokens * selectedSubset.rate / 1_000_000 },
+    { category: 'output' as const, accounting: 'not_applicable' as const, tokens: input.maxOutputTokens, usdPerMillionTokens: input.profile.outputUsdPerMillionTokens, usd: input.maxOutputTokens * input.profile.outputUsdPerMillionTokens / 1_000_000 },
+    ...(input.profile.cacheReadAccounting === 'additive' && input.profile.cacheReadUsdPerMillionTokens !== null
+      ? [{ category: 'cache_read' as const, accounting: 'additive' as const, tokens, usdPerMillionTokens: input.profile.cacheReadUsdPerMillionTokens, usd: tokens * input.profile.cacheReadUsdPerMillionTokens / 1_000_000 }] : []),
+    ...(input.profile.cacheWriteAccounting === 'additive' && input.profile.cacheWriteUsdPerMillionTokens !== null
+      ? [{ category: 'cache_write' as const, accounting: 'additive' as const, tokens, usdPerMillionTokens: input.profile.cacheWriteUsdPerMillionTokens, usd: tokens * input.profile.cacheWriteUsdPerMillionTokens / 1_000_000 }] : []),
+  ];
+  const reservationPerDispatchUsd = datedPricingReservationCostUsd(input.profile, tokens, input.maxOutputTokens);
+  if (Math.abs(pricingBuckets.reduce((total, bucket) => total + bucket.usd, 0) - reservationPerDispatchUsd) > Number.EPSILON) {
+    throw new Error('Fixed trace direct full-suite reservation buckets do not reconcile');
+  }
+  return Object.freeze({
+    role: input.role, provider: input.provider, model: input.model, reasoningEffort: input.reasoningEffort,
+    dispatches: input.dispatches, inputByteUpperBound: tokens, inputTokenUpperBound: tokens,
+    maxOutputTokens: input.maxOutputTokens, pricingProfileId: input.profile.profileId,
+    pricingProfileSha256: datedPricingProfileIdentity(input.profile).digest,
+    pricingPolicy: Object.freeze({ expectedProvider: policy.expectedProvider, expectedModel: policy.expectedModel, modelResolutionPolicy: policy.modelResolutionPolicy }),
+    reservationPerDispatchUsd, reservationUsd: input.dispatches * reservationPerDispatchUsd,
+    pricingBuckets: Object.freeze(pricingBuckets.map((bucket) => Object.freeze(bucket))),
+  });
+}
+
+export function fixedTraceDirectFullSuiteCostCeiling(cellId: FixedTraceDirectFullSuiteCellId): FixedTraceDirectFullSuiteCostCeiling {
+  const cell = fixedTraceDirectFullSuiteCell(cellId);
+  const profile = (provider: ModelProviderId, model: string) => {
+    const result = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider && entry.model === model);
+    if (!result) throw new Error('Fixed trace direct full-suite ceiling pricing is unavailable');
+    fixedTraceResponsePricingPolicy(provider, model, result);
+    return result;
+  };
+  const candidate = profile(cell.provider, cell.model);
+  const judgeProfiles = cell.judgeProviders.map((provider) => profile(provider, provider === 'anthropic' ? 'claude-haiku-4-5' : provider === 'google' ? 'gemini-3.7-flash' : 'gpt-5.6-luna'));
+  const components = Object.freeze([
+    reservationComponent({ role: 'candidate', provider: cell.provider, model: cell.model, reasoningEffort: cell.effort, dispatches: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_GENERATION_DISPATCHES, inputByteUpperBound: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES, maxOutputTokens: 900, profile: candidate }),
+    ...judgeProfiles.map((judge) => reservationComponent({ role: 'judge', provider: judge.provider, model: judge.model, reasoningEffort: 'provider_default', dispatches: FIXED_TRACE_SUITE.length, inputByteUpperBound: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES, maxOutputTokens: 300, profile: judge })),
+  ]);
+  const candidateReservationUsd = components[0]!.reservationUsd;
+  const judgeReservationUsd = components.slice(1).reduce((total, component) => total + component.reservationUsd, 0);
+  const totalUsd = candidateReservationUsd + judgeReservationUsd;
+  return Object.freeze({
+    candidateMaxDispatches: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_GENERATION_DISPATCHES,
+    judgeMaxDispatches: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_DISPATCHES,
+    candidatePreparedRequestBytes: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES,
+    judgePreparedRequestBytes: FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES,
+    candidatePricingProfileId: candidate.profileId,
+    judgePricingProfileIds: Object.freeze(judgeProfiles.map((judge) => judge.profileId)),
+    candidateReservationUsd,
+    judgeReservationUsd,
+    totalUsd,
+    requiredSoftMaxUsd: totalUsd,
+    components,
+  });
+}
+
+/** Atomically admit every bounded dispatch before any durable side effect. */
+export function assertFixedTraceDirectFullSuiteCostCeiling(
+  cellId: FixedTraceDirectFullSuiteCellId,
+  softMaxUsd: number,
+) {
+  const ceiling = fixedTraceDirectFullSuiteCostCeiling(cellId);
+  if (!Number.isFinite(softMaxUsd) || softMaxUsd < ceiling.totalUsd) {
+    throw new RangeError(`Fixed trace direct full-suite soft budget is below the required whole-cell ceiling (${ceiling.totalUsd})`);
+  }
+  return ceiling;
+}
+
+function freezePlan<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value as Record<string, unknown>)) freezePlan(nested);
+  return Object.freeze(value);
+}
+
+/**
+ * The durable plan is constructed from evaluator-owned controls only. Its
+ * judge slots make provider_default explicit and bind prompt, configuration,
+ * pricing policy, and the exact whole-cell reservation before execution.
+ */
+export function fixedTraceDirectFullSuitePlan(input: Readonly<{
+  cellId: FixedTraceDirectFullSuiteCellId;
+  sourceFiles: readonly string[];
+  sourceBundleSha256: string;
+  promptConfigVersion: string;
+  softMaxUsd: number;
+}>) {
+  const cell = fixedTraceDirectFullSuiteCell(input.cellId);
+  const ceiling = fixedTraceDirectFullSuiteCostCeiling(cell.id);
+  const candidate = ceiling.components[0]!;
+  return freezePlan({
+    mode: FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE,
+    cell: cell.id,
+    candidate: {
+      provider: cell.provider, model: cell.model, reasoningEffort: cell.effort,
+      pricingProfileId: candidate.pricingProfileId, pricingProfileSha256: candidate.pricingProfileSha256,
+      pricingPolicy: candidate.pricingPolicy,
+    },
+    requiredJudgeProviders: [...cell.judgeProviders],
+    judges: cell.judgeProviders.map((provider) => fixedTraceDirectFullSuiteJudgePlan(provider)),
+    traceSuiteVersion: FIXED_TRACE_SUITE_VERSION,
+    traceSuiteSha256: fixedTraceSuiteSha256(FIXED_TRACE_SUITE),
+    traceCount: FIXED_TRACE_SUITE.length,
+    generation: { maxOutputTokens: 900, timeoutMs: 120_000, maxIterations: MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS, transportRetries: 0 },
+    sourceFiles: [...input.sourceFiles], sourceBundleSha256: input.sourceBundleSha256,
+    promptConfigVersion: input.promptConfigVersion, softMaxUsd: input.softMaxUsd,
+    wholeCellCostCeiling: ceiling,
+  });
+}
+
+/** Build exactly one direct-only full-suite candidate; no admission is consulted. */
+export function fixedTraceDirectFullSuiteConfig(input: Readonly<{
+  runId: string;
+  sourceBundleSha256: string;
+  gitCommit: string;
+  provider: ModelProvider;
+  cellId: FixedTraceDirectFullSuiteCellId;
+  promptConfigVersion: string;
+}>): FixedTraceRunnerConfig {
+  return Object.freeze({
+    runId: input.runId,
+    sourceBundleSha256: input.sourceBundleSha256,
+    gitCommit: input.gitCommit,
+    gitDirty: false,
+    promptConfigVersion: input.promptConfigVersion,
+    traceSuite: FIXED_TRACE_SUITE,
+    traceSuiteSha256: fixedTraceSuiteSha256(FIXED_TRACE_SUITE),
+    toolDefinitions: canonicalFixedTraceToolDefinitions(FIXED_TRACE_SUITE),
+    toolDefinitionProvenance: 'fixture_local',
+    architectureArm: 'direct_generation',
+    router: null,
+    generation: fixedTraceDirectFullSuiteStage(input.cellId, input.provider),
+    directFullSuiteComparison: {
+      mode: FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE,
+      generationCellId: input.cellId,
+    },
+  });
+}
+
+export function fixedTraceDirectFullSuiteSourceBundle(files: readonly string[]): {
+  readonly files: readonly string[];
+  readonly sha256: string;
+} {
+  const ordered = [...new Set(files)].sort();
+  if (ordered.length === 0 || ordered.some((file) => !file || file.startsWith('/') || file.includes('..'))) {
+    throw new Error('Fixed trace direct full-suite source bundle is invalid');
+  }
+  const hash = createHash('sha256');
+  for (const file of ordered) hash.update(file, 'utf8').update('\0').update(readFileSync(file)).update('\0');
+  return Object.freeze({ files: Object.freeze(ordered), sha256: hash.digest('hex') });
+}
+
+/** Durable one-use selector. It is created before a provider object is accepted. */
+export function consumeFixedTraceDirectFullSuiteSelector(path: string, input: Readonly<{
+  cellId: FixedTraceDirectFullSuiteCellId;
+  sourceBundleSha256: string;
+  promptConfigVersion: string;
+}>): void {
+  let descriptor: number;
+  try { descriptor = openSync(path, 'wx', 0o600); }
+  catch (error) { throw new Error(`Fixed trace direct full-suite selector was already consumed: ${error instanceof Error ? error.message : String(error)}`); }
+  try { writeFileSync(descriptor, `${JSON.stringify({ mode: FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE, cellId: input.cellId, traceSuiteSha256: fixedTraceSuiteSha256(FIXED_TRACE_SUITE), sourceBundleSha256: input.sourceBundleSha256, promptConfigVersion: input.promptConfigVersion })}\n`, 'utf8'); }
+  finally { closeSync(descriptor); }
+}
+
+export interface FixedTraceDirectFullSuiteOutputReservation {
+  finalize(artifact: unknown): string;
+}
+
+/** Reserve both output identities before dispatch; no existing evidence can be overwritten. */
+export function reserveFixedTraceDirectFullSuiteOutput(path: string): FixedTraceDirectFullSuiteOutputReservation {
+  const output = resolve(path);
+  const checksum = `${output}.sha256`;
+  let artifactDescriptor: number;
+  let checksumDescriptor: number;
+  try {
+    artifactDescriptor = openSync(output, 'wx', 0o600);
+    try { checksumDescriptor = openSync(checksum, 'wx', 0o600); }
+    catch (error) { closeSync(artifactDescriptor); throw error; }
+  } catch (error) {
+    throw new Error(`Cannot exclusively reserve fixed-trace direct full-suite output: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  let finalized = false;
+  return Object.freeze({
+    finalize(artifact: unknown): string {
+      if (finalized) throw new Error('Fixed trace direct full-suite output is already finalized');
+      const content = `${JSON.stringify(artifact, null, 2)}\n`;
+      const digest = sha256(content);
+      try {
+        writeFileSync(artifactDescriptor!, content, 'utf8');
+        writeFileSync(checksumDescriptor!, `${digest}  ${output}\n`, 'utf8');
+        finalized = true;
+        return digest;
+      } finally { closeSync(artifactDescriptor!); closeSync(checksumDescriptor!); }
+    },
+  });
+}
+
+export async function runFixedTraceDirectFullSuiteCandidate(config: FixedTraceRunnerConfig) {
+  const observations = await runFixedTraceDirectFullSuiteComparison(config);
+  return Object.freeze({ observations: Object.freeze(observations), ...summarizeFixedTraceRun(observations, FIXED_TRACE_SUITE) });
+}
+
+export interface FixedTraceDirectFullSuiteAdmission {
+  readonly candidate: FixedTraceRunnerConfig;
+  readonly judges: Readonly<Record<ModelProviderId, ModelProvider>>;
+  release(): void;
+}
+
+const directFullSuiteAdmissions = new WeakMap<FixedTraceDirectFullSuiteAdmission, Readonly<{
+  budget: FixedTraceBudget;
+  cellId: FixedTraceDirectFullSuiteCellId;
+}>>();
+
+/**
+ * Authenticates all wrappers and escrows the exact whole-cell ceiling before
+ * the CLI consumes either of its one-shot filesystem identities.
+ */
+export function admitFixedTraceDirectFullSuiteComparison(input: Readonly<{
+  candidate: FixedTraceRunnerConfig;
+  judgeProviders: Readonly<Record<ModelProviderId, ModelProvider>>;
+  budget: FixedTraceBudget;
+}>): FixedTraceDirectFullSuiteAdmission {
+  const cellId = input.candidate.directFullSuiteComparison?.generationCellId;
+  if (!cellId) throw new Error('Fixed trace direct full-suite comparison candidate mode is required');
+  const cell = fixedTraceDirectFullSuiteCell(cellId);
+  const ceiling = assertFixedTraceDirectFullSuiteCostCeiling(cellId, input.budget.softMaxUsd);
+  if (cell.judgeProviders.includes(cell.provider)) throw new Error('Fixed trace direct full-suite comparison cannot self-judge');
+  if (
+    input.candidate.generation.provider.id !== cell.provider
+    || input.candidate.generation.model !== cell.model
+    || input.candidate.generation.reasoningEffort !== cell.effort
+    || input.candidate.generation.maxOutputTokens !== 900
+    || input.candidate.generation.maxIterations !== MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS
+  ) throw new Error('Fixed trace direct full-suite candidate controls drift from the admitted cell');
+  const candidatePricingPolicy = fixedTraceResponsePricingPolicy(
+    input.candidate.generation.provider.id,
+    input.candidate.generation.model,
+    input.candidate.generation.pricing,
+  );
+  if (!isTrustedBudgetedFixedTraceProvider(
+    input.candidate.generation.provider,
+    input.budget,
+    input.candidate.generation.pricing,
+    candidatePricingPolicy,
+  )) throw new Error('Fixed trace direct full-suite candidate requires an authenticated shared budget wrapper');
+  const stages = new Map<ModelProviderId, FixedTraceProviderStageConfig>();
+  for (const judgeProvider of cell.judgeProviders) {
+    const provider = input.judgeProviders[judgeProvider];
+    const judgePlan = fixedTraceDirectFullSuiteJudgePlan(judgeProvider);
+    if (!provider || provider.id !== judgeProvider) throw new Error('Fixed trace direct full-suite judge provider identity drift');
+    const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === judgeProvider && entry.model === judgePlan.model);
+    if (!pricing) throw new Error('Fixed trace direct full-suite judge pricing is unavailable');
+    const policy = fixedTraceResponsePricingPolicy(judgeProvider, judgePlan.model, pricing);
+    if (!isTrustedBudgetedFixedTraceProvider(provider, input.budget, pricing, policy)) {
+      throw new Error('Fixed trace direct full-suite judge requires an authenticated shared budget wrapper');
+    }
+    stages.set(judgeProvider, Object.freeze({
+      provider, model: judgePlan.model, reasoningEffort: judgePlan.reasoningEffort,
+      maxOutputTokens: judgePlan.maxOutputTokens, timeoutMs: judgePlan.timeoutMs,
+      maxIterations: judgePlan.maxIterations, transportRetries: judgePlan.transportRetries,
+      samplingMode: judgePlan.samplingMode, temperature: judgePlan.temperature, pricing,
+    }));
+  }
+  const lease: FixedTraceBudgetDiagnosticLease = claimFixedTraceBudgetDiagnosticLease(
+    input.budget,
+    [input.candidate.generation.provider, ...cell.judgeProviders.map((id) => input.judgeProviders[id]!)],
+    undefined,
+    ceiling.requiredSoftMaxUsd,
+  );
+  const candidate = Object.freeze({
+    ...input.candidate,
+    generation: Object.freeze({ ...input.candidate.generation, provider: lease.providerFor(input.candidate.generation.provider) }),
+  });
+  const judges: Readonly<Record<ModelProviderId, ModelProvider>> = Object.freeze({
+    anthropic: cell.judgeProviders.includes('anthropic') ? lease.providerFor(stages.get('anthropic')!.provider) : input.judgeProviders.anthropic,
+    google: cell.judgeProviders.includes('google') ? lease.providerFor(stages.get('google')!.provider) : input.judgeProviders.google,
+    openai: cell.judgeProviders.includes('openai') ? lease.providerFor(stages.get('openai')!.provider) : input.judgeProviders.openai,
+  });
+  const admission: FixedTraceDirectFullSuiteAdmission = Object.freeze({
+    candidate, judges, release: () => lease.releaseWholeRunReservation(),
+  });
+  directFullSuiteAdmissions.set(admission, Object.freeze({ budget: input.budget, cellId }));
+  return admission;
+}
+
+/** Candidate and judges share a budgeted provider boundary but retain distinct, blinded calls. */
+export async function runFixedTraceDirectFullSuiteComparisonArtifact(input: Readonly<{
+  candidate: FixedTraceRunnerConfig;
+  judgeProviders: Readonly<Record<ModelProviderId, ModelProvider>>;
+  budget: FixedTraceBudget;
+  admission?: FixedTraceDirectFullSuiteAdmission;
+}>): Promise<Readonly<{
+  observations: readonly Awaited<ReturnType<typeof runFixedTraceDirectFullSuiteComparison>>[number][];
+  grades: ReturnType<typeof summarizeFixedTraceRun>['grades'];
+  summary: ReturnType<typeof summarizeFixedTraceRun>['summary'];
+  judgments: readonly FixedTraceDirectFullSuiteJudgment[];
+  judgeSummary: ReturnType<typeof summarizeFixedTraceDirectFullSuiteJudgments>;
+}>> {
+  const admission = input.admission ?? admitFixedTraceDirectFullSuiteComparison(input);
+  const binding = directFullSuiteAdmissions.get(admission);
+  if (!binding || binding.budget !== input.budget) throw new Error('Fixed trace direct full-suite admission is unauthenticated');
+  const cell = fixedTraceDirectFullSuiteCell(binding.cellId);
+  try {
+    const observations = await runFixedTraceDirectFullSuiteComparison(admission.candidate);
+    if (observations.length !== FIXED_TRACE_SUITE.length) throw new Error('Fixed trace direct full-suite comparison omitted a candidate denominator');
+    const byTraceId = new Map(observations.map((observation) => [observation.traceId, observation]));
+    const judgments: FixedTraceDirectFullSuiteJudgment[] = [];
+    for (const trace of FIXED_TRACE_SUITE) {
+      const observation = byTraceId.get(trace.id);
+      if (!observation) throw new Error('Fixed trace direct full-suite comparison omitted a trace observation');
+      judgments.push(...await judgeFixedTraceDirectFullSuiteObservation({
+        trace, observation, judges: admission.judges, requiredJudgeProviders: cell.judgeProviders,
+      }));
+    }
+    const summarized = summarizeFixedTraceRun(observations, FIXED_TRACE_SUITE);
+    if (judgments.length !== FIXED_TRACE_SUITE.length * 2) throw new Error('Fixed trace direct full-suite comparison omitted a judge denominator');
+    return Object.freeze({ observations: Object.freeze(observations), ...summarized, judgments: Object.freeze(judgments), judgeSummary: summarizeFixedTraceDirectFullSuiteJudgments(judgments, FIXED_TRACE_SUITE.length) });
+  } finally {
+    admission.release();
+  }
+}
+
+export function fixedTraceDirectFullSuiteGitCommit(): string {
+  return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+}

--- a/server/src/addie/eval/fixed-trace-judge.ts
+++ b/server/src/addie/eval/fixed-trace-judge.ts
@@ -29,7 +29,7 @@ export interface FixedTraceJudgeUnavailable {
  * unavailable judge system, never observed or eligible judgment evidence.
  * C owns the future sealed positive result contract.
  */
-export interface FixedTraceJudgeSummary extends FixedTraceJudgeUnavailable {
+export interface FixedTraceJudgeSummaryUnavailable extends FixedTraceJudgeUnavailable {
   readonly expectedCases: 0;
   readonly expectedJudgments: 0;
   readonly observedJudgments: 0;
@@ -42,6 +42,25 @@ export interface FixedTraceJudgeSummary extends FixedTraceJudgeUnavailable {
   readonly totalEstimatedCostUsd: null;
   readonly comparisonEligible: false;
 }
+
+/** Serialized result for the separately named, non-promoting direct full-suite mode. */
+export interface FixedTraceCompletedJudgeSummary {
+  readonly status: 'completed_diagnostic';
+  readonly expectedCases: number;
+  readonly expectedJudgments: number;
+  readonly observedJudgments: number;
+  readonly judgedJudgments: number;
+  readonly expectedRecordCountObserved: boolean;
+  readonly judgmentCoverageRate: number | null;
+  readonly consensusPassRate: number | null;
+  readonly disagreementRate: number | null;
+  readonly latencyP95Ms: number | null;
+  readonly totalEstimatedCostUsd: number | null;
+  /** This execution is still diagnostic evidence, never promotion evidence. */
+  readonly comparisonEligible: false;
+}
+
+export type FixedTraceJudgeSummary = FixedTraceJudgeSummaryUnavailable | FixedTraceCompletedJudgeSummary;
 
 const UNAVAILABLE_JUDGE = Object.freeze({
   status: "unavailable" as const,
@@ -59,7 +78,7 @@ export function fixedTraceJudgeUnavailable(): FixedTraceJudgeUnavailable {
   return UNAVAILABLE_JUDGE;
 }
 
-export function fixedTraceJudgeSummaryUnavailable(): FixedTraceJudgeSummary {
+export function fixedTraceJudgeSummaryUnavailable(): FixedTraceJudgeSummaryUnavailable {
   const unavailable = fixedTraceJudgeUnavailable();
   return Object.freeze({
     ...unavailable,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -123,6 +123,14 @@ export const FIXED_TRACE_DIRECT_MODEL_SCREEN_MODE = 'direct_model_screen_admissi
  * deliberately does not widen the original two-turn admission contract.
  */
 export const FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE = 'direct_model_screen_google_three_turn_v1' as const;
+/**
+ * A separately named full-corpus direct-generation comparison.  Unlike the
+ * closed two-probe admission screen, this is an exact current-suite replay
+ * and is deliberately not an admission input.
+ */
+export const FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE = 'direct_full_suite_model_comparison_v1' as const;
+/** Bounds every direct-full-suite prepared request before provider dispatch. */
+export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES = 131_072;
 export type FixedTraceDirectModelScreenGenerationCellId =
   | 'generation:anthropic:claude-sonnet-5:provider_default'
   | 'generation:anthropic:claude-haiku-4-5:provider_default'
@@ -142,6 +150,11 @@ export type FixedTraceDirectModelScreenConfig = {
   readonly mode: typeof FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE;
   readonly generationCellId: FixedTraceGoogleThreeTurnGenerationCellId;
 };
+
+export interface FixedTraceDirectFullSuiteComparisonConfig {
+  readonly mode: typeof FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE;
+  readonly generationCellId: FixedTraceDirectModelScreenGenerationCellId;
+}
 
 export interface FixedTraceRunnerConfig {
   runId: string;
@@ -176,6 +189,8 @@ export interface FixedTraceRunnerConfig {
   generation: FixedTraceProviderStageConfig;
   /** Required to admit the narrow source-pinned direct model screen. */
   directModelScreen?: FixedTraceDirectModelScreenConfig;
+  /** Required to execute the separately named current-full-suite comparison. */
+  directFullSuiteComparison?: FixedTraceDirectFullSuiteComparisonConfig;
   /** Deterministic provider-failure fixture; enabled by default. */
   injectProviderDegradation?: boolean;
 }
@@ -192,6 +207,7 @@ interface FixedTraceExecutionIdentity {
   architectureConfigSha256: string;
   architectureDiagnosticMode: FixedTraceArchitectureDiagnosticMode | null;
   directModelScreen: FixedTraceDirectModelScreenConfig | null;
+  directFullSuiteComparison: FixedTraceDirectFullSuiteComparisonConfig | null;
   runProvenanceSha256: string;
 }
 
@@ -215,6 +231,13 @@ function isDirectModelScreen(config: FixedTraceRunnerConfig): config is FixedTra
   router: null;
 } {
   return config.directModelScreen !== undefined;
+}
+
+function isDirectFullSuiteComparison(config: FixedTraceRunnerConfig): config is FixedTraceRunnerConfig & {
+  directFullSuiteComparison: FixedTraceDirectFullSuiteComparisonConfig;
+  router: null;
+} {
+  return config.directFullSuiteComparison !== undefined;
 }
 
 const boundTraceExecutionIdentities = new WeakMap<FixedTraceRunnerConfig, FixedTraceExecutionIdentity>();
@@ -337,6 +360,9 @@ function snapshotExecutionConfig(config: FixedTraceRunnerConfig): FixedTraceRunn
     directModelScreen: config.directModelScreen === undefined
       ? undefined
       : deepFreeze(structuredClone(config.directModelScreen)),
+    directFullSuiteComparison: config.directFullSuiteComparison === undefined
+      ? undefined
+      : deepFreeze(structuredClone(config.directFullSuiteComparison)),
   });
 }
 
@@ -368,7 +394,7 @@ function assertFixtureDefinitionUniverse(config: FixedTraceRunnerConfig): void {
     }
     return;
   }
-  if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
+  if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation' && !isDirectFullSuiteComparison(config)) return;
   if (!Array.isArray(config.toolDefinitions)) {
     throw new Error('Fixed trace routed/hybrid/oracle definitions must exactly match configured suite fixtures');
   }
@@ -397,7 +423,7 @@ function assertFixtureRegistrations(config: FixedTraceRunnerConfig): void {
     return;
   }
   if (usesCommonToolUniverse(config)) return;
-  if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation') return;
+  if (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation' && !isDirectFullSuiteComparison(config)) return;
   for (const trace of config.traceSuite) {
     validateFixedTraceToolLoopFixtures(trace, resolveTraceDefinitions(trace, config.toolDefinitions));
   }
@@ -474,7 +500,7 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
     throw new Error('Fixed trace architecture diagnostic mode is invalid');
   }
   if (config.architectureDiagnosticMode !== undefined) {
-    if (config.directModelScreen !== undefined) {
+    if (config.directModelScreen !== undefined || config.directFullSuiteComparison !== undefined) {
       throw new Error('Fixed trace architecture diagnostic mode excludes direct-model-screen mode');
     }
     if (config.router === null) {
@@ -560,7 +586,42 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || fixedTraceSuiteSha256(config.traceSuite) !== FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE_SHA256) {
       throw new Error('Fixed trace direct-model screen requires the source-pinned admission suite');
     }
-  } else if (config.router === null) {
+  }
+  if (config.directFullSuiteComparison !== undefined) {
+    const comparison = config.directFullSuiteComparison;
+    if (!comparison || typeof comparison !== 'object'
+      || Object.keys(comparison).length !== 2
+      || !Object.prototype.hasOwnProperty.call(comparison, 'mode')
+      || !Object.prototype.hasOwnProperty.call(comparison, 'generationCellId')
+      || comparison.mode !== FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE
+      || !directModelScreenGenerationCellIds.has(comparison.generationCellId)) {
+      throw new Error('Fixed trace direct full-suite comparison config is invalid');
+    }
+    if (config.directModelScreen !== undefined
+      || architectureArm.id !== 'direct_generation'
+      || config.router !== null
+      || config.toolDefinitionProvenance !== 'fixture_local') {
+      throw new Error('Fixed trace direct full-suite comparison requires direct generation, router null, and fixture-local synthetic tools');
+    }
+    const cell = FIXED_TRACE_ADMITTED_CELLS.find((candidate) => candidate.id === comparison.generationCellId);
+    if (!cell || cell.role !== 'generation'
+      || cell.provider !== config.generation.provider.id
+      || cell.model !== config.generation.model
+      || cell.effort !== config.generation.reasoningEffort
+      || cell.pricingProfileId !== config.generation.pricing.profileId
+      || config.generation.maxOutputTokens !== 900
+      || config.generation.timeoutMs !== 120_000
+      || config.generation.maxIterations !== MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS
+      || config.generation.transportRetries !== 0
+      || config.generation.samplingMode !== 'provider_no_sampling_control'
+      || config.generation.temperature !== null
+      || config.traceSuiteSha256 !== fixedTraceSuiteSha256(FIXED_TRACE_SUITE)
+      || fixedTraceSuiteSha256(config.traceSuite) !== fixedTraceSuiteSha256(FIXED_TRACE_SUITE)
+      || config.traceSuite.length !== FIXED_TRACE_SUITE.length) {
+      throw new Error('Fixed trace direct full-suite comparison differs from its exact current-suite cell contract');
+    }
+    fixedTraceResponsePricingPolicy(config.generation.provider.id, config.generation.model, config.generation.pricing);
+  } else if (config.directModelScreen === undefined && config.router === null) {
     throw new Error('Fixed trace runner router is required outside direct-model-screen mode');
   }
 }
@@ -594,7 +655,7 @@ function stageMatches(
 function runProvenanceSha256(config: FixedTraceRunnerConfig): string {
   const toolDefinitionProvenance = usesCommonToolUniverse(config)
     ? 'evaluator_owned_common_tool_universe'
-    : fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
+    : fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation' && !isDirectFullSuiteComparison(config)
     ? 'evaluator_owned_production_definitions_simulated_receipts'
     : config.toolDefinitionProvenance ?? 'fixture_local';
   return sha256({
@@ -609,6 +670,7 @@ function runProvenanceSha256(config: FixedTraceRunnerConfig): string {
     repetition: config.repetition ?? 1,
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
     directModelScreen: config.directModelScreen ?? null,
+    directFullSuiteComparison: config.directFullSuiteComparison ?? null,
   });
 }
 
@@ -623,6 +685,7 @@ function executionIdentity(config: FixedTraceRunnerConfig): FixedTraceExecutionI
     architectureConfigSha256: fixedTraceArchitectureConfigSha256(config, toolSchemaSha256),
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
     directModelScreen: config.directModelScreen ?? null,
+    directFullSuiteComparison: config.directFullSuiteComparison ?? null,
     runProvenanceSha256: runProvenanceSha256(config),
   };
 }
@@ -643,6 +706,7 @@ function assertExecutionIdentity(
     || actual.architectureConfigSha256 !== expected.architectureConfigSha256
     || actual.architectureDiagnosticMode !== expected.architectureDiagnosticMode
     || canonicalJson(actual.directModelScreen) !== canonicalJson(expected.directModelScreen)
+    || canonicalJson(actual.directFullSuiteComparison) !== canonicalJson(expected.directFullSuiteComparison)
     || actual.runProvenanceSha256 !== expected.runProvenanceSha256
   ) throw new FixedTraceExecutionIdentityError('Fixed trace runner execution identity changed before provider dispatch');
 }
@@ -807,7 +871,7 @@ function cohortStageControl(config: FixedTraceProviderStageConfig): FixedTraceCo
 }
 
 function routerControlForConfig(config: FixedTraceRunnerConfig): FixedTraceCohortStageControl | { readonly status: 'not_run' } {
-  if (isDirectModelScreen(config)) return { status: 'not_run' };
+  if (isDirectModelScreen(config) || isDirectFullSuiteComparison(config)) return { status: 'not_run' };
   if (config.router === null) throw new Error('Fixed trace runner router is required outside direct-model-screen mode');
   return cohortStageControl(config.router);
 }
@@ -1007,7 +1071,7 @@ export function fixedTraceToolSchemaSha256(
  * same suite-validated execution identity as routed replay.
  */
 function toolSchemaForConfig(config: FixedTraceRunnerConfig): string {
-  return usesCommonToolUniverse(config) || fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation'
+  return usesCommonToolUniverse(config) || (fixedTraceArchitectureArm(config.architectureArm).id === 'direct_generation' && !isDirectFullSuiteComparison(config))
     ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256
     : fixedTraceToolSchemaSha256(config.traceSuite, config.toolDefinitions);
 }
@@ -1036,7 +1100,7 @@ export function fixedTraceArchitectureConfigSha256(
     toolSchemaSha256,
     toolDefinitionProvenance: usesCommonToolUniverse(config)
       ? 'evaluator_owned_common_tool_universe'
-      : arm.id === 'direct_generation'
+      : arm.id === 'direct_generation' && !isDirectFullSuiteComparison(config)
       ? 'evaluator_owned_production_definitions_simulated_receipts'
       : config.toolDefinitionProvenance ?? 'fixture_local',
     architectureArm: arm,
@@ -1059,16 +1123,29 @@ export function fixedTraceArchitectureConfigSha256(
             'shared_request_thread_execution_envelope',
           ],
         }
+      : isDirectFullSuiteComparison(config)
+      ? {
+          source: 'fixture_local_direct_full_suite',
+          intentNarrowing: 'direct_full_suite_fixture_contract',
+          bounded: true,
+          deployable: false,
+          toolNames: [...new Set(config.traceSuite.flatMap((trace) => trace.toolFixtures.map((fixture) => fixture.name)))].sort(),
+          toolNamesSha256: null,
+          toolSchemaSha256,
+          definitionHandlerSha256: null,
+        }
       : fixedTraceToolUniverseProvenance(arm.id),
     executionEnvelope: usesCommonToolUniverse(config)
       ? { source: 'evaluator_owned_synthetic_receipt_envelope', deployable: false }
+      : isDirectFullSuiteComparison(config)
+      ? { source: 'fixture_expectation', deployable: false }
       : fixedTraceExecutionEnvelopeProvenance(arm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, arm.id),
     routerControl: routerControlForConfig(config),
     generationControl: cohortStageControl(config.generation),
     providerDegradationInjectionEnabled: config.injectProviderDegradation !== false,
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
-    directModelScreenMode: config.directModelScreen?.mode ?? null,
+    directModelScreenMode: config.directModelScreen?.mode ?? config.directFullSuiteComparison?.mode ?? null,
     architectureDiagnostic: config.architectureDiagnosticMode === undefined
       ? null
       : fixedTraceArchitectureDiagnosticMappingBinding(config.architectureDiagnosticMode),
@@ -1151,13 +1228,13 @@ function baseMetadata(
     toolSchemaSha256,
     toolDefinitionProvenance: usesCommonToolUniverse(config)
       ? 'evaluator_owned_common_tool_universe'
-      : architectureArm.id === 'direct_generation'
+      : architectureArm.id === 'direct_generation' && !isDirectFullSuiteComparison(config)
       ? 'evaluator_owned_production_definitions_simulated_receipts'
       : config.toolDefinitionProvenance ?? 'fixture_local',
     stageControlVersion: FIXED_TRACE_STAGE_CONTROL_VERSION,
     architectureConfigSha256: fixedTraceArchitectureConfigSha256(config, toolSchemaSha256),
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
-    directModelScreenMode: config.directModelScreen?.mode ?? null,
+    directModelScreenMode: config.directModelScreen?.mode ?? config.directFullSuiteComparison?.mode ?? null,
     architectureDiagnostic: config.architectureDiagnosticMode === undefined
       ? null
       : fixedTraceArchitectureDiagnosticCaseProvenance(config.architectureDiagnosticMode, trace.id),
@@ -1183,6 +1260,17 @@ function baseMetadata(
             'shared_request_thread_execution_envelope',
           ],
         }
+      : isDirectFullSuiteComparison(config)
+      ? {
+          source: 'fixture_local_direct_full_suite',
+          intentNarrowing: 'direct_full_suite_fixture_contract',
+          bounded: true,
+          deployable: false,
+          toolNames: [...trace.toolFixtures.map((fixture) => fixture.name)].sort(),
+          toolNamesSha256: null,
+          toolSchemaSha256,
+          definitionHandlerSha256: null,
+        }
       : {
           ...fixedTraceToolUniverseProvenance(architectureArm.id),
           toolNames: architectureArm.id === 'direct_generation'
@@ -1191,6 +1279,8 @@ function baseMetadata(
         },
     executionEnvelope: usesCommonToolUniverse(config)
       ? { source: 'evaluator_owned_synthetic_receipt_envelope', deployable: false }
+      : isDirectFullSuiteComparison(config)
+      ? { source: 'fixture_expectation', deployable: false }
       : fixedTraceExecutionEnvelopeProvenance(architectureArm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, architectureArm.id),
     directArmAdmission: admission,
@@ -1270,7 +1360,7 @@ function directModelScreenProviderExposuresMatch(
     returnedModel: string;
   }[],
 ): boolean {
-  return !isDirectModelScreen(config) || exposures.every((exposure) => (
+  return (!isDirectModelScreen(config) && !isDirectFullSuiteComparison(config)) || exposures.every((exposure) => (
     exposure.preparedProvider === config.generation.provider.id
     && exposure.preparedModel === config.generation.model
     && exposure.returnedProvider === config.generation.provider.id
@@ -1401,6 +1491,7 @@ export async function runFixedTraceCase(
       || boundIdentity.architectureConfigSha256 !== identity.architectureConfigSha256
       || boundIdentity.architectureDiagnosticMode !== identity.architectureDiagnosticMode
       || canonicalJson(boundIdentity.directModelScreen) !== canonicalJson(identity.directModelScreen)
+      || canonicalJson(boundIdentity.directFullSuiteComparison) !== canonicalJson(identity.directFullSuiteComparison)
       || boundIdentity.runProvenanceSha256 !== identity.runProvenanceSha256
     )
   ) throw new FixedTraceExecutionIdentityError('Fixed trace runner execution identity changed after dispatch binding');
@@ -1419,7 +1510,8 @@ export async function runFixedTraceCase(
   const architectureArm = fixedTraceArchitectureArm(executionConfig.architectureArm);
   if (architectureArm.id === 'direct_generation'
     && executionConfig.architectureDiagnosticMode === undefined
-    && !isDirectModelScreen(executionConfig)) {
+    && !isDirectModelScreen(executionConfig)
+    && !isDirectFullSuiteComparison(executionConfig)) {
     // The evaluator's receipts and fixture facts are diagnostic only; an
     // admission result can never open a direct-production dispatch path.
   return {
@@ -1460,7 +1552,7 @@ export async function runFixedTraceCase(
         response: null,
         // Direct generation is deliberately a fixed surface policy: it does
         // not inspect routing expectations, fixtures, rubric, or grades.
-        plan: {
+        plan: isDirectFullSuiteComparison(executionConfig) ? oracleRoute(executionTrace) : {
           action: 'respond' as const,
           tool_sets: [],
           confidence: 'high' as const,
@@ -1611,6 +1703,11 @@ export async function runFixedTraceCase(
         },
         beforeDispatch: (prepared) => {
           assertBeforeDispatch();
+          if (
+            isDirectFullSuiteComparison(executionConfig)
+            && Buffer.byteLength(JSON.stringify(prepared.providerRequest), 'utf8')
+              > FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES
+          ) throw new FixedTracePreparationError('generation', new Error('Fixed trace direct full-suite prepared request exceeds its reviewed byte ceiling'));
           dispatched = true;
           dispatchedCalls++;
           invocations.push(prepared);
@@ -1735,6 +1832,20 @@ export async function runFixedTraceDirectModelScreen(
   const observations = await runFixedTraceSuite(config);
   if (observations.length !== FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE.length) {
     throw new Error('Fixed trace direct-model screen did not preserve the complete admission denominator');
+  }
+  return observations;
+}
+
+/** Executes exactly one approved cell across the current complete suite. */
+export async function runFixedTraceDirectFullSuiteComparison(
+  config: FixedTraceRunnerConfig,
+): Promise<FixedTraceObservation[]> {
+  if (!isDirectFullSuiteComparison(config)) {
+    throw new Error('Fixed trace direct full-suite comparison requires direct_full_suite_model_comparison_v1 mode');
+  }
+  const observations = await runFixedTraceSuite(config);
+  if (observations.length !== FIXED_TRACE_SUITE.length) {
+    throw new Error('Fixed trace direct full-suite comparison did not preserve the complete denominator');
   }
   return observations;
 }

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -359,8 +359,8 @@ export interface FixedTraceRunMetadata {
   architectureConfigSha256: string;
   /** Set only by an exact synthetic architecture diagnostic declaration. */
   architectureDiagnosticMode?: 'synthetic_pack_v1' | 'synthetic_pilot_v1' | 'synthetic_sonnet_full_pack_v1' | null;
-  /** Set only by the exact source-pinned direct model-screen declaration. */
-  directModelScreenMode?: 'direct_model_screen_admission_v1' | 'direct_model_screen_google_three_turn_v1' | null;
+  /** Set only by an exact direct model comparison declaration. */
+  directModelScreenMode?: 'direct_model_screen_admission_v1' | 'direct_model_screen_google_three_turn_v1' | 'direct_full_suite_model_comparison_v1' | null;
   /** Evaluator-only pack/pilot and cluster binding for architecture diagnostics. */
   architectureDiagnostic: {
     packDigest: string;
@@ -2668,6 +2668,7 @@ const directModelScreenGoogleThreeTurnGenerationCells = new Set([
   'google:gemini-3.7-flash:medium',
   'google:gemini-3.7-flash:high',
 ]);
+const directFullSuiteGenerationCells = directModelScreenGenerationCells;
 
 /** Rebind untrusted direct-screen metadata to the sole evaluator-owned pack. */
 function directModelScreenMetadataFailures(
@@ -2675,6 +2676,9 @@ function directModelScreenMetadataFailures(
   metadata: FixedTraceRunMetadata,
   tools: ReadonlyArray<FixedTraceToolObservation>,
 ): string[] {
+  if (metadata.directModelScreenMode === 'direct_full_suite_model_comparison_v1') {
+    return directFullSuiteMetadataFailures(trace, metadata);
+  }
   const failures: string[] = [];
   const googleThreeTurn = metadata.directModelScreenMode === 'direct_model_screen_google_three_turn_v1';
   const canonicalTrace = FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE.find(
@@ -2682,8 +2686,8 @@ function directModelScreenMetadataFailures(
   );
   if (
     metadata.traceSuiteSha256 !== FIXED_TRACE_DIRECT_MODEL_SCREEN_ADMISSION_SUITE_SHA256
-    || !canonicalTrace
-    || canonicalJson(trace) !== canonicalJson(canonicalTrace)
+      || !canonicalTrace
+      || canonicalJson(trace) !== canonicalJson(canonicalTrace)
   ) failures.push('direct_model_screen_admission_suite_invalid');
 
   const control = metadata.generationControl;
@@ -2747,7 +2751,7 @@ function directModelScreenMetadataFailures(
     || !Number.isSafeInteger(dispatchedCalls)
     || dispatchedCalls !== expectedExposureCount
     || !Array.isArray(exposures)
-    || exposures.length !== expectedExposureCount
+    || exposures.length !== dispatchedCalls
     || exposures.some((exposure, index) => (
       exposure.attempt !== index + 1
       || exposure.preparedProvider !== control.requestedProvider
@@ -2771,6 +2775,47 @@ function directModelScreenMetadataFailures(
     || !Array.isArray(router.providerExposures)
     || router.providerExposures.length !== 0
   ) failures.push('direct_model_screen_router_not_run_invalid');
+  return failures;
+}
+
+/** Exact current-suite contract; intentionally separate from the closed two-probe screen. */
+function directFullSuiteMetadataFailures(trace: FixedTraceCase, metadata: FixedTraceRunMetadata): string[] {
+  const failures: string[] = [];
+  const fail = (reason: string) => failures.push(`direct_full_suite_${reason}`);
+  if (metadata.traceSuiteSha256 !== fixedTraceSuiteSha256(FIXED_TRACE_SUITE)
+    || !FIXED_TRACE_SUITE.some((candidate) => candidate.id === trace.id && canonicalJson(candidate) === canonicalJson(trace))) fail('suite_invalid');
+  const control = metadata.generationControl;
+  const tuple = `${control.requestedProvider}:${control.requestedModel}:${control.reasoningEffort}`;
+  if (!directFullSuiteGenerationCells.has(tuple) || control.configuredMaxOutputTokens !== 900
+    || control.timeoutMs !== 120_000 || control.maxIterations !== 12 || control.transportRetries !== 0
+    || control.samplingMode !== 'provider_no_sampling_control' || control.temperature !== null) fail('generation_control_invalid');
+  try { fixedTraceResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing); }
+  catch { fail('generation_pricing_invalid'); }
+  const generation = metadata.generation;
+  const localSurface = ['ignore', 'react'].includes(trace.routing.action);
+  if (localSurface) {
+    if (generation.source !== 'not_run' || generation.dispatched || generation.dispatchedCalls !== 0
+      || generation.providerExposures?.length !== 0 || generation.requestedProvider !== null || generation.requestedModel !== null
+      || generation.returnedProvider !== null || generation.returnedModel !== null || generation.modelResolution !== null
+      || generation.usageKnown || generation.usage !== null || generation.estimatedCostUsd !== 0) fail('local_surface_generation_invalid');
+  } else if (generation.dispatched) {
+    const exposures = generation.providerExposures;
+    if (generation.source !== 'provider' || generation.modelResolution !== 'exact'
+      || generation.requestedProvider !== control.requestedProvider || generation.requestedModel !== control.requestedModel
+      || generation.returnedProvider !== control.requestedProvider || generation.returnedModel !== control.requestedModel
+      || !Number.isSafeInteger(generation.dispatchedCalls) || (generation.dispatchedCalls ?? 0) < 1
+      || !Array.isArray(exposures) || exposures.length !== (generation.dispatchedCalls ?? -1)
+      || exposures.some((entry, index) => entry.attempt !== index + 1 || entry.preparedProvider !== control.requestedProvider
+        || entry.preparedModel !== control.requestedModel || entry.returnedProvider !== control.requestedProvider || entry.returnedModel !== control.requestedModel)) fail('dispatched_generation_identity_invalid');
+  } else if (generation.source !== 'local' || generation.requestedProvider !== control.requestedProvider
+    || generation.requestedModel !== control.requestedModel || generation.returnedProvider !== null || generation.returnedModel !== null
+    || generation.modelResolution !== 'local' || generation.dispatchedCalls !== 0
+    || !Array.isArray(generation.providerExposures)
+    || generation.providerExposures.some((entry, index) => entry.attempt !== index + 1
+      || entry.preparedProvider !== control.requestedProvider || entry.preparedModel !== control.requestedModel
+      || entry.returnedProvider !== null || entry.returnedModel !== null)) {
+    fail('local_generation_identity_invalid');
+  }
   return failures;
 }
 
@@ -2982,7 +3027,7 @@ function metadataFailures(
   }
   if (typeof metadata.providerDegradationInjectionEnabled !== 'boolean') failures.push('provider_degradation_policy_invalid');
   const directModelScreenMode = metadata.directModelScreenMode ?? null;
-  if (directModelScreenMode !== null && directModelScreenMode !== 'direct_model_screen_admission_v1' && directModelScreenMode !== 'direct_model_screen_google_three_turn_v1') {
+  if (directModelScreenMode !== null && directModelScreenMode !== 'direct_model_screen_admission_v1' && directModelScreenMode !== 'direct_model_screen_google_three_turn_v1' && directModelScreenMode !== 'direct_full_suite_model_comparison_v1') {
     failures.push('direct_model_screen_mode_invalid');
   }
   failures.push(...cohortControlFailures('router', metadata.routerControl));
@@ -3042,7 +3087,7 @@ function metadataFailures(
     failures.push('router_control_missing');
   }
   const toolUniverse = metadata.toolUniverse;
-  if (!toolUniverse || !['fixture_local_routed_replay', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe', 'fixture_oracle'].includes(toolUniverse.source)) {
+  if (!toolUniverse || !['fixture_local_routed_replay', 'fixture_local_direct_full_suite', 'evaluator_owned_production_definitions_simulated_receipts', 'evaluator_owned_common_tool_universe', 'fixture_oracle'].includes(toolUniverse.source)) {
     failures.push('tool_universe_provenance_invalid');
   } else if (metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe') {
     if (
@@ -3057,6 +3102,13 @@ function metadataFailures(
       ])
     ) failures.push('tool_universe_provenance_invalid');
   } else if (
+    directModelScreenMode === 'direct_full_suite_model_comparison_v1'
+    && (toolUniverse.source !== 'fixture_local_direct_full_suite' || toolUniverse.intentNarrowing !== 'direct_full_suite_fixture_contract' || !toolUniverse.bounded || toolUniverse.deployable
+      || toolUniverse.toolSchemaSha256 !== metadata.toolSchemaSha256
+      || toolUniverse.definitionHandlerSha256 !== null)
+  ) {
+    failures.push('tool_universe_provenance_invalid');
+  } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
     && (toolUniverse.source !== 'fixture_local_routed_replay' || toolUniverse.intentNarrowing !== 'production_quick_match_or_llm_router' || !toolUniverse.bounded || toolUniverse.deployable)
   ) {
@@ -3067,7 +3119,7 @@ function metadataFailures(
   ) {
     failures.push('tool_universe_provenance_invalid');
   } else if (
-    arm?.id === 'direct_generation'
+    arm?.id === 'direct_generation' && directModelScreenMode !== 'direct_full_suite_model_comparison_v1'
     && (toolUniverse.source !== 'evaluator_owned_production_definitions_simulated_receipts' || toolUniverse.intentNarrowing !== 'not_applied' || !toolUniverse.bounded || toolUniverse.deployable
       || toolUniverse.toolNamesSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNamesSha256
       || toolUniverse.toolSchemaSha256 !== FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolSchemaSha256
@@ -3080,7 +3132,7 @@ function metadataFailures(
   ) {
     failures.push('tool_universe_provenance_invalid');
   }
-  const expectedToolNames = metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe' || arm?.id === 'direct_generation'
+  const expectedToolNames = metadata.toolDefinitionProvenance === 'evaluator_owned_common_tool_universe' || (arm?.id === 'direct_generation' && directModelScreenMode !== 'direct_full_suite_model_comparison_v1')
     ? FIXED_TRACE_DIRECT_TOOL_UNIVERSE.toolNames
     : [...trace.toolFixtures.map((fixture) => fixture.name)].sort();
   if (!sameToolUniverseNames(toolUniverse?.toolNames ?? null, expectedToolNames)) {
@@ -3114,6 +3166,11 @@ function metadataFailures(
       failures.push('execution_envelope_provenance_invalid');
     }
   } else if (
+    directModelScreenMode === 'direct_full_suite_model_comparison_v1'
+    && (executionEnvelope.source !== 'fixture_expectation' || executionEnvelope.deployable)
+  ) {
+    failures.push('execution_envelope_provenance_invalid');
+  } else if (
     arm?.id === 'deterministic_policy_llm_fallback_hybrid'
     && (executionEnvelope.source !== 'fixture_expectation' || executionEnvelope.deployable)
   ) {
@@ -3124,7 +3181,7 @@ function metadataFailures(
   ) {
     failures.push('execution_envelope_provenance_invalid');
   } else if (
-    arm?.id === 'direct_generation'
+    arm?.id === 'direct_generation' && directModelScreenMode !== 'direct_full_suite_model_comparison_v1'
     && (executionEnvelope.source !== 'evaluator_owned_shared_request_thread_envelope' || executionEnvelope.deployable)
   ) {
     failures.push('execution_envelope_provenance_invalid');
@@ -3139,11 +3196,13 @@ function metadataFailures(
       ? null
       : metadata.routerControl.configuredMaxOutputTokens,
   ));
-  failures.push(...stageMetadataFailures(
-    'generation', metadata.generation, metadata.generationControl, metadata.generation.source === 'not_run'
-      ? null
-      : caseControl?.maxOutputTokens ?? metadata.generationControl.configuredMaxOutputTokens,
-  ));
+  if (!(directModelScreenMode === 'direct_full_suite_model_comparison_v1' && ['ignore', 'react'].includes(trace.routing.action))) {
+    failures.push(...stageMetadataFailures(
+      'generation', metadata.generation, metadata.generationControl, metadata.generation.source === 'not_run'
+        ? null
+        : caseControl?.maxOutputTokens ?? metadata.generationControl.configuredMaxOutputTokens,
+    ));
+  }
   return failures;
 }
 

--- a/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
+++ b/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
@@ -1,0 +1,132 @@
+/** One exact, direct-only current-suite candidate per invocation. */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const CELLS = [
+  'generation:anthropic:claude-sonnet-5:provider_default', 'generation:anthropic:claude-haiku-4-5:provider_default',
+  'generation:google:gemini-3.7-flash:provider_default', 'generation:google:gemini-3.7-flash:low',
+  'generation:google:gemini-3.7-flash:medium', 'generation:google:gemini-3.7-flash:high',
+] as const;
+type CellId = typeof CELLS[number];
+
+interface Arguments {
+  readonly validateOnly: boolean;
+  readonly execute: boolean;
+  readonly cell: CellId;
+  readonly softMaxUsd: number;
+  readonly output: string;
+  readonly selector: string;
+}
+
+function value(name: string): string | undefined {
+  return process.argv.slice(2).find((argument) => argument.startsWith(`${name}=`))?.slice(name.length + 1);
+}
+
+function parseArguments(): Arguments {
+  const values = process.argv.slice(2);
+  for (const argument of values) {
+    if (argument === '--validate-only' || argument === '--execute' || argument.startsWith('--cell=') || argument.startsWith('--soft-max-usd=') || argument.startsWith('--output=') || argument.startsWith('--selector=')) continue;
+    throw new Error(`Unsupported fixed-trace direct full-suite option: ${argument}`);
+  }
+  const validateOnly = values.includes('--validate-only');
+  const execute = values.includes('--execute');
+  if (validateOnly === execute) throw new Error('Specify exactly one of --validate-only or --execute');
+  const cell = value('--cell');
+  const softMaxUsd = Number(value('--soft-max-usd'));
+  const output = value('--output');
+  const selector = value('--selector');
+  if (!cell || !output?.trim() || !selector?.trim() || !Number.isFinite(softMaxUsd) || softMaxUsd <= 0) {
+    throw new Error('--cell, positive --soft-max-usd, --output, and --selector are required');
+  }
+  if (!(CELLS as readonly string[]).includes(cell)) throw new Error('Fixed trace direct full-suite comparison cell is unsupported');
+  for (const name of ['--cell=', '--soft-max-usd=', '--output=', '--selector=']) {
+    if (values.filter((argument) => argument.startsWith(name)).length !== 1) throw new Error(`Exactly one ${name.slice(2, -1)} value is required`);
+  }
+  return { validateOnly, execute, cell: cell as CellId, softMaxUsd, output, selector };
+}
+
+const arguments_ = parseArguments();
+// No evaluator module (and therefore no application startup side effect) is
+// imported before the parser has rejected malformed CLI input.
+// This artifact protocol reserves stdout for its single machine-readable
+// record; evaluator startup logs must not interleave with it.
+process.env.LOG_LEVEL = 'silent';
+const fullSuite = await import('../../src/addie/eval/fixed-trace-direct-full-suite.js');
+const runner = await import('../../src/addie/eval/fixed-trace-runner.js');
+const budgetModule = await import('../../src/addie/eval/fixed-trace-budget.js');
+const pricingModule = await import('../../src/addie/eval/dated-pricing-cohort.js');
+const cell = fullSuite.fixedTraceDirectFullSuiteCell(arguments_.cell);
+const sources = fullSuite.fixedTraceDirectFullSuiteSourceBundle([
+  'server/src/addie/eval/fixed-trace-direct-full-suite.ts', 'server/src/addie/eval/fixed-trace-runner.ts',
+  'server/src/addie/eval/fixed-trace-suite.ts', 'server/src/addie/eval/fixed-trace-tool-loop.ts',
+  'server/src/addie/eval/fixed-trace-budget.ts', 'server/src/addie/eval/fixed-trace-tools.ts', 'server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts',
+  'server/tests/manual/fixed-trace-direct-full-suite-eval.ts',
+]);
+const promptConfigVersion = createHash('sha256').update(readFileSync('server/src/addie/prompts.ts'))
+  .update(readFileSync('server/src/addie/rules/index.ts')).digest('hex');
+const plan = fullSuite.fixedTraceDirectFullSuitePlan({
+  cellId: cell.id, sourceFiles: sources.files, sourceBundleSha256: sources.sha256,
+  promptConfigVersion, softMaxUsd: arguments_.softMaxUsd,
+});
+fullSuite.assertFixedTraceDirectFullSuiteCostCeiling(cell.id, arguments_.softMaxUsd);
+if (arguments_.validateOnly) {
+  console.log(JSON.stringify({ validateOnly: true, providerCalls: 0, outputWritten: false, selectorConsumed: false, plan }));
+  process.exit(0);
+}
+if (existsSync(arguments_.selector) || existsSync(arguments_.output) || existsSync(`${arguments_.output}.sha256`)) {
+  throw new Error('Selector or output already exists; this configuration is one-shot');
+}
+if (execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim()) throw new Error('Git source drift: execute only from an exact clean reviewed head');
+if (readFileSync('.git/HEAD', 'utf8').length === 0) throw new Error('Git source identity is unavailable');
+const budget = new budgetModule.FixedTraceBudget(arguments_.softMaxUsd);
+async function providerFor(id: 'anthropic' | 'google' | 'openai') {
+  if (id === 'anthropic') {
+    const apiKey = fullSuite.fixedTraceDirectFullSuiteAnthropicApiKey(process.env);
+    if (!apiKey) throw new Error('ADDIE_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY is required for candidate or judge');
+    const { AnthropicModelProvider } = await import('../../src/addie/model-providers/anthropic-provider.js');
+    return new AnthropicModelProvider(apiKey, undefined, { transportMaxRetries: 0 });
+  }
+  if (id === 'google') {
+    if (!process.env.GEMINI_API_KEY) throw new Error('GEMINI_API_KEY is required for candidate or judge');
+    const { GoogleGenerateContentProvider } = await import('../../src/addie/model-providers/google-generate-content-provider.js');
+    return new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY);
+  }
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required for candidate or judge');
+  const { OpenAIResponsesProvider } = await import('../../src/addie/model-providers/openai-responses-provider.js');
+  return new OpenAIResponsesProvider(process.env.OPENAI_API_KEY);
+}
+function budgetedProvider(provider: Awaited<ReturnType<typeof providerFor>>, model: string) {
+  const pricing = pricingModule.datedPricingProfilesForFixedTrace().find((candidate) => candidate.provider === provider.id && candidate.model === model);
+  if (!pricing) throw new Error('Current reviewed pricing is unavailable for selected provider identity');
+  return new budgetModule.BudgetedFixedTraceProvider(provider, budget, pricing, budgetModule.fixedTraceResponsePricingPolicy(provider.id, model, pricing));
+}
+const rawCandidate = await providerFor(cell.provider);
+const rawJudges = Object.fromEntries(await Promise.all(cell.judgeProviders.map(async (id) => [id, await providerFor(id)]))) as Record<'anthropic' | 'google' | 'openai', Awaited<ReturnType<typeof providerFor>>>;
+const candidateProvider = budgetedProvider(rawCandidate, cell.model);
+const judgeProviders = Object.fromEntries(cell.judgeProviders.map((id) => [id, budgetedProvider(rawJudges[id]!, id === 'anthropic' ? 'claude-haiku-4-5' : id === 'google' ? 'gemini-3.7-flash' : 'gpt-5.6-luna')]));
+const candidateConfig = fullSuite.fixedTraceDirectFullSuiteConfig({
+  runId: `direct-full-suite-${cell.id}-${Date.now()}`, sourceBundleSha256: sources.sha256,
+  gitCommit: fullSuite.fixedTraceDirectFullSuiteGitCommit(), provider: candidateProvider, cellId: cell.id, promptConfigVersion,
+});
+runner.preflightFixedTraceRunnerConfig(candidateConfig);
+// This is the actual all-call escrow, not merely the numeric preflight. It
+// must happen before either durable one-shot identity is consumed.
+const admission = fullSuite.admitFixedTraceDirectFullSuiteComparison({ candidate: candidateConfig, judgeProviders, budget });
+let output: ReturnType<typeof fullSuite.reserveFixedTraceDirectFullSuiteOutput> | null = null;
+try {
+  fullSuite.consumeFixedTraceDirectFullSuiteSelector(arguments_.selector, { cellId: cell.id, sourceBundleSha256: sources.sha256, promptConfigVersion });
+  output = fullSuite.reserveFixedTraceDirectFullSuiteOutput(arguments_.output);
+  const result = await fullSuite.runFixedTraceDirectFullSuiteComparisonArtifact({ candidate: candidateConfig, judgeProviders, budget, admission });
+  const { evaluateFixedTraceRollout } = await import('../../src/addie/eval/fixed-trace-rollout.js');
+  const artifact = { artifactVersion: 'addie-fixed-trace-direct-full-suite-v1', plan, budget: budget.snapshot(), result, rollout: evaluateFixedTraceRollout(result.summary, result.judgeSummary, budget.snapshot()) };
+  const artifactSha256 = output.finalize(artifact);
+  console.log(JSON.stringify({ output: arguments_.output, artifactSha256, comparisonComplete: result.summary.complete, plan }));
+} catch (error) {
+  if (output === null) {
+    admission.release();
+    throw error;
+  }
+  const artifactSha256 = output.finalize({ artifactVersion: 'addie-fixed-trace-direct-full-suite-v1', plan, budget: budget.snapshot(), failure: error instanceof Error ? error.message : String(error) });
+  throw new Error(`Fixed trace direct full-suite comparison failed; preserved artifact ${arguments_.output} (${artifactSha256})`, { cause: error });
+}

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -349,7 +349,7 @@ describe('fixed trace provider budget', () => {
     const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);
 
     await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow(
-      'Fixed trace budget usage is invalid',
+      'Invalid normalized usage field: inputTokens',
     );
     expect(budget.snapshot()).toMatchObject({
       reservedUsd: 0,

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const tsx = realpathSync(resolve(root, 'node_modules/.bin/tsx'));
+
+describe('fixed-trace direct full-suite CLI', () => {
+  it('keeps validate-only provider-free and stdout to one exact JSON line', () => {
+    const result = spawnSync(process.execPath, [
+      tsx, 'server/tests/manual/fixed-trace-direct-full-suite-eval.ts', '--validate-only',
+      '--cell=generation:google:gemini-3.7-flash:high', '--soft-max-usd=300',
+      '--output=/tmp/addie-full-suite.json', '--selector=/tmp/addie-full-suite.used',
+    ], { cwd: root, encoding: 'utf8', env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test' } });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const lines = result.stdout.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      validateOnly: true, providerCalls: 0, outputWritten: false, selectorConsumed: false,
+      plan: { mode: 'direct_full_suite_model_comparison_v1', traceCount: 32, requiredJudgeProviders: ['anthropic', 'openai'], wholeCellCostCeiling: { totalUsd: expect.any(Number) } },
+    });
+  }, 20_000);
+
+  it('rejects an impossible whole-cell cap without consuming selector or output', () => {
+    const suffix = `${process.pid}-${Date.now()}`;
+    const output = `/tmp/addie-full-suite-${suffix}.json`;
+    const selector = `/tmp/addie-full-suite-${suffix}.used`;
+    const result = spawnSync(process.execPath, [
+      tsx, 'server/tests/manual/fixed-trace-direct-full-suite-eval.ts', '--validate-only',
+      '--cell=generation:google:gemini-3.7-flash:high', '--soft-max-usd=0.000001',
+      `--output=${output}`, `--selector=${selector}`,
+    ], { cwd: root, encoding: 'utf8', env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test' } });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('whole-cell ceiling');
+    expect(() => realpathSync(output)).toThrow();
+    expect(() => realpathSync(selector)).toThrow();
+  }, 20_000);
+});

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -1,0 +1,183 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { ModelProvider, ModelProviderCapabilities, ModelProviderId, ModelRequest, ModelRespondOptions, ModelResponse, NormalizedModelEvent, PreparedModelInvocation } from '../../../src/addie/model-providers/model-provider.js';
+import { BudgetedFixedTraceProvider, FixedTraceBudget, fixedTraceEstimatedCostUsd, fixedTraceResponsePricingPolicy } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
+import { FIXED_TRACE_DIRECT_FULL_SUITE_CELLS, admitFixedTraceDirectFullSuiteComparison, assertFixedTraceDirectFullSuiteCostCeiling, consumeFixedTraceDirectFullSuiteSelector, fixedTraceDirectFullSuiteAnthropicApiKey, fixedTraceDirectFullSuiteCell, fixedTraceDirectFullSuiteConfig, fixedTraceDirectFullSuiteCostCeiling, fixedTraceDirectFullSuitePlan, reserveFixedTraceDirectFullSuiteOutput, runFixedTraceDirectFullSuiteComparisonArtifact } from '../../../src/addie/eval/fixed-trace-direct-full-suite.js';
+import { FIXED_TRACE_SUITE, FIXED_TRACE_SUITE_VERSION, fixedTraceSuiteSha256 } from '../../../src/addie/eval/fixed-trace-suite.js';
+
+const CAPABILITIES: ModelProviderCapabilities = { streaming: false, structuredOutput: true, reasoning: true, reasoningEfforts: ['provider_default', 'low', 'medium', 'high'], customTools: true, providerWebSearch: false, imageInput: false, documentInput: false };
+const HASH = createHash('sha256').update('direct-full-suite-test').digest('hex');
+
+class FakeProvider implements ModelProvider {
+  readonly capabilities = CAPABILITIES;
+  readonly requests: ModelRequest[] = [];
+  readonly prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({ provider: this.id, model: request.model, capabilities: this.capabilities, requestMetadata: request.requestMetadata, providerRequest: structuredClone(request) as unknown as Readonly<Record<string, unknown>> }));
+  constructor(readonly id: ModelProviderId, readonly failAfterDispatch = false, readonly responsePatch: Partial<ModelResponse> = {}) {}
+  async *respond(request: ModelRequest, options: ModelRespondOptions = {}): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request); await options.beforeDispatch?.(prepared); this.requests.push(structuredClone(request));
+    if (this.failAfterDispatch) throw new Error('synthetic post-dispatch transport loss');
+    const judge = request.requestMetadata?.purpose === 'fixed_trace_blinded_judge';
+    const response: ModelResponse = { provider: this.id, model: request.model, id: `${this.id}-${this.requests.length}`, content: [{ type: 'text', text: judge ? '{"pass":true,"finding":"synthetic"}' : 'Synthetic fixed-trace response.' }], finishReason: 'stop', providerFinishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, ...this.responsePatch };
+    yield { type: 'response_start', provider: response.provider, model: response.model, id: response.id };
+    yield { type: 'text_delta', index: 0, text: response.content[0]!.type === 'text' ? response.content[0]!.text : '' };
+    yield { type: 'response_complete', response };
+  }
+}
+
+function budgeted(provider: ModelProvider, model: string, budget: FixedTraceBudget): BudgetedFixedTraceProvider {
+  const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider.id && entry.model === model)!;
+  return new BudgetedFixedTraceProvider(provider, budget, pricing, fixedTraceResponsePricingPolicy(provider.id, model, pricing));
+}
+
+async function run(cellId: typeof FIXED_TRACE_DIRECT_FULL_SUITE_CELLS[number], fail = false, judgeResponsePatch: Partial<ModelResponse> = {}) {
+  const cell = fixedTraceDirectFullSuiteCell(cellId); const budget = new FixedTraceBudget(300);
+  const rawCandidate = new FakeProvider(cell.provider, fail);
+  const candidate = budgeted(rawCandidate, cell.model, budget);
+  const rawJudges = { anthropic: new FakeProvider('anthropic', false, judgeResponsePatch), google: new FakeProvider('google', false, judgeResponsePatch), openai: new FakeProvider('openai', false, judgeResponsePatch) };
+  const judges = {
+    anthropic: budgeted(rawJudges.anthropic, 'claude-haiku-4-5', budget),
+    google: budgeted(rawJudges.google, 'gemini-3.7-flash', budget),
+    openai: budgeted(rawJudges.openai, 'gpt-5.6-luna', budget),
+  };
+  const candidateConfig = fixedTraceDirectFullSuiteConfig({ runId: `test-${cellId}`, sourceBundleSha256: HASH, gitCommit: 'abcdef0', provider: candidate, cellId, promptConfigVersion: HASH });
+  return { cell, budget, rawCandidate, rawJudges, result: await runFixedTraceDirectFullSuiteComparisonArtifact({ candidate: candidateConfig, judgeProviders: judges, budget }) };
+}
+
+describe('fixed-trace direct full-suite comparison', () => {
+  it('selects the Addie Anthropic credential alias before the generic fallback without constructing a provider', () => {
+    expect(fixedTraceDirectFullSuiteAnthropicApiKey({ ADDIE_ANTHROPIC_API_KEY: 'session-only' })).toBe('session-only');
+    expect(fixedTraceDirectFullSuiteAnthropicApiKey({ ANTHROPIC_API_KEY: 'fallback-only' })).toBe('fallback-only');
+    expect(fixedTraceDirectFullSuiteAnthropicApiKey({ ADDIE_ANTHROPIC_API_KEY: 'session', ANTHROPIC_API_KEY: 'fallback' })).toBe('session');
+    expect(fixedTraceDirectFullSuiteAnthropicApiKey({})).toBeUndefined();
+  });
+
+  it.each(FIXED_TRACE_DIRECT_FULL_SUITE_CELLS)('runs only the exact direct candidate and two provider-excluding judge slots for %s', async (cellId) => {
+    const { cell, budget, rawCandidate, rawJudges, result } = await run(cellId);
+    expect(FIXED_TRACE_SUITE_VERSION).toBe('addie-fixed-traces-v32');
+    expect(FIXED_TRACE_SUITE).toHaveLength(32);
+    expect(fixedTraceSuiteSha256(FIXED_TRACE_SUITE)).toBe('5f7f0a6d653a4757991728a1d9de8aee69b40d580dafb65e98941c1f9e3fea83');
+    expect(result.observations).toHaveLength(32);
+    expect(result.observations.every((entry) => entry.metadata.router.source === 'not_run' && entry.routeDisposition === 'direct_surface_policy')).toBe(true);
+    expect(result.observations.find((observation) => observation.traceId === 'surface-channel-chatter')?.metadata.generation).toMatchObject({ source: 'not_run', dispatched: false, dispatchedCalls: 0, requestedProvider: null, returnedProvider: null });
+    expect(result.observations.find((observation) => observation.traceId === 'provider-unavailable')?.metadata.generation).toMatchObject({ source: 'local', dispatched: false, dispatchedCalls: 0, returnedProvider: null, returnedModel: null, modelResolution: 'local' });
+    expect(result.grades.find((grade) => grade.traceId === 'provider-unavailable')?.failures).not.toContain('direct_full_suite_local_generation_identity_invalid');
+    expect(result.judgments).toHaveLength(64);
+    expect(new Set(result.judgments.map((entry) => entry.judgeProvider))).toEqual(new Set(cell.judgeProviders));
+    // The canonical corpus's two deterministic ignore/react surfaces remain
+    // in the 32-case denominator without a generation request.
+    expect(rawCandidate.requests).toHaveLength(30);
+    expect(rawCandidate.requests.every((request) => request.requestMetadata?.purpose === 'fixed_trace_generation')).toBe(true);
+    expect(Object.values(rawJudges).flatMap((provider) => provider.requests).every((request) => request.requestMetadata?.purpose === 'fixed_trace_blinded_judge')).toBe(true);
+    expect(result.judgments[0]).toMatchObject({
+      requestedProvider: cell.judgeProviders[0], requestedReasoningEffort: 'provider_default',
+      returnedReasoningEffort: null, usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: 'stop', promptConfigVersion: 'addie-fixed-trace-blinded-judge-v2',
+    });
+    expect(result.judgments[0]?.promptSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.judgments[0]?.providerRequestSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.judgments[0]?.judgeConfigSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.judgments[0]?.pricingProfileId).toBeTruthy();
+    expect(result.judgments[0]?.pricingSource).toBeTruthy();
+    expect(budget.snapshot().reservedUsd).toBe(0);
+  }, 30_000);
+
+  it('publishes deterministic per-cell whole-run ceilings with all 384 candidate and 64 judge calls', () => {
+    expect(FIXED_TRACE_DIRECT_FULL_SUITE_CELLS.map((cellId) => [cellId, fixedTraceDirectFullSuiteCostCeiling(cellId).requiredSoftMaxUsd])).toEqual([
+      ['generation:anthropic:claude-sonnet-5:provider_default', 242.15941759999998],
+      ['generation:anthropic:claude-haiku-4-5:provider_default', 122.1520448],
+      ['generation:google:gemini-3.7-flash:provider_default', 44.5568512],
+      ['generation:google:gemini-3.7-flash:low', 44.5568512],
+      ['generation:google:gemini-3.7-flash:medium', 44.5568512],
+      ['generation:google:gemini-3.7-flash:high', 44.5568512],
+    ]);
+    const ceiling = fixedTraceDirectFullSuiteCostCeiling('generation:anthropic:claude-sonnet-5:provider_default');
+    expect(ceiling).toMatchObject({ candidateMaxDispatches: 384, judgeMaxDispatches: 64, requiredSoftMaxUsd: ceiling.totalUsd });
+    expect(ceiling.components.reduce((calls, component) => calls + component.dispatches, 0)).toBe(448);
+    expect(ceiling.components.flatMap((component) => component.pricingBuckets).some((bucket) => bucket.accounting === 'additive')).toBe(true);
+  });
+
+  it('escrows the whole cell before execution without double-counting per-call reservations', async () => {
+    const cell = fixedTraceDirectFullSuiteCell('generation:google:gemini-3.7-flash:high');
+    const budget = new FixedTraceBudget(300);
+    const rawCandidate = new FakeProvider('google');
+    const candidate = budgeted(rawCandidate, cell.model, budget);
+    const rawJudges = { anthropic: new FakeProvider('anthropic'), google: new FakeProvider('google'), openai: new FakeProvider('openai') };
+    const judges = {
+      anthropic: budgeted(rawJudges.anthropic, 'claude-haiku-4-5', budget),
+      google: budgeted(rawJudges.google, 'gemini-3.7-flash', budget),
+      openai: budgeted(rawJudges.openai, 'gpt-5.6-luna', budget),
+    };
+    const config = fixedTraceDirectFullSuiteConfig({ runId: 'admission', sourceBundleSha256: HASH, gitCommit: 'abcdef0', provider: candidate, cellId: cell.id, promptConfigVersion: HASH });
+    const admission = admitFixedTraceDirectFullSuiteComparison({ candidate: config, judgeProviders: judges, budget });
+    expect(budget.snapshot().reservedUsd).toBe(fixedTraceDirectFullSuiteCostCeiling(cell.id).totalUsd);
+    expect(rawCandidate.requests).toHaveLength(0);
+    const result = await runFixedTraceDirectFullSuiteComparisonArtifact({ candidate: config, judgeProviders: judges, budget, admission });
+    const candidatePricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === cell.provider && entry.model === cell.model)!;
+    const expectedCandidateCost = 30 * fixedTraceEstimatedCostUsd({ inputTokens: 1, outputTokens: 1 }, candidatePricing);
+    const expectedJudgeCost = result.judgments.reduce((total, judgment) => total + (judgment.estimatedCostUsd ?? 0), 0);
+    expect(budget.snapshot()).toMatchObject({ reservedUsd: 0, exposureUnknown: false });
+    expect(budget.snapshot().accountedSpendUsd).toBeCloseTo(expectedCandidateCost + expectedJudgeCost, 14);
+  }, 30_000);
+
+  it('preserves exact judge provenance and fails closed on wrong identity or missing normalized usage', async () => {
+    const wrongIdentity = await run('generation:google:gemini-3.7-flash:high', false, { model: 'unreviewed-model' });
+    expect(wrongIdentity.result.judgments[0]).toMatchObject({
+      status: 'unknown_exposure', requestedProvider: 'anthropic', requestedReasoningEffort: 'provider_default',
+      returnedProvider: 'anthropic', returnedModel: 'unreviewed-model', usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      estimatedCostUsd: null, pricingPolicy: { expectedProvider: 'anthropic', expectedModel: 'claude-haiku-4-5' },
+    });
+    const missingUsage = await run('generation:google:gemini-3.7-flash:high', false, { usage: { inputTokens: -1, outputTokens: 1 } as ModelResponse['usage'] });
+    expect(missingUsage.result.judgments[0]).toMatchObject({
+      status: 'unknown_exposure', returnedProvider: 'anthropic', returnedModel: 'claude-haiku-4-5', usage: null, estimatedCostUsd: null,
+    });
+    const plan = fixedTraceDirectFullSuitePlan({ cellId: 'generation:google:gemini-3.7-flash:high', sourceFiles: ['fixture.ts'], sourceBundleSha256: HASH, promptConfigVersion: HASH, softMaxUsd: 300 });
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(plan.judges).toEqual(expect.arrayContaining([expect.objectContaining({ provider: 'anthropic', reasoningEffort: 'provider_default', pricingProfileSha256: expect.stringMatching(/^sha256:/) })]));
+  }, 30_000);
+
+  it('keeps post-dispatch unknown exposure and every missing judge slot in denominator', async () => {
+    const { budget, result } = await run('generation:anthropic:claude-haiku-4-5:provider_default', true);
+    expect(budget.snapshot().exposureUnknown).toBe(true);
+    expect(result.observations).toHaveLength(32);
+    expect(result.judgments).toHaveLength(64);
+    expect(result.judgments.every((judgment) => judgment.status === 'not_dispatched_budget')).toBe(true);
+  }, 30_000);
+
+  it('rejects an unbudgeted artifact entry point before any candidate dispatch', async () => {
+    const cell = fixedTraceDirectFullSuiteCell('generation:anthropic:claude-haiku-4-5:provider_default');
+    const candidate = new FakeProvider('anthropic');
+    const judges = { anthropic: new FakeProvider('anthropic'), google: new FakeProvider('google'), openai: new FakeProvider('openai') };
+    const config = fixedTraceDirectFullSuiteConfig({ runId: 'unbudgeted', sourceBundleSha256: HASH, gitCommit: 'abcdef0', provider: candidate, cellId: cell.id, promptConfigVersion: HASH });
+    await expect(runFixedTraceDirectFullSuiteComparisonArtifact({ candidate: config, judgeProviders: judges, budget: new FixedTraceBudget(300) })).rejects.toThrow('authenticated shared budget wrapper');
+    expect(candidate.requests).toHaveLength(0);
+  });
+
+  it('atomically rejects an undersized whole-cell cap before candidate dispatch', async () => {
+    const cell = fixedTraceDirectFullSuiteCell('generation:google:gemini-3.7-flash:high');
+    const candidate = new FakeProvider('google');
+    const judges = { anthropic: new FakeProvider('anthropic'), google: new FakeProvider('google'), openai: new FakeProvider('openai') };
+    const ceiling = fixedTraceDirectFullSuiteCostCeiling(cell.id);
+    expect(ceiling.totalUsd).toBeGreaterThan(0);
+    expect(() => assertFixedTraceDirectFullSuiteCostCeiling(cell.id, ceiling.totalUsd / 2)).toThrow('whole-cell ceiling');
+    const config = fixedTraceDirectFullSuiteConfig({ runId: 'undersized', sourceBundleSha256: HASH, gitCommit: 'abcdef0', provider: budgeted(candidate, cell.model, new FixedTraceBudget(300)), cellId: cell.id, promptConfigVersion: HASH });
+    await expect(runFixedTraceDirectFullSuiteComparisonArtifact({ candidate: config, judgeProviders: judges, budget: new FixedTraceBudget(0.000001) })).rejects.toThrow('whole-cell ceiling');
+    expect(candidate.requests).toHaveLength(0);
+  });
+
+  it('uses exclusive 0600 selector, artifact, and checksum evidence', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'addie-fixed-trace-'));
+    const selector = join(directory, 'used'); const output = join(directory, 'artifact.json');
+    consumeFixedTraceDirectFullSuiteSelector(selector, { cellId: FIXED_TRACE_DIRECT_FULL_SUITE_CELLS[0], sourceBundleSha256: HASH, promptConfigVersion: HASH });
+    expect(() => consumeFixedTraceDirectFullSuiteSelector(selector, { cellId: FIXED_TRACE_DIRECT_FULL_SUITE_CELLS[0], sourceBundleSha256: HASH, promptConfigVersion: HASH })).toThrow('already consumed');
+    const reservation = reserveFixedTraceDirectFullSuiteOutput(output); const digest = reservation.finalize({ safe: true });
+    expect(readFileSync(`${output}.sha256`, 'utf8')).toContain(digest);
+    expect(statSync(selector).mode & 0o777).toBe(0o600);
+    expect(statSync(output).mode & 0o777).toBe(0o600);
+    expect(statSync(`${output}.sha256`).mode & 0o777).toBe(0o600);
+    expect(() => reserveFixedTraceDirectFullSuiteOutput(output)).toThrow('exclusively reserve');
+  });
+});

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -15,10 +15,23 @@ const HASH = createHash('sha256').update('direct-full-suite-test').digest('hex')
 class FakeProvider implements ModelProvider {
   readonly capabilities = CAPABILITIES;
   readonly requests: ModelRequest[] = [];
+  /** Boundary values observed before an SDK request is allowed to leave. */
+  readonly boundaryInvocations: PreparedModelInvocation[] = [];
   readonly prepare = vi.fn((request: ModelRequest): PreparedModelInvocation => ({ provider: this.id, model: request.model, capabilities: this.capabilities, requestMetadata: request.requestMetadata, providerRequest: structuredClone(request) as unknown as Readonly<Record<string, unknown>> }));
-  constructor(readonly id: ModelProviderId, readonly failAfterDispatch = false, readonly responsePatch: Partial<ModelResponse> = {}) {}
+  constructor(
+    readonly id: ModelProviderId,
+    readonly failAfterDispatch = false,
+    readonly responsePatch: Partial<ModelResponse> = {},
+    readonly dispatchPreparation?: (request: ModelRequest, preliminary: PreparedModelInvocation) => PreparedModelInvocation,
+  ) {}
   async *respond(request: ModelRequest, options: ModelRespondOptions = {}): AsyncIterable<NormalizedModelEvent> {
-    const prepared = this.prepare(request); await options.beforeDispatch?.(prepared); this.requests.push(structuredClone(request));
+    const preliminary = this.prepare(request);
+    const prepared = this.dispatchPreparation?.(request, preliminary) ?? preliminary;
+    this.boundaryInvocations.push(structuredClone(prepared));
+    await options.beforeDispatch?.(prepared);
+    // This is intentionally after the policy boundary: it represents the
+    // fake's one actual SDK dispatch, not merely a prepared invocation.
+    this.requests.push(structuredClone(request));
     if (this.failAfterDispatch) throw new Error('synthetic post-dispatch transport loss');
     const judge = request.requestMetadata?.purpose === 'fixed_trace_blinded_judge';
     const response: ModelResponse = { provider: this.id, model: request.model, id: `${this.id}-${this.requests.length}`, content: [{ type: 'text', text: judge ? '{"pass":true,"finding":"synthetic"}' : 'Synthetic fixed-trace response.' }], finishReason: 'stop', providerFinishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, ...this.responsePatch };
@@ -33,11 +46,20 @@ function budgeted(provider: ModelProvider, model: string, budget: FixedTraceBudg
   return new BudgetedFixedTraceProvider(provider, budget, pricing, fixedTraceResponsePricingPolicy(provider.id, model, pricing));
 }
 
-async function run(cellId: typeof FIXED_TRACE_DIRECT_FULL_SUITE_CELLS[number], fail = false, judgeResponsePatch: Partial<ModelResponse> = {}) {
+async function run(
+  cellId: typeof FIXED_TRACE_DIRECT_FULL_SUITE_CELLS[number],
+  fail = false,
+  judgeResponsePatch: Partial<ModelResponse> = {},
+  judgeOverrides: Partial<Record<ModelProviderId, FakeProvider>> = {},
+) {
   const cell = fixedTraceDirectFullSuiteCell(cellId); const budget = new FixedTraceBudget(300);
   const rawCandidate = new FakeProvider(cell.provider, fail);
   const candidate = budgeted(rawCandidate, cell.model, budget);
-  const rawJudges = { anthropic: new FakeProvider('anthropic', false, judgeResponsePatch), google: new FakeProvider('google', false, judgeResponsePatch), openai: new FakeProvider('openai', false, judgeResponsePatch) };
+  const rawJudges = {
+    anthropic: judgeOverrides.anthropic ?? new FakeProvider('anthropic', false, judgeResponsePatch),
+    google: judgeOverrides.google ?? new FakeProvider('google', false, judgeResponsePatch),
+    openai: judgeOverrides.openai ?? new FakeProvider('openai', false, judgeResponsePatch),
+  };
   const judges = {
     anthropic: budgeted(rawJudges.anthropic, 'claude-haiku-4-5', budget),
     google: budgeted(rawJudges.google, 'gemini-3.7-flash', budget),
@@ -137,6 +159,42 @@ describe('fixed-trace direct full-suite comparison', () => {
     const plan = fixedTraceDirectFullSuitePlan({ cellId: 'generation:google:gemini-3.7-flash:high', sourceFiles: ['fixture.ts'], sourceBundleSha256: HASH, promptConfigVersion: HASH, softMaxUsd: 300 });
     expect(Object.isFrozen(plan)).toBe(true);
     expect(plan.judges).toEqual(expect.arrayContaining([expect.objectContaining({ provider: 'anthropic', reasoningEffort: 'provider_default', pricingProfileSha256: expect.stringMatching(/^sha256:/) })]));
+  }, 30_000);
+
+  it('records the exact dispatch-boundary judge invocation rather than an earlier preparation', async () => {
+    const divergent = new FakeProvider('anthropic', false, {}, (_request, preliminary) => Object.freeze({
+      ...preliminary,
+      providerRequest: Object.freeze({ ...preliminary.providerRequest, dispatch_boundary_only: true }),
+    }));
+    const { result } = await run(
+      'generation:google:gemini-3.7-flash:high',
+      false,
+      {},
+      { anthropic: divergent },
+    );
+    const actual = divergent.boundaryInvocations[0]!;
+    const judgment = result.judgments.find((entry) => entry.judgeProvider === 'anthropic')!;
+    expect(divergent.prepare).toHaveBeenCalledTimes(32);
+    expect(actual.providerRequest).toMatchObject({ dispatch_boundary_only: true });
+    expect(judgment.providerRequestSha256).toBe(createHash('sha256').update(JSON.stringify(actual.providerRequest), 'utf8').digest('hex'));
+  }, 30_000);
+
+  it('rejects an oversized exact judge boundary invocation before SDK dispatch', async () => {
+    const oversized = new FakeProvider('anthropic', false, {}, (_request, preliminary) => Object.freeze({
+      ...preliminary,
+      providerRequest: Object.freeze({ ...preliminary.providerRequest, dispatch_boundary_padding: 'x'.repeat(65_537) }),
+    }));
+    const { result } = await run(
+      'generation:google:gemini-3.7-flash:high',
+      false,
+      {},
+      { anthropic: oversized },
+    );
+    const anthropicJudgments = result.judgments.filter((entry) => entry.judgeProvider === 'anthropic');
+    expect(oversized.boundaryInvocations).toHaveLength(32);
+    expect(oversized.requests).toHaveLength(0);
+    expect(anthropicJudgments.every((entry) => entry.status === 'missing' && entry.dispatched === false)).toBe(true);
+    expect(anthropicJudgments[0]?.providerRequestSha256).toBe(createHash('sha256').update(JSON.stringify(oversized.boundaryInvocations[0]!.providerRequest), 'utf8').digest('hex'));
   }, 30_000);
 
   it('keeps post-dispatch unknown exposure and every missing judge slot in denominator', async () => {


### PR DESCRIPTION
Implements the closed, direct-generation-only full-suite comparison capability for #6846 and #6842.

- Adds a separately named manual launcher; preserves `eval:addie-fixed-traces` routed CLI/default behavior.
- Binds each invocation to one of the six exact cells, the canonical immutable 32-case v32 corpus/hash, fixture-only tools, zero retries, full production loop limits, fail-closed provenance, budget reservations, one-shot selector, and 0600 exclusive artifact/checksum evidence.
- Adds independent blinded judge topology (Google+OpenAI for Anthropic candidates; Anthropic+OpenAI for Google candidates), with local/no-dispatch metadata kept in the denominator without fabricated identities.
- Validate-only is provider-free and exactly one JSON stdout line; the Anthropic launcher lookup uses `ADDIE_ANTHROPIC_API_KEY` before `ANTHROPIC_API_KEY` without logging either.

Validation completed offline: `npx tsc --project server/tsconfig.json --noEmit`; focused Vitest suite (80 passing); direct validate-only (one JSON line, zero provider calls). The normal commit hook completed root unit/lint gates but its repository-wide server-unit phase did not return before the execution monitor expired/hung; the commit and push therefore used `--no-verify` as directed. Required GitHub CI remains the merge gate. No provider/API calls or paid runs were made.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
