### PR TITLE
chore(deps): bump @adcp/sdk to 14.0.0-rc.33

### DIFF
--- a/.changeset/bump-typescript-sdk-rc33.md
+++ b/.changeset/bump-typescript-sdk-rc33.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Update the TypeScript SDK checkpoint and current RC.1 guidance to `@adcp/sdk@14.0.0-rc.33`.

--- a/docs/building/by-layer/L4/choose-your-sdk.mdx
+++ b/docs/building/by-layer/L4/choose-your-sdk.mdx
@@ -27,7 +27,7 @@ What "shipped" means at each layer is the [L0–L3 checklist](/docs/building/cro
 
 | SDK | Current package | 3.2 RC support | L0 | L1 | L2 | L3 |
 |---|---|---|:-:|:-:|:-:|:-:|
-| **`@adcp/sdk`** (TypeScript) | `14.0.0-rc.32` | Exact `3.2.0-rc.1` support | ✅ | ✅ | ✅ | ✅ |
+| **`@adcp/sdk`** (TypeScript) | `14.0.0-rc.33` | Exact `3.2.0-rc.1` support | ✅ | ✅ | ✅ | ✅ |
 | **`adcp`** (Python) | `8.0.0b14` | Exact `3.2.0-rc.1` schemas and types; higher-level helpers remain partial | ✅ | ⚠️ | ⚠️ | ⚠️ |
 | **`adcp/v3`** (Go) | `v3.2.1` | Exact `3.2.0-rc.1` generated schemas and types; higher layers remain role-dependent | ✅ | ⚠️ | ⚠️ | ⚠️ |
 
@@ -59,7 +59,7 @@ and the [Slack community](/docs/community/joining-slack).
 [![npm version](https://img.shields.io/npm/v/@adcp/sdk)](https://www.npmjs.com/package/@adcp/sdk)
 
 ```bash
-npm install @adcp/sdk@14.0.0-rc.32
+npm install @adcp/sdk@14.0.0-rc.33
 ```
 
 ```javascript
@@ -168,11 +168,11 @@ Both SDKs share the same positional shape: `adcp <agent> [tool] [payload]`. The 
 ### JavaScript CLI
 
 ```bash
-npx @adcp/sdk@14.0.0-rc.32 --help
-npx @adcp/sdk@14.0.0-rc.32 --save-auth my-agent https://sales.example.com/mcp
-npx @adcp/sdk@14.0.0-rc.32 my-agent list_products '{"adcp_version":"3.2-rc.1","account":{"account_id":"account_123"}}'
+npx @adcp/sdk@14.0.0-rc.33 --help
+npx @adcp/sdk@14.0.0-rc.33 --save-auth my-agent https://sales.example.com/mcp
+npx @adcp/sdk@14.0.0-rc.33 my-agent list_products '{"adcp_version":"3.2-rc.1","account":{"account_id":"account_123"}}'
 # or against the built-in public test agent:
-npx @adcp/sdk@14.0.0-rc.32 test-mcp list_products '{"adcp_version":"3.2-rc.1"}'
+npx @adcp/sdk@14.0.0-rc.33 test-mcp list_products '{"adcp_version":"3.2-rc.1"}'
 ```
 
 The CLI also drives storyboards (`adcp storyboard run`), conformance grading (`adcp grade`), and registry diagnostics. See `--help` for the full surface.

--- a/docs/learning/supplements/buyer-briefs-and-get-products.mdx
+++ b/docs/learning/supplements/buyer-briefs-and-get-products.mdx
@@ -14,7 +14,7 @@ The goal is not to make the brief verbose. The goal is to put intent in the brie
 <Note>
 This module teaches the AdCP 3.2 targeting-aware discovery contract. The public
 training seller supports the exact `3.2-rc.1` wire bundle with
-`@adcp/sdk@14.0.0-rc.32`. Verify those advertised capabilities before the lab;
+`@adcp/sdk@14.0.0-rc.33`. Verify those advertised capabilities before the lab;
 unknown-field acceptance by an older seller is not evidence of support.
 </Note>
 

--- a/docs/learning/tracks/buyer.mdx
+++ b/docs/learning/tracks/buyer.mdx
@@ -257,7 +257,7 @@ New to running tool calls and reading JSON in a terminal? Do [A2b: Testing your 
 
 <Note>
 The public training seller implements targeting-aware discovery on the exact
-AdCP `3.2-rc.1` wire bundle. Pin `@adcp/sdk@14.0.0-rc.32`, verify the
+AdCP `3.2-rc.1` wire bundle. Pin `@adcp/sdk@14.0.0-rc.33`, verify the
 seller's advertised version and lifecycle tools, and retain the request,
 response, and package readback as assessment evidence. Do not treat an
 uncapable seller silently ignoring unknown fields as validation.
@@ -281,7 +281,7 @@ To see the seller responses your agent must handle, you can inspect the test sel
 
 ```bash
 # Inspects the test SELLER's get_products response — the shape your buyer agent must parse.
-npx @adcp/sdk@14.0.0-rc.32 test-mcp get_products '{"adcp_version":"3.2-rc.1","idempotency_key":"550e8400-e29b-41d4-a716-446655442065","buying_mode":"brief","brief":"your campaign brief"}'
+npx @adcp/sdk@14.0.0-rc.33 test-mcp get_products '{"adcp_version":"3.2-rc.1","idempotency_key":"550e8400-e29b-41d4-a716-446655442065","buying_mode":"brief","brief":"your campaign brief"}'
 ```
 
 See [Build a caller](/docs/building/by-layer/L4/build-a-caller) for client setup and [Validate Your Agent](/docs/building/verification/validate-your-agent) for the storyboard workflow.

--- a/docs/media-buy/product-discovery/proposal-negotiation.mdx
+++ b/docs/media-buy/product-discovery/proposal-negotiation.mdx
@@ -542,7 +542,7 @@ The deterministic training profiles expose the exact `3.2-rc.1` proposal-negotia
 | Constrained seller | `/sales/profiles/constrained-seller/mcp` | USD floors, product conflicts, and at most two available alternatives |
 | Finalization failure | `/sales/profiles/finalization-failure/mcp` | `hold_unavailable` plus `batch_aborted` siblings with no committed successors |
 
-Pin the release candidate exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into prerelease behavior. SDK `14.0.0-rc.32` accepts `wireAdcpVersion: "3.2-rc.1"` on its single- and multi-agent client configuration; raw calls remain useful for inspecting the exact envelope as below.
+Pin the release candidate exactly on every call. A stable `3.2` selector intentionally negotiates to the seller's stable compatibility response instead of silently opting into prerelease behavior. SDK `14.0.0-rc.33` accepts `wireAdcpVersion: "3.2-rc.1"` on its single- and multi-agent client configuration; raw calls remain useful for inspecting the exact envelope as below.
 
 ### Try the lifecycle with Addie or Sage
 

--- a/docs/reference/3-2-beta.mdx
+++ b/docs/reference/3-2-beta.mdx
@@ -16,7 +16,7 @@ change 3.2 surfaces before GA.
 
 The 3.2 prerelease cycle started with a protocol-first beta checkpoint.
 RC.1 is the current signed protocol checkpoint. TypeScript SDK
-`14.0.0-rc.32`, Python SDK `8.0.0b14`, and Go SDK `adcp/v3@v3.2.1` embed it
+`14.0.0-rc.33`, Python SDK `8.0.0b14`, and Go SDK `adcp/v3@v3.2.1` embed it
 exactly:
 
 <Info>
@@ -42,7 +42,7 @@ package tag or from an SDK generated against an earlier checkpoint.
 | `3.2.0-beta.11` | Previous protocol checkpoint | Pinned adopters comparing beta.11 and RC.0 behavior |
 | `3.2.0-rc.0` | Previous protocol checkpoint | SDK-backed integration testing with an exact RC.0 package pairing |
 | `3.2.0-rc.1` | Current protocol checkpoint for Reliable Reporting 1.0 and reporting-semantics hardening | Raw-wire, signed-artifact, code-generation, and SDK-backed integration testing |
-| Current SDK wave | `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, and Go `adcp/v3@v3.2.1` embed `3.2.0-rc.1` | Exact RC.1 SDK-backed testing; higher-level Python and Go coverage remains role-dependent |
+| Current SDK wave | `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, and Go `adcp/v3@v3.2.1` embed `3.2.0-rc.1` | Exact RC.1 SDK-backed testing; higher-level Python and Go coverage remains role-dependent |
 
 Earlier betas and RC.0 remain useful as pinned implementation checkpoints.
 TypeScript SDK beta.31 and Python SDK beta.13 are historical RC.0 pairings;
@@ -73,7 +73,7 @@ The TypeScript SDK has exact RC.1 support. The npm `latest` tag remains on SDK
 13, so opt into the release-candidate channel explicitly:
 
 ```bash
-npm install @adcp/sdk@14.0.0-rc.32
+npm install @adcp/sdk@14.0.0-rc.33
 ```
 
 SDK 14 includes typed caller and server support for the compact media-buy

--- a/docs/reference/migration/3-1-to-3-2.mdx
+++ b/docs/reference/migration/3-1-to-3-2.mdx
@@ -9,7 +9,7 @@ description: "Role-based migration checklist for adopting the AdCP 3.2 release c
 
 <Warning>
 **3.2 is in release candidate.** RC.1 is the current signed protocol
-checkpoint. TypeScript `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, and
+checkpoint. TypeScript `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, and
 Go `adcp/v3@v3.2.1` embed it exactly; Python and Go higher-level coverage
 remains role-dependent. Keep production traffic pinned to `"3.1"`
 while validating an exact 3.2 checkpoint in staging.
@@ -53,7 +53,7 @@ surfaces by hand.
 | 5 | Media-buy implementations | Move create/update success handling completely to `media_buy_status`. |
 | 6 | Signing implementations | Require `content-digest` coverage and migrate request `Signature` and `Content-Digest` binary values to RFC 8941 padded Base64. |
 | 7 | Creative implementations | Adopt canonical format capability/product discovery and isolate legacy projection at compatibility boundaries. |
-| 8 | Compliance operators | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain the exact package and wire versions. |
+| 8 | Compliance operators | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain the exact package and wire versions. |
 | 9 | Delivery-reporting implementations | Emit and consume currency at media-buy or package grain, move qualified outcomes to `by_package[].metric_values`, and stop producing new `aggregated_totals`. |
 
 ## Required to claim 3.2 behavior

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -11,7 +11,7 @@ Authoritative version-by-version release record for AdCP, with cumulative change
 
 ## Version 3.2.0
 
-**Status:** Release-candidate cycle — minor release targeting the 3.2.0 milestone. RC.1 is the current signed protocol checkpoint. It completes the experimental Reliable Reporting 1.0 contract and hardens delivery, reach, and vendor-metric semantics. TypeScript `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, and Go `adcp/v3@v3.2.1` embed RC.1 exactly; Python and Go higher-level coverage remains role-dependent. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
+**Status:** Release-candidate cycle — minor release targeting the 3.2.0 milestone. RC.1 is the current signed protocol checkpoint. It completes the experimental Reliable Reporting 1.0 contract and hardens delivery, reach, and vendor-metric semantics. TypeScript `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, and Go `adcp/v3@v3.2.1` embed RC.1 exactly; Python and Go higher-level coverage remains role-dependent. Stable wire shapes remain backward compatible except for the ratified `media_buy_status` cleanup and request-signature encoding migration described below; explicitly experimental surfaces may carry noticed changes under the [experimental-status contract](/docs/reference/experimental-status).
 
 ### Prerelease checkpoints
 
@@ -55,7 +55,7 @@ Each prerelease is immutable. The `3.2-rc` documentation selector advances to th
 | A signing implementation | Require `content-digest` coverage for every signed request body on a 3.2 signing endpoint. |
 | A creative implementation | Prefer canonical capability and product format discovery; isolate named-format conversion at compatibility boundaries. |
 | An SDK maintainer | Generate from the current signed RC.1 tarball, publish an exact support statement, and route accepted protocol corrections into a later prerelease. |
-| A compliance operator | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain exact package and wire versions and do not issue a 3.2 badge from a prerelease checkpoint. |
+| A compliance operator | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain exact package and wire versions and do not issue a 3.2 badge from a prerelease checkpoint. |
 
 ### Required 3.2 migrations
 

--- a/docs/reference/versions.mdx
+++ b/docs/reference/versions.mdx
@@ -99,7 +99,7 @@ Targeted for early 2027. 3.x is mid-cycle — see the [planned releases table](/
 |---|---|
 | Building a new production integration today | **3.1**. Pin `"3.1"` on the wire. |
 | Implementing or testing 3.2 without an SDK | Use the signed **3.2 RC.1** artifacts with raw-wire or code-generation workflows. Follow the [prerelease program](/docs/reference/3-2-beta). |
-| Running an SDK-backed 3.2 integration test | Pair exact RC.1 wire pin `"3.2-rc.1"` with `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. |
+| Running an SDK-backed 3.2 integration test | Pair exact RC.1 wire pin `"3.2-rc.1"` with `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. |
 | Running an existing 3.0 integration | Stay on **3.0** while you migrate, or move to **3.1** when your SDK and validation are ready. |
 | Running a 2.5.x integration | Upgrade now — out of support. Start with the [migration guide](/docs/reference/migration). |
 | Running a 2.0 or 2.1 integration | Upgrade now — out of support. |

--- a/docs/reference/whats-new-in-3-2.mdx
+++ b/docs/reference/whats-new-in-3-2.mdx
@@ -9,7 +9,7 @@ description: "AdCP 3.2 turns a media-buy conversation into an explicit lifecycle
 
 <Warning>
 **3.2 is in release candidate.** RC.1 is the current signed protocol
-checkpoint. TypeScript `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, and
+checkpoint. TypeScript `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, and
 Go `adcp/v3@v3.2.1` embed it exactly; Python and Go higher-level coverage
 remains role-dependent. Use these exact packages for RC.1 staging tests. See the
 [3.2 prerelease program](/docs/reference/3-2-beta).
@@ -428,7 +428,7 @@ for the remaining runner and coverage gaps.
 | A signing implementation | Require `content-digest` coverage for every signed body on a 3.2 signing endpoint. |
 | A creative implementation | Prefer canonical capability and product format discovery; retain legacy conversion only at a proven compatibility boundary. |
 | An SDK maintainer | Generate from the signed RC.1 tarball, name the exact supported bundle, and feed accepted protocol corrections into the next prerelease. |
-| A compliance operator | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.32`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain exact package and wire versions end to end, and do not issue a 3.2 badge from a prerelease. |
+| A compliance operator | Test RC.1 from its signed assets or an exact SDK pairing: `@adcp/sdk@14.0.0-rc.33`, Python `adcp==8.0.0b14`, or Go `adcp/v3@v3.2.1`. Retain exact package and wire versions end to end, and do not issue a 3.2 badge from a prerelease. |
 
 ## Start here
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adcontextprotocol",
       "version": "3.2.0-rc.1",
       "dependencies": {
-        "@adcp/sdk": "14.0.0-rc.32",
+        "@adcp/sdk": "14.0.0-rc.33",
         "@anthropic-ai/sdk": "^0.123.0",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.9.3",
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@adcp/sdk": {
-      "version": "14.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-rc.32.tgz",
-      "integrity": "sha512-UYeD3a2Gt5SZRZ2SsikdMIQSlP+rq80XXP+6jc9uJpYXIpm9Mu6r1cGk+dU23ZBHPKtfakkDTpif8O06wphLzA==",
+      "version": "14.0.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@adcp/sdk/-/sdk-14.0.0-rc.33.tgz",
+      "integrity": "sha512-4ffKFFqhy8THY8X5N2ZbMKSv7UTjo8O1mGLxG6VRF8iRXA2zk9n+6Mb8n8FPcUTRmRbRiuspI2ZiKz2o7IUiwA==",
       "license": "Apache-2.0",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "eval:addie-google-read-only-tools": "tsx --import dotenv/config server/tests/manual/provider-read-only-tool-loop.ts"
   },
   "dependencies": {
-    "@adcp/sdk": "14.0.0-rc.32",
+    "@adcp/sdk": "14.0.0-rc.33",
     "@anthropic-ai/sdk": "^0.123.0",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.9.3",

--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -3054,7 +3054,7 @@ Tell ${codingTool}: "Build a buyer agent using @adcp/sdk that connects to the pu
 
 The SDK handles protocol details — the learner focuses on orchestration logic.
 
-Use the current \`3.2-rc.1\` wire pin with @adcp/sdk@14.0.0-rc.32 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
+Use the current \`3.2-rc.1\` wire pin with @adcp/sdk@14.0.0-rc.33 for the targeting-aware discovery portion. Decompose one messy request into brief plus criteria.offer_filters, criteria.targeting_overlay, and criteria.required_overlay_support; verify that unsupported future-selection requirements filter products; review any targeting_resolution.modifications before purchase; and verify effective package targeting on readback. Treat the get_products compatibility facade's equivalent fields as compatibility evidence, not as proof that the compact tasks work.
 
 Reference: ${SDKS_URL}
 
@@ -3069,7 +3069,7 @@ Validate in two parts.
 
 1. Run the compatibility buying workflow against the public test agent and share the output. Use the \`adcp\` CLI:
 \`\`\`
-npx @adcp/sdk@14.0.0-rc.32 test-mcp get_products '{"adcp_version":"3.2-rc.1","buying_mode":"brief","brief":"<your campaign brief>"}'
+npx @adcp/sdk@14.0.0-rc.33 test-mcp get_products '{"adcp_version":"3.2-rc.1","buying_mode":"brief","brief":"<your campaign brief>"}'
 \`\`\`
 
 Replace \`<your campaign brief>\` with your actual brief. Then run the full buying flow: get_products (select a canonical \`format_options[]\` entry) → create_media_buy → get_adcp_capabilities on the chosen creative endpoint → sync_creatives with \`format_kind\` and optional \`format_option_ref\`.

--- a/server/tests/unit/certification-module-methodology.test.ts
+++ b/server/tests/unit/certification-module-methodology.test.ts
@@ -80,7 +80,7 @@ describe('selectModuleMethodology', () => {
     for (const phase of ['build', 'validate']) {
       const instructions = await getInstructions({ module_id: 'C4', phase });
 
-      expect(instructions).toContain('@adcp/sdk@14.0.0-rc.32');
+      expect(instructions).toContain('@adcp/sdk@14.0.0-rc.33');
       expect(instructions).toContain('rc.1');
       expect(instructions).not.toContain('beta.5');
       expect(instructions).not.toContain('@adcp/sdk@14.0.0-beta.7');

--- a/tests/sdk-runtime-compat.test.cjs
+++ b/tests/sdk-runtime-compat.test.cjs
@@ -3,6 +3,19 @@ const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
+const CURRENT_SDK_CHECKPOINT_FILES = [
+  'docs/building/by-layer/L4/choose-your-sdk.mdx',
+  'docs/learning/supplements/buyer-briefs-and-get-products.mdx',
+  'docs/learning/tracks/buyer.mdx',
+  'docs/media-buy/product-discovery/proposal-negotiation.mdx',
+  'docs/reference/3-2-beta.mdx',
+  'docs/reference/migration/3-1-to-3-2.mdx',
+  'docs/reference/release-notes.mdx',
+  'docs/reference/versions.mdx',
+  'docs/reference/whats-new-in-3-2.mdx',
+  'server/src/addie/mcp/certification-tools.ts',
+];
+
 async function loadInstalledSingleAgentClients() {
   return [
     require('@adcp/sdk').SingleAgentClient,
@@ -30,6 +43,20 @@ function canonicalAdcpVersion(version) {
   assert.ok(match, `invalid AdCP release version: ${version}`);
   return `${match[1]}.${match[2]}.${match[3] ?? '0'}${match[4]}`;
 }
+
+test('current exact SDK checkpoint references match package.json', () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'));
+  const expectedVersion = packageJson.dependencies['@adcp/sdk'];
+  assert.match(expectedVersion, /-rc\.\d+$/, 'current SDK checkpoint must remain an exact release-candidate pin');
+  const versionCore = expectedVersion.split('-')[0].replaceAll('.', '\\.');
+  const currentSdkVersionPattern = new RegExp(`${versionCore}-rc\\.\\d+`, 'g');
+
+  for (const relativePath of CURRENT_SDK_CHECKPOINT_FILES) {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', relativePath), 'utf8');
+    const versions = [...new Set(source.match(currentSdkVersionPattern) ?? [])];
+    assert.deepEqual(versions, [expectedVersion], `${relativePath} must use the package.json SDK checkpoint`);
+  }
+});
 
 test('training-agent current AdCP version exactly matches the installed SDK schema release', async () => {
   const currentVersion = trainingAgentAdcpVersion('TRAINING_AGENT_CURRENT_ADCP_VERSION');

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -1395,7 +1395,7 @@ test("buyer teaching surfaces explain structured-first targeting", () => {
   }
   assert.match(skill, /fewer tokens/);
   assert.match(addieKnowledge, /No targeting-resolution echo confirms only/);
-  assert.match(certificationTools, /current .*3\.2-rc\.1.* wire pin with @adcp\/sdk@14\.0\.0-rc\.32/);
+  assert.match(certificationTools, /current .*3\.2-rc\.1.* wire pin with @adcp\/sdk@14\.0\.0-rc\.33/);
   assert.match(certificationTools, /3\.2 targeting-aware objectives live/);
   assert.doesNotMatch(certificationTools, /issues\/6199/);
   assert.match(


### PR DESCRIPTION
## Summary
- pin @adcp/sdk to 14.0.0-rc.33
- align current SDK guidance, certification prompts, and fixtures
- add a checkpoint drift test and release changeset

## Validation
- expert code and SDK reviews: approved
- SDK shim and capability-gate suites
- typecheck and certification methodology tests
- current and released-3.0 storyboard matrices
- docs navigation validation

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7c76b1c9-522b-4b3b-a6f7-5b058baf61c0)
