### PR TITLE
test: derive current release checkpoints

### DIFF
--- a/server/tests/integration/training-agent-3-0-compat-tools.test.ts
+++ b/server/tests/integration/training-agent-3-0-compat-tools.test.ts
@@ -18,10 +18,11 @@ vi.mock('../../src/logger.js', () => ({
 const { createTrainingAgentRouter } = await import('../../src/training-agent/index.js');
 const { createTrainingAgentServer } = await import('../../src/training-agent/task-handlers.js');
 const { stopSessionCleanup } = await import('../../src/training-agent/state.js');
+const { TRAINING_AGENT_CURRENT_ADCP_VERSION } = await import('../../src/training-agent/types.js');
 
 const COMPAT_CTX = { mode: 'open' as const, storyboardCompat: { version: '3.0' as const } };
 const AUTH = 'Bearer compat-tools-token';
-const CURRENT_ADCP_VERSION = '3.2-rc.1';
+const CURRENT_ADCP_VERSION = TRAINING_AGENT_CURRENT_ADCP_VERSION;
 
 async function simulateListTools(server: ReturnType<typeof createTrainingAgentServer>): Promise<string[]> {
   const requestHandlers = (server as any)._requestHandlers as Map<string, Function>;

--- a/server/tests/integration/training-agent-reporting-reliability.test.ts
+++ b/server/tests/integration/training-agent-reporting-reliability.test.ts
@@ -24,10 +24,13 @@ import {
   stopSessionCleanup,
 } from '../../src/training-agent/state.js';
 import { buildCatalog } from '../../src/training-agent/product-factory.js';
-import type { MediaBuyState } from '../../src/training-agent/types.js';
+import {
+  TRAINING_AGENT_CURRENT_ADCP_VERSION,
+  type MediaBuyState,
+} from '../../src/training-agent/types.js';
 
 const PUBLIC_TEST_TOKEN = '1v8tAhASaUYYp4odoQ1PnMpdqNaMiTrCRqYo9OJp6IQ';
-const ADCP_VERSION = '3.2-rc.1';
+const ADCP_VERSION = TRAINING_AGENT_CURRENT_ADCP_VERSION;
 
 async function boot(): Promise<{ url: string; close(): Promise<void> }> {
   const app = express();

--- a/server/tests/unit/certification-module-methodology.test.ts
+++ b/server/tests/unit/certification-module-methodology.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 // certification-tools.ts imports the certification-db module; stub it so this
 // pure-function test never touches a real database.
@@ -30,6 +31,13 @@ import {
   SAGE_VOICE_EXEMPLARS,
   selectModuleMethodology,
 } from '../../src/addie/mcp/certification-tools.js';
+import { TRAINING_AGENT_CURRENT_ADCP_VERSION } from '../../src/training-agent/types.js';
+
+const SDK_PACKAGE_VERSION = (
+  JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')) as {
+    dependencies: Record<string, string>;
+  }
+).dependencies['@adcp/sdk'];
 
 // Distinctive markers from each methodology block.
 const TEACHING_MARKER = 'Teaching approach';
@@ -80,10 +88,11 @@ describe('selectModuleMethodology', () => {
     for (const phase of ['build', 'validate']) {
       const instructions = await getInstructions({ module_id: 'C4', phase });
 
-      expect(instructions).toContain('@adcp/sdk@14.0.0-rc.33');
-      expect(instructions).toContain('rc.1');
-      expect(instructions).not.toContain('beta.5');
-      expect(instructions).not.toContain('@adcp/sdk@14.0.0-beta.7');
+      expect(instructions).toContain(`@adcp/sdk@${SDK_PACKAGE_VERSION}`);
+      expect(instructions).toContain(TRAINING_AGENT_CURRENT_ADCP_VERSION);
+      const documentedSdkPins = [...instructions.matchAll(/@adcp\/sdk@([^\s`'"<>]+)/g)]
+        .map((match) => match[1]);
+      expect(new Set(documentedSdkPins)).toEqual(new Set([SDK_PACKAGE_VERSION]));
     }
   });
 

--- a/server/tests/unit/reporting-reliability-regressions.test.ts
+++ b/server/tests/unit/reporting-reliability-regressions.test.ts
@@ -41,6 +41,7 @@ import { SYNC_REPORTING_RECEIPTS_SCHEMA } from '../../src/training-agent/tenants
 import { handleGetMediaBuyDelivery } from '../../src/training-agent/task-handlers.js';
 import { legacyGetReportingStatusHandler } from '../../src/training-agent/v6-sales-platform.js';
 import { validateSourceSchema } from '../../src/training-agent/source-schema.js';
+import { TRAINING_AGENT_CURRENT_ADCP_VERSION } from '../../src/training-agent/types.js';
 import { canonicalize } from '@adcp/sdk';
 import { createHash } from 'node:crypto';
 
@@ -160,7 +161,7 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
     const published = publishZeroRowReportingCoreLifecycleProbe(principal, accountId);
     const response = await handleGetMediaBuyDelivery({
       account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id,
-    }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: '3.2-rc.1' });
+    }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(response).toMatchObject({
       reporting_period: { start: '2026-08-01T00:00:00.000Z', end: '2026-08-01T01:00:00.000Z' },
       media_buy_deliveries: [],
@@ -205,7 +206,7 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
     expect(rc0).not.toHaveProperty('adjustment_receipts');
     await expect(handler({ account, view: 'periods', changes_after: 'reporting_change_1_deadbeefdeadbeef', adcp_version: '3.2-rc.0' } as never, context as never))
       .rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
-    const rc1 = await handler({ account, view: 'periods', adcp_version: '3.2-rc.1' } as never, context as never) as Record<string, unknown>;
+    const rc1 = await handler({ account, view: 'periods', adcp_version: TRAINING_AGENT_CURRENT_ADCP_VERSION } as never, context as never) as Record<string, unknown>;
     expect(rc1).toHaveProperty('changes_checkpoint');
     expect(rc1).toHaveProperty('adjustments');
   });
@@ -219,19 +220,19 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
     await withDurableReportingLedger(principal, accountId, true, () => undefined, naturalAccount);
     clearReportingAccountBindingCacheForTesting();
     const read = await handleGetMediaBuyDelivery({ account: naturalAccount, reporting_revision_id: published.reporting_revision_id }, {
-      mode: 'training', principal, servedAdcpVersion: '3.2-rc.1',
+      mode: 'training', principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION,
     });
     expect(read).toMatchObject({ reporting_revision: { reporting_revision_id: published.reporting_revision_id } });
     const omittedAccount = await handleGetMediaBuyDelivery({ reporting_revision_id: published.reporting_revision_id }, {
-      mode: 'training', principal, servedAdcpVersion: '3.2-rc.1', resolvedAccountId: 'synthetic_wrong_context',
+      mode: 'training', principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION, resolvedAccountId: 'synthetic_wrong_context',
     });
     expect(omittedAccount).toMatchObject({ reporting_revision: { reporting_revision_id: published.reporting_revision_id } });
     const opaque = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id }, {
-      mode: 'training', principal, servedAdcpVersion: '3.2-rc.1', resolvedAccountId: 'synthetic_wrong_context',
+      mode: 'training', principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION, resolvedAccountId: 'synthetic_wrong_context',
     });
     expect(opaque).toMatchObject({ reporting_revision: { reporting_revision_id: published.reporting_revision_id } });
     const unauthorized = await handleGetMediaBuyDelivery({ account: naturalAccount, reporting_revision_id: published.reporting_revision_id }, {
-      mode: 'training', principal: 'other-consumer', servedAdcpVersion: '3.2-rc.1',
+      mode: 'training', principal: 'other-consumer', servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION,
     });
     expect(unauthorized).toMatchObject({ errors: [{ code: 'REPORTING_REVISION_NOT_FOUND' }] });
   });
@@ -252,7 +253,7 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
       { period_start: '2026-08-01T00:00:00.000Z', period_end: '2026-08-01T01:00:00.000Z', impressions: 1 },
       { period_start: '2026-08-01T01:00:00.000Z', period_end: '2026-08-01T02:00:00.000Z', impressions: 2 },
     ]);
-    const context = { mode: 'training' as const, principal, servedAdcpVersion: '3.2-rc.1' as const };
+    const context = { mode: 'training' as const, principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION };
     const expectedProbeIds = accounts.map(candidate => candidate.accountId).sort();
     const expectProbeSet = (alsoPersistedOwner: boolean) => {
       const trace = reportingRevisionReadTraceForTesting();
@@ -320,9 +321,9 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
     ];
     const published = publishReportingCoreLifecycleProbeRows(principal, accountId, rows);
     const status = getReportingStatusForAccount({ view: 'revision', reporting_revision_id: published.reporting_revision_id } as TrainingGetReportingStatusRequest, principal, accountId);
-    const read = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { max_results: 1 } }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: '3.2-rc.1' });
+    const read = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { max_results: 1 } }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(read).toMatchObject({ reporting_rows: [{ impressions: 7 }], reporting_revision: { revision_content_sha256: published.revision_content_sha256 }, reporting_revision_binding: { content_sha256: published.revision_content_sha256 }, pagination: { total_count: 2, has_more: true } });
-    const next = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { max_results: 1, cursor: (read.pagination as { cursor: string }).cursor } }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: '3.2-rc.1' });
+    const next = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { max_results: 1, cursor: (read.pagination as { cursor: string }).cursor } }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(next).toMatchObject({ reporting_rows: [{ impressions: 3 }], reporting_revision: read.reporting_revision, reporting_revision_binding: read.reporting_revision_binding, pagination: { total_count: 2, has_more: false } });
     expect((status.revision as Record<string, unknown>).revision_content_sha256).toBe(published.revision_content_sha256);
     expect((read.reporting_revision_binding as Record<string, unknown>).content_sha256).toBe(createHash('sha256').update(canonicalize({
@@ -330,12 +331,12 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
       control_totals: [{ name: 'impressions', value: '10', value_type: 'integer', unit: 'impressions' }],
       reporting_rows: rows,
     })).digest('hex'));
-    const mixed = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, include_package_daily_breakdown: false }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: '3.2-rc.1' });
+    const mixed = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, include_package_daily_breakdown: false }, { mode: 'training', principal, resolvedAccountId: accountId, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(mixed).toMatchObject({ errors: [{ code: 'VALIDATION_ERROR' }] });
     const cursor = (read.pagination as { cursor: string }).cursor;
-    const tampered = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { cursor: `${cursor}x` } }, { mode: 'training', principal, servedAdcpVersion: '3.2-rc.1' });
+    const tampered = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { cursor: `${cursor}x` } }, { mode: 'training', principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(tampered).toMatchObject({ errors: [{ code: 'REPORTING_REVISION_NOT_FOUND' }] });
-    const wrongPrincipal = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { cursor } }, { mode: 'training', principal: 'other-principal', servedAdcpVersion: '3.2-rc.1' });
+    const wrongPrincipal = await handleGetMediaBuyDelivery({ account: { account_id: accountId }, reporting_revision_id: published.reporting_revision_id, pagination: { cursor } }, { mode: 'training', principal: 'other-principal', servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION });
     expect(wrongPrincipal).toMatchObject({ errors: [{ code: 'REPORTING_REVISION_NOT_FOUND' }] });
     expect(validateSourceSchema('media-buy/get-media-buy-delivery-request.json', { pagination: { max_results: 1 } }).valid).toBe(false);
   });
@@ -350,7 +351,7 @@ describe('Reliable Reporting pipeline – PR #7228 regression suite', () => {
       { period_start: '2026-08-01T01:00:00.000Z', period_end: '2026-08-01T02:00:00.000Z', impressions: 2 },
     ]);
     await withDurableReportingLedger(principal, accountId, true, () => undefined, naturalAccount);
-    const context = { mode: 'training' as const, principal, servedAdcpVersion: '3.2-rc.1' as const };
+    const context = { mode: 'training' as const, principal, servedAdcpVersion: TRAINING_AGENT_CURRENT_ADCP_VERSION };
     const first = await handleGetMediaBuyDelivery({
       account: naturalAccount, reporting_revision_id: published.reporting_revision_id, pagination: { max_results: 1 },
     }, context);

--- a/tests/sdk-runtime-compat.test.cjs
+++ b/tests/sdk-runtime-compat.test.cjs
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const semver = require('semver');
 const test = require('node:test');
 
 const CURRENT_SDK_CHECKPOINT_FILES = [
@@ -44,16 +45,41 @@ function canonicalAdcpVersion(version) {
   return `${match[1]}.${match[2]}.${match[3] ?? '0'}${match[4]}`;
 }
 
+function sdkCheckpointVersions(source, expectedVersion) {
+  const exactVersion = semver.parse(expectedVersion);
+  assert.equal(exactVersion?.version, expectedVersion, 'current SDK checkpoint must remain an exact package version');
+  const versionCore = `${exactVersion.major}.${exactVersion.minor}.${exactVersion.patch}`;
+  const escapedVersionCore = versionCore.replaceAll('.', '\\.');
+  const prereleaseChannel = exactVersion.prerelease.length > 0
+    ? String(exactVersion.prerelease[0])
+    : undefined;
+  const semverBuild = String.raw`(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?`;
+  const tokenStart = String.raw`(?<![0-9A-Za-z.+-])`;
+  const tokenEnd = String.raw`(?![0-9A-Za-z.+-])`;
+  const currentSdkVersionPattern = prereleaseChannel
+    ? new RegExp(`${tokenStart}${escapedVersionCore}-${prereleaseChannel}(?:\\.[0-9A-Za-z-]+)*${semverBuild}${tokenEnd}`, 'g')
+    : new RegExp(`${tokenStart}${escapedVersionCore}${semverBuild}${tokenEnd}`, 'g');
+  return [...new Set(source.match(currentSdkVersionPattern) ?? [])];
+}
+
+test('SDK checkpoint matching compares complete SemVer tokens', () => {
+  assert.deepEqual(
+    sdkCheckpointVersions('114.0.0-rc.33 14.0.0-rc.33+build.1 14.0.0-rc.33', '14.0.0-rc.33'),
+    ['14.0.0-rc.33+build.1', '14.0.0-rc.33'],
+  );
+  assert.deepEqual(
+    sdkCheckpointVersions('114.0.0 14.0.0-rc.33 14.0.0+build.1 14.0.0', '14.0.0'),
+    ['14.0.0+build.1', '14.0.0'],
+  );
+});
+
 test('current exact SDK checkpoint references match package.json', () => {
   const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8'));
   const expectedVersion = packageJson.dependencies['@adcp/sdk'];
-  assert.match(expectedVersion, /-rc\.\d+$/, 'current SDK checkpoint must remain an exact release-candidate pin');
-  const versionCore = expectedVersion.split('-')[0].replaceAll('.', '\\.');
-  const currentSdkVersionPattern = new RegExp(`${versionCore}-rc\\.\\d+`, 'g');
 
   for (const relativePath of CURRENT_SDK_CHECKPOINT_FILES) {
     const source = fs.readFileSync(path.resolve(__dirname, '..', relativePath), 'utf8');
-    const versions = [...new Set(source.match(currentSdkVersionPattern) ?? [])];
+    const versions = sdkCheckpointVersions(source, expectedVersion);
     assert.deepEqual(versions, [expectedVersion], `${relativePath} must use the package.json SDK checkpoint`);
   }
 });

--- a/tests/targeting-aware-discovery.test.cjs
+++ b/tests/targeting-aware-discovery.test.cjs
@@ -8,6 +8,28 @@ const YAML = require("yaml");
 
 const SCHEMA_ROOT = path.join(__dirname, "..", "static", "schemas", "source");
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function currentCheckpoint() {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8")
+  );
+  const trainingAgentTypes = fs.readFileSync(
+    path.join(__dirname, "..", "server", "src", "training-agent", "types.ts"),
+    "utf8"
+  );
+  const wireVersion = trainingAgentTypes.match(
+    /TRAINING_AGENT_CURRENT_ADCP_VERSION\s*=\s*'([^']+)'/
+  );
+  assert.ok(wireVersion, "training-agent current AdCP version must be explicit");
+  return {
+    sdkVersion: packageJson.dependencies["@adcp/sdk"],
+    wireVersion: wireVersion[1],
+  };
+}
+
 async function loadSchema(uri) {
   if (!uri.startsWith("/schemas/"))
     throw new Error(`Unexpected schema URI: ${uri}`);
@@ -1395,7 +1417,13 @@ test("buyer teaching surfaces explain structured-first targeting", () => {
   }
   assert.match(skill, /fewer tokens/);
   assert.match(addieKnowledge, /No targeting-resolution echo confirms only/);
-  assert.match(certificationTools, /current .*3\.2-rc\.1.* wire pin with @adcp\/sdk@14\.0\.0-rc\.33/);
+  const { sdkVersion, wireVersion } = currentCheckpoint();
+  assert.match(
+    certificationTools,
+    new RegExp(
+      `current .*${escapeRegExp(wireVersion)}.* wire pin with @adcp/sdk@${escapeRegExp(sdkVersion)}`
+    )
+  );
   assert.match(certificationTools, /3\.2 targeting-aware objectives live/);
   assert.doesNotMatch(certificationTools, /issues\/6199/);
   assert.match(


### PR DESCRIPTION
## Summary
- derive current TypeScript SDK pins from package.json in compatibility and methodology tests
- derive the current wire version from TRAINING_AGENT_CURRENT_ADCP_VERSION in unit and integration tests
- keep historical prerelease literals only where they are explicit compatibility-boundary fixtures
- harden checkpoint matching around complete SemVer tokens, including stable releases and build metadata

## Validation
- pre-commit suite (70 files / 1,059 tests plus repository lint guards)
- npm run test:sdk-shims (12 tests)
- targeted unit tests (45 tests)
- targeted integration tests (10 tests)
- targeting/runtime Node tests (29 tests)
- npm run typecheck

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7c76b1c9-522b-4b3b-a6f7-5b058baf61c0)
