### PR TITLE
fix(addie): preserve full-suite provider continuations

### DIFF
--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -7,6 +7,7 @@ import type {
   NormalizedModelEvent,
   PreparedModelInvocation,
 } from '../model-providers/model-provider.js';
+import { isDeepStrictEqual } from 'node:util';
 import {
   GOOGLE_ROUTER_MODEL,
   isGoogleRouterModelRevision,
@@ -226,6 +227,7 @@ interface BudgetedDelegateIdentity {
   readonly capabilities: ModelProvider['capabilities'];
   readonly prepare: ModelProvider['prepare'];
   readonly respond: ModelProvider['respond'];
+  readonly snapshotResponse?: ModelProvider['snapshotResponse'];
   readonly deriveProviderToolReceipt?: ModelProvider['deriveProviderToolReceipt'];
 }
 
@@ -254,6 +256,7 @@ function snapshotDelegateIdentity(delegate: ModelProvider): BudgetedDelegateIden
   const capabilities = deepFreeze(structuredClone(delegate.capabilities)) as ModelProvider['capabilities'];
   const prepare = delegate.prepare;
   const respond = delegate.respond;
+  const snapshotResponse = delegate.snapshotResponse;
   const deriveProviderToolReceipt = delegate.deriveProviderToolReceipt;
   if (typeof id !== 'string' || !id.trim() || typeof prepare !== 'function' || typeof respond !== 'function') {
     throw new Error('Fixed trace budget delegate identity is invalid');
@@ -264,6 +267,7 @@ function snapshotDelegateIdentity(delegate: ModelProvider): BudgetedDelegateIden
     capabilities,
     prepare: prepare.bind(delegate),
     respond: respond.bind(delegate),
+    snapshotResponse: snapshotResponse?.bind(delegate),
     deriveProviderToolReceipt: deriveProviderToolReceipt?.bind(delegate),
   });
 }
@@ -582,10 +586,21 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
             throw new Error('Fixed trace provider completed without dispatch admission');
           }
           // The delegate still owns `event.response` and may mutate it when
-          // the iterator resumes after this yield. One evaluator-owned frozen
-          // snapshot is therefore the sole terminal response used for
-          // approval, settlement, and the outward event.
-          const response = deepFreeze(structuredClone(event.response));
+          // the iterator resumes after this yield. An adapter may preserve
+          // opaque same-provider continuation state while snapshotting, but
+          // it may not alter the canonical response it supplied.
+          // Capture the canonical value before invoking an adapter hook. The
+          // hook is permitted to transfer opaque continuation state into its
+          // own clone, never to mutate the delegate-owned response or change
+          // the usage that is settled below.
+          const canonicalResponse = structuredClone(event.response);
+          const snapshot = this.#delegate.snapshotResponse
+            ? this.#delegate.snapshotResponse(event.response)
+            : structuredClone(event.response);
+          if (!isDeepStrictEqual(snapshot, canonicalResponse)) {
+            throw new Error('Fixed trace provider response snapshot differs from its terminal response');
+          }
+          const response = deepFreeze(snapshot);
           if (fixedTraceResponseUsesPricingPolicy(this.#responsePricingPolicy, response)) {
             try {
               this.#budget.complete(reservation, response.usage, this.#pricing);

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -130,7 +130,7 @@ export const FIXED_TRACE_DIRECT_MODEL_SCREEN_GOOGLE_THREE_TURN_MODE = 'direct_mo
  */
 export const FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE = 'direct_full_suite_model_comparison_v1' as const;
 /** Bounds every direct-full-suite prepared request before provider dispatch. */
-export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES = 131_072;
+export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES = 262_144;
 export type FixedTraceDirectModelScreenGenerationCellId =
   | 'generation:anthropic:claude-sonnet-5:provider_default'
   | 'generation:anthropic:claude-haiku-4-5:provider_default'

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -400,6 +400,17 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     });
   }
 
+  /** Preserve opaque Google continuation parts when an evaluator snapshots a response. */
+  snapshotResponse(response: ModelResponse): ModelResponse {
+    const snapshot = structuredClone(response);
+    for (const [index, content] of response.content.entries()) {
+      const continuation = googleContinuationParts.get(content);
+      const clonedContent = snapshot.content[index];
+      if (continuation && clonedContent) rememberGoogleContinuation(clonedContent, continuation);
+    }
+    return deepFreeze(snapshot);
+  }
+
   async *respond(
     request: ModelRequest,
     options: ModelRespondOptions = {},

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -285,6 +285,13 @@ export interface ModelProvider {
   readonly capabilities: ModelProviderCapabilities;
   prepare(request: ModelRequest): PreparedModelInvocation;
   respond(request: ModelRequest, options?: ModelRespondOptions): AsyncIterable<NormalizedModelEvent>;
+  /**
+   * Optionally make an immutable response snapshot while retaining adapter-only
+   * continuation bindings. The returned value must be structurally identical
+   * to `response`; this is for opaque state such as a provider thought token,
+   * never a second normalization path.
+   */
+  snapshotResponse?(response: ModelResponse): ModelResponse;
   deriveProviderToolReceipt?(
     call: ModelProviderToolCallContent,
     result: ModelProviderToolResultContent,

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -322,6 +322,41 @@ describe('fixed trace provider budget', () => {
     });
   });
 
+  it('rejects an adapter snapshot hook that mutates the canonical response before accounting', async () => {
+    const original = structuredClone(RESPONSE);
+    const delegate: ModelProvider = {
+      id: 'openai',
+      capabilities: CAPABILITIES,
+      prepare(request): PreparedModelInvocation {
+        return {
+          provider: 'openai', model: request.model, capabilities: CAPABILITIES,
+          providerRequest: { model: request.model },
+        };
+      },
+      snapshotResponse(response): ModelResponse {
+        response.usage.inputTokens = 0;
+        response.usage.outputTokens = 0;
+        return response;
+      },
+      async *respond(request, options = {}): AsyncIterable<NormalizedModelEvent> {
+        await options.beforeDispatch?.(this.prepare(request));
+        yield { type: 'response_complete', response: original };
+      },
+    };
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow(
+      'Fixed trace provider response snapshot differs from its terminal response',
+    );
+    expect(budget.snapshot()).toMatchObject({
+      accountedSpendUsd: 0,
+      dispatchedCalls: 1,
+      completedCalls: 0,
+      exposureUnknown: true,
+    });
+  });
+
   it('halts later calls after a dispatched response has unknown usage', async () => {
     const delegate = new BudgetScriptedProvider([new Error('transport failed'), RESPONSE]);
     const budget = new FixedTraceBudget(1);

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -52,7 +52,7 @@ async function run(
   judgeResponsePatch: Partial<ModelResponse> = {},
   judgeOverrides: Partial<Record<ModelProviderId, FakeProvider>> = {},
 ) {
-  const cell = fixedTraceDirectFullSuiteCell(cellId); const budget = new FixedTraceBudget(300);
+  const cell = fixedTraceDirectFullSuiteCell(cellId); const budget = new FixedTraceBudget(fixedTraceDirectFullSuiteCostCeiling(cellId).requiredSoftMaxUsd);
   const rawCandidate = new FakeProvider(cell.provider, fail);
   const candidate = budgeted(rawCandidate, cell.model, budget);
   const rawJudges = {
@@ -109,12 +109,12 @@ describe('fixed-trace direct full-suite comparison', () => {
 
   it('publishes deterministic per-cell whole-run ceilings with all 384 candidate and 64 judge calls', () => {
     expect(FIXED_TRACE_DIRECT_FULL_SUITE_CELLS.map((cellId) => [cellId, fixedTraceDirectFullSuiteCostCeiling(cellId).requiredSoftMaxUsd])).toEqual([
-      ['generation:anthropic:claude-sonnet-5:provider_default', 242.15941759999998],
-      ['generation:anthropic:claude-haiku-4-5:provider_default', 122.1520448],
-      ['generation:google:gemini-3.7-flash:provider_default', 44.5568512],
-      ['generation:google:gemini-3.7-flash:low', 44.5568512],
-      ['generation:google:gemini-3.7-flash:medium', 44.5568512],
-      ['generation:google:gemini-3.7-flash:high', 44.5568512],
+      ['generation:anthropic:claude-sonnet-5:provider_default', 478.71816320000005],
+      ['generation:anthropic:claude-haiku-4-5:provider_default', 240.43141760000003],
+      ['generation:google:gemini-3.7-flash:provider_default', 82.30558719999999],
+      ['generation:google:gemini-3.7-flash:low', 82.30558719999999],
+      ['generation:google:gemini-3.7-flash:medium', 82.30558719999999],
+      ['generation:google:gemini-3.7-flash:high', 82.30558719999999],
     ]);
     const ceiling = fixedTraceDirectFullSuiteCostCeiling('generation:anthropic:claude-sonnet-5:provider_default');
     expect(ceiling).toMatchObject({ candidateMaxDispatches: 384, judgeMaxDispatches: 64, requiredSoftMaxUsd: ceiling.totalUsd });

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -26,6 +26,8 @@ import {
 import { createOfficialDocsReadOnlyToolBoundary } from '../../../src/addie/jobs/official-docs-read-only-tools.js';
 import { executeFixedTraceToolLoop } from '../../../src/addie/eval/fixed-trace-tool-loop.js';
 import { FIXED_TRACE_SUITE } from '../../../src/addie/eval/fixed-trace-suite.js';
+import { BudgetedFixedTraceProvider, FixedTraceBudget, fixedTraceResponsePricingPolicy } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 
 const { googleGenAIConstructor } = vi.hoisted(() => ({
   googleGenAIConstructor: vi.fn(function FakeGoogleGenAI() {
@@ -602,7 +604,16 @@ describe('GoogleGenerateContentProvider', () => {
         }],
         usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 5 },
       }));
-    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+    const rawProvider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+    const pricing = datedPricingProfilesForFixedTrace().find((profile) => (
+      profile.provider === 'google' && profile.model === GOOGLE_ROUTER_MODEL
+    ))!;
+    const provider = new BudgetedFixedTraceProvider(
+      rawProvider,
+      new FixedTraceBudget(1),
+      pricing,
+      fixedTraceResponsePricingPolicy('google', GOOGLE_ROUTER_MODEL, pricing),
+    );
     const handler = vi.fn().mockResolvedValue('Found the versioning guide.');
     const handlerFactory = vi.fn().mockReturnValue(new Map([
       ['search_docs', handler],


### PR DESCRIPTION
Fixes two real-provider failures found by the first two direct full-suite matrix cells. Preserves Google opaque continuation state through the fixed-trace budget wrapper, validates snapshot structural equivalence, and raises the candidate prepared-request hard ceiling from 128 KiB to 256 KiB with matching whole-cell escrow tests. No provider calls are made by this PR. The two attempted cells have immutable failed artifacts and will not be rerun.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
