### PR TITLE
fix(addie): settle approved Claude revision aliases

### DIFF
--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -12,6 +12,7 @@ import {
   GOOGLE_ROUTER_MODEL,
   isGoogleRouterModelRevision,
 } from '../model-providers/google-generate-content-provider.js';
+import { resolveKnownClaudePricingModel } from '../claude-pricing.js';
 import { GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION } from '../model-cost-pricing.js';
 import {
   datedPricingCostUsd,
@@ -195,6 +196,9 @@ export function fixedTraceResponseUsesPricingPolicy(
   const approved = approvedResponsePricing(policy);
   if (response.provider !== policy.expectedProvider) return false;
   if (response.model === policy.expectedModel) return true;
+  if (response.provider === 'anthropic') {
+    return resolveKnownClaudePricingModel(response.model) === policy.expectedModel;
+  }
   return policy.modelResolutionPolicy === 'google_router_dated_revision_v1'
     && approved.profileId === GOOGLE_GEMINI_3_7_FLASH_PRICING_VERSION
     && isGoogleRouterModelRevision(response.model);

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -5,6 +5,7 @@ import {
   FixedTraceBudgetAdmissionError,
   fixedTraceEstimatedCostUsd,
   fixedTraceApprovedPricingProfiles,
+  fixedTraceResponseUsesPricingPolicy,
   fixedTraceResponsePricingPolicy,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
 import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
@@ -149,8 +150,14 @@ describe('fixed trace provider budget', () => {
   });
 
   it('retains the reviewed Haiku, Luna, and Gemini rate cohorts', () => {
-    expect(fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', HAIKU_4_5_PRICING))
+    const haikuPolicy = fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', HAIKU_4_5_PRICING);
+    expect(haikuPolicy)
       .toMatchObject({ pricingProfileId: HAIKU_4_5_PRICING.profileId });
+    expect(fixedTraceResponseUsesPricingPolicy(haikuPolicy, {
+      ...RESPONSE,
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+    })).toBe(true);
     expect(fixedTraceEstimatedCostUsd({
       inputTokens: 100, outputTokens: 20, cacheReadTokens: 1_000, cacheWriteTokens: 200,
     }, HAIKU_4_5_PRICING)).toBe(0.00055);


### PR DESCRIPTION
Fixes the fixed-trace budget ledger to recognize the repository-approved Claude dated revision aliases, matching the existing pricing cohort identity resolver. This was found through the one-shot Haiku direct-full-suite artifact: a returned dated Haiku ID otherwise closes the ledger as unknown exposure and prevents valid downstream judge calls. Adds focused coverage. No completed provider cell is rerun; the immutable Haiku artifact remains evidence.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
