### PR TITLE
fix(addie): align dated Claude identity ledgers

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.39';
+export const CODE_VERSION = '2026.09.40';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -82,7 +82,9 @@ interface FixedTraceApprovedPricing extends FixedTraceBudgetPricing {
 export function fixedTraceModelResolutionPolicy(
   provider: ModelProvider['id'],
   model: string,
+  allowDatedAnthropicRevision = false,
 ): FixedTraceModelResolutionPolicy {
+  if (allowDatedAnthropicRevision && provider === 'anthropic') return 'anthropic_dated_revision_v1';
   return provider === 'google' && model === GOOGLE_ROUTER_MODEL
     ? 'google_router_dated_revision_v1'
     : 'exact_model_identity_v1';
@@ -164,6 +166,34 @@ export function fixedTraceResponsePricingPolicy(
   expectedModel: string,
   pricing: FixedTraceBudgetPricing & { readonly profileId: string },
 ): FixedTraceResponsePricingPolicy {
+  return fixedTraceResponsePricingPolicyForResolution(
+    expectedProvider,
+    expectedModel,
+    pricing,
+    fixedTraceModelResolutionPolicy(expectedProvider, expectedModel),
+  );
+}
+
+/** The only policy constructor that permits dated Anthropic full-suite receipts. */
+export function fixedTraceDirectFullSuiteResponsePricingPolicy(
+  expectedProvider: ModelProvider['id'],
+  expectedModel: string,
+  pricing: FixedTraceBudgetPricing & { readonly profileId: string },
+): FixedTraceResponsePricingPolicy {
+  return fixedTraceResponsePricingPolicyForResolution(
+    expectedProvider,
+    expectedModel,
+    pricing,
+    fixedTraceModelResolutionPolicy(expectedProvider, expectedModel, true),
+  );
+}
+
+function fixedTraceResponsePricingPolicyForResolution(
+  expectedProvider: ModelProvider['id'],
+  expectedModel: string,
+  pricing: FixedTraceBudgetPricing & { readonly profileId: string },
+  modelResolutionPolicy: FixedTraceModelResolutionPolicy,
+): FixedTraceResponsePricingPolicy {
   const approved = FIXED_TRACE_APPROVED_PRICING.find((entry) => (
     entry.expectedProvider === expectedProvider
     && entry.expectedModel === expectedModel
@@ -183,7 +213,7 @@ export function fixedTraceResponsePricingPolicy(
     expectedProvider: approved.expectedProvider,
     expectedModel: approved.expectedModel,
     pricingProfileId: approved.profileId,
-    modelResolutionPolicy: approved.modelResolutionPolicy,
+    modelResolutionPolicy,
   });
   approvedResponsePricingPolicies.set(policy, approved);
   return policy;
@@ -191,12 +221,12 @@ export function fixedTraceResponsePricingPolicy(
 
 export function fixedTraceResponseUsesPricingPolicy(
   policy: FixedTraceResponsePricingPolicy,
-  response: ModelResponse,
+  response: Pick<ModelResponse, 'provider' | 'model'>,
 ): boolean {
   const approved = approvedResponsePricing(policy);
   if (response.provider !== policy.expectedProvider) return false;
   if (response.model === policy.expectedModel) return true;
-  if (response.provider === 'anthropic') {
+  if (policy.modelResolutionPolicy === 'anthropic_dated_revision_v1' && response.provider === 'anthropic') {
     return resolveKnownClaudePricingModel(response.model) === policy.expectedModel;
   }
   return policy.modelResolutionPolicy === 'google_router_dated_revision_v1'

--- a/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { collectModelResponse, InvalidModelEventStreamError } from '../model-providers/events.js';
 import type { ModelFinishReason, ModelOutputSchema, ModelProvider, ModelProviderId, ModelReasoningEffort, ModelRequest, ModelResponse, ModelUsage } from '../model-providers/model-provider.js';
 import { datedPricingProfileIdentity, datedPricingProfilesForFixedTrace } from './dated-pricing-cohort.js';
-import { fixedTraceDirectFullSuiteResponsePricingPolicy, fixedTraceEstimatedCostUsd } from './fixed-trace-budget.js';
+import { fixedTraceDirectFullSuiteResponsePricingPolicy, fixedTraceEstimatedCostUsd, fixedTraceResponseUsesPricingPolicy } from './fixed-trace-budget.js';
 import { assertFixedTraceBlindedModelJudgePacket } from './fixed-trace-model-judge-control-plane.js';
 import { FIXED_TRACE_JUDGE_PROMPT_VERSION } from './fixed-trace-judge.js';
 import type { FixedTraceCompletedJudgeSummary } from './fixed-trace-judge.js';
@@ -280,8 +280,16 @@ export async function judgeFixedTraceDirectFullSuiteObservation(input: Readonly<
       ), stage.provider.id);
       const usage = snapshotUsage(response.usage);
       const parsed = response.finishReason === 'stop' ? verdict(text(response)) : null;
-      const identityExact = response.provider === stage.provider.id && response.model === stage.model;
-      const settled = dispatched && identityExact && usage !== null;
+      // This is deliberately the same full-suite-scoped policy that admits
+      // the provider boundary. A reviewed dated Anthropic receipt can settle
+      // only in this paid full-suite path; unknown and cross-family receipts
+      // remain fail-closed.
+      const responsePricingPolicy = fixedTraceDirectFullSuiteResponsePricingPolicy(
+        stage.provider.id,
+        stage.model,
+        stage.pricing,
+      );
+      const settled = dispatched && fixedTraceResponseUsesPricingPolicy(responsePricingPolicy, response) && usage !== null;
       results.push(Object.freeze({
         traceId: input.trace.id, judgeProvider, judgeModel: stage.model,
         status: !settled ? 'unknown_exposure' : !parsed ? 'malformed' : parsed.pass ? 'pass' : 'fail',

--- a/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { collectModelResponse, InvalidModelEventStreamError } from '../model-providers/events.js';
 import type { ModelFinishReason, ModelOutputSchema, ModelProvider, ModelProviderId, ModelReasoningEffort, ModelRequest, ModelResponse, ModelUsage } from '../model-providers/model-provider.js';
 import { datedPricingProfileIdentity, datedPricingProfilesForFixedTrace } from './dated-pricing-cohort.js';
-import { fixedTraceEstimatedCostUsd, fixedTraceResponsePricingPolicy } from './fixed-trace-budget.js';
+import { fixedTraceDirectFullSuiteResponsePricingPolicy, fixedTraceEstimatedCostUsd } from './fixed-trace-budget.js';
 import { assertFixedTraceBlindedModelJudgePacket } from './fixed-trace-model-judge-control-plane.js';
 import { FIXED_TRACE_JUDGE_PROMPT_VERSION } from './fixed-trace-judge.js';
 import type { FixedTraceCompletedJudgeSummary } from './fixed-trace-judge.js';
@@ -122,7 +122,7 @@ export function fixedTraceDirectFullSuiteJudgePlan(provider: ModelProviderId): F
   const model = judgeModel(provider);
   const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider && entry.model === model);
   if (!pricing) throw new Error('Fixed trace direct full-suite judge pricing is unavailable');
-  const policy = fixedTraceResponsePricingPolicy(provider, model, pricing);
+  const policy = fixedTraceDirectFullSuiteResponsePricingPolicy(provider, model, pricing);
   const base = {
     provider, model, reasoningEffort: 'provider_default' as const,
     maxOutputTokens: 300 as const, timeoutMs: 30_000 as const, maxIterations: 1 as const,

--- a/server/src/addie/eval/fixed-trace-direct-full-suite.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite.ts
@@ -7,7 +7,7 @@ import {
   FixedTraceBudget,
   type FixedTraceBudgetDiagnosticLease,
   claimFixedTraceBudgetDiagnosticLease,
-  fixedTraceResponsePricingPolicy,
+  fixedTraceDirectFullSuiteResponsePricingPolicy,
   isTrustedBudgetedFixedTraceProvider,
 } from './fixed-trace-budget.js';
 import { FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES, fixedTraceDirectFullSuiteJudgePlan, judgeFixedTraceDirectFullSuiteObservation, summarizeFixedTraceDirectFullSuiteJudgments, type FixedTraceDirectFullSuiteJudgment } from './fixed-trace-direct-full-suite-judge.js';
@@ -87,7 +87,7 @@ export function fixedTraceDirectFullSuiteStage(
     candidate.provider === cell.provider && candidate.model === cell.model
   ));
   if (!pricing || provider.id !== cell.provider) throw new Error('Fixed trace direct full-suite provider or pricing identity drift');
-  fixedTraceResponsePricingPolicy(cell.provider, cell.model, pricing);
+  fixedTraceDirectFullSuiteResponsePricingPolicy(cell.provider, cell.model, pricing);
   return Object.freeze({
     provider, model: cell.model, reasoningEffort: cell.effort, maxOutputTokens: 900,
     timeoutMs: 120_000, maxIterations: 12, transportRetries: 0,
@@ -155,7 +155,7 @@ function reservationComponent(input: Readonly<{
   maxOutputTokens: number;
   profile: DatedPricingProfile;
 }>): FixedTraceDirectFullSuiteCostComponent {
-  const policy = fixedTraceResponsePricingPolicy(input.provider, input.model, input.profile);
+  const policy = fixedTraceDirectFullSuiteResponsePricingPolicy(input.provider, input.model, input.profile);
   const tokens = input.inputByteUpperBound;
   const selectedSubset = [
     { category: 'input' as const, rate: input.profile.inputUsdPerMillionTokens },
@@ -192,7 +192,7 @@ export function fixedTraceDirectFullSuiteCostCeiling(cellId: FixedTraceDirectFul
   const profile = (provider: ModelProviderId, model: string) => {
     const result = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider && entry.model === model);
     if (!result) throw new Error('Fixed trace direct full-suite ceiling pricing is unavailable');
-    fixedTraceResponsePricingPolicy(provider, model, result);
+    fixedTraceDirectFullSuiteResponsePricingPolicy(provider, model, result);
     return result;
   };
   const candidate = profile(cell.provider, cell.model);
@@ -397,7 +397,7 @@ export function admitFixedTraceDirectFullSuiteComparison(input: Readonly<{
     || input.candidate.generation.maxOutputTokens !== 900
     || input.candidate.generation.maxIterations !== MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS
   ) throw new Error('Fixed trace direct full-suite candidate controls drift from the admitted cell');
-  const candidatePricingPolicy = fixedTraceResponsePricingPolicy(
+  const candidatePricingPolicy = fixedTraceDirectFullSuiteResponsePricingPolicy(
     input.candidate.generation.provider.id,
     input.candidate.generation.model,
     input.candidate.generation.pricing,
@@ -415,7 +415,7 @@ export function admitFixedTraceDirectFullSuiteComparison(input: Readonly<{
     if (!provider || provider.id !== judgeProvider) throw new Error('Fixed trace direct full-suite judge provider identity drift');
     const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === judgeProvider && entry.model === judgePlan.model);
     if (!pricing) throw new Error('Fixed trace direct full-suite judge pricing is unavailable');
-    const policy = fixedTraceResponsePricingPolicy(judgeProvider, judgePlan.model, pricing);
+    const policy = fixedTraceDirectFullSuiteResponsePricingPolicy(judgeProvider, judgePlan.model, pricing);
     if (!isTrustedBudgetedFixedTraceProvider(provider, input.budget, pricing, policy)) {
       throw new Error('Fixed trace direct full-suite judge requires an authenticated shared budget wrapper');
     }

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -39,6 +39,7 @@ import {
 } from './fixed-trace-tool-loop.js';
 import {
   FixedTraceBudgetAdmissionError,
+  fixedTraceDirectFullSuiteResponsePricingPolicy,
   fixedTraceEstimatedCostUsd,
   fixedTraceModelResolutionPolicy as fixedTraceBudgetModelResolutionPolicy,
   fixedTraceResponsePricingPolicy,
@@ -850,11 +851,15 @@ function validateStageConfig(name: string, config: FixedTraceProviderStageConfig
 export function fixedTraceModelResolutionPolicy(
   provider: ModelProvider['id'],
   model: string,
+  allowDatedAnthropicRevision = false,
 ): FixedTraceModelResolutionPolicy {
-  return fixedTraceBudgetModelResolutionPolicy(provider, model);
+  return fixedTraceBudgetModelResolutionPolicy(provider, model, allowDatedAnthropicRevision);
 }
 
-function cohortStageControl(config: FixedTraceProviderStageConfig): FixedTraceCohortStageControl {
+function cohortStageControl(
+  config: FixedTraceProviderStageConfig,
+  allowDatedAnthropicRevision = false,
+): FixedTraceCohortStageControl {
   return {
     requestedProvider: config.provider.id,
     requestedModel: config.model,
@@ -865,7 +870,7 @@ function cohortStageControl(config: FixedTraceProviderStageConfig): FixedTraceCo
     transportRetries: config.transportRetries,
     samplingMode: config.samplingMode,
     temperature: config.temperature,
-    modelResolutionPolicy: fixedTraceModelResolutionPolicy(config.provider.id, config.model),
+    modelResolutionPolicy: fixedTraceModelResolutionPolicy(config.provider.id, config.model, allowDatedAnthropicRevision),
     pricing: { ...config.pricing },
   };
 }
@@ -886,20 +891,28 @@ function modelResolution(
 ): 'exact' | 'provider_canonicalized' {
   if (response.model === config.model) return 'exact';
   // Preserve the provider-returned identity verbatim. Validation uses the
-  // fingerprinted policy to admit only the one reviewed Google revision form.
+  // fingerprinted policy to admit only reviewed provider revision forms.
   return 'provider_canonicalized';
 }
 
-/** The only non-literal returned model accepted by this diagnostic profile. */
+/** The only returned model identities accepted by this diagnostic profile. */
 function returnedModelUsesRecordedPricing(
   config: FixedTraceProviderStageConfig,
-  response: ModelResponse,
+  response: Pick<ModelResponse, 'provider' | 'model'>,
+  allowDatedAnthropicRevision = false,
 ): boolean {
-  return fixedTraceResponseUsesPricingPolicy(fixedTraceResponsePricingPolicy(
+  const policy = allowDatedAnthropicRevision
+    ? fixedTraceDirectFullSuiteResponsePricingPolicy(
+      config.provider.id,
+      config.model,
+      config.pricing,
+    )
+    : fixedTraceResponsePricingPolicy(
     config.provider.id,
     config.model,
     config.pricing,
-  ), response);
+    );
+  return fixedTraceResponseUsesPricingPolicy(policy, response);
 }
 
 function providerStageMetadata(
@@ -909,12 +922,13 @@ function providerStageMetadata(
   usage: ModelUsage,
   state: StageInvocationState,
   recordedExposures?: NonNullable<FixedTraceModelStageMetadata["providerExposures"]>,
+  allowDatedAnthropicRevision = false,
 ): FixedTraceModelStageMetadata {
   // Provider responses are outside evaluator ownership. Retaining their usage
   // object would let a later provider turn mutate already-recorded cost and
   // usage evidence after this case has completed.
   const recordedUsage = deepFreeze(structuredClone(usage));
-  const resolvedPricing = returnedModelUsesRecordedPricing(config, response);
+  const resolvedPricing = returnedModelUsesRecordedPricing(config, response, allowDatedAnthropicRevision);
   return {
     source: 'provider',
     dispatched: state.dispatched,
@@ -1142,7 +1156,7 @@ export function fixedTraceArchitectureConfigSha256(
       : fixedTraceExecutionEnvelopeProvenance(arm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, arm.id),
     routerControl: routerControlForConfig(config),
-    generationControl: cohortStageControl(config.generation),
+    generationControl: cohortStageControl(config.generation, isDirectFullSuiteComparison(config)),
     providerDegradationInjectionEnabled: config.injectProviderDegradation !== false,
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
     directModelScreenMode: config.directModelScreen?.mode ?? config.directFullSuiteComparison?.mode ?? null,
@@ -1286,7 +1300,7 @@ function baseMetadata(
     directArmAdmission: admission,
     caseControl: trace.caseControl ?? null,
     routerControl: routerControlForConfig(config),
-    generationControl: cohortStageControl(config.generation),
+    generationControl: cohortStageControl(config.generation, isDirectFullSuiteComparison(config)),
     router,
     generation,
   };
@@ -1350,7 +1364,13 @@ function fallbackOutput(status: FixedTraceTerminalStatus): string {
   return '';
 }
 
-/** This screen deliberately accepts no provider model alias or revision. */
+/**
+ * The older two-probe direct-screen diagnostic deliberately remains literal.
+ * The full-suite comparison instead validates returned identities with the
+ * same reviewed, fingerprinted pricing policy that settles their cost. Both
+ * retain a literal dispatch boundary, and the latter never admits arbitrary
+ * provider model names.
+ */
 function directModelScreenProviderExposuresMatch(
   config: FixedTraceRunnerConfig,
   exposures: readonly {
@@ -1360,11 +1380,17 @@ function directModelScreenProviderExposuresMatch(
     returnedModel: string;
   }[],
 ): boolean {
-  return (!isDirectModelScreen(config) && !isDirectFullSuiteComparison(config)) || exposures.every((exposure) => (
+  if (!isDirectModelScreen(config) && !isDirectFullSuiteComparison(config)) return true;
+  return exposures.every((exposure) => (
     exposure.preparedProvider === config.generation.provider.id
     && exposure.preparedModel === config.generation.model
-    && exposure.returnedProvider === config.generation.provider.id
-    && exposure.returnedModel === config.generation.model
+    && (isDirectFullSuiteComparison(config)
+      ? returnedModelUsesRecordedPricing(config.generation, {
+          provider: exposure.returnedProvider,
+          model: exposure.returnedModel,
+        }, true)
+      : exposure.returnedProvider === config.generation.provider.id
+        && exposure.returnedModel === config.generation.model)
   ));
 }
 
@@ -1722,13 +1748,20 @@ export async function runFixedTraceCase(
       result.usage,
       state,
       result.providerExposures,
+      isDirectFullSuiteComparison(executionConfig),
     );
-    const terminalStatus = hasCompleteReturnedProviderIdentities(
+    const completeProviderIdentities = hasCompleteReturnedProviderIdentities(
       state,
       undefined,
       result.providerExposures,
-    ) && returnedModelUsesRecordedPricing(generationConfig, result.response)
-      && directModelScreenProviderExposuresMatch(executionConfig, result.providerExposures)
+    );
+    const responseUsesRecordedPricing = returnedModelUsesRecordedPricing(
+      generationConfig,
+      result.response,
+      isDirectFullSuiteComparison(executionConfig),
+    );
+    const exposureIdentitiesMatch = directModelScreenProviderExposuresMatch(executionConfig, result.providerExposures);
+    const terminalStatus = completeProviderIdentities && responseUsesRecordedPricing && exposureIdentitiesMatch
       ? terminalStatusForFinishReason(result.response.finishReason, result.text)
       : 'unknown_exposure';
     return {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -8,7 +8,9 @@ import {
 } from './fixed-trace-architecture.js';
 import {
   fixedTraceEstimatedCostUsd,
+  fixedTraceDirectFullSuiteResponsePricingPolicy,
   fixedTraceModelResolutionPolicy,
+  fixedTraceResponseUsesPricingPolicy,
   fixedTraceResponsePricingPolicy,
   type FixedTraceBudgetPricing,
 } from './fixed-trace-budget.js';
@@ -278,11 +280,12 @@ export interface FixedTracePricing extends FixedTraceBudgetPricing {
 
 /**
  * A closed response-model policy. Most profiles require literal model identity;
- * the Google router profile is the one reviewed exception for its dated model
- * revisions. The policy is fingerprinted with the requested controls.
+ * the reviewed Anthropic and Google profiles accept only their provider's
+ * dated revisions. The policy is fingerprinted with the requested controls.
  */
 export type FixedTraceModelResolutionPolicy =
   | 'exact_model_identity_v1'
+  | 'anthropic_dated_revision_v1'
   | 'google_router_dated_revision_v1';
 
 /** Immutable requested settings for one stage in every member of a cohort. */
@@ -2640,9 +2643,13 @@ function cohortControlFailures(
     || (pricing.cacheReadAccounting !== 'unsupported' && pricing.cacheReadUsdPerMillionTokens === null)
     || (pricing.cacheWriteAccounting !== 'unsupported' && pricing.cacheWriteUsdPerMillionTokens === null)
   ) fail('configured_pricing_invalid');
-  if (!['exact_model_identity_v1', 'google_router_dated_revision_v1'].includes(control.modelResolutionPolicy)) {
+  if (!['exact_model_identity_v1', 'anthropic_dated_revision_v1', 'google_router_dated_revision_v1'].includes(control.modelResolutionPolicy)) {
     fail('configured_model_resolution_policy_invalid');
   }
+  if (
+    control.modelResolutionPolicy === 'anthropic_dated_revision_v1'
+    && control.requestedProvider !== 'anthropic'
+  ) fail('configured_model_resolution_policy_invalid');
   if (
     control.modelResolutionPolicy === 'google_router_dated_revision_v1'
     && (
@@ -2789,9 +2796,24 @@ function directFullSuiteMetadataFailures(trace: FixedTraceCase, metadata: FixedT
   if (!directFullSuiteGenerationCells.has(tuple) || control.configuredMaxOutputTokens !== 900
     || control.timeoutMs !== 120_000 || control.maxIterations !== 12 || control.transportRetries !== 0
     || control.samplingMode !== 'provider_no_sampling_control' || control.temperature !== null) fail('generation_control_invalid');
-  try { fixedTraceResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing); }
+  try { fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing); }
   catch { fail('generation_pricing_invalid'); }
   const generation = metadata.generation;
+  let returnedGenerationIdentityUsesPricing = false;
+  if (generation.returnedProvider !== null && generation.returnedModel !== null) {
+    try {
+      returnedGenerationIdentityUsesPricing = fixedTraceResponseUsesPricingPolicy(
+        fixedTraceDirectFullSuiteResponsePricingPolicy(
+          control.requestedProvider,
+          control.requestedModel,
+          control.pricing,
+        ),
+        { provider: generation.returnedProvider, model: generation.returnedModel },
+      );
+    } catch {
+      // Forged controls and unknown provider identities remain failures.
+    }
+  }
   const localSurface = ['ignore', 'react'].includes(trace.routing.action);
   if (localSurface) {
     if (generation.source !== 'not_run' || generation.dispatched || generation.dispatchedCalls !== 0
@@ -2800,13 +2822,24 @@ function directFullSuiteMetadataFailures(trace: FixedTraceCase, metadata: FixedT
       || generation.usageKnown || generation.usage !== null || generation.estimatedCostUsd !== 0) fail('local_surface_generation_invalid');
   } else if (generation.dispatched) {
     const exposures = generation.providerExposures;
-    if (generation.source !== 'provider' || generation.modelResolution !== 'exact'
+    if (generation.source !== 'provider'
       || generation.requestedProvider !== control.requestedProvider || generation.requestedModel !== control.requestedModel
-      || generation.returnedProvider !== control.requestedProvider || generation.returnedModel !== control.requestedModel
+      || !returnedGenerationIdentityUsesPricing
+      || generation.modelResolution !== (generation.returnedModel === control.requestedModel ? 'exact' : 'provider_canonicalized')
       || !Number.isSafeInteger(generation.dispatchedCalls) || (generation.dispatchedCalls ?? 0) < 1
       || !Array.isArray(exposures) || exposures.length !== (generation.dispatchedCalls ?? -1)
-      || exposures.some((entry, index) => entry.attempt !== index + 1 || entry.preparedProvider !== control.requestedProvider
-        || entry.preparedModel !== control.requestedModel || entry.returnedProvider !== control.requestedProvider || entry.returnedModel !== control.requestedModel)) fail('dispatched_generation_identity_invalid');
+      || exposures.some((entry, index) => {
+        if (entry.attempt !== index + 1 || entry.preparedProvider !== control.requestedProvider
+          || entry.preparedModel !== control.requestedModel) return true;
+        try {
+          return !fixedTraceResponseUsesPricingPolicy(
+            fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing),
+            { provider: entry.returnedProvider, model: entry.returnedModel },
+          );
+        } catch {
+          return true;
+        }
+      })) fail('dispatched_generation_identity_invalid');
   } else if (generation.source !== 'local' || generation.requestedProvider !== control.requestedProvider
     || generation.requestedModel !== control.requestedModel || generation.returnedProvider !== null || generation.returnedModel !== null
     || generation.modelResolution !== 'local' || generation.dispatchedCalls !== 0
@@ -2830,6 +2863,7 @@ function stageMetadataFailures(
   stage: FixedTraceModelStageMetadata,
   control: FixedTraceCohortStageControl | FixedTraceNotRunCohortStageControl,
   expectedEffectiveMaxOutputTokens: number | null,
+  allowDatedAnthropicRevision = false,
 ): string[] {
   const failures: string[] = [];
   const fail = (reason: string) => failures.push(`${stageName}_${reason}`);
@@ -2923,14 +2957,30 @@ function stageMetadataFailures(
     if (stage.modelResolution === null || stage.modelResolution === 'local') fail('model_resolution_invalid');
     if (stage.returnedProvider !== stage.requestedProvider) fail('provider_identity_mismatch');
     if (stage.modelResolution === 'exact' && stage.returnedModel !== stage.requestedModel) fail('exact_model_identity_mismatch');
-    if (stage.modelResolution === 'provider_canonicalized' && (
-      control.modelResolutionPolicy !== 'google_router_dated_revision_v1'
-      || stage.returnedProvider !== 'google'
-      || stage.requestedModel !== GOOGLE_ROUTER_MODEL
-      || stage.returnedModel === null
-      || !isGoogleRouterModelRevision(stage.returnedModel)
-      || stage.returnedModel === stage.requestedModel
-    )) fail('model_resolution_policy_mismatch');
+    if (stage.modelResolution === 'provider_canonicalized') {
+      let canonicalizedIdentityApproved = false;
+      if (control.modelResolutionPolicy === 'anthropic_dated_revision_v1'
+        && stage.returnedProvider === 'anthropic'
+        && stage.returnedModel !== null) {
+        try {
+          canonicalizedIdentityApproved = fixedTraceResponseUsesPricingPolicy(
+            allowDatedAnthropicRevision
+              ? fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing)
+              : fixedTraceResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing),
+            { provider: stage.returnedProvider, model: stage.returnedModel },
+          );
+        } catch {
+          // Forged controls and unknown provider identities remain failures.
+        }
+      } else if (control.modelResolutionPolicy === 'google_router_dated_revision_v1') {
+        canonicalizedIdentityApproved = stage.returnedProvider === 'google'
+          && stage.requestedModel === GOOGLE_ROUTER_MODEL
+          && stage.returnedModel !== null
+          && isGoogleRouterModelRevision(stage.returnedModel)
+          && stage.returnedModel !== stage.requestedModel;
+      }
+      if (!canonicalizedIdentityApproved) fail('model_resolution_policy_mismatch');
+    }
     if (stage.modelResolution === 'exact' && control.modelResolutionPolicy === 'exact_model_identity_v1' && stage.returnedModel !== control.requestedModel) {
       fail('model_resolution_policy_mismatch');
     }
@@ -3201,6 +3251,7 @@ function metadataFailures(
       'generation', metadata.generation, metadata.generationControl, metadata.generation.source === 'not_run'
         ? null
         : caseControl?.maxOutputTokens ?? metadata.generationControl.configuredMaxOutputTokens,
+      directModelScreenMode === 'direct_full_suite_model_comparison_v1',
     ));
   }
   return failures;

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -3,6 +3,7 @@ import {
   BudgetedFixedTraceProvider,
   FixedTraceBudget,
   FixedTraceBudgetAdmissionError,
+  fixedTraceDirectFullSuiteResponsePricingPolicy,
   fixedTraceEstimatedCostUsd,
   fixedTraceApprovedPricingProfiles,
   fixedTraceResponseUsesPricingPolicy,
@@ -153,11 +154,16 @@ describe('fixed trace provider budget', () => {
     const haikuPolicy = fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', HAIKU_4_5_PRICING);
     expect(haikuPolicy)
       .toMatchObject({ pricingProfileId: HAIKU_4_5_PRICING.profileId });
-    expect(fixedTraceResponseUsesPricingPolicy(haikuPolicy, {
+    const datedHaikuResponse = {
       ...RESPONSE,
       provider: 'anthropic',
       model: 'claude-haiku-4-5-20251001',
-    })).toBe(true);
+    } as const;
+    expect(fixedTraceResponseUsesPricingPolicy(haikuPolicy, datedHaikuResponse)).toBe(false);
+    expect(fixedTraceResponseUsesPricingPolicy(
+      fixedTraceDirectFullSuiteResponsePricingPolicy('anthropic', 'claude-haiku-4-5', HAIKU_4_5_PRICING),
+      datedHaikuResponse,
+    )).toBe(true);
     expect(fixedTraceEstimatedCostUsd({
       inputTokens: 100, outputTokens: 20, cacheReadTokens: 1_000, cacheWriteTokens: 200,
     }, HAIKU_4_5_PRICING)).toBe(0.00055);

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -162,6 +162,52 @@ describe('fixed-trace direct full-suite comparison', () => {
     expect(plan.judges).toEqual(expect.arrayContaining([expect.objectContaining({ provider: 'anthropic', reasoningEffort: 'provider_default', pricingProfileSha256: expect.stringMatching(/^sha256:/) })]));
   }, 30_000);
 
+  it('settles a reviewed dated Claude judge receipt while rejecting unreviewed and cross-family receipts', async () => {
+    const datedModel = 'claude-haiku-4-5-20251001';
+    const datedJudge = await run(
+      'generation:google:gemini-3.7-flash:high',
+      false,
+      {},
+      { anthropic: new FakeProvider('anthropic', false, { model: datedModel }) },
+    );
+    const datedJudgments = datedJudge.result.judgments.filter((entry) => entry.judgeProvider === 'anthropic');
+    expect(datedJudgments).toHaveLength(32);
+    expect(datedJudgments.every((entry) => entry.status === 'pass' && entry.exposure === 'settled')).toBe(true);
+    expect(datedJudgments.every((entry) => entry.returnedModel === datedModel && entry.estimatedCostUsd !== null)).toBe(true);
+    expect(datedJudge.budget.snapshot()).toMatchObject({ exposureUnknown: false });
+
+    const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === 'anthropic' && entry.model === 'claude-haiku-4-5')!;
+    const policy = fixedTraceDirectFullSuiteResponsePricingPolicy('anthropic', 'claude-haiku-4-5', pricing);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'anthropic', model: 'claude-unreviewed-20990101' })).toBe(false);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'google', model: 'gemini-3.7-flash' })).toBe(false);
+
+    const unreviewedJudge = await run(
+      'generation:google:gemini-3.7-flash:high',
+      false,
+      {},
+      { anthropic: new FakeProvider('anthropic', false, { model: 'claude-unreviewed-20990101' }) },
+    );
+    const rejected = unreviewedJudge.result.judgments.filter((entry) => entry.judgeProvider === 'anthropic');
+    expect(rejected[0]).toMatchObject({
+      status: 'unknown_exposure', exposure: 'unknown', estimatedCostUsd: null,
+      returnedProvider: 'anthropic', returnedModel: 'claude-unreviewed-20990101',
+    });
+    expect(rejected.slice(1).every((entry) => entry.status === 'not_dispatched_budget' && entry.exposure === 'not_dispatched')).toBe(true);
+    expect(unreviewedJudge.budget.snapshot()).toMatchObject({ exposureUnknown: true });
+
+    const crossFamilyJudge = await run(
+      'generation:google:gemini-3.7-flash:high',
+      false,
+      {},
+      { anthropic: new FakeProvider('anthropic', false, { provider: 'google', model: 'gemini-3.7-flash' }) },
+    );
+    expect(crossFamilyJudge.result.judgments.find((entry) => entry.judgeProvider === 'anthropic')).toMatchObject({
+      status: 'unknown_exposure', exposure: 'unknown', estimatedCostUsd: null,
+      returnedProvider: 'google', returnedModel: 'gemini-3.7-flash',
+    });
+    expect(crossFamilyJudge.budget.snapshot()).toMatchObject({ exposureUnknown: true });
+  }, 30_000);
+
   it('admits a dated Claude candidate identity only when it is approved by the recorded pricing policy', async () => {
     const datedModel = 'claude-haiku-4-5-20251001';
     const { budget, result } = await run(

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { ModelProvider, ModelProviderCapabilities, ModelProviderId, ModelRequest, ModelRespondOptions, ModelResponse, NormalizedModelEvent, PreparedModelInvocation } from '../../../src/addie/model-providers/model-provider.js';
-import { BudgetedFixedTraceProvider, FixedTraceBudget, fixedTraceEstimatedCostUsd, fixedTraceResponsePricingPolicy } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { BudgetedFixedTraceProvider, FixedTraceBudget, fixedTraceDirectFullSuiteResponsePricingPolicy, fixedTraceEstimatedCostUsd, fixedTraceResponseUsesPricingPolicy } from '../../../src/addie/eval/fixed-trace-budget.js';
 import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 import { FIXED_TRACE_DIRECT_FULL_SUITE_CELLS, admitFixedTraceDirectFullSuiteComparison, assertFixedTraceDirectFullSuiteCostCeiling, consumeFixedTraceDirectFullSuiteSelector, fixedTraceDirectFullSuiteAnthropicApiKey, fixedTraceDirectFullSuiteCell, fixedTraceDirectFullSuiteConfig, fixedTraceDirectFullSuiteCostCeiling, fixedTraceDirectFullSuitePlan, reserveFixedTraceDirectFullSuiteOutput, runFixedTraceDirectFullSuiteComparisonArtifact } from '../../../src/addie/eval/fixed-trace-direct-full-suite.js';
 import { FIXED_TRACE_SUITE, FIXED_TRACE_SUITE_VERSION, fixedTraceSuiteSha256 } from '../../../src/addie/eval/fixed-trace-suite.js';
@@ -43,7 +43,7 @@ class FakeProvider implements ModelProvider {
 
 function budgeted(provider: ModelProvider, model: string, budget: FixedTraceBudget): BudgetedFixedTraceProvider {
   const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.provider === provider.id && entry.model === model)!;
-  return new BudgetedFixedTraceProvider(provider, budget, pricing, fixedTraceResponsePricingPolicy(provider.id, model, pricing));
+  return new BudgetedFixedTraceProvider(provider, budget, pricing, fixedTraceDirectFullSuiteResponsePricingPolicy(provider.id, model, pricing));
 }
 
 async function run(
@@ -51,9 +51,10 @@ async function run(
   fail = false,
   judgeResponsePatch: Partial<ModelResponse> = {},
   judgeOverrides: Partial<Record<ModelProviderId, FakeProvider>> = {},
+  candidateResponsePatch: Partial<ModelResponse> = {},
 ) {
   const cell = fixedTraceDirectFullSuiteCell(cellId); const budget = new FixedTraceBudget(fixedTraceDirectFullSuiteCostCeiling(cellId).requiredSoftMaxUsd);
-  const rawCandidate = new FakeProvider(cell.provider, fail);
+  const rawCandidate = new FakeProvider(cell.provider, fail, candidateResponsePatch);
   const candidate = budgeted(rawCandidate, cell.model, budget);
   const rawJudges = {
     anthropic: judgeOverrides.anthropic ?? new FakeProvider('anthropic', false, judgeResponsePatch),
@@ -159,6 +160,41 @@ describe('fixed-trace direct full-suite comparison', () => {
     const plan = fixedTraceDirectFullSuitePlan({ cellId: 'generation:google:gemini-3.7-flash:high', sourceFiles: ['fixture.ts'], sourceBundleSha256: HASH, promptConfigVersion: HASH, softMaxUsd: 300 });
     expect(Object.isFrozen(plan)).toBe(true);
     expect(plan.judges).toEqual(expect.arrayContaining([expect.objectContaining({ provider: 'anthropic', reasoningEffort: 'provider_default', pricingProfileSha256: expect.stringMatching(/^sha256:/) })]));
+  }, 30_000);
+
+  it('admits a dated Claude candidate identity only when it is approved by the recorded pricing policy', async () => {
+    const datedModel = 'claude-haiku-4-5-20251001';
+    const { budget, result } = await run(
+      'generation:anthropic:claude-haiku-4-5:provider_default',
+      false,
+      {},
+      {},
+      { model: datedModel },
+    );
+    const providerObservations = result.observations.filter((observation) => observation.metadata.generation.source === 'provider');
+    expect(providerObservations).toHaveLength(30);
+    const control = providerObservations[0]!.metadata.generationControl;
+    expect(fixedTraceResponseUsesPricingPolicy(fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing), { provider: 'anthropic', model: datedModel })).toBe(true);
+    expect(providerObservations.every((observation) => observation.metadata.generation.returnedModel === datedModel)).toBe(true);
+    expect(providerObservations.every((observation) => observation.metadata.generation.modelResolution === 'provider_canonicalized')).toBe(true);
+    expect(providerObservations.map((observation) => observation.terminalStatus)).not.toContain('unknown_exposure');
+    expect(result.grades.filter((grade) => providerObservations.some((observation) => observation.traceId === grade.traceId))
+      .every((grade) => !grade.failures.includes('generation_model_resolution_policy_mismatch'))).toBe(true);
+    expect(budget.snapshot()).toMatchObject({ exposureUnknown: false });
+  }, 30_000);
+
+  it('continues to fail closed for an unreviewed Claude candidate identity', async () => {
+    const { result } = await run(
+      'generation:anthropic:claude-haiku-4-5:provider_default',
+      false,
+      {},
+      {},
+      { model: 'claude-unreviewed-20990101' },
+    );
+    const providerObservations = result.observations.filter((observation) => observation.metadata.generation.source === 'provider');
+    expect(providerObservations).toHaveLength(1);
+    expect(providerObservations[0]?.terminalStatus).toBe('unknown_exposure');
+    expect(result.observations).toHaveLength(32);
   }, 30_000);
 
   it('records the exact dispatch-boundary judge invocation rather than an earlier preparation', async () => {


### PR DESCRIPTION
Align fixed-trace runner and artifact validation with the reviewed Anthropic dated-revision pricing policy. Preserves exact dispatch identities and fails closed for unknown models.\n\nValidation: focused direct full-suite positive/negative identity regressions; fixed-trace metadata/budget/runner suites; typecheck.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
