### PR TITLE
fix(addie): scope direct suite runner pricing

### DIFF
--- a/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
+++ b/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
@@ -99,7 +99,15 @@ async function providerFor(id: 'anthropic' | 'google' | 'openai') {
 function budgetedProvider(provider: Awaited<ReturnType<typeof providerFor>>, model: string) {
   const pricing = pricingModule.datedPricingProfilesForFixedTrace().find((candidate) => candidate.provider === provider.id && candidate.model === model);
   if (!pricing) throw new Error('Current reviewed pricing is unavailable for selected provider identity');
-  return new budgetModule.BudgetedFixedTraceProvider(provider, budget, pricing, budgetModule.fixedTraceResponsePricingPolicy(provider.id, model, pricing));
+  // The real provider entry point is part of the explicit paid direct
+  // full-suite boundary, so it must use the same narrow dated-receipt policy
+  // as the evaluator. The generic policy intentionally remains exact.
+  return new budgetModule.BudgetedFixedTraceProvider(
+    provider,
+    budget,
+    pricing,
+    budgetModule.fixedTraceDirectFullSuiteResponsePricingPolicy(provider.id, model, pricing),
+  );
 }
 const rawCandidate = await providerFor(cell.provider);
 const rawJudges = Object.fromEntries(await Promise.all(cell.judgeProviders.map(async (id) => [id, await providerFor(id)]))) as Record<'anthropic' | 'google' | 'openai', Awaited<ReturnType<typeof providerFor>>>;

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const root = process.cwd();
 const tsx = realpathSync(resolve(root, 'node_modules/.bin/tsx'));
 
 describe('fixed-trace direct full-suite CLI', () => {
+  it('binds real provider calls to the explicit full-suite receipt policy', () => {
+    const source = readFileSync(resolve(root, 'server/tests/manual/fixed-trace-direct-full-suite-eval.ts'), 'utf8');
+    expect(source).toContain('fixedTraceDirectFullSuiteResponsePricingPolicy(provider.id, model, pricing)');
+    expect(source).not.toContain('fixedTraceResponsePricingPolicy(provider.id, model, pricing)');
+  });
+
   it('keeps validate-only provider-free and stdout to one exact JSON line', () => {
     const result = spawnSync(process.execPath, [
       tsx, 'server/tests/manual/fixed-trace-direct-full-suite-eval.ts', '--validate-only',


### PR DESCRIPTION
Routes the real paid direct-full-suite CLI wrapper through the already reviewed explicit full-suite receipt policy, preserving reviewed dated Anthropic aliases without broadening generic identity acceptance. Adds a CLI-boundary regression.\n\nValidation: focused CLI/direct-suite/budget tests (39), typecheck, diff check.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
