### PR TITLE
fix(addie): settle empty bounded Google responses

### DIFF
--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -325,7 +325,12 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
   if (candidate.content !== undefined && candidate.content.role !== 'model') {
     throw new Error('Malformed Google response role');
   }
-  if (finishReason !== 'refusal' && content.length < 1) throw new Error('Empty Google response output');
+  // A bounded reasoning turn can consume its complete output allowance before
+  // emitting visible text. It is still a settled MAX_TOKENS receipt, not an
+  // unknown provider exposure; retain its normalized usage and let the
+  // evaluator record the explicit truncated outcome. Empty STOP responses
+  // remain invalid.
+  if (finishReason !== 'refusal' && finishReason !== 'length' && content.length < 1) throw new Error('Empty Google response output');
 
   const hasToolCalls = content.some((item) => item.type === 'tool_call');
   if (hasToolCalls) {

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -548,6 +548,13 @@ describe('GoogleGenerateContentProvider', () => {
     expect(() => normalizeGoogleResponse(googleResponse({ candidates: [{ finishReason: 'STOP', content: { parts: [{ functionCall: { id: 'x', name: 'search_docs', args: [] } }] } }] }))).toThrow('Malformed Google function call');
     expect(() => normalizeGoogleResponse(googleResponse({ candidates: [{ finishReason: 'MAX_TOKENS', content: { role: 'model', parts: [{ functionCall: { id: 'x', name: 'search_docs', args: {} }, thoughtSignature: 'sig' }] } }] }))).toThrow('incompatible finish reason');
     expect(normalizeGoogleResponse(googleResponse({
+      candidates: [{ finishReason: 'MAX_TOKENS', content: { role: 'model', parts: [] } }],
+      usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 32, totalTokenCount: 36 },
+    }))).toMatchObject({ finishReason: 'length', content: [], usage: { inputTokens: 4, outputTokens: 32 } });
+    expect(() => normalizeGoogleResponse(googleResponse({
+      candidates: [{ finishReason: 'STOP', content: { role: 'model', parts: [] } }],
+    }))).toThrow('Empty Google response output');
+    expect(normalizeGoogleResponse(googleResponse({
       candidates: [],
       promptFeedback: { blockReason: 'SAFETY' },
       usageMetadata: { promptTokenCount: 4, totalTokenCount: 4 },


### PR DESCRIPTION
Treat a valid Google MAX_TOKENS response with no visible content as an explicit truncated receipt, preserving normalized usage and bounded fail-closed behavior for other empty outcomes.\n\nValidation: focused Google provider + fixed direct full-suite tests (55), typecheck, diff check.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
