### PR TITLE
fix(addie): retain safe fixed-trace failure diagnostics

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -1368,6 +1368,21 @@ function fallbackOutput(status: FixedTraceTerminalStatus): string {
 
 const FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES = 512;
 
+function boundedUtf8Prefix(value: string, maxBytes: number): string {
+  let byteLength = 0;
+  let end = 0;
+  // Iterate only until the byte budget is exhausted, preserving complete
+  // Unicode code points so the later UTF-8 encoding is always well-formed.
+  for (const codePoint of value) {
+    const value = codePoint.codePointAt(0)!;
+    const codePointBytes = value <= 0x7f ? 1 : value <= 0x7ff ? 2 : value <= 0xffff ? 3 : 4;
+    if (byteLength + codePointBytes > maxBytes) break;
+    byteLength += codePointBytes;
+    end += codePoint.length;
+  }
+  return value.slice(0, end);
+}
+
 /**
  * Error messages may contain provider-generated text, request fragments, or
  * credentials. Preserve only a fixed-width fingerprint of a bounded prefix
@@ -1382,7 +1397,7 @@ function fixedTraceFailureMessageSha256(error: unknown): string {
     // An exotic thrown value must not prevent fail-closed failure recording.
   }
   return createHash('sha256')
-    .update(Buffer.from(message, 'utf8').subarray(0, FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES))
+    .update(boundedUtf8Prefix(message, FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES), 'utf8')
     .digest('hex');
 }
 

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -18,7 +18,7 @@ import {
 } from '../router.js';
 import type { AddieTool } from '../types.js';
 import { buildModelToolDefinitions } from '../tool-wire-shape.js';
-import { collectModelResponse } from '../model-providers/events.js';
+import { InvalidModelEventStreamError, collectModelResponse } from '../model-providers/events.js';
 import type {
   ModelFinishReason,
   ModelMessage,
@@ -29,6 +29,7 @@ import type {
   ModelUsage,
   PreparedModelInvocation,
 } from '../model-providers/model-provider.js';
+import { UnexpectedModelIdentityError } from '../model-providers/model-provider.js';
 import {
   executeFixedTraceToolLoop,
   FixedTraceToolLoopBoundaryError,
@@ -85,6 +86,7 @@ import {
   fixedTraceSuiteSha256,
   type FixedTraceCase,
   type FixedTraceCohortStageControl,
+  type FixedTraceFailureDiagnostic,
   type FixedTraceModelResolutionPolicy,
   type FixedTraceModelStageMetadata,
   type FixedTraceObservation,
@@ -1364,6 +1366,66 @@ function fallbackOutput(status: FixedTraceTerminalStatus): string {
   return '';
 }
 
+const FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES = 512;
+
+/**
+ * Error messages may contain provider-generated text, request fragments, or
+ * credentials. Preserve only a fixed-width fingerprint of a bounded prefix
+ * so immutable evaluator evidence can correlate a failure without retaining
+ * provider contents.
+ */
+function fixedTraceFailureMessageSha256(error: unknown): string {
+  let message = '';
+  try {
+    if (error instanceof Error && typeof error.message === 'string') message = error.message;
+  } catch {
+    // An exotic thrown value must not prevent fail-closed failure recording.
+  }
+  return createHash('sha256')
+    .update(Buffer.from(message, 'utf8').subarray(0, FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES))
+    .digest('hex');
+}
+
+function fixedTraceFailureDiagnostic(
+  error: unknown,
+  timedOut: boolean,
+  dispatched: boolean,
+): FixedTraceFailureDiagnostic | null {
+  if (error instanceof FixedTraceBudgetAdmissionError || error instanceof FixedTraceToolLoopBoundaryError) return null;
+  if (timedOut && dispatched) {
+    return Object.freeze({
+      kind: 'provider_timeout',
+      reason: 'timeout_after_dispatch',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+    });
+  }
+  if (error instanceof InvalidModelEventStreamError) {
+    return Object.freeze({
+      kind: 'normalization_error',
+      reason: 'invalid_normalized_model_event',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+    });
+  }
+  if (error instanceof UnexpectedModelIdentityError) {
+    return Object.freeze({
+      kind: 'provider_identity_error',
+      reason: 'unexpected_model_identity',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+    });
+  }
+  return Object.freeze(error instanceof Error
+    ? {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        messageSha256: fixedTraceFailureMessageSha256(error),
+      }
+    : {
+        kind: 'provider_non_error_throw',
+        reason: 'non_error_throw',
+        messageSha256: fixedTraceFailureMessageSha256(error),
+      });
+}
+
 /**
  * The older two-probe direct-screen diagnostic deliberately remains literal.
  * The full-suite comparison instead validates returned identities with the
@@ -1417,6 +1479,7 @@ async function executeRouter(
   output: string;
   status: FixedTraceTerminalStatus | null;
   metadata: FixedTraceModelStageMetadata;
+  failureDiagnostic: FixedTraceFailureDiagnostic | null;
 }> {
   const request: ModelRequest = {
     ...buildRouterModelRequest({
@@ -1460,7 +1523,7 @@ async function executeRouter(
     const status = hasCompleteReturnedProviderIdentities(state, response)
       ? terminalStatusForFinishReason(response.finishReason, output)
       : 'unknown_exposure';
-    if (status !== 'complete') return { request, response, plan: null, output, status, metadata };
+    if (status !== 'complete') return { request, response, plan: null, output, status, metadata, failureDiagnostic: null };
     try {
       return {
         request,
@@ -1469,9 +1532,10 @@ async function executeRouter(
         output,
         status: null,
         metadata,
+        failureDiagnostic: null,
       };
     } catch {
-      return { request, response, plan: null, output, status: 'malformed', metadata };
+      return { request, response, plan: null, output, status: 'malformed', metadata, failureDiagnostic: null };
     }
   } catch (error) {
     if (error instanceof FixedTraceExecutionIdentityError || error instanceof FixedTracePreparationError) throw error;
@@ -1492,6 +1556,7 @@ async function executeRouter(
       output: fallbackOutput(terminalStatus),
       status: terminalStatus,
       metadata: localStageMetadata(request, config, state),
+      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched),
     };
   } finally {
     clearTimeout(timeout);
@@ -1554,6 +1619,7 @@ export async function runFixedTraceCase(
       routeDisposition: 'not_admitted',
       boundaryReason: null,
       localReplacementReason: null,
+      failureDiagnostic: null,
       finishReason: null,
       output: fallbackOutput('not_admitted_architecture'),
       flagged: true,
@@ -1588,6 +1654,7 @@ export async function runFixedTraceCase(
         output: '',
         status: null,
         metadata: notRunStageMetadata(executionTrace),
+        failureDiagnostic: null,
       }
     : architectureArm.id === 'oracle_route_diagnostic'
     ? {
@@ -1597,6 +1664,7 @@ export async function runFixedTraceCase(
         output: '',
         status: null,
         metadata: notRunStageMetadata(executionTrace),
+        failureDiagnostic: null,
       }
     : hybridDecision?.mode === 'local_terminal'
       ? {
@@ -1606,6 +1674,7 @@ export async function runFixedTraceCase(
           output: '',
           status: null,
           metadata: notRunStageMetadata(executionTrace),
+          failureDiagnostic: null,
         }
     : await executeRouter(
       executionTrace,
@@ -1623,6 +1692,7 @@ export async function runFixedTraceCase(
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
       boundaryReason: null,
       localReplacementReason: null,
+      failureDiagnostic: routed.failureDiagnostic,
       finishReason: routed.response?.finishReason ?? null,
       output: routed.output,
       flagged: true,
@@ -1645,6 +1715,7 @@ export async function runFixedTraceCase(
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
       boundaryReason: null,
       localReplacementReason: null,
+      failureDiagnostic: null,
       finishReason: null,
       output: '',
       flagged: false,
@@ -1691,6 +1762,7 @@ export async function runFixedTraceCase(
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
       boundaryReason: null,
       localReplacementReason: null,
+      failureDiagnostic: null,
       finishReason: null,
       output: fallbackOutput('provider_error'),
       flagged: true,
@@ -1772,6 +1844,7 @@ export async function runFixedTraceCase(
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
       boundaryReason: null,
       localReplacementReason: result.localReplacementReason ? 'failed_lookup_evidence' : null,
+      failureDiagnostic: null,
       finishReason: result.response.finishReason,
       output: result.text,
       flagged: result.localReplacementReason !== null || terminalStatus !== 'complete',
@@ -1820,6 +1893,7 @@ export async function runFixedTraceCase(
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
       boundaryReason: error instanceof FixedTraceToolLoopBoundaryError ? error.reason : null,
       localReplacementReason: null,
+      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched),
       finishReason: null,
       output: fallbackOutput(finalTerminalStatus),
       flagged: true,

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -107,6 +107,28 @@ export type FixedTraceBoundaryReason =
 export type FixedTraceLocalReplacementReason = 'failed_lookup_evidence';
 
 /**
+ * A bounded, non-secret classification of a caught evaluator provider failure.
+ * `messageSha256` fingerprints at most the evaluator-owned byte bound of the
+ * thrown message; raw provider text, requests, and artifacts are never kept.
+ */
+export interface FixedTraceFailureDiagnostic {
+  readonly kind:
+    | 'provider_transport_error'
+    | 'provider_timeout'
+    | 'normalization_error'
+    | 'provider_identity_error'
+    | 'provider_non_error_throw';
+  readonly reason:
+    | 'provider_exception'
+    | 'timeout_after_dispatch'
+    | 'invalid_normalized_model_event'
+    | 'unexpected_model_identity'
+    | 'non_error_throw';
+  /** SHA-256 of no more than 512 UTF-8 bytes; the message itself is omitted. */
+  readonly messageSha256: string;
+}
+
+/**
  * A deterministic, versioned trace-suite execution control. It is hashed with
  * the suite and is never caller-supplied by the runner.
  */
@@ -408,6 +430,8 @@ export interface FixedTraceObservation {
   boundaryReason: FixedTraceBoundaryReason | null;
   /** Reason provider prose was replaced locally after a completed generation, otherwise null. */
   localReplacementReason: FixedTraceLocalReplacementReason | null;
+  /** Present only for a caught provider/normalization failure; never raw provider detail. */
+  failureDiagnostic: FixedTraceFailureDiagnostic | null;
   finishReason: ModelFinishReason | null;
   output: string;
   flagged: boolean;

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -1209,10 +1209,14 @@ describe('fixed trace artifact runner', () => {
     });
   });
 
-  it('records a frozen, bounded non-secret transport diagnostic while closing unknown exposure', async () => {
+  it('bounds an extremely large provider error before fingerprinting without leaking raw content', async () => {
     const selectedTrace = trace('knowledge-task-model');
+    // The Euro sign does not fit in the two remaining byte-budget slots. The
+    // fingerprint must omit it entirely rather than include an invalid UTF-8
+    // byte fragment, and must never encode the 8 MiB provider-controlled tail.
+    const boundedPrefix = 'a'.repeat(510);
     const secret = 'synthetic-secret-token';
-    const errorMessage = `transport lost after provider artifact: ${selectedTrace.request.message}; authorization=${secret}; ${'x'.repeat(2_048)}`;
+    const errorMessage = `${boundedPrefix}\u20acprovider artifact; authorization=${secret}; ${'x'.repeat(8 * 1024 * 1024)}`;
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
     const delegate = new ScriptedProvider([new Error(errorMessage)]);
     const budget = new FixedTraceBudget(1);
@@ -1233,14 +1237,14 @@ describe('fixed trace artifact runner', () => {
         kind: 'provider_transport_error',
         reason: 'provider_exception',
         messageSha256: createHash('sha256')
-          .update(Buffer.from(errorMessage, 'utf8').subarray(0, 512))
+          .update(boundedPrefix, 'utf8')
           .digest('hex'),
       },
     });
     expect(Object.isFrozen(observation.failureDiagnostic)).toBe(true);
     expect(observation.failureDiagnostic?.messageSha256).toHaveLength(64);
     expect(serialized).not.toContain(secret);
-    expect(serialized).not.toContain(selectedTrace.request.message);
+    expect(serialized).not.toContain('\u20acprovider artifact');
     expect(serialized).not.toContain('provider artifact');
     expect(delegate.respondCalls).toHaveLength(1);
     expect(budget.snapshot()).toMatchObject({ dispatchedCalls: 1, exposureUnknown: true });

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -110,6 +110,19 @@ class ScriptedProvider implements ModelProvider {
   }
 }
 
+class InvalidNormalizedEventProvider extends ScriptedProvider {
+  override async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request);
+    await options.beforeDispatch?.(prepared);
+    this.respondCalls.push(structuredClone(request));
+    // Deliberately violate the normalized-stream contract after dispatch.
+    yield { type: 'text_delta', index: 0, text: 'untrusted provider contents' };
+  }
+}
+
 class DeferredBeforeDispatchProvider extends ScriptedProvider {
   private releaseDispatch!: () => void;
   private readonly dispatchReleased = new Promise<void>((resolve) => { this.releaseDispatch = resolve; });
@@ -719,6 +732,7 @@ describe('fixed trace artifact runner', () => {
       terminalStatus: 'unknown_exposure',
       finishReason: 'stop',
       flagged: true,
+      failureDiagnostic: null,
       metadata: {
         generation: {
           source: 'provider',
@@ -1193,6 +1207,67 @@ describe('fixed trace artifact runner', () => {
       deterministicPass: true,
       metadataPass: true,
     });
+  });
+
+  it('records a frozen, bounded non-secret transport diagnostic while closing unknown exposure', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const secret = 'synthetic-secret-token';
+    const errorMessage = `transport lost after provider artifact: ${selectedTrace.request.message}; authorization=${secret}; ${'x'.repeat(2_048)}`;
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const delegate = new ScriptedProvider([new Error(errorMessage)]);
+    const budget = new FixedTraceBudget(1);
+    const generation = new BudgetedFixedTraceProvider(
+      delegate,
+      budget,
+      stage(delegate, 3).pricing,
+      fixedTraceResponsePricingPolicy('anthropic', 'claude-haiku-4-5', stage(delegate, 3).pricing),
+    );
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const serialized = JSON.stringify(observation);
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        messageSha256: createHash('sha256')
+          .update(Buffer.from(errorMessage, 'utf8').subarray(0, 512))
+          .digest('hex'),
+      },
+    });
+    expect(Object.isFrozen(observation.failureDiagnostic)).toBe(true);
+    expect(observation.failureDiagnostic?.messageSha256).toHaveLength(64);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain(selectedTrace.request.message);
+    expect(serialized).not.toContain('provider artifact');
+    expect(delegate.respondCalls).toHaveLength(1);
+    expect(budget.snapshot()).toMatchObject({ dispatchedCalls: 1, exposureUnknown: true });
+    expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({ terminalFailure: true, deterministicPass: false });
+  });
+
+  it('classifies malformed normalized router events without dispatching generation', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const router = new InvalidNormalizedEventProvider([]);
+    const generation = new ScriptedProvider([]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'router',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'normalization_error',
+        reason: 'invalid_normalized_model_event',
+        messageSha256: createHash('sha256')
+          .update('Normalized event received before response_start', 'utf8')
+          .digest('hex'),
+      },
+    });
+    expect(Object.isFrozen(observation.failureDiagnostic)).toBe(true);
+    expect(generation.respondCalls).toHaveLength(0);
+    expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({ terminalFailure: true, deterministicPass: false });
   });
 
   it('keeps exact usage for a dispatched malformed tool turn', async () => {

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -240,6 +240,7 @@ function passingObservation(trace: FixedTraceCase): FixedTraceObservation {
     terminalStatus,
     boundaryReason: null,
     localReplacementReason: null,
+    failureDiagnostic: null,
     finishReason: terminalStatus === 'truncated' ? 'length' : terminalStatus === 'provider_error' ? null : 'stop',
     output: outputMarkers.join(' '),
     flagged: trace.expectation.requireFlagged ?? false,


### PR DESCRIPTION
## Summary
- retain a bounded SHA-256 fingerprint and category for caught evaluator provider failures
- preserve unknown exposure, budget closure, dispatch, retry, and grading behavior
- add regression coverage for redaction, byte bound, freezing, and normalized-stream errors

## Verification
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-runner.test.ts server/tests/unit/addie/fixed-trace-suite.test.ts` (136 passed)
- `npm run typecheck`

This is diagnostic evidence only. It stores no raw provider response, prompt, request, or secret, and does not alter existing artifacts.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
