### PR TITLE
fix(addie): record safe provider failure status

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -1368,6 +1368,67 @@ function fallbackOutput(status: FixedTraceTerminalStatus): string {
 
 const FIXED_TRACE_FAILURE_MESSAGE_MAX_BYTES = 512;
 
+/**
+ * Caught values are provider-controlled. In particular, a revoked proxy can
+ * throw while `instanceof` asks it for its prototype, so every catch-path
+ * classification must be fail-closed.
+ */
+function isFixedTraceBudgetAdmissionError(error: unknown): error is FixedTraceBudgetAdmissionError {
+  try {
+    return error instanceof FixedTraceBudgetAdmissionError;
+  } catch {
+    return false;
+  }
+}
+
+function isFixedTraceToolLoopBoundaryError(error: unknown): error is FixedTraceToolLoopBoundaryError {
+  try {
+    return error instanceof FixedTraceToolLoopBoundaryError;
+  } catch {
+    return false;
+  }
+}
+
+function isFixedTraceExecutionIdentityError(error: unknown): error is FixedTraceExecutionIdentityError {
+  try {
+    return error instanceof FixedTraceExecutionIdentityError;
+  } catch {
+    return false;
+  }
+}
+
+function isFixedTracePreparationError(error: unknown): error is FixedTracePreparationError {
+  try {
+    return error instanceof FixedTracePreparationError;
+  } catch {
+    return false;
+  }
+}
+
+function isInvalidModelEventStreamError(error: unknown): error is InvalidModelEventStreamError {
+  try {
+    return error instanceof InvalidModelEventStreamError;
+  } catch {
+    return false;
+  }
+}
+
+function isUnexpectedModelIdentityError(error: unknown): error is UnexpectedModelIdentityError {
+  try {
+    return error instanceof UnexpectedModelIdentityError;
+  } catch {
+    return false;
+  }
+}
+
+function isError(error: unknown): error is Error {
+  try {
+    return error instanceof Error;
+  } catch {
+    return false;
+  }
+}
+
 function boundedUtf8Prefix(value: string, maxBytes: number): string {
   let byteLength = 0;
   let end = 0;
@@ -1392,7 +1453,7 @@ function boundedUtf8Prefix(value: string, maxBytes: number): string {
 function fixedTraceFailureMessageSha256(error: unknown): string {
   let message = '';
   try {
-    if (error instanceof Error && typeof error.message === 'string') message = error.message;
+    if (isError(error) && typeof error.message === 'string') message = error.message;
   } catch {
     // An exotic thrown value must not prevent fail-closed failure recording.
   }
@@ -1425,7 +1486,7 @@ function fixedTraceFailureDiagnostic(
   timedOut: boolean,
   dispatched: boolean,
 ): FixedTraceFailureDiagnostic | null {
-  if (error instanceof FixedTraceBudgetAdmissionError || error instanceof FixedTraceToolLoopBoundaryError) return null;
+  if (isFixedTraceBudgetAdmissionError(error) || isFixedTraceToolLoopBoundaryError(error)) return null;
   if (timedOut && dispatched) {
     return Object.freeze({
       kind: 'provider_timeout',
@@ -1433,21 +1494,21 @@ function fixedTraceFailureDiagnostic(
       messageSha256: fixedTraceFailureMessageSha256(error),
     });
   }
-  if (error instanceof InvalidModelEventStreamError) {
+  if (isInvalidModelEventStreamError(error)) {
     return Object.freeze({
       kind: 'normalization_error',
       reason: 'invalid_normalized_model_event',
       messageSha256: fixedTraceFailureMessageSha256(error),
     });
   }
-  if (error instanceof UnexpectedModelIdentityError) {
+  if (isUnexpectedModelIdentityError(error)) {
     return Object.freeze({
       kind: 'provider_identity_error',
       reason: 'unexpected_model_identity',
       messageSha256: fixedTraceFailureMessageSha256(error),
     });
   }
-  if (error instanceof Error) {
+  if (isError(error)) {
     const httpStatus = fixedTraceFailureHttpStatus(error);
     return Object.freeze({
       kind: 'provider_transport_error',
@@ -1575,10 +1636,10 @@ async function executeRouter(
       return { request, response, plan: null, output, status: 'malformed', metadata, failureDiagnostic: null };
     }
   } catch (error) {
-    if (error instanceof FixedTraceExecutionIdentityError || error instanceof FixedTracePreparationError) throw error;
-    if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
+    if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
+    if (isFixedTraceBudgetAdmissionError(error)) invocations.push(error.prepared);
     const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
-    const status = error instanceof FixedTraceBudgetAdmissionError
+    const status = isFixedTraceBudgetAdmissionError(error)
       ? 'not_dispatched_budget'
       : timedOut && dispatched
         ? 'timeout_after_dispatch'
@@ -1890,14 +1951,14 @@ export async function runFixedTraceCase(
       rejectedToolCalls: [],
     };
   } catch (error) {
-    if (error instanceof FixedTraceExecutionIdentityError || error instanceof FixedTracePreparationError) throw error;
-    if (error instanceof FixedTraceBudgetAdmissionError) invocations.push(error.prepared);
-    const checkpoint = error instanceof FixedTraceToolLoopBoundaryError
+    if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
+    if (isFixedTraceBudgetAdmissionError(error)) invocations.push(error.prepared);
+    const checkpoint = isFixedTraceToolLoopBoundaryError(error)
       ? error.checkpoint
       : undefined;
-    const terminalStatus = error instanceof FixedTraceBudgetAdmissionError
+    const terminalStatus = isFixedTraceBudgetAdmissionError(error)
       ? 'not_dispatched_budget'
-      : error instanceof FixedTraceToolLoopBoundaryError
+      : isFixedTraceToolLoopBoundaryError(error)
       ? 'malformed'
       : timedOut && dispatched
         ? 'timeout_after_dispatch'
@@ -1928,7 +1989,7 @@ export async function runFixedTraceCase(
       terminalStage: 'generation',
       terminalStatus: finalTerminalStatus,
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
-      boundaryReason: error instanceof FixedTraceToolLoopBoundaryError ? error.reason : null,
+      boundaryReason: isFixedTraceToolLoopBoundaryError(error) ? error.reason : null,
       localReplacementReason: null,
       failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched),
       finishReason: null,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -37,6 +37,8 @@ import {
   validateFixedTraceToolLoopEnvironment,
   validateFixedTraceToolLoopFixtures,
   type FixedTraceEvaluatorToolEnvironment,
+  type FixedTraceToolLoopCheckpoint,
+  type FixedTraceToolLoopReason,
 } from './fixed-trace-tool-loop.js';
 import {
   FixedTraceBudgetAdmissionError,
@@ -45,6 +47,7 @@ import {
   fixedTraceModelResolutionPolicy as fixedTraceBudgetModelResolutionPolicy,
   fixedTraceResponsePricingPolicy,
   fixedTraceResponseUsesPricingPolicy,
+  type FixedTraceBudgetRejectionReason,
 } from './fixed-trace-budget.js';
 import {
   FIXED_TRACE_DIRECT_TOOL_UNIVERSE,
@@ -1389,6 +1392,154 @@ function isFixedTraceToolLoopBoundaryError(error: unknown): error is FixedTraceT
   }
 }
 
+type FixedTraceBudgetAdmission = Readonly<{
+  prepared: PreparedModelInvocation;
+}>;
+
+type FixedTraceToolLoopBoundary = Readonly<{
+  reason: FixedTraceToolLoopReason;
+  checkpoint: FixedTraceToolLoopCheckpoint | undefined;
+}>;
+
+const FIXED_TRACE_PROVIDER_IDS = new Set<ModelProvider['id']>(['anthropic', 'openai', 'google']);
+const FIXED_TRACE_REASONING_EFFORTS = new Set<ModelReasoningEffort>([
+  'provider_default', 'none', 'low', 'medium', 'high',
+]);
+const FIXED_TRACE_BUDGET_REJECTION_REASONS = new Set<FixedTraceBudgetRejectionReason>([
+  'budget_exposure_unknown', 'soft_limit_exceeded',
+]);
+const FIXED_TRACE_TOOL_LOOP_REASONS = new Set<FixedTraceToolLoopReason>([
+  'duplicate_tool_definition', 'duplicate_tool_call', 'fixture_definition_mismatch',
+  'iteration_limit_exceeded', 'preexisting_tool_state', 'provider_tool_not_allowed',
+  'provider_continuation_not_allowed', 'tool_call_limit_exceeded', 'tool_input_invalid',
+  'tool_schema_invalid', 'unknown_tool_call',
+]);
+const FIXED_TRACE_TOOL_RESULT_STATUSES = new Set([
+  'ok', 'empty', 'access_denied', 'invalid_input', 'recoverable_error', 'error',
+]);
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isSafeTokenCount(value: unknown): boolean {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isModelUsage(value: unknown): value is ModelUsage {
+  if (!isPlainRecord(value) || !isSafeTokenCount(value.inputTokens) || !isSafeTokenCount(value.outputTokens)) {
+    return false;
+  }
+  return (value.cacheReadTokens === undefined || isSafeTokenCount(value.cacheReadTokens))
+    && (value.cacheWriteTokens === undefined || isSafeTokenCount(value.cacheWriteTokens));
+}
+
+function isPreparedModelInvocation(value: unknown): value is PreparedModelInvocation {
+  if (!isPlainRecord(value)
+    || !FIXED_TRACE_PROVIDER_IDS.has(value.provider as ModelProvider['id'])
+    || typeof value.model !== 'string'
+    || !value.model.trim()
+    || !isPlainRecord(value.capabilities)
+    || !isPlainRecord(value.providerRequest)) return false;
+  const capabilities = value.capabilities;
+  if (
+    typeof capabilities.streaming !== 'boolean'
+    || typeof capabilities.structuredOutput !== 'boolean'
+    || typeof capabilities.reasoning !== 'boolean'
+    || !Array.isArray(capabilities.reasoningEfforts)
+    || capabilities.reasoningEfforts.some((effort) => !FIXED_TRACE_REASONING_EFFORTS.has(effort as ModelReasoningEffort))
+    || typeof capabilities.customTools !== 'boolean'
+    || typeof capabilities.providerWebSearch !== 'boolean'
+    || typeof capabilities.imageInput !== 'boolean'
+    || typeof capabilities.documentInput !== 'boolean'
+  ) return false;
+  if (value.requestMetadata !== undefined) {
+    if (!isPlainRecord(value.requestMetadata) || Object.values(value.requestMetadata).some((entry) => (
+      typeof entry !== 'string' && typeof entry !== 'number' && typeof entry !== 'boolean'
+    ))) return false;
+  }
+  return true;
+}
+
+function isFixedTraceToolExecution(value: unknown): boolean {
+  if (!isPlainRecord(value)
+    || !Number.isSafeInteger(value.sequence) || (value.sequence as number) < 1
+    || typeof value.callId !== 'string' || !value.callId.trim()
+    || typeof value.transcriptSha256 !== 'string' || !/^[a-f0-9]{64}$/.test(value.transcriptSha256)
+    || typeof value.name !== 'string' || !value.name.trim()
+    || typeof value.description !== 'string'
+    || !isPlainRecord(value.input)
+    || (value.effect !== 'read' && value.effect !== 'preview' && value.effect !== 'mutation')
+    || (value.policyDisposition !== 'allowed' && value.policyDisposition !== 'blocked')
+    || !FIXED_TRACE_TOOL_RESULT_STATUSES.has(value.resultStatus as string)
+    || typeof value.simulated !== 'boolean'
+  ) return false;
+  return true;
+}
+
+function isFixedTraceRejectedToolCall(value: unknown): boolean {
+  return isPlainRecord(value)
+    && typeof value.name === 'string'
+    && value.name.trim().length > 0
+    && FIXED_TRACE_TOOL_LOOP_REASONS.has(value.reason as FixedTraceToolLoopReason);
+}
+
+function isFixedTraceProviderExposure(value: unknown): boolean {
+  return isPlainRecord(value)
+    && Number.isSafeInteger(value.attempt)
+    && (value.attempt as number) >= 1
+    && FIXED_TRACE_PROVIDER_IDS.has(value.preparedProvider as ModelProvider['id'])
+    && typeof value.preparedModel === 'string'
+    && value.preparedModel.trim().length > 0
+    && FIXED_TRACE_PROVIDER_IDS.has(value.returnedProvider as ModelProvider['id'])
+    && typeof value.returnedModel === 'string'
+    && value.returnedModel.trim().length > 0;
+}
+
+function isFixedTraceToolLoopCheckpoint(value: unknown): value is FixedTraceToolLoopCheckpoint {
+  return isPlainRecord(value)
+    && isModelUsage(value.usage)
+    && Array.isArray(value.tools)
+    && value.tools.every(isFixedTraceToolExecution)
+    && Array.isArray(value.rejectedToolCalls)
+    && value.rejectedToolCalls.every(isFixedTraceRejectedToolCall)
+    && Array.isArray(value.providerExposures)
+    && value.providerExposures.every(isFixedTraceProviderExposure);
+}
+
+/**
+ * An internal error can be wrapped in a provider-controlled proxy. Take an
+ * owned snapshot while reading its fields so later observation construction
+ * never dereferences the caught value. Any inaccessible or malformed field
+ * deliberately loses its internal-error privilege.
+ */
+function snapshotFixedTraceBudgetAdmission(error: unknown): FixedTraceBudgetAdmission | null {
+  if (!isFixedTraceBudgetAdmissionError(error)) return null;
+  try {
+    const reason = error.reason;
+    const prepared = structuredClone(error.prepared);
+    if (!FIXED_TRACE_BUDGET_REJECTION_REASONS.has(reason) || !isPreparedModelInvocation(prepared)) return null;
+    return Object.freeze({ prepared });
+  } catch {
+    return null;
+  }
+}
+
+function snapshotFixedTraceToolLoopBoundary(error: unknown): FixedTraceToolLoopBoundary | null {
+  if (!isFixedTraceToolLoopBoundaryError(error)) return null;
+  try {
+    const reason = error.reason;
+    const checkpoint = error.checkpoint === undefined ? undefined : structuredClone(error.checkpoint);
+    if (!FIXED_TRACE_TOOL_LOOP_REASONS.has(reason)
+      || (checkpoint !== undefined && !isFixedTraceToolLoopCheckpoint(checkpoint))) return null;
+    return Object.freeze({ reason, checkpoint });
+  } catch {
+    return null;
+  }
+}
+
 function isFixedTraceExecutionIdentityError(error: unknown): error is FixedTraceExecutionIdentityError {
   try {
     return error instanceof FixedTraceExecutionIdentityError;
@@ -1485,8 +1636,9 @@ function fixedTraceFailureDiagnostic(
   error: unknown,
   timedOut: boolean,
   dispatched: boolean,
+  recognizedInternalError = false,
 ): FixedTraceFailureDiagnostic | null {
-  if (isFixedTraceBudgetAdmissionError(error) || isFixedTraceToolLoopBoundaryError(error)) return null;
+  if (recognizedInternalError) return null;
   if (timedOut && dispatched) {
     return Object.freeze({
       kind: 'provider_timeout',
@@ -1637,9 +1789,11 @@ async function executeRouter(
     }
   } catch (error) {
     if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
-    if (isFixedTraceBudgetAdmissionError(error)) invocations.push(error.prepared);
+    const budgetAdmission = snapshotFixedTraceBudgetAdmission(error);
+    const toolLoopBoundary = snapshotFixedTraceToolLoopBoundary(error);
+    if (budgetAdmission) invocations.push(budgetAdmission.prepared);
     const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
-    const status = isFixedTraceBudgetAdmissionError(error)
+    const status = budgetAdmission
       ? 'not_dispatched_budget'
       : timedOut && dispatched
         ? 'timeout_after_dispatch'
@@ -1654,7 +1808,7 @@ async function executeRouter(
       output: fallbackOutput(terminalStatus),
       status: terminalStatus,
       metadata: localStageMetadata(request, config, state),
-      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched),
+      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched, Boolean(budgetAdmission || toolLoopBoundary)),
     };
   } finally {
     clearTimeout(timeout);
@@ -1952,13 +2106,13 @@ export async function runFixedTraceCase(
     };
   } catch (error) {
     if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
-    if (isFixedTraceBudgetAdmissionError(error)) invocations.push(error.prepared);
-    const checkpoint = isFixedTraceToolLoopBoundaryError(error)
-      ? error.checkpoint
-      : undefined;
-    const terminalStatus = isFixedTraceBudgetAdmissionError(error)
+    const budgetAdmission = snapshotFixedTraceBudgetAdmission(error);
+    const toolLoopBoundary = snapshotFixedTraceToolLoopBoundary(error);
+    if (budgetAdmission) invocations.push(budgetAdmission.prepared);
+    const checkpoint = toolLoopBoundary?.checkpoint;
+    const terminalStatus = budgetAdmission
       ? 'not_dispatched_budget'
-      : isFixedTraceToolLoopBoundaryError(error)
+      : toolLoopBoundary
       ? 'malformed'
       : timedOut && dispatched
         ? 'timeout_after_dispatch'
@@ -1989,9 +2143,9 @@ export async function runFixedTraceCase(
       terminalStage: 'generation',
       terminalStatus: finalTerminalStatus,
       routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
-      boundaryReason: isFixedTraceToolLoopBoundaryError(error) ? error.reason : null,
+      boundaryReason: toolLoopBoundary?.reason ?? null,
       localReplacementReason: null,
-      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched),
+      failureDiagnostic: fixedTraceFailureDiagnostic(error, timedOut, dispatched, Boolean(budgetAdmission || toolLoopBoundary)),
       finishReason: null,
       output: fallbackOutput(finalTerminalStatus),
       flagged: true,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -1401,6 +1401,25 @@ function fixedTraceFailureMessageSha256(error: unknown): string {
     .digest('hex');
 }
 
+/**
+ * Preserve only a conventional, valid HTTP status from a caught provider
+ * exception. Provider error objects are untrusted, including accessors, so a
+ * hostile property read is treated as absent evidence.
+ */
+function fixedTraceFailureHttpStatus(error: Error): number | undefined {
+  for (const key of ['status', 'statusCode'] as const) {
+    try {
+      const value = (error as Error & Record<string, unknown>)[key];
+      if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) {
+        return value;
+      }
+    } catch {
+      // A provider-defined getter must not change the terminal failure path.
+    }
+  }
+  return undefined;
+}
+
 function fixedTraceFailureDiagnostic(
   error: unknown,
   timedOut: boolean,
@@ -1428,17 +1447,20 @@ function fixedTraceFailureDiagnostic(
       messageSha256: fixedTraceFailureMessageSha256(error),
     });
   }
-  return Object.freeze(error instanceof Error
-    ? {
-        kind: 'provider_transport_error',
-        reason: 'provider_exception',
-        messageSha256: fixedTraceFailureMessageSha256(error),
-      }
-    : {
-        kind: 'provider_non_error_throw',
-        reason: 'non_error_throw',
-        messageSha256: fixedTraceFailureMessageSha256(error),
-      });
+  if (error instanceof Error) {
+    const httpStatus = fixedTraceFailureHttpStatus(error);
+    return Object.freeze({
+      kind: 'provider_transport_error',
+      reason: 'provider_exception',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+      ...(httpStatus === undefined ? {} : { httpStatus }),
+    });
+  }
+  return Object.freeze({
+    kind: 'provider_non_error_throw',
+    reason: 'non_error_throw',
+    messageSha256: fixedTraceFailureMessageSha256(error),
+  });
 }
 
 /**

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -126,6 +126,8 @@ export interface FixedTraceFailureDiagnostic {
     | 'non_error_throw';
   /** SHA-256 of no more than 512 UTF-8 bytes; the message itself is omitted. */
   readonly messageSha256: string;
+  /** Validated HTTP status from a caught provider exception, when safely available. */
+  readonly httpStatus?: number;
 }
 
 /**

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -15,8 +15,10 @@ import { runFixedTraceDiagnosticCandidate } from '../../../src/addie/eval/fixed-
 import {
   BudgetedFixedTraceProvider,
   FixedTraceBudget,
+  FixedTraceBudgetAdmissionError,
   fixedTraceResponsePricingPolicy,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { FixedTraceToolLoopBoundaryError } from '../../../src/addie/eval/fixed-trace-tool-loop.js';
 import {
   FIXED_TRACE_SUITE,
   FIXED_TRACE_HYBRID_EVALUATOR_SUITE,
@@ -1172,6 +1174,77 @@ describe('fixed trace artifact runner', () => {
     });
     expect(delegate.respondCalls).toHaveLength(0);
     expect(gradeFixedTrace(trace('knowledge-task-model'), observation).metadataPass).toBe(true);
+  });
+
+  it('fails closed when a budget-admission error proxy hides its prepared receipt', async () => {
+    const prepared: PreparedModelInvocation = {
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      capabilities: CAPABILITIES,
+      providerRequest: {},
+    };
+    const hostile = new Proxy(
+      new FixedTraceBudgetAdmissionError('soft_limit_exceeded', prepared),
+      { get: () => { throw new Error('hostile budget-admission field access'); } },
+    );
+    expect(hostile).toBeInstanceOf(FixedTraceBudgetAdmissionError);
+
+    const observation = await runFixedTraceCase(
+      trace('knowledge-task-model'),
+      config(new ThrowingProvider(hostile), new ScriptedProvider([])),
+    );
+
+    expect(observation).toMatchObject({
+      terminalStage: 'router',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+      },
+    });
+    expect(gradeFixedTrace(trace('knowledge-task-model'), observation)).toMatchObject({
+      terminalFailure: true,
+      deterministicPass: false,
+    });
+  });
+
+  it('fails closed when a tool-loop boundary error proxy hides its checkpoint receipt', async () => {
+    const hostile = new Proxy(
+      new FixedTraceToolLoopBoundaryError('iteration_limit_exceeded', {
+        usage: { inputTokens: 0, outputTokens: 0 },
+        tools: [],
+        rejectedToolCalls: [],
+        providerExposures: [],
+      }),
+      { get: () => { throw new Error('hostile tool-loop-boundary field access'); } },
+    );
+    expect(hostile).toBeInstanceOf(FixedTraceToolLoopBoundaryError);
+
+    const observation = await runFixedTraceCase(
+      trace('knowledge-task-model'),
+      config(
+        new ScriptedProvider([routeResponse('respond', ['knowledge'])]),
+        new ThrowingProvider(hostile),
+      ),
+    );
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      boundaryReason: null,
+      tools: [],
+      rejectedToolCalls: [],
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+      },
+    });
+    expect(gradeFixedTrace(trace('knowledge-task-model'), observation)).toMatchObject({
+      terminalFailure: true,
+      deterministicPass: false,
+    });
   });
 
   it('attributes malformed router output to the router and preserves its cost', async () => {

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -111,6 +111,22 @@ class ScriptedProvider implements ModelProvider {
   }
 }
 
+class ThrowingProvider extends ScriptedProvider {
+  constructor(private readonly thrown: unknown) {
+    super([]);
+  }
+
+  override async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request);
+    await options.beforeDispatch?.(prepared);
+    this.respondCalls.push(structuredClone(request));
+    throw this.thrown;
+  }
+}
+
 class InvalidNormalizedEventProvider extends ScriptedProvider {
   override async *respond(
     request: ModelRequest,
@@ -1332,6 +1348,59 @@ describe('fixed trace artifact runner', () => {
     });
     expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
     expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('fails closed for a hostile Error proxy without reading diagnostics', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const secret = 'synthetic-hostile-error-secret';
+    const hostileError = new Proxy(Object.assign(new Error(secret), { status: 503 }), {
+      getPrototypeOf: () => { throw new Error('hostile prototype access'); },
+      get: () => { throw new Error('hostile diagnostic access'); },
+    });
+    const generation = new ThrowingProvider(hostileError);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const serialized = JSON.stringify(observation);
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_non_error_throw',
+        reason: 'non_error_throw',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+      },
+    });
+    expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    expect(serialized).not.toContain(secret);
+    expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('fails closed for a revoked Error proxy', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const secret = 'synthetic-revoked-error-secret';
+    const { proxy, revoke } = Proxy.revocable(Object.assign(new Error(secret), { status: 429 }), {});
+    revoke();
+    const router = new ThrowingProvider(proxy);
+    const generation = new ScriptedProvider([]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const serialized = JSON.stringify(observation);
+
+    expect(observation).toMatchObject({
+      terminalStage: 'router',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_non_error_throw',
+        reason: 'non_error_throw',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+      },
+    });
+    expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    expect(serialized).not.toContain(secret);
+    expect(router.respondCalls).toHaveLength(1);
+    expect(generation.respondCalls).toHaveLength(0);
   });
 
   it('classifies malformed normalized router events without dispatching generation', async () => {

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { ApiError } from '@google/genai';
 import Ajv from 'ajv';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -1249,6 +1250,88 @@ describe('fixed trace artifact runner', () => {
     expect(delegate.respondCalls).toHaveLength(1);
     expect(budget.snapshot()).toMatchObject({ dispatchedCalls: 1, exposureUnknown: true });
     expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({ terminalFailure: true, deterministicPass: false });
+  });
+
+  it('retains only a valid HTTP status from caught provider exceptions', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const providerError = Object.assign(new ApiError({
+      message: 'provider response body: synthetic-secret-token',
+      status: 429,
+    }), {
+      statusCode: 503,
+      body: 'provider response body: synthetic-secret-token',
+      headers: { authorization: 'synthetic-secret-token' },
+      name: 'provider-error-with-details',
+      stack: 'provider stack: synthetic-secret-token',
+    });
+    const generation = new ScriptedProvider([providerError]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const serialized = JSON.stringify(observation);
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        httpStatus: 429,
+      },
+    });
+    expect(serialized).not.toContain('synthetic-secret-token');
+    expect(serialized).not.toContain('provider response body');
+    expect(serialized).not.toContain('provider-error-with-details');
+    expect(serialized).not.toContain('provider stack');
+  });
+
+  it.each([
+    ['statusCode alias', 'statusCode', 503, 503],
+    ['string', 'status', '503', undefined],
+    ['fractional', 'status', 503.5, undefined],
+    ['below HTTP range', 'status', 99, undefined],
+    ['above HTTP range', 'status', 600, undefined],
+  ] as const)('handles %s provider status values safely', async (_description, key, value, expectedStatus) => {
+    const selectedTrace = trace('knowledge-task-model');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const providerError = Object.defineProperty(new Error('provider failure'), key, {
+      value,
+      enumerable: true,
+    });
+    const generation = new ScriptedProvider([providerError]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: { kind: 'provider_transport_error', reason: 'provider_exception' },
+    });
+    if (expectedStatus === undefined) {
+      expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    } else {
+      expect(observation.failureDiagnostic).toMatchObject({ httpStatus: expectedStatus });
+    }
+  });
+
+  it('fails safe when provider status getters throw', async () => {
+    const selectedTrace = trace('knowledge-task-model');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const providerError = Object.defineProperties(new Error('provider failure'), {
+      status: { get: () => { throw new Error('provider status getter'); }, enumerable: true },
+      statusCode: { get: () => { throw new Error('provider status code getter'); }, enumerable: true },
+    });
+    const generation = new ScriptedProvider([providerError]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: { kind: 'provider_transport_error', reason: 'provider_exception' },
+    });
+    expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    expect(generation.respondCalls).toHaveLength(1);
   });
 
   it('classifies malformed normalized router events without dispatching generation', async () => {


### PR DESCRIPTION
## Summary
- record only validated HTTP status (100–599) for caught fixed-trace provider exceptions
- keep the existing bounded/redacted error fingerprint and reject hostile/non-numeric statuses
- add regression coverage for status/statusCode extraction and hostile values

## Verification
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-runner.test.ts`
- `npx tsc --project server/tsconfig.json --noEmit`

No provider, retry, budget, grading, cap, or artifact-write behavior changes.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
