### PR TITLE
fix(addie): classify bounded Gemini failures

### DIFF
--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -1642,14 +1642,17 @@ function fixedTraceFailureDiagnostic(
   recognizedInternalError = false,
 ): FixedTraceFailureDiagnostic | null {
   if (recognizedInternalError) return null;
-  const adapterFailure = modelProviderAdapterFailure(error);
   if (timedOut && dispatched) {
     return Object.freeze({
       kind: 'provider_timeout',
       reason: 'timeout_after_dispatch',
-      messageSha256: fixedTraceFailureMessageSha256(error),
+      // A timeout is terminal without consulting a provider-owned rejection.
+      // Keep its fingerprint deterministic without dereferencing an untrusted
+      // thrown value.
+      messageSha256: fixedTraceFailureMessageSha256(undefined),
     });
   }
+  const adapterFailure = modelProviderAdapterFailure(error);
   if (isInvalidModelEventStreamError(error)) {
     return Object.freeze({
       kind: 'normalization_error',
@@ -1809,6 +1812,21 @@ async function executeRouter(
       return { request, response, plan: null, output, status: 'malformed', metadata, failureDiagnostic: null };
     }
   } catch (error) {
+    if (timedOut && dispatched) {
+      const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
+      const terminalStatus = hasCompleteReturnedProviderIdentities(state)
+        ? 'timeout_after_dispatch'
+        : 'unknown_exposure';
+      return {
+        request,
+        response: null,
+        plan: null,
+        output: fallbackOutput(terminalStatus),
+        status: terminalStatus,
+        metadata: localStageMetadata(request, config, state),
+        failureDiagnostic: fixedTraceFailureDiagnostic(undefined, true, true),
+      };
+    }
     if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
     const budgetAdmission = snapshotFixedTraceBudgetAdmission(error);
     const toolLoopBoundary = snapshotFixedTraceToolLoopBoundary(error);
@@ -2126,6 +2144,34 @@ export async function runFixedTraceCase(
       rejectedToolCalls: [],
     };
   } catch (error) {
+    if (timedOut && dispatched) {
+      const state = {
+        invocations,
+        dispatched,
+        dispatchedCalls,
+        latencyMs: Date.now() - startedAt,
+      };
+      const finalTerminalStatus = hasCompleteReturnedProviderIdentities(state)
+        ? 'timeout_after_dispatch'
+        : 'unknown_exposure';
+      const generation = localStageMetadata(generationRequest, generationConfig, state);
+      return {
+        traceId: executionTrace.id,
+        metadata: baseMetadata(executionTrace, executionConfig, toolSchemaSha256, routed.metadata, generation),
+        terminalStage: 'generation',
+        terminalStatus: finalTerminalStatus,
+        routeDisposition: routeDisposition(architectureArm.id, hybridDecision?.mode === 'local_terminal'),
+        boundaryReason: null,
+        localReplacementReason: null,
+        failureDiagnostic: fixedTraceFailureDiagnostic(undefined, true, true),
+        finishReason: null,
+        output: fallbackOutput(finalTerminalStatus),
+        flagged: true,
+        route,
+        tools: [],
+        rejectedToolCalls: [],
+      };
+    }
     if (isFixedTraceExecutionIdentityError(error) || isFixedTracePreparationError(error)) throw error;
     const budgetAdmission = snapshotFixedTraceBudgetAdmission(error);
     const toolLoopBoundary = snapshotFixedTraceToolLoopBoundary(error);

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -29,7 +29,10 @@ import type {
   ModelUsage,
   PreparedModelInvocation,
 } from '../model-providers/model-provider.js';
-import { UnexpectedModelIdentityError } from '../model-providers/model-provider.js';
+import {
+  modelProviderAdapterFailure,
+  UnexpectedModelIdentityError,
+} from '../model-providers/model-provider.js';
 import {
   executeFixedTraceToolLoop,
   FixedTraceToolLoopBoundaryError,
@@ -1639,6 +1642,7 @@ function fixedTraceFailureDiagnostic(
   recognizedInternalError = false,
 ): FixedTraceFailureDiagnostic | null {
   if (recognizedInternalError) return null;
+  const adapterFailure = modelProviderAdapterFailure(error);
   if (timedOut && dispatched) {
     return Object.freeze({
       kind: 'provider_timeout',
@@ -1651,6 +1655,23 @@ function fixedTraceFailureDiagnostic(
       kind: 'normalization_error',
       reason: 'invalid_normalized_model_event',
       messageSha256: fixedTraceFailureMessageSha256(error),
+    });
+  }
+  if (adapterFailure?.kind === 'adapter_response_normalization') {
+    return Object.freeze({
+      kind: 'adapter_response_error',
+      reason: 'adapter_response_normalization',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+      origin: adapterFailure.kind,
+    });
+  }
+  if (adapterFailure?.kind === 'provider_transport') {
+    return Object.freeze({
+      kind: 'provider_transport_error',
+      reason: 'provider_exception',
+      messageSha256: fixedTraceFailureMessageSha256(error),
+      origin: adapterFailure.kind,
+      ...(adapterFailure.httpStatus === undefined ? {} : { httpStatus: adapterFailure.httpStatus }),
     });
   }
   if (isUnexpectedModelIdentityError(error)) {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -116,16 +116,20 @@ export interface FixedTraceFailureDiagnostic {
     | 'provider_transport_error'
     | 'provider_timeout'
     | 'normalization_error'
+    | 'adapter_response_error'
     | 'provider_identity_error'
     | 'provider_non_error_throw';
   readonly reason:
     | 'provider_exception'
     | 'timeout_after_dispatch'
     | 'invalid_normalized_model_event'
+    | 'adapter_response_normalization'
     | 'unexpected_model_identity'
     | 'non_error_throw';
   /** SHA-256 of no more than 512 UTF-8 bytes; the message itself is omitted. */
   readonly messageSha256: string;
+  /** Adapter-controlled failure boundary, when the adapter established one. */
+  readonly origin?: 'provider_transport' | 'adapter_response_normalization';
   /** Validated HTTP status from a caught provider exception, when safely available. */
   readonly httpStatus?: number;
 }

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -18,7 +18,10 @@ import type {
   NormalizedModelEvent,
   PreparedModelInvocation,
 } from './model-provider.js';
-import { UnexpectedModelIdentityError } from './model-provider.js';
+import {
+  markModelProviderAdapterFailure,
+  UnexpectedModelIdentityError,
+} from './model-provider.js';
 import { assertPlainJson, validateModelCapabilities } from './capabilities.js';
 import { validateNormalizedModelResponse } from './events.js';
 
@@ -66,6 +69,22 @@ function assertSafeCount(value: unknown, label: string): asserts value is number
   if (!Number.isSafeInteger(value) || (value as number) < 0) {
     throw new Error(`Malformed Google ${label}`);
   }
+}
+
+/** Read only a conventional HTTP receipt from an untrusted SDK exception. */
+function googleTransportHttpStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  for (const key of ['status', 'statusCode'] as const) {
+    try {
+      const value = (error as Record<string, unknown>)[key];
+      if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) {
+        return value;
+      }
+    } catch {
+      // An SDK or proxy getter is not receipt evidence.
+    }
+  }
+  return undefined;
 }
 
 function textOnly(content: ModelMessageContent[], label: string): string {
@@ -428,11 +447,25 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     const prepared = this.prepare(request);
     if (options.signal?.aborted) throw options.signal.reason;
     await options.beforeDispatch?.(prepared);
-    const response = await this.transport.models.generateContent(
-      prepared.providerRequest as unknown as GenerateContentParameters,
-      { signal: options.signal },
-    );
-    const normalized = normalizeGoogleResponse(response);
+    let response: GenerateContentResponse;
+    try {
+      response = await this.transport.models.generateContent(
+        prepared.providerRequest as unknown as GenerateContentParameters,
+        { signal: options.signal },
+      );
+    } catch (error) {
+      // Do not expose provider error fields here. The runner receives only an
+      // adapter-owned boundary marker and its own bounded fingerprint.
+      markModelProviderAdapterFailure(error, 'provider_transport', googleTransportHttpStatus(error));
+      throw error;
+    }
+    let normalized: ModelResponse;
+    try {
+      normalized = normalizeGoogleResponse(response);
+    } catch (error) {
+      markModelProviderAdapterFailure(error, 'adapter_response_normalization');
+      throw error;
+    }
     if (!isGoogleRouterModelRevision(normalized.model)) {
       throw new UnexpectedModelIdentityError('google', request.model, normalized.model);
     }

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -461,6 +461,12 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     } catch (error) {
       // Do not expose provider error fields here. The runner receives a
       // constant-message adapter error plus the only safe receipt field.
+      // A post-dispatch abort is terminal. Do not inspect a provider-owned
+      // rejection in that case: even descriptor inspection can invoke a
+      // hostile proxy trap before the runner can record its timeout.
+      if (options.signal?.aborted) {
+        throw createModelProviderAdapterError('provider_transport');
+      }
       throw createModelProviderAdapterError(
         'provider_transport',
         googleTransportHttpStatus(error),

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -19,7 +19,7 @@ import type {
   PreparedModelInvocation,
 } from './model-provider.js';
 import {
-  markModelProviderAdapterFailure,
+  createModelProviderAdapterError,
   UnexpectedModelIdentityError,
 } from './model-provider.js';
 import { assertPlainJson, validateModelCapabilities } from './capabilities.js';
@@ -76,12 +76,17 @@ function googleTransportHttpStatus(error: unknown): number | undefined {
   if (typeof error !== 'object' || error === null) return undefined;
   for (const key of ['status', 'statusCode'] as const) {
     try {
-      const value = (error as Record<string, unknown>)[key];
+      // A data descriptor lets us reject accessors without invoking them. A
+      // proxy that prevents descriptor inspection is likewise absent evidence.
+      const descriptor = Object.getOwnPropertyDescriptor(error, key);
+      if (!descriptor || !('value' in descriptor)) continue;
+      const value = descriptor.value;
       if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) {
         return value;
       }
     } catch {
-      // An SDK or proxy getter is not receipt evidence.
+      // An SDK proxy is not receipt evidence.
+      return undefined;
     }
   }
   return undefined;
@@ -454,17 +459,18 @@ export class GoogleGenerateContentProvider implements ModelProvider {
         { signal: options.signal },
       );
     } catch (error) {
-      // Do not expose provider error fields here. The runner receives only an
-      // adapter-owned boundary marker and its own bounded fingerprint.
-      markModelProviderAdapterFailure(error, 'provider_transport', googleTransportHttpStatus(error));
-      throw error;
+      // Do not expose provider error fields here. The runner receives a
+      // constant-message adapter error plus the only safe receipt field.
+      throw createModelProviderAdapterError(
+        'provider_transport',
+        googleTransportHttpStatus(error),
+      );
     }
     let normalized: ModelResponse;
     try {
       normalized = normalizeGoogleResponse(response);
-    } catch (error) {
-      markModelProviderAdapterFailure(error, 'adapter_response_normalization');
-      throw error;
+    } catch {
+      throw createModelProviderAdapterError('adapter_response_normalization');
     }
     if (!isGoogleRouterModelRevision(normalized.model)) {
       throw new UnexpectedModelIdentityError('google', request.model, normalized.model);

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -7,6 +7,55 @@
  */
 
 export type ModelProviderId = 'anthropic' | 'openai' | 'google';
+export type ModelProviderAdapterFailureKind =
+  | 'provider_transport'
+  | 'adapter_response_normalization';
+
+export interface ModelProviderAdapterFailure {
+  readonly kind: ModelProviderAdapterFailureKind;
+  readonly httpStatus?: number;
+}
+
+// Keep the raw caught value out of the public error shape. Evaluators can
+// classify the adapter-owned boundary through this private identity binding
+// without serializing a provider body, message, or credential.
+const adapterFailures = new WeakMap<object, ModelProviderAdapterFailure>();
+
+export function markModelProviderAdapterFailure(
+  error: unknown,
+  kind: ModelProviderAdapterFailureKind,
+  httpStatus?: number,
+): void {
+  if (typeof error !== 'object' || error === null) return;
+  try {
+    const validHttpStatus = typeof httpStatus === 'number'
+      && Number.isInteger(httpStatus)
+      && httpStatus >= 100
+      && httpStatus <= 599
+      ? httpStatus
+      : undefined;
+    adapterFailures.set(error, Object.freeze({
+      kind,
+      ...(validHttpStatus === undefined ? {} : { httpStatus: validHttpStatus }),
+    }));
+  } catch {
+    // A revoked proxy cannot carry an adapter marker. It remains an unknown,
+    // fail-closed provider throw at the evaluator boundary.
+  }
+}
+
+/**
+ * Returns only an adapter-controlled category. It intentionally never reads
+ * properties from a provider-thrown value, which may be a hostile proxy.
+ */
+export function modelProviderAdapterFailure(error: unknown): ModelProviderAdapterFailure | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  try {
+    return adapterFailures.get(error);
+  } catch {
+    return undefined;
+  }
+}
 export type ModelFallbackReason =
   | 'primary_unavailable'
   | 'primary_rate_limited'

--- a/server/src/addie/model-providers/model-provider.ts
+++ b/server/src/addie/model-providers/model-provider.ts
@@ -16,42 +16,60 @@ export interface ModelProviderAdapterFailure {
   readonly httpStatus?: number;
 }
 
-// Keep the raw caught value out of the public error shape. Evaluators can
-// classify the adapter-owned boundary through this private identity binding
-// without serializing a provider body, message, or credential.
-const adapterFailures = new WeakMap<object, ModelProviderAdapterFailure>();
+/** The only message an adapter failure is allowed to expose to evaluators. */
+export const MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE = 'Model provider adapter failure';
 
-export function markModelProviderAdapterFailure(
-  error: unknown,
-  kind: ModelProviderAdapterFailureKind,
-  httpStatus?: number,
-): void {
-  if (typeof error !== 'object' || error === null) return;
-  try {
-    const validHttpStatus = typeof httpStatus === 'number'
-      && Number.isInteger(httpStatus)
-      && httpStatus >= 100
-      && httpStatus <= 599
-      ? httpStatus
-      : undefined;
-    adapterFailures.set(error, Object.freeze({
+function validHttpStatus(value: unknown): number | undefined {
+  return typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= 100
+    && value <= 599
+    ? value
+    : undefined;
+}
+
+// The caught provider value must never escape the adapter. Keeping the safe
+// classification in a private field also prevents it from becoming artifact
+// data through Error serialization.
+class ModelProviderAdapterError extends Error {
+  readonly #failure: ModelProviderAdapterFailure;
+
+  constructor(
+    kind: ModelProviderAdapterFailureKind,
+    httpStatus?: number,
+  ) {
+    super(MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE);
+    this.name = 'ModelProviderAdapterError';
+    const safeHttpStatus = validHttpStatus(httpStatus);
+    this.#failure = Object.freeze({
       kind,
-      ...(validHttpStatus === undefined ? {} : { httpStatus: validHttpStatus }),
-    }));
-  } catch {
-    // A revoked proxy cannot carry an adapter marker. It remains an unknown,
-    // fail-closed provider throw at the evaluator boundary.
+      ...(safeHttpStatus === undefined ? {} : { httpStatus: safeHttpStatus }),
+    });
+  }
+
+  failure(): ModelProviderAdapterFailure {
+    return this.#failure;
   }
 }
 
 /**
- * Returns only an adapter-controlled category. It intentionally never reads
- * properties from a provider-thrown value, which may be a hostile proxy.
+ * Creates an adapter-owned error without preserving the caught provider value
+ * or any provider-controlled diagnostic text.
+ */
+export function createModelProviderAdapterError(
+  kind: ModelProviderAdapterFailureKind,
+  httpStatus?: number,
+): Error {
+  return new ModelProviderAdapterError(kind, httpStatus);
+}
+
+/**
+ * Returns only adapter-owned metadata. Provider-thrown values cannot carry
+ * this marker, and hostile proxies are treated as unclassified.
  */
 export function modelProviderAdapterFailure(error: unknown): ModelProviderAdapterFailure | undefined {
-  if (typeof error !== 'object' || error === null) return undefined;
   try {
-    return adapterFailures.get(error);
+    return error instanceof ModelProviderAdapterError ? error.failure() : undefined;
   } catch {
     return undefined;
   }

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -57,9 +57,15 @@ import type {
   PreparedModelInvocation,
 } from '../../../src/addie/model-providers/model-provider.js';
 import {
-  markModelProviderAdapterFailure,
+  createModelProviderAdapterError,
+  MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE,
   UnsupportedModelCapabilityError,
 } from '../../../src/addie/model-providers/model-provider.js';
+import {
+  GOOGLE_ROUTER_MODEL,
+  GoogleGenerateContentProvider,
+  type GoogleGenerateContentTransport,
+} from '../../../src/addie/model-providers/google-generate-content-provider.js';
 import type { AddieTool } from '../../../src/addie/types.js';
 
 const HASH = createHash('sha256').update('fixed-trace-runner-test').digest('hex');
@@ -129,6 +135,21 @@ class ThrowingProvider extends ScriptedProvider {
     await options.beforeDispatch?.(prepared);
     this.respondCalls.push(structuredClone(request));
     throw this.thrown;
+  }
+}
+
+class AdapterTimeoutProvider extends ScriptedProvider {
+  override async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request);
+    await options.beforeDispatch?.(prepared);
+    this.respondCalls.push(structuredClone(request));
+    await new Promise<void>((resolve) => {
+      options.signal?.addEventListener('abort', resolve, { once: true });
+    });
+    throw createModelProviderAdapterError('provider_transport', 504);
   }
 }
 
@@ -1377,14 +1398,25 @@ describe('fixed trace artifact runner', () => {
     expect(serialized).not.toContain('provider stack');
   });
 
-  it('records adapter-established transport provenance without retaining provider details', async () => {
+  it('hashes only the Google adapter message when an SDK error contains a provider body', async () => {
     const selectedTrace = trace('bounded-truncation');
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
-    const providerError = new Error('synthetic provider body must not be retained');
-    markModelProviderAdapterFailure(providerError, 'provider_transport', 400);
-    const generation = new ThrowingProvider(providerError);
+    const secret = 'synthetic-sdk-provider-body-secret';
+    const generateContent = vi.fn().mockRejectedValue(new ApiError({
+      message: `Google SDK error: {"error":{"message":"${secret}"}}`,
+      status: 429,
+    }));
+    const generation = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    } satisfies GoogleGenerateContentTransport);
 
-    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: {
+        ...stage(generation, 3),
+        model: GOOGLE_ROUTER_MODEL,
+        reasoningEffort: 'provider_default',
+      },
+    }));
 
     expect(observation).toMatchObject({
       terminalStage: 'generation',
@@ -1393,21 +1425,36 @@ describe('fixed trace artifact runner', () => {
         kind: 'provider_transport_error',
         reason: 'provider_exception',
         origin: 'provider_transport',
-        httpStatus: 400,
+        httpStatus: 429,
+        messageSha256: createHash('sha256')
+          .update(MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE, 'utf8')
+          .digest('hex'),
       },
     });
-    expect(JSON.stringify(observation)).not.toContain('synthetic provider body');
-    expect(generation.respondCalls).toHaveLength(1);
+    expect(JSON.stringify(observation)).not.toContain(secret);
+    expect(generateContent).toHaveBeenCalledOnce();
   });
 
   it('records adapter response normalization as a distinct safe failure category', async () => {
     const selectedTrace = trace('bounded-truncation');
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
-    const adapterError = new Error('synthetic malformed provider payload');
-    markModelProviderAdapterFailure(adapterError, 'adapter_response_normalization');
-    const generation = new ThrowingProvider(adapterError);
+    const generateContent = vi.fn().mockResolvedValue({
+      responseId: 'google_1',
+      modelVersion: GOOGLE_ROUTER_MODEL,
+      candidates: [],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+    });
+    const generation = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    } satisfies GoogleGenerateContentTransport);
 
-    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: {
+        ...stage(generation, 3),
+        model: GOOGLE_ROUTER_MODEL,
+        reasoningEffort: 'provider_default',
+      },
+    }));
 
     expect(observation).toMatchObject({
       terminalStage: 'generation',
@@ -1416,24 +1463,30 @@ describe('fixed trace artifact runner', () => {
         kind: 'adapter_response_error',
         reason: 'adapter_response_normalization',
         origin: 'adapter_response_normalization',
+        messageSha256: createHash('sha256')
+          .update(MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE, 'utf8')
+          .digest('hex'),
       },
     });
-    expect(JSON.stringify(observation)).not.toContain('synthetic malformed provider payload');
-    expect(generation.respondCalls).toHaveLength(1);
+    expect(generateContent).toHaveBeenCalledOnce();
   });
 
-  it('retains an adapter marker from a hostile provider proxy without reading its details', async () => {
+  it('classifies a sanitized primitive Google rejection as provider transport', async () => {
     const selectedTrace = trace('bounded-truncation');
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
-    const secret = 'synthetic-hostile-marked-provider-secret';
-    const hostile = new Proxy(Object.assign(new Error(secret), { status: 400 }), {
-      get: () => { throw new Error('hostile marked provider property'); },
-      getPrototypeOf: () => { throw new Error('hostile marked provider prototype'); },
-    });
-    markModelProviderAdapterFailure(hostile, 'provider_transport');
-    const generation = new ThrowingProvider(hostile);
+    const secret = 'synthetic-primitive-provider-secret';
+    const generateContent = vi.fn().mockRejectedValue(secret);
+    const generation = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    } satisfies GoogleGenerateContentTransport);
 
-    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: {
+        ...stage(generation, 3),
+        model: GOOGLE_ROUTER_MODEL,
+        reasoningEffort: 'provider_default',
+      },
+    }));
 
     expect(observation).toMatchObject({
       terminalStage: 'generation',
@@ -1442,10 +1495,35 @@ describe('fixed trace artifact runner', () => {
         kind: 'provider_transport_error',
         reason: 'provider_exception',
         origin: 'provider_transport',
-        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+        messageSha256: createHash('sha256')
+          .update(MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE, 'utf8')
+          .digest('hex'),
       },
     });
     expect(JSON.stringify(observation)).not.toContain(secret);
+    expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    expect(generateContent).toHaveBeenCalledOnce();
+  });
+
+  it('keeps timeout classification ahead of a sanitized adapter transport error', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const generation = new AdapterTimeoutProvider([]);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: { ...stage(generation, 3), timeoutMs: 1 },
+    }));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_timeout',
+        reason: 'timeout_after_dispatch',
+      },
+    });
+    expect(observation.failureDiagnostic).not.toHaveProperty('origin');
+    expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
     expect(generation.respondCalls).toHaveLength(1);
   });
 

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -153,25 +153,6 @@ class AdapterTimeoutProvider extends ScriptedProvider {
   }
 }
 
-class HostileTimeoutProvider extends ScriptedProvider {
-  constructor(private readonly thrown: unknown) {
-    super([]);
-  }
-
-  override async *respond(
-    request: ModelRequest,
-    options: ModelRespondOptions = {},
-  ): AsyncIterable<NormalizedModelEvent> {
-    const prepared = this.prepare(request);
-    await options.beforeDispatch?.(prepared);
-    this.respondCalls.push(structuredClone(request));
-    await new Promise<void>((resolve) => {
-      options.signal?.addEventListener('abort', resolve, { once: true });
-    });
-    throw this.thrown;
-  }
-}
-
 class InvalidNormalizedEventProvider extends ScriptedProvider {
   override async *respond(
     request: ModelRequest,
@@ -1546,7 +1527,7 @@ describe('fixed trace artifact runner', () => {
     expect(generation.respondCalls).toHaveLength(1);
   });
 
-  it('does not inspect a hostile provider rejection after dispatch timeout', async () => {
+  it('does not inspect a hostile Google transport rejection after dispatch timeout', async () => {
     const selectedTrace = trace('bounded-truncation');
     const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
     const secret = 'synthetic-timeout-proxy-secret';
@@ -1556,10 +1537,22 @@ describe('fixed trace artifact runner', () => {
       getPrototypeOf: () => { proxyTrap(); throw new Error('hostile prototype access'); },
       getOwnPropertyDescriptor: () => { proxyTrap(); throw new Error('hostile descriptor access'); },
     });
-    const generation = new HostileTimeoutProvider(providerError);
+    const generateContent = vi.fn((_request, options?: { signal?: AbortSignal }) => (
+      new Promise<never>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => reject(providerError), { once: true });
+      })
+    ));
+    const generation = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    } satisfies GoogleGenerateContentTransport);
 
     const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
-      generation: { ...stage(generation, 3), timeoutMs: 1 },
+      generation: {
+        ...stage(generation, 3),
+        model: GOOGLE_ROUTER_MODEL,
+        reasoningEffort: 'provider_default',
+        timeoutMs: 1,
+      },
     }));
 
     expect(observation).toMatchObject({
@@ -1568,11 +1561,13 @@ describe('fixed trace artifact runner', () => {
       failureDiagnostic: {
         kind: 'provider_timeout',
         reason: 'timeout_after_dispatch',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
       },
     });
     expect(proxyTrap).not.toHaveBeenCalled();
     expect(JSON.stringify(observation)).not.toContain(secret);
-    expect(generation.respondCalls).toHaveLength(1);
+    expect(generateContent).toHaveBeenCalledOnce();
+    expect(generateContent.mock.calls[0][1]).toMatchObject({ signal: expect.any(AbortSignal) });
   });
 
   it.each([

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -56,7 +56,10 @@ import type {
   NormalizedModelEvent,
   PreparedModelInvocation,
 } from '../../../src/addie/model-providers/model-provider.js';
-import { UnsupportedModelCapabilityError } from '../../../src/addie/model-providers/model-provider.js';
+import {
+  markModelProviderAdapterFailure,
+  UnsupportedModelCapabilityError,
+} from '../../../src/addie/model-providers/model-provider.js';
 import type { AddieTool } from '../../../src/addie/types.js';
 
 const HASH = createHash('sha256').update('fixed-trace-runner-test').digest('hex');
@@ -1372,6 +1375,78 @@ describe('fixed trace artifact runner', () => {
     expect(serialized).not.toContain('provider response body');
     expect(serialized).not.toContain('provider-error-with-details');
     expect(serialized).not.toContain('provider stack');
+  });
+
+  it('records adapter-established transport provenance without retaining provider details', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const providerError = new Error('synthetic provider body must not be retained');
+    markModelProviderAdapterFailure(providerError, 'provider_transport', 400);
+    const generation = new ThrowingProvider(providerError);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        origin: 'provider_transport',
+        httpStatus: 400,
+      },
+    });
+    expect(JSON.stringify(observation)).not.toContain('synthetic provider body');
+    expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('records adapter response normalization as a distinct safe failure category', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const adapterError = new Error('synthetic malformed provider payload');
+    markModelProviderAdapterFailure(adapterError, 'adapter_response_normalization');
+    const generation = new ThrowingProvider(adapterError);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'adapter_response_error',
+        reason: 'adapter_response_normalization',
+        origin: 'adapter_response_normalization',
+      },
+    });
+    expect(JSON.stringify(observation)).not.toContain('synthetic malformed provider payload');
+    expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('retains an adapter marker from a hostile provider proxy without reading its details', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const secret = 'synthetic-hostile-marked-provider-secret';
+    const hostile = new Proxy(Object.assign(new Error(secret), { status: 400 }), {
+      get: () => { throw new Error('hostile marked provider property'); },
+      getPrototypeOf: () => { throw new Error('hostile marked provider prototype'); },
+    });
+    markModelProviderAdapterFailure(hostile, 'provider_transport');
+    const generation = new ThrowingProvider(hostile);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_transport_error',
+        reason: 'provider_exception',
+        origin: 'provider_transport',
+        messageSha256: createHash('sha256').update('', 'utf8').digest('hex'),
+      },
+    });
+    expect(JSON.stringify(observation)).not.toContain(secret);
+    expect(generation.respondCalls).toHaveLength(1);
   });
 
   it.each([

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -153,6 +153,25 @@ class AdapterTimeoutProvider extends ScriptedProvider {
   }
 }
 
+class HostileTimeoutProvider extends ScriptedProvider {
+  constructor(private readonly thrown: unknown) {
+    super([]);
+  }
+
+  override async *respond(
+    request: ModelRequest,
+    options: ModelRespondOptions = {},
+  ): AsyncIterable<NormalizedModelEvent> {
+    const prepared = this.prepare(request);
+    await options.beforeDispatch?.(prepared);
+    this.respondCalls.push(structuredClone(request));
+    await new Promise<void>((resolve) => {
+      options.signal?.addEventListener('abort', resolve, { once: true });
+    });
+    throw this.thrown;
+  }
+}
+
 class InvalidNormalizedEventProvider extends ScriptedProvider {
   override async *respond(
     request: ModelRequest,
@@ -1524,6 +1543,35 @@ describe('fixed trace artifact runner', () => {
     });
     expect(observation.failureDiagnostic).not.toHaveProperty('origin');
     expect(observation.failureDiagnostic).not.toHaveProperty('httpStatus');
+    expect(generation.respondCalls).toHaveLength(1);
+  });
+
+  it('does not inspect a hostile provider rejection after dispatch timeout', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const secret = 'synthetic-timeout-proxy-secret';
+    const proxyTrap = vi.fn();
+    const providerError = new Proxy(Object.assign(new Error(secret), { status: 504 }), {
+      get: () => { proxyTrap(); throw new Error('hostile property access'); },
+      getPrototypeOf: () => { proxyTrap(); throw new Error('hostile prototype access'); },
+      getOwnPropertyDescriptor: () => { proxyTrap(); throw new Error('hostile descriptor access'); },
+    });
+    const generation = new HostileTimeoutProvider(providerError);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: { ...stage(generation, 3), timeoutMs: 1 },
+    }));
+
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'unknown_exposure',
+      failureDiagnostic: {
+        kind: 'provider_timeout',
+        reason: 'timeout_after_dispatch',
+      },
+    });
+    expect(proxyTrap).not.toHaveBeenCalled();
+    expect(JSON.stringify(observation)).not.toContain(secret);
     expect(generation.respondCalls).toHaveLength(1);
   });
 

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -15,6 +15,7 @@ import {
   type GoogleGenerateContentTransport,
 } from '../../../src/addie/model-providers/google-generate-content-provider.js';
 import {
+  MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE,
   modelProviderAdapterFailure,
   UnexpectedModelIdentityError,
   UnsupportedModelCapabilityError,
@@ -572,7 +573,8 @@ describe('GoogleGenerateContentProvider', () => {
     }
 
     expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport', httpStatus: 400 });
-    expect(thrown).toMatchObject({ message: secret });
+    expect(thrown).toMatchObject({ message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE });
+    expect(JSON.stringify(thrown)).not.toContain(secret);
     expect(generateContent).toHaveBeenCalledTimes(3);
     expect(generateContent.mock.calls.map(([entry]) => entry.config?.maxOutputTokens)).toEqual([32, 32, 32]);
   });
@@ -581,6 +583,7 @@ describe('GoogleGenerateContentProvider', () => {
     const secret = 'synthetic-hostile-provider-secret';
     const hostile = new Proxy(Object.assign(new Error(secret), { status: 400 }), {
       get: () => { throw new Error('hostile provider error property'); },
+      getOwnPropertyDescriptor: () => { throw new Error('hostile provider error descriptor'); },
     });
     const generateContent = vi.fn().mockRejectedValue(hostile);
     const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
@@ -593,7 +596,61 @@ describe('GoogleGenerateContentProvider', () => {
     }
 
     expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport' });
+    expect(thrown).toMatchObject({ message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE });
     expect(generateContent).toHaveBeenCalledOnce();
+  });
+
+  it('sanitizes primitive transport rejections into a safe transport boundary', async () => {
+    const secret = 'synthetic-primitive-provider-secret';
+    const generateContent = vi.fn().mockRejectedValue(secret);
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL)));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport' });
+    expect(thrown).toMatchObject({ message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE });
+    expect(JSON.stringify(thrown)).not.toContain(secret);
+    expect(generateContent).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['a string', '503'],
+    ['a fraction', 503.5],
+    ['an out-of-range value', 600],
+  ])('fails closed for malformed transport status %s', async (_description, status) => {
+    const generateContent = vi.fn().mockRejectedValue(Object.assign(new Error('provider body'), { status }));
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL)));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport' });
+  });
+
+  it('fails closed when a proxy prevents safe transport-status inspection', async () => {
+    const providerError = new Proxy(Object.assign(new Error('provider body'), { status: 429 }), {
+      getOwnPropertyDescriptor: () => { throw new Error('hostile status descriptor'); },
+    });
+    const generateContent = vi.fn().mockRejectedValue(providerError);
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL)));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport' });
   });
 
   it('marks malformed Gemini responses as adapter normalization failures', async () => {
@@ -609,6 +666,7 @@ describe('GoogleGenerateContentProvider', () => {
     }
 
     expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'adapter_response_normalization' });
+    expect(thrown).toMatchObject({ message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE });
   });
 
   it('fails closed on unsupported capabilities and malformed responses', () => {
@@ -668,7 +726,9 @@ describe('GoogleGenerateContentProvider', () => {
       signal: controller.signal,
       beforeDispatch: (prepared) => { seenRequest = prepared.providerRequest; },
     }), 'google');
-    await expect(consumed).rejects.toThrow('aborted');
+    await expect(consumed).rejects.toMatchObject({
+      message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE,
+    });
     expect(generateContent.mock.calls[0][0]).toBe(seenRequest);
     expect(generateContent.mock.calls[0][0].config.abortSignal).toBeUndefined();
     expect(generateContent.mock.calls[0][1]).toEqual({ signal: controller.signal });
@@ -853,7 +913,9 @@ describe('GoogleGenerateContentProvider', () => {
       },
       replaySafety: 'pure_local',
       handler,
-    }], { authorizeToolExecution: allowPureLocalTool })).rejects.toThrow('missing its thought signature');
+    }], { authorizeToolExecution: allowPureLocalTool })).rejects.toMatchObject({
+      message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE,
+    });
     expect(generateContent).toHaveBeenCalledOnce();
     expect(handler).not.toHaveBeenCalled();
   });
@@ -887,7 +949,9 @@ describe('GoogleGenerateContentProvider', () => {
         },
         replaySafety: 'pure_local',
         handler,
-      }], { authorizeToolExecution: allowPureLocalTool })).rejects.toThrow('Malformed Google response role');
+      }], { authorizeToolExecution: allowPureLocalTool })).rejects.toMatchObject({
+        message: MODEL_PROVIDER_ADAPTER_FAILURE_MESSAGE,
+      });
       expect(generateContent).toHaveBeenCalledOnce();
       expect(handler).not.toHaveBeenCalled();
     }

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -15,6 +15,7 @@ import {
   type GoogleGenerateContentTransport,
 } from '../../../src/addie/model-providers/google-generate-content-provider.js';
 import {
+  modelProviderAdapterFailure,
   UnexpectedModelIdentityError,
   UnsupportedModelCapabilityError,
   type ModelRequest,
@@ -535,6 +536,79 @@ describe('GoogleGenerateContentProvider', () => {
     expect(beforeDispatch).toHaveBeenCalledTimes(1);
     expect(normalized.finishReason).toBe('stop');
     expect(normalized.usage).toEqual({ inputTokens: 10, outputTokens: 8 });
+  });
+
+  it('preserves the 32-token ceiling and classifies a high-thinking transport rejection once', async () => {
+    const secret = 'synthetic-provider-body-secret';
+    const generateContent = vi.fn(async (providerRequest: {
+      config?: { maxOutputTokens?: number; thinkingConfig?: { thinkingLevel?: unknown } };
+    }) => {
+      if (
+        providerRequest.config?.maxOutputTokens === 32
+        && providerRequest.config.thinkingConfig?.thinkingLevel === 'HIGH'
+      ) throw Object.assign(new Error(secret), { status: 400 });
+      return googleResponse({
+        candidates: [{ finishReason: 'MAX_TOKENS', content: { role: 'model', parts: [] } }],
+        usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 32, totalTokenCount: 36 },
+      });
+    });
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+
+    for (const effort of ['low', 'medium'] as const) {
+      await expect(collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL, {
+        maxOutputTokens: 32,
+        reasoning: { effort },
+      })))).resolves.toMatchObject({ finishReason: 'length', usage: { outputTokens: 32 } });
+    }
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL, {
+        maxOutputTokens: 32,
+        reasoning: { effort: 'high' },
+      })));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport', httpStatus: 400 });
+    expect(thrown).toMatchObject({ message: secret });
+    expect(generateContent).toHaveBeenCalledTimes(3);
+    expect(generateContent.mock.calls.map(([entry]) => entry.config?.maxOutputTokens)).toEqual([32, 32, 32]);
+  });
+
+  it('does not inspect a hostile transport error while classifying its boundary', async () => {
+    const secret = 'synthetic-hostile-provider-secret';
+    const hostile = new Proxy(Object.assign(new Error(secret), { status: 400 }), {
+      get: () => { throw new Error('hostile provider error property'); },
+    });
+    const generateContent = vi.fn().mockRejectedValue(hostile);
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL)));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'provider_transport' });
+    expect(generateContent).toHaveBeenCalledOnce();
+  });
+
+  it('marks malformed Gemini responses as adapter normalization failures', async () => {
+    const provider = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent: vi.fn().mockResolvedValue(googleResponse({ candidates: [] })) },
+    });
+
+    let thrown: unknown;
+    try {
+      await collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL)));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(modelProviderAdapterFailure(thrown)).toEqual({ kind: 'adapter_response_normalization' });
   });
 
   it('fails closed on unsupported capabilities and malformed responses', () => {


### PR DESCRIPTION
## Summary
- mark Google GenerateContent failures at the adapter boundary as either provider transport or response normalization without copying provider fields
- preserve only a validated HTTP receipt plus the evaluator’s existing bounded message fingerprint in fixed-trace artifacts
- retain the 32-token bounded fixture and prove the high-only rejection path with a local fake; low and medium retain bounded MAX_TOKENS receipts

## Verification
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/model-provider-openai-google.test.ts server/tests/unit/addie/fixed-trace-runner.test.ts` (115 passed)
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts` (19 passed)
- `npm run typecheck` (passed)
- `git diff --check` (passed)

No paid or provider calls were made.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
