### PR TITLE
fix(addie): accept bounded Gemini usage omission

### DIFF
--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -293,15 +293,10 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
   const candidate = response.candidates[0];
   if (typeof candidate.finishReason !== 'string') throw new Error('Malformed Google finish reason');
   const finishReason = normalizeFinishReason(candidate.finishReason);
-  // Gemini can omit the visible-candidate count when a bounded reasoning turn
-  // consumes its output allowance. That receipt has zero visible output; its
-  // validated thoughts count remains part of the actual billed output usage.
-  if (response.usageMetadata.candidatesTokenCount === undefined) {
-    if (finishReason !== 'length') throw new Error('Malformed Google output usage');
-  } else {
+  const hasOmittedCandidateOutputUsage = response.usageMetadata.candidatesTokenCount === undefined;
+  if (!hasOmittedCandidateOutputUsage) {
     assertSafeCount(response.usageMetadata.candidatesTokenCount, 'output usage');
   }
-  const outputTokens = response.usageMetadata.candidatesTokenCount ?? 0;
   const parts = candidate.content?.parts;
   if (candidate.content === undefined) {
     // Gemini can omit content after a bounded reasoning turn consumes its
@@ -313,6 +308,13 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
   if ((parts?.length ?? 0) > MAX_GOOGLE_RESPONSE_PARTS) {
     throw new Error('Google response content part limit exceeded');
   }
+  // Gemini can omit the visible-candidate count only when a bounded reasoning
+  // turn consumes its output allowance before emitting a candidate payload.
+  // Its validated thoughts count remains part of the actual billed output usage.
+  if (hasOmittedCandidateOutputUsage && (finishReason !== 'length' || (parts?.length ?? 0) !== 0)) {
+    throw new Error('Malformed Google output usage');
+  }
+  const outputTokens = response.usageMetadata.candidatesTokenCount ?? 0;
   const content: ModelMessageContent[] = [];
   for (const part of parts ?? []) {
     const keys = Object.keys(part).filter((key) => part[key as keyof typeof part] !== undefined);

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -268,8 +268,7 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
     assertSafeCount(response.usageMetadata.thoughtsTokenCount, 'thought usage');
   }
   if ((response.candidates?.length ?? 0) === 0 && response.promptFeedback?.blockReason) {
-    const outputTokens = response.usageMetadata.candidatesTokenCount ?? 0;
-    assertSafeCount(outputTokens, 'output usage');
+    assertSafeCount(response.usageMetadata.candidatesTokenCount, 'output usage');
     if (!Object.values(BlockedReason).includes(response.promptFeedback.blockReason)) {
       throw new Error('Malformed Google prompt block reason');
     }
@@ -282,19 +281,27 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
       providerFinishReason: `PROMPT_${response.promptFeedback.blockReason}`,
       usage: {
         inputTokens: response.usageMetadata.promptTokenCount,
-        outputTokens: outputTokens + (response.usageMetadata.thoughtsTokenCount ?? 0),
+        outputTokens: response.usageMetadata.candidatesTokenCount + (response.usageMetadata.thoughtsTokenCount ?? 0),
       },
     } satisfies ModelResponse);
     validateNormalizedModelResponse(refused);
     return refused;
   }
-  assertSafeCount(response.usageMetadata.candidatesTokenCount, 'output usage');
   if (!Array.isArray(response.candidates) || response.candidates.length !== 1) {
     throw new Error('Google response requires exactly one candidate');
   }
   const candidate = response.candidates[0];
   if (typeof candidate.finishReason !== 'string') throw new Error('Malformed Google finish reason');
   const finishReason = normalizeFinishReason(candidate.finishReason);
+  // Gemini can omit the visible-candidate count when a bounded reasoning turn
+  // consumes its output allowance. That receipt has zero visible output; its
+  // validated thoughts count remains part of the actual billed output usage.
+  if (response.usageMetadata.candidatesTokenCount === undefined) {
+    if (finishReason !== 'length') throw new Error('Malformed Google output usage');
+  } else {
+    assertSafeCount(response.usageMetadata.candidatesTokenCount, 'output usage');
+  }
+  const outputTokens = response.usageMetadata.candidatesTokenCount ?? 0;
   const parts = candidate.content?.parts;
   if (candidate.content === undefined) {
     // Gemini can omit content after a bounded reasoning turn consumes its
@@ -381,7 +388,7 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
     providerFinishReason: candidate.finishReason,
     usage: {
       inputTokens: response.usageMetadata.promptTokenCount,
-      outputTokens: response.usageMetadata.candidatesTokenCount + (response.usageMetadata.thoughtsTokenCount ?? 0),
+      outputTokens: outputTokens + (response.usageMetadata.thoughtsTokenCount ?? 0),
       ...(response.usageMetadata.cachedContentTokenCount !== undefined && {
         cacheReadTokens: response.usageMetadata.cachedContentTokenCount,
       }),

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -18,6 +18,7 @@ import {
   FixedTraceBudgetAdmissionError,
   fixedTraceResponsePricingPolicy,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
+import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 import { FixedTraceToolLoopBoundaryError } from '../../../src/addie/eval/fixed-trace-tool-loop.js';
 import {
   FIXED_TRACE_SUITE,
@@ -1469,6 +1470,49 @@ describe('fixed trace artifact runner', () => {
       },
     });
     expect(generateContent).toHaveBeenCalledOnce();
+  });
+
+  it('grades an omitted Gemini visible-output receipt as a settled bounded truncation', async () => {
+    const selectedTrace = trace('bounded-truncation');
+    const router = new ScriptedProvider([routeResponse('respond', ['knowledge'])]);
+    const generateContent = vi.fn().mockResolvedValue({
+      responseId: 'google_1',
+      modelVersion: GOOGLE_ROUTER_MODEL,
+      candidates: [{ finishReason: 'MAX_TOKENS', content: { role: 'model', parts: [] } }],
+      usageMetadata: { promptTokenCount: 10, thoughtsTokenCount: 32, totalTokenCount: 42 },
+    });
+    const generation = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent },
+    } satisfies GoogleGenerateContentTransport);
+
+    const observation = await runFixedTraceCase(selectedTrace, config(router, generation, {
+      generation: {
+        ...stage(generation, 3),
+        model: GOOGLE_ROUTER_MODEL,
+        reasoningEffort: 'high',
+        pricing: datedPricingProfilesForFixedTrace().find((profile) => (
+          profile.provider === 'google' && profile.model === GOOGLE_ROUTER_MODEL
+        ))!,
+      },
+    }));
+
+    expect(generateContent).toHaveBeenCalledOnce();
+    expect(generateContent.mock.calls[0]?.[0]).toMatchObject({
+      config: { maxOutputTokens: 32, thinkingConfig: { thinkingLevel: 'HIGH' } },
+    });
+    expect(observation).toMatchObject({
+      terminalStage: 'generation',
+      terminalStatus: 'truncated',
+      finishReason: 'length',
+      output: '',
+      flagged: true,
+      metadata: { generation: { source: 'provider', usage: { inputTokens: 10, outputTokens: 32 } } },
+    });
+    expect(gradeFixedTrace(selectedTrace, observation)).toMatchObject({
+      deterministicPass: true,
+      metadataPass: true,
+      terminalFailure: true,
+    });
   });
 
   it('classifies a sanitized primitive Google rejection as provider transport', async () => {

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -689,7 +689,7 @@ describe('GoogleGenerateContentProvider', () => {
     expect(normalizeGoogleResponse(googleResponse({
       candidates: [],
       promptFeedback: { blockReason: 'SAFETY' },
-      usageMetadata: { promptTokenCount: 4, totalTokenCount: 4 },
+      usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 0, totalTokenCount: 4 },
     })).finishReason).toBe('refusal');
     expect(normalizeGoogleResponse(googleResponse({
       candidates: [{ finishReason: 'SAFETY', content: { role: 'model', parts: [] } }],
@@ -715,6 +715,35 @@ describe('GoogleGenerateContentProvider', () => {
     expect(() => normalizeGoogleResponse(googleResponse({
       candidates: [{ finishReason: 'MAX_TOKENS', content: { role: 'model' } }],
     }))).toThrow('Malformed Google response content');
+  });
+
+  it.each([
+    ['empty content', { role: 'model', parts: [] }],
+    ['omitted content', undefined],
+  ])('accepts a MAX_TOKENS receipt with omitted visible output usage and %s', (_description, content) => {
+    const candidate = content === undefined
+      ? { finishReason: 'MAX_TOKENS' }
+      : { finishReason: 'MAX_TOKENS', content };
+    expect(normalizeGoogleResponse(googleResponse({
+      candidates: [candidate],
+      usageMetadata: { promptTokenCount: 4, thoughtsTokenCount: 32, totalTokenCount: 36 },
+    }))).toMatchObject({
+      finishReason: 'length',
+      content: [],
+      usage: { inputTokens: 4, outputTokens: 32 },
+    });
+  });
+
+  it.each([
+    ['STOP', { candidates: [{ finishReason: 'STOP', content: { role: 'model', parts: [{ text: 'visible' }] } }] }],
+    ['SAFETY', { candidates: [{ finishReason: 'SAFETY', content: { role: 'model', parts: [] } }] }],
+    ['RECITATION', { candidates: [{ finishReason: 'RECITATION', content: { role: 'model', parts: [] } }] }],
+    ['prompt SAFETY', { candidates: [], promptFeedback: { blockReason: 'SAFETY' } }],
+  ])('rejects omitted visible output usage for a %s refusal or terminal receipt', (_description, response) => {
+    expect(() => normalizeGoogleResponse(googleResponse({
+      ...response,
+      usageMetadata: { promptTokenCount: 4, thoughtsTokenCount: 32, totalTokenCount: 36 },
+    }))).toThrow('output usage');
   });
 
   it('propagates an abort signal in the exact request seen before dispatch', async () => {

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -735,6 +735,16 @@ describe('GoogleGenerateContentProvider', () => {
   });
 
   it.each([
+    ['visible text', { role: 'model', parts: [{ text: 'visible' }] }],
+    ['a function call', { role: 'model', parts: [{ functionCall: { id: 'call_1', name: 'search_docs', args: {} }, thoughtSignature: 'sig' }] }],
+  ])('rejects a MAX_TOKENS receipt with omitted visible output usage and %s', (_description, content) => {
+    expect(() => normalizeGoogleResponse(googleResponse({
+      candidates: [{ finishReason: 'MAX_TOKENS', content }],
+      usageMetadata: { promptTokenCount: 4, thoughtsTokenCount: 32, totalTokenCount: 36 },
+    }))).toThrow('output usage');
+  });
+
+  it.each([
     ['STOP', { candidates: [{ finishReason: 'STOP', content: { role: 'model', parts: [{ text: 'visible' }] } }] }],
     ['SAFETY', { candidates: [{ finishReason: 'SAFETY', content: { role: 'model', parts: [] } }] }],
     ['RECITATION', { candidates: [{ finishReason: 'RECITATION', content: { role: 'model', parts: [] } }] }],


### PR DESCRIPTION
Accepts an omitted visible candidate token count only for a settled Gemini MAX_TOKENS response, accounting it as zero while preserving validated thought-token usage. Keeps all non-length paths fail-closed. Regression coverage includes adapter and fixed-trace runner behavior.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
