### PR TITLE
fix(addie): retain fixed-trace settlement diagnostics

### DIFF
--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -330,14 +330,19 @@ export function fixedTraceSettlementDiagnosticCursor(provider: ModelProvider): n
 export function fixedTraceSettlementDiagnosticLedger(
   provider: ModelProvider,
   cursor: number,
+  dispatchedCalls: number,
 ): FixedTraceSettlementDiagnosticLedger {
-  if (!Number.isSafeInteger(cursor) || cursor < 0) {
+  if (!Number.isSafeInteger(cursor) || cursor < 0
+    || !Number.isSafeInteger(dispatchedCalls) || dispatchedCalls < 0) {
     throw new RangeError('Fixed trace settlement diagnostic cursor is invalid');
   }
   const binding = budgetedProviderBindings.get(provider);
   if (!binding) return Object.freeze({
-    fromDispatchExclusive: cursor,
-    throughDispatch: cursor,
+    // Ordinary providers cannot produce wrapper receipts, but their empty
+    // interval is still stage-local evidence: it covers every dispatch the
+    // runner observed in this stage.
+    fromDispatchExclusive: 0,
+    throughDispatch: dispatchedCalls,
     truncated: false,
     entries: Object.freeze([]),
   });
@@ -345,6 +350,12 @@ export function fixedTraceSettlementDiagnosticLedger(
   const throughDispatch = binding.dispatchSequence - cursor;
   if (throughDispatch < 0) {
     throw new RangeError('Fixed trace settlement diagnostic cursor is ahead of provider dispatches');
+  }
+  // A wrapped provider owns authoritative dispatch and settlement state. Do
+  // not allow a runner-side count to shift its receipt interval or omit a
+  // redacted unknown-settlement receipt.
+  if (throughDispatch !== dispatchedCalls) {
+    throw new RangeError('Fixed trace settlement diagnostic dispatch count does not match the budget wrapper');
   }
   return Object.freeze({
     fromDispatchExclusive: 0,

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -23,6 +23,11 @@ import {
   type EvaluationPricingCandidateId,
 } from './dated-pricing-cohort.js';
 import type { FixedTraceModelResolutionPolicy } from './fixed-trace-suite.js';
+import type {
+  FixedTraceSettlementDiagnostic,
+  FixedTraceSettlementDiagnosticLedger,
+} from './fixed-trace-suite.js';
+import { createHash } from 'node:crypto';
 
 export interface FixedTraceBudgetPricing {
   inputUsdPerMillionTokens: number;
@@ -253,6 +258,8 @@ interface BudgetedProviderBinding {
   readonly responsePricingPolicy: FixedTraceResponsePricingPolicy;
   readonly delegate: BudgetedDelegateIdentity;
   lease: object | null;
+  dispatchSequence: number;
+  settlementDiagnostics: FixedTraceSettlementDiagnostic[];
 }
 
 interface BudgetedDelegateIdentity {
@@ -272,6 +279,72 @@ interface BudgetedDelegateIdentity {
 const budgetedProviderBindings = new WeakMap<object, BudgetedProviderBinding>();
 const exclusiveBudgetLeases = new WeakMap<FixedTraceBudget, object>();
 const exclusiveCloneIdentities = new WeakMap<object, BudgetedDelegateIdentity>();
+const FIXED_TRACE_SETTLEMENT_DIAGNOSTIC_LIMIT = 8;
+const FIXED_TRACE_SETTLEMENT_FINGERPRINT_DOMAIN = 'adcp:addie:fixed-trace:settlement-diagnostic:v1\0';
+
+function settlementErrorFingerprint(
+  reason: FixedTraceSettlementDiagnostic['reason'],
+): string {
+  // A diagnostic artifact can be retained beyond the local execution logs.
+  // Fingerprint only our closed category, never provider-owned error text.
+  return createHash('sha256')
+    .update(FIXED_TRACE_SETTLEMENT_FINGERPRINT_DOMAIN, 'utf8')
+    .update(reason, 'utf8')
+    .digest('hex');
+}
+
+function recordSettlementDiagnostic(
+  provider: object,
+  dispatchSequence: number,
+  reason: FixedTraceSettlementDiagnostic['reason'],
+): void {
+  const binding = budgetedProviderBindings.get(provider);
+  if (!binding) throw new Error('Fixed trace budget wrapper binding is unavailable');
+  binding.settlementDiagnostics.push(Object.freeze({
+    dispatchSequence,
+    status: 'exposure_unknown',
+    reason,
+    errorFingerprintSha256: settlementErrorFingerprint(reason),
+  }));
+  if (binding.settlementDiagnostics.length > FIXED_TRACE_SETTLEMENT_DIAGNOSTIC_LIMIT) {
+    binding.settlementDiagnostics.splice(0, binding.settlementDiagnostics.length - FIXED_TRACE_SETTLEMENT_DIAGNOSTIC_LIMIT);
+  }
+}
+
+/**
+ * Capture an opaque cursor before entering a provider stage. It is meaningful
+ * only for the frozen budget wrapper; ordinary providers deliberately report
+ * an empty ledger so the runner remains usable in local-only tests.
+ */
+export function fixedTraceSettlementDiagnosticCursor(provider: ModelProvider): number {
+  return budgetedProviderBindings.get(provider)?.dispatchSequence ?? 0;
+}
+
+/** Return the bounded, redacted settlement receipts emitted after `cursor`. */
+export function fixedTraceSettlementDiagnosticLedger(
+  provider: ModelProvider,
+  cursor: number,
+): FixedTraceSettlementDiagnosticLedger {
+  if (!Number.isSafeInteger(cursor) || cursor < 0) {
+    throw new RangeError('Fixed trace settlement diagnostic cursor is invalid');
+  }
+  const binding = budgetedProviderBindings.get(provider);
+  if (!binding) return Object.freeze({
+    fromDispatchExclusive: cursor,
+    throughDispatch: cursor,
+    truncated: false,
+    entries: Object.freeze([]),
+  });
+  const oldestRetained = binding.settlementDiagnostics[0]?.dispatchSequence;
+  return Object.freeze({
+    fromDispatchExclusive: cursor,
+    throughDispatch: binding.dispatchSequence,
+    truncated: oldestRetained !== undefined && cursor < oldestRetained - 1,
+    entries: Object.freeze(binding.settlementDiagnostics
+      .filter((entry) => entry.dispatchSequence > cursor)
+      .map((entry) => Object.freeze({ ...entry }))),
+  });
+}
 
 function deepFreeze<T>(value: T): T {
   if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
@@ -580,6 +653,8 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
       responsePricingPolicy: this.#responsePricingPolicy,
       delegate: delegateIdentity,
       lease: null,
+      dispatchSequence: 0,
+      settlementDiagnostics: [],
     });
     // A diagnostic run retains these exact wrapper objects by reference. Lock
     // their own properties now, before untrusted provider code can resume.
@@ -602,6 +677,8 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
     let reservation: Reservation | null = null;
     let dispatchStarted = false;
     let settled = false;
+    let dispatchSequence: number | null = null;
+    let interruptedReason: FixedTraceSettlementDiagnostic['reason'] = 'response_stream_interrupted';
     try {
       for await (const event of this.#delegate.respond(request, {
         ...options,
@@ -617,6 +694,9 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
           }
           this.#budget.markDispatched(reservation);
           dispatchStarted = true;
+          const binding = budgetedProviderBindings.get(this);
+          if (!binding) throw new Error('Fixed trace budget wrapper binding is unavailable');
+          dispatchSequence = ++binding.dispatchSequence;
         },
       })) {
         if (event.type === 'response_complete') {
@@ -636,6 +716,7 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
             ? this.#delegate.snapshotResponse(event.response)
             : structuredClone(event.response);
           if (!isDeepStrictEqual(snapshot, canonicalResponse)) {
+            interruptedReason = 'response_processing_failed';
             throw new Error('Fixed trace provider response snapshot differs from its terminal response');
           }
           const response = deepFreeze(snapshot);
@@ -647,6 +728,7 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
               // evidence while closing admission: a malformed or absent usage
               // block means this dispatch cannot be settled at any rate.
               this.#budget.markExposureUnknown(reservation);
+              recordSettlementDiagnostic(this, dispatchSequence!, 'usage_or_cost_settlement_failed');
             }
           } else {
             // Do not settle an unapproved returned identity at the requested
@@ -654,6 +736,7 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
             // records unknown cost and fails its stage contract; the shared
             // ledger closes before any subsequent provider call.
             this.#budget.markExposureUnknown(reservation);
+            recordSettlementDiagnostic(this, dispatchSequence!, 'identity_policy_rejected');
           }
           settled = true;
           yield { type: 'response_complete', response };
@@ -663,7 +746,10 @@ export class BudgetedFixedTraceProvider implements ModelProvider {
       }
     } finally {
       if (reservation && !settled) {
-        if (dispatchStarted) this.#budget.markExposureUnknown(reservation);
+        if (dispatchStarted) {
+          this.#budget.markExposureUnknown(reservation);
+          recordSettlementDiagnostic(this, dispatchSequence!, interruptedReason);
+        }
         else this.#budget.cancel(reservation);
       }
     }

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -320,7 +320,13 @@ export function fixedTraceSettlementDiagnosticCursor(provider: ModelProvider): n
   return budgetedProviderBindings.get(provider)?.dispatchSequence ?? 0;
 }
 
-/** Return the bounded, redacted settlement receipts emitted after `cursor`. */
+/**
+ * Return the bounded, redacted settlement receipts emitted after `cursor`.
+ *
+ * The cursor is wrapper-private global state. Published sequences are local
+ * to this stage so a serialized receipt range is intrinsically bound to the
+ * stage's own dispatch count and cannot claim a prior or future stage.
+ */
 export function fixedTraceSettlementDiagnosticLedger(
   provider: ModelProvider,
   cursor: number,
@@ -336,13 +342,20 @@ export function fixedTraceSettlementDiagnosticLedger(
     entries: Object.freeze([]),
   });
   const oldestRetained = binding.settlementDiagnostics[0]?.dispatchSequence;
+  const throughDispatch = binding.dispatchSequence - cursor;
+  if (throughDispatch < 0) {
+    throw new RangeError('Fixed trace settlement diagnostic cursor is ahead of provider dispatches');
+  }
   return Object.freeze({
-    fromDispatchExclusive: cursor,
-    throughDispatch: binding.dispatchSequence,
+    fromDispatchExclusive: 0,
+    throughDispatch,
     truncated: oldestRetained !== undefined && cursor < oldestRetained - 1,
     entries: Object.freeze(binding.settlementDiagnostics
       .filter((entry) => entry.dispatchSequence > cursor)
-      .map((entry) => Object.freeze({ ...entry }))),
+      .map((entry) => Object.freeze({
+        ...entry,
+        dispatchSequence: entry.dispatchSequence - cursor,
+      }))),
   });
 }
 

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -50,6 +50,8 @@ import {
   fixedTraceModelResolutionPolicy as fixedTraceBudgetModelResolutionPolicy,
   fixedTraceResponsePricingPolicy,
   fixedTraceResponseUsesPricingPolicy,
+  fixedTraceSettlementDiagnosticCursor,
+  fixedTraceSettlementDiagnosticLedger,
   type FixedTraceBudgetRejectionReason,
 } from './fixed-trace-budget.js';
 import {
@@ -752,6 +754,7 @@ interface StageInvocationState {
   dispatched: boolean;
   dispatchedCalls: number;
   latencyMs: number;
+  settlementDiagnosticCursor?: number;
 }
 
 function providerExposures(
@@ -953,6 +956,10 @@ function providerStageMetadata(
     returnedProvider: response.provider,
     returnedModel: response.model,
     providerExposures: providerExposures(state, response, recordedExposures),
+    settlementLedger: fixedTraceSettlementDiagnosticLedger(
+      config.provider,
+      state.settlementDiagnosticCursor ?? fixedTraceSettlementDiagnosticCursor(config.provider),
+    ),
     modelResolution: modelResolution(config, response),
     promptSha256: promptSha256(request),
     providerRequestSha256: providerRequestSha256(state.invocations),
@@ -992,6 +999,10 @@ function localStageMetadata(
     returnedProvider: null,
     returnedModel: null,
     providerExposures: providerExposures(state, undefined, recordedExposures),
+    settlementLedger: fixedTraceSettlementDiagnosticLedger(
+      config.provider,
+      state.settlementDiagnosticCursor ?? fixedTraceSettlementDiagnosticCursor(config.provider),
+    ),
     modelResolution: 'local',
     promptSha256: promptSha256(request),
     providerRequestSha256: providerRequestSha256(state.invocations),
@@ -1023,6 +1034,12 @@ function notRunStageMetadata(trace: FixedTraceCase): FixedTraceModelStageMetadat
     returnedProvider: null,
     returnedModel: null,
     providerExposures: Object.freeze([]),
+    settlementLedger: Object.freeze({
+      fromDispatchExclusive: 0,
+      throughDispatch: 0,
+      truncated: false,
+      entries: Object.freeze([]),
+    }),
     modelResolution: null,
     promptSha256: null,
     providerRequestSha256: null,
@@ -1779,6 +1796,7 @@ async function executeRouter(
   let dispatched = false;
   let dispatchedCalls = 0;
   let timedOut = false;
+  const settlementDiagnosticCursor = fixedTraceSettlementDiagnosticCursor(config.provider);
   const controller = new AbortController();
   const startedAt = Date.now();
   // `prepare` is the provider boundary's deterministic validation and request
@@ -1804,7 +1822,7 @@ async function executeRouter(
         invocations.push(prepared);
       },
     }), config.provider.id);
-    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
+    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt, settlementDiagnosticCursor };
     const metadata = providerStageMetadata(request, config, response, response.usage, state);
     const output = extractRouterResponseText(response.content);
     const status = hasCompleteReturnedProviderIdentities(state, response)
@@ -1826,7 +1844,7 @@ async function executeRouter(
     }
   } catch (error) {
     if (timedOut && dispatched) {
-      const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
+      const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt, settlementDiagnosticCursor };
       const terminalStatus = hasCompleteReturnedProviderIdentities(state)
         ? 'timeout_after_dispatch'
         : 'unknown_exposure';
@@ -1844,7 +1862,7 @@ async function executeRouter(
     const budgetAdmission = snapshotFixedTraceBudgetAdmission(error);
     const toolLoopBoundary = snapshotFixedTraceToolLoopBoundary(error);
     if (budgetAdmission) invocations.push(budgetAdmission.prepared);
-    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
+    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt, settlementDiagnosticCursor };
     const status = budgetAdmission
       ? 'not_dispatched_budget'
       : timedOut && dispatched
@@ -2046,6 +2064,7 @@ export async function runFixedTraceCase(
   let dispatched = false;
   let dispatchedCalls = 0;
   const startedAt = Date.now();
+  const settlementDiagnosticCursor = fixedTraceSettlementDiagnosticCursor(generationConfig.provider);
 
   if (executionTrace.category === 'provider_degradation' && executionConfig.injectProviderDegradation !== false) {
     invocations.push(prepareFixedTraceRequest('generation', generationConfig, {
@@ -2122,7 +2141,7 @@ export async function runFixedTraceCase(
         },
       },
     );
-    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt };
+    const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt, settlementDiagnosticCursor };
     const generation = providerStageMetadata(
       generationRequest,
       generationConfig,
@@ -2169,6 +2188,7 @@ export async function runFixedTraceCase(
         dispatched,
         dispatchedCalls,
         latencyMs: Date.now() - startedAt,
+        settlementDiagnosticCursor,
       };
       const finalTerminalStatus = hasCompleteReturnedProviderIdentities(state)
         ? 'timeout_after_dispatch'
@@ -2208,6 +2228,7 @@ export async function runFixedTraceCase(
       dispatched,
       dispatchedCalls,
       latencyMs: Date.now() - startedAt,
+      settlementDiagnosticCursor,
     };
     const generation = localStageMetadata(
       generationRequest,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -959,6 +959,7 @@ function providerStageMetadata(
     settlementLedger: fixedTraceSettlementDiagnosticLedger(
       config.provider,
       state.settlementDiagnosticCursor ?? fixedTraceSettlementDiagnosticCursor(config.provider),
+      state.dispatchedCalls,
     ),
     modelResolution: modelResolution(config, response),
     promptSha256: promptSha256(request),
@@ -1002,6 +1003,7 @@ function localStageMetadata(
     settlementLedger: fixedTraceSettlementDiagnosticLedger(
       config.provider,
       state.settlementDiagnosticCursor ?? fixedTraceSettlementDiagnosticCursor(config.provider),
+      state.dispatchedCalls,
     ),
     modelResolution: 'local',
     promptSha256: promptSha256(request),

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -358,11 +358,30 @@ export interface FixedTraceSettlementDiagnosticLedger {
   entries: readonly FixedTraceSettlementDiagnostic[];
 }
 
+const FIXED_TRACE_SETTLEMENT_FINGERPRINT_DOMAIN = 'adcp:addie:fixed-trace:settlement-diagnostic:v1\0';
+const fixedTraceSettlementDiagnosticReasons = new Set<FixedTraceSettlementDiagnostic['reason']>([
+  'identity_policy_rejected',
+  'usage_or_cost_settlement_failed',
+  'response_processing_failed',
+  'response_stream_interrupted',
+]);
+
+function fixedTraceSettlementDiagnosticFingerprint(
+  reason: FixedTraceSettlementDiagnostic['reason'],
+): string {
+  // This is intentionally derived only from the closed wrapper category.
+  // Never admit provider-owned error material to a retained artifact.
+  return createHash('sha256')
+    .update(FIXED_TRACE_SETTLEMENT_FINGERPRINT_DOMAIN, 'utf8')
+    .update(reason, 'utf8')
+    .digest('hex');
+}
+
 export interface FixedTraceModelStageMetadata {
   source: 'provider' | 'local' | 'not_run';
   dispatched: boolean;
   /** Exact calls which crossed the stage's before-dispatch boundary. */
-  dispatchedCalls?: number;
+  dispatchedCalls: number;
   requestedProvider: ModelProviderId | null;
   requestedModel: string | null;
   returnedProvider: ModelProviderId | null;
@@ -376,7 +395,7 @@ export interface FixedTraceModelStageMetadata {
     returnedModel: string | null;
   }[];
   /** Bounded wrapper receipts for unpriceable dispatched completions. */
-  settlementLedger?: FixedTraceSettlementDiagnosticLedger;
+  settlementLedger: FixedTraceSettlementDiagnosticLedger;
   modelResolution: 'exact' | 'provider_canonicalized' | 'local' | null;
   promptSha256: string | null;
   providerRequestSha256: string | null;
@@ -2922,25 +2941,51 @@ function stageMetadataFailures(
   const failures: string[] = [];
   const fail = (reason: string) => failures.push(`${stageName}_${reason}`);
   const settlementLedger = stage.settlementLedger;
-  if (settlementLedger !== undefined) {
-    const entries = settlementLedger.entries;
+  if (settlementLedger === undefined) {
+    fail('settlement_ledger_missing');
+  } else if (!isPlainRecord(settlementLedger)
+    || Object.keys(settlementLedger).length !== 4
+    || !['fromDispatchExclusive', 'throughDispatch', 'truncated', 'entries']
+      .every((key) => Object.prototype.hasOwnProperty.call(settlementLedger, key))) {
+    fail('settlement_ledger_invalid');
+  } else {
+    const entries = settlementLedger.entries as unknown;
+    const dispatchedCalls = stage.dispatchedCalls;
     if (
       !Number.isSafeInteger(settlementLedger.fromDispatchExclusive)
-      || settlementLedger.fromDispatchExclusive < 0
+      // Serialized ranges are stage-local: the wrapper's global cursor is
+      // deliberately not artifact material. This prevents a receipt from a
+      // different stage being shifted into this one.
+      || settlementLedger.fromDispatchExclusive !== 0
       || !Number.isSafeInteger(settlementLedger.throughDispatch)
-      || settlementLedger.throughDispatch < settlementLedger.fromDispatchExclusive
-      || typeof settlementLedger.truncated !== 'boolean'
+      || typeof dispatchedCalls !== 'number'
+      || !Number.isSafeInteger(dispatchedCalls)
+      || (dispatchedCalls ?? -1) < 0
+      || stage.dispatched !== ((dispatchedCalls ?? 0) > 0)
+      // The cursor is captured immediately before this stage. A stage cannot
+      // claim another stage's receipts, omit an in-range call, or be truncated.
+      || settlementLedger.throughDispatch !== settlementLedger.fromDispatchExclusive + (dispatchedCalls ?? -1)
+      || settlementLedger.truncated !== false
       || !Array.isArray(entries)
       || entries.length > 8
       || entries.some((entry, index) => (
-        !Number.isSafeInteger(entry.dispatchSequence)
-        || entry.dispatchSequence <= settlementLedger.fromDispatchExclusive
-        || entry.dispatchSequence > settlementLedger.throughDispatch
+        !isPlainRecord(entry)
+        || Object.keys(entry).length !== 4
+        || !['dispatchSequence', 'status', 'reason', 'errorFingerprintSha256']
+          .every((key) => Object.prototype.hasOwnProperty.call(entry, key))
+        || !Number.isSafeInteger(entry.dispatchSequence)
+        || entry.dispatchSequence !== settlementLedger.throughDispatch
         || (index > 0 && entry.dispatchSequence <= entries[index - 1]!.dispatchSequence)
         || entry.status !== 'exposure_unknown'
-        || !['identity_policy_rejected', 'usage_or_cost_settlement_failed', 'response_processing_failed', 'response_stream_interrupted'].includes(entry.reason)
+        || !fixedTraceSettlementDiagnosticReasons.has(entry.reason as FixedTraceSettlementDiagnostic['reason'])
+        || typeof entry.errorFingerprintSha256 !== 'string'
         || !isSha256(entry.errorFingerprintSha256)
+        || entry.errorFingerprintSha256 !== fixedTraceSettlementDiagnosticFingerprint(
+          entry.reason as FixedTraceSettlementDiagnostic['reason'],
+        )
       ))
+      || (stage.dispatched && (!stage.usageKnown || stage.estimatedCostUsd === null || stage.pricingSource === null)
+        && entries.length === 0)
     ) fail('settlement_ledger_invalid');
   }
   if ('status' in control) {

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -337,6 +337,27 @@ export interface FixedTraceNotRunCohortStageControl {
   readonly status: 'not_run';
 }
 
+/**
+ * A bounded, redacted receipt from the budget wrapper when a dispatched
+ * response could not be settled. Provider output and error text never enter
+ * this record; the fingerprint is derived only from the versioned, safe
+ * failure category.
+ */
+export interface FixedTraceSettlementDiagnostic {
+  dispatchSequence: number;
+  status: 'exposure_unknown';
+  reason: 'identity_policy_rejected' | 'usage_or_cost_settlement_failed' | 'response_processing_failed' | 'response_stream_interrupted';
+  errorFingerprintSha256: string;
+}
+
+/** Per-stage view of the wrapper-owned, fixed-size settlement ledger. */
+export interface FixedTraceSettlementDiagnosticLedger {
+  fromDispatchExclusive: number;
+  throughDispatch: number;
+  truncated: boolean;
+  entries: readonly FixedTraceSettlementDiagnostic[];
+}
+
 export interface FixedTraceModelStageMetadata {
   source: 'provider' | 'local' | 'not_run';
   dispatched: boolean;
@@ -354,6 +375,8 @@ export interface FixedTraceModelStageMetadata {
     returnedProvider: ModelProviderId | null;
     returnedModel: string | null;
   }[];
+  /** Bounded wrapper receipts for unpriceable dispatched completions. */
+  settlementLedger?: FixedTraceSettlementDiagnosticLedger;
   modelResolution: 'exact' | 'provider_canonicalized' | 'local' | null;
   promptSha256: string | null;
   providerRequestSha256: string | null;
@@ -2801,6 +2824,7 @@ function directModelScreenMetadataFailures(
   const directModelScreenNotRunRouterKeys = [
     'source', 'dispatched', 'dispatchedCalls', 'requestedProvider', 'requestedModel',
     'returnedProvider', 'returnedModel', 'providerExposures', 'modelResolution',
+    'settlementLedger',
     'promptSha256', 'providerRequestSha256', 'reasoningEffort', 'effectiveMaxOutputTokens',
     'timeoutMs', 'maxIterations', 'transportRetries', 'samplingMode', 'temperature',
     'usageKnown', 'usage', 'estimatedCostUsd', 'pricingSource', 'pricingProfileId', 'latencyMs',
@@ -2897,6 +2921,28 @@ function stageMetadataFailures(
 ): string[] {
   const failures: string[] = [];
   const fail = (reason: string) => failures.push(`${stageName}_${reason}`);
+  const settlementLedger = stage.settlementLedger;
+  if (settlementLedger !== undefined) {
+    const entries = settlementLedger.entries;
+    if (
+      !Number.isSafeInteger(settlementLedger.fromDispatchExclusive)
+      || settlementLedger.fromDispatchExclusive < 0
+      || !Number.isSafeInteger(settlementLedger.throughDispatch)
+      || settlementLedger.throughDispatch < settlementLedger.fromDispatchExclusive
+      || typeof settlementLedger.truncated !== 'boolean'
+      || !Array.isArray(entries)
+      || entries.length > 8
+      || entries.some((entry, index) => (
+        !Number.isSafeInteger(entry.dispatchSequence)
+        || entry.dispatchSequence <= settlementLedger.fromDispatchExclusive
+        || entry.dispatchSequence > settlementLedger.throughDispatch
+        || (index > 0 && entry.dispatchSequence <= entries[index - 1]!.dispatchSequence)
+        || entry.status !== 'exposure_unknown'
+        || !['identity_policy_rejected', 'usage_or_cost_settlement_failed', 'response_processing_failed', 'response_stream_interrupted'].includes(entry.reason)
+        || !isSha256(entry.errorFingerprintSha256)
+      ))
+    ) fail('settlement_ledger_invalid');
+  }
   if ('status' in control) {
     if (
       control.status !== 'not_run'
@@ -2924,6 +2970,7 @@ function stageMetadataFailures(
       || stage.pricingProfileId !== null
       || stage.latencyMs !== 0
       || (stage.providerExposures?.length ?? 0) !== 0
+      || (settlementLedger?.entries.length ?? 0) !== 0
     ) fail('not_run_control_invalid');
     return failures;
   }

--- a/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
@@ -151,7 +151,7 @@ describe('fixed-trace architecture diagnostic execution', () => {
   it('preserves unknown provider exposure in a finalized diagnostic artifact instead of inventing cost certainty', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'architecture-diagnostic-'));
     const output = join(directory, 'artifact.json');
-    const { admission, budget } = admitted(true);
+    const { admission, budget, raw } = admitted(true);
     const artifact = await runFixedTraceArchitectureDiagnosticArtifact({
       admission, budget, runRootId: 'architecture-test-root', runStartedAt: '2026-09-07T00:00:00.000Z', plan: plan(),
     });
@@ -161,7 +161,20 @@ describe('fixed-trace architecture diagnostic execution', () => {
     // be represented as a completed settled execution.
     expect(artifact).toMatchObject({ complete: false, comparisonEligible: false, failure: null });
     expect(artifact.runs).toHaveLength(3);
+    const settlementEntries = (artifact.runs as Array<{ observations: Array<{
+      metadata: { generation: { settlementLedger?: { entries: unknown[] } } };
+    }> }>)
+      .flatMap((run) => run.observations)
+      .flatMap((observation) => observation.metadata.generation.settlementLedger?.entries ?? []);
+    expect(settlementEntries).toEqual([expect.objectContaining({
+      status: 'exposure_unknown',
+      reason: 'identity_policy_rejected',
+      errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    })]);
     expect(budget.snapshot()).toMatchObject({ exposureUnknown: true, completedCalls: 0, dispatchedCalls: 1, reservedUsd: 0 });
+    expect(raw.calls).toHaveLength(1);
+    expect(readFileSync(output, 'utf8')).toContain('identity_policy_rejected');
+    expect(readFileSync(output, 'utf8')).not.toContain('Fixed trace budget usage is invalid');
     expect(readFileSync(`${output}.sha256`, 'utf8')).toBe(`${digest}  ${output}\n`);
     expect(createHash('sha256').update(readFileSync(output, 'utf8')).digest('hex')).toBe(digest);
   });

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -8,6 +8,8 @@ import {
   fixedTraceApprovedPricingProfiles,
   fixedTraceResponseUsesPricingPolicy,
   fixedTraceResponsePricingPolicy,
+  fixedTraceSettlementDiagnosticCursor,
+  fixedTraceSettlementDiagnosticLedger,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
 import { datedPricingProfilesForFixedTrace } from '../../../src/addie/eval/dated-pricing-cohort.js';
 import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
@@ -216,6 +218,7 @@ describe('fixed trace provider budget', () => {
     const delegate = new BudgetScriptedProvider([mismatched, RESPONSE]);
     const budget = new FixedTraceBudget(1);
     const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);
+    const cursor = fixedTraceSettlementDiagnosticCursor(provider);
 
     await expect(collectModelResponse(provider.respond(REQUEST))).resolves.toEqual(mismatched);
     expect(budget.snapshot()).toMatchObject({
@@ -223,6 +226,17 @@ describe('fixed trace provider budget', () => {
       dispatchedCalls: 1,
       completedCalls: 0,
       exposureUnknown: true,
+    });
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor)).toEqual({
+      fromDispatchExclusive: 0,
+      throughDispatch: 1,
+      truncated: false,
+      entries: [{
+        dispatchSequence: 1,
+        status: 'exposure_unknown',
+        reason: 'identity_policy_rejected',
+        errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }],
     });
     await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toMatchObject({
       name: 'FixedTraceBudgetAdmissionError', reason: 'budget_exposure_unknown',
@@ -411,6 +425,7 @@ describe('fixed trace provider budget', () => {
     }]);
     const budget = new FixedTraceBudget(1);
     const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);
+    const cursor = fixedTraceSettlementDiagnosticCursor(provider);
 
     await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow(
       'Invalid normalized usage field: inputTokens',
@@ -422,6 +437,63 @@ describe('fixed trace provider budget', () => {
       completedCalls: 0,
       exposureUnknown: true,
     });
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor).entries).toEqual([{
+      dispatchSequence: 1,
+      status: 'exposure_unknown',
+      reason: 'usage_or_cost_settlement_failed',
+      errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    }]);
+  });
+
+  it('treats missing terminal usage as unknown exposure and rejects every later dispatch', async () => {
+    const missingUsage = { ...RESPONSE, usage: undefined } as unknown as ModelResponse;
+    const delegate = new BudgetScriptedProvider([missingUsage, RESPONSE]);
+    const budget = new FixedTraceBudget(1);
+    const provider = new BudgetedFixedTraceProvider(delegate, budget, PRICING, RESPONSE_PRICING_POLICY);
+    const cursor = fixedTraceSettlementDiagnosticCursor(provider);
+
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow();
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor).entries).toEqual([{
+      dispatchSequence: 1,
+      status: 'exposure_unknown',
+      reason: 'usage_or_cost_settlement_failed',
+      errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    }]);
+    await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toMatchObject({
+      name: 'FixedTraceBudgetAdmissionError', reason: 'budget_exposure_unknown',
+    });
+    expect(delegate.dispatches).toHaveBeenCalledTimes(1);
+  });
+
+  it('fingerprints interrupted provider errors by safe category without retaining their raw contents', async () => {
+    const firstSecret = 'provider output: keep-this-out-of-artifacts';
+    const firstDelegate = new BudgetScriptedProvider([new Error(firstSecret)]);
+    const firstProvider = new BudgetedFixedTraceProvider(
+      firstDelegate, new FixedTraceBudget(1), PRICING, RESPONSE_PRICING_POLICY,
+    );
+    const firstCursor = fixedTraceSettlementDiagnosticCursor(firstProvider);
+
+    await expect(collectModelResponse(firstProvider.respond(REQUEST))).rejects.toThrow(firstSecret);
+    const firstLedger = fixedTraceSettlementDiagnosticLedger(firstProvider, firstCursor);
+    expect(firstLedger.entries).toEqual([{
+      dispatchSequence: 1,
+      status: 'exposure_unknown',
+      reason: 'response_stream_interrupted',
+      errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    }]);
+    expect(JSON.stringify(firstLedger)).not.toContain(firstSecret);
+
+    const secondSecret = 'a distinct provider failure that must also stay private';
+    const secondDelegate = new BudgetScriptedProvider([new Error(secondSecret)]);
+    const secondProvider = new BudgetedFixedTraceProvider(
+      secondDelegate, new FixedTraceBudget(1), PRICING, RESPONSE_PRICING_POLICY,
+    );
+    const secondCursor = fixedTraceSettlementDiagnosticCursor(secondProvider);
+    await expect(collectModelResponse(secondProvider.respond(REQUEST))).rejects.toThrow(secondSecret);
+    const secondLedger = fixedTraceSettlementDiagnosticLedger(secondProvider, secondCursor);
+    expect(JSON.stringify(secondLedger)).not.toContain(secondSecret);
+    expect(secondLedger.entries[0]!.errorFingerprintSha256)
+      .toBe(firstLedger.entries[0]!.errorFingerprintSha256);
   });
 
   it('does not mark exposure unknown when the caller hook blocks dispatch', async () => {

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -97,6 +97,21 @@ class BudgetScriptedProvider implements ModelProvider {
 }
 
 describe('fixed trace provider budget', () => {
+  it('projects an ordinary provider as an empty stage-local settlement interval', () => {
+    const provider = new BudgetScriptedProvider([]);
+
+    expect(fixedTraceSettlementDiagnosticLedger(
+      provider,
+      fixedTraceSettlementDiagnosticCursor(provider),
+      2,
+    )).toEqual({
+      fromDispatchExclusive: 0,
+      throughDispatch: 2,
+      truncated: false,
+      entries: [],
+    });
+  });
+
   it('exposes only reviewed production pricing and rejects former test profiles before dispatch', () => {
     const liveProfiles = fixedTraceApprovedPricingProfiles();
     expect(liveProfiles).toHaveLength(4);
@@ -227,7 +242,7 @@ describe('fixed trace provider budget', () => {
       completedCalls: 0,
       exposureUnknown: true,
     });
-    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor)).toEqual({
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor, 1)).toEqual({
       fromDispatchExclusive: 0,
       throughDispatch: 1,
       truncated: false,
@@ -238,6 +253,9 @@ describe('fixed trace provider budget', () => {
         errorFingerprintSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       }],
     });
+    expect(() => fixedTraceSettlementDiagnosticLedger(provider, cursor, 0)).toThrow(
+      'Fixed trace settlement diagnostic dispatch count does not match the budget wrapper',
+    );
     await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toMatchObject({
       name: 'FixedTraceBudgetAdmissionError', reason: 'budget_exposure_unknown',
     });
@@ -437,7 +455,7 @@ describe('fixed trace provider budget', () => {
       completedCalls: 0,
       exposureUnknown: true,
     });
-    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor).entries).toEqual([{
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor, 1).entries).toEqual([{
       dispatchSequence: 1,
       status: 'exposure_unknown',
       reason: 'usage_or_cost_settlement_failed',
@@ -453,7 +471,7 @@ describe('fixed trace provider budget', () => {
     const cursor = fixedTraceSettlementDiagnosticCursor(provider);
 
     await expect(collectModelResponse(provider.respond(REQUEST))).rejects.toThrow();
-    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor).entries).toEqual([{
+    expect(fixedTraceSettlementDiagnosticLedger(provider, cursor, 1).entries).toEqual([{
       dispatchSequence: 1,
       status: 'exposure_unknown',
       reason: 'usage_or_cost_settlement_failed',
@@ -474,7 +492,7 @@ describe('fixed trace provider budget', () => {
     const firstCursor = fixedTraceSettlementDiagnosticCursor(firstProvider);
 
     await expect(collectModelResponse(firstProvider.respond(REQUEST))).rejects.toThrow(firstSecret);
-    const firstLedger = fixedTraceSettlementDiagnosticLedger(firstProvider, firstCursor);
+    const firstLedger = fixedTraceSettlementDiagnosticLedger(firstProvider, firstCursor, 1);
     expect(firstLedger.entries).toEqual([{
       dispatchSequence: 1,
       status: 'exposure_unknown',
@@ -490,7 +508,7 @@ describe('fixed trace provider budget', () => {
     );
     const secondCursor = fixedTraceSettlementDiagnosticCursor(secondProvider);
     await expect(collectModelResponse(secondProvider.respond(REQUEST))).rejects.toThrow(secondSecret);
-    const secondLedger = fixedTraceSettlementDiagnosticLedger(secondProvider, secondCursor);
+    const secondLedger = fixedTraceSettlementDiagnosticLedger(secondProvider, secondCursor, 1);
     expect(JSON.stringify(secondLedger)).not.toContain(secondSecret);
     expect(secondLedger.entries[0]!.errorFingerprintSha256)
       .toBe(firstLedger.entries[0]!.errorFingerprintSha256);

--- a/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
+++ b/server/tests/unit/addie/fixed-trace-common-tool-universe.test.ts
@@ -203,6 +203,18 @@ describe('fixed-trace common evaluator tool universe', () => {
     expect(router.requests).toHaveLength(1);
     expect(generation.requests).toHaveLength(1);
     expect(serialized[0]!.metadata.toolDefinitionProvenance).toBe('evaluator_owned_common_tool_universe');
+    expect(serialized[0]!.metadata.router.settlementLedger).toEqual({
+      fromDispatchExclusive: 0,
+      throughDispatch: 1,
+      truncated: false,
+      entries: [],
+    });
+    expect(serialized[0]!.metadata.generation.settlementLedger).toEqual({
+      fromDispatchExclusive: 0,
+      throughDispatch: 1,
+      truncated: false,
+      entries: [],
+    });
     expect(regraded.grades[0]).toMatchObject({ metadataPass: true });
     expect(regraded.grades[0]!.failures).not.toContain('tool_universe_provenance_invalid');
     expect(regraded.grades[0]!.failures).not.toContain('execution_envelope_provenance_invalid');

--- a/server/tests/unit/addie/fixed-trace-runner.test.ts
+++ b/server/tests/unit/addie/fixed-trace-runner.test.ts
@@ -856,12 +856,24 @@ describe('fixed trace artifact runner', () => {
       dispatched: true,
       usage: { inputTokens: 10, outputTokens: 5 },
       estimatedCostUsd: 0.000035,
+      settlementLedger: {
+        fromDispatchExclusive: 0,
+        throughDispatch: 1,
+        truncated: false,
+        entries: [],
+      },
     });
     expect(observation.metadata.generation).toMatchObject({
       source: 'provider',
       dispatched: true,
       usage: { inputTokens: 20, outputTokens: 10 },
       estimatedCostUsd: 0.00007,
+      settlementLedger: {
+        fromDispatchExclusive: 0,
+        throughDispatch: 2,
+        truncated: false,
+        entries: [],
+      },
     });
     expect(observation.metadata.generation.providerRequestSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(generation.respondCalls).toHaveLength(2);

--- a/server/tests/unit/addie/fixed-trace-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-suite.test.ts
@@ -61,7 +61,7 @@ const HASH = createHash('sha256').update('fixture').digest('hex');
 function stage(
   overrides: Partial<FixedTraceModelStageMetadata> = {},
 ): FixedTraceModelStageMetadata {
-  return {
+  const value = {
     source: 'provider',
     dispatched: true,
     requestedProvider: 'anthropic',
@@ -86,6 +86,19 @@ function stage(
     latencyMs: 5,
     ...overrides,
   };
+  // Derive the default after overrides: local/not-run fixtures must not
+  // inherit the provider fixture's one-dispatch ledger.
+  const dispatchedCalls = overrides.dispatchedCalls ?? (value.dispatched ? 1 : 0);
+  return {
+    ...value,
+    dispatchedCalls,
+    settlementLedger: value.settlementLedger ?? {
+      fromDispatchExclusive: 0,
+      throughDispatch: dispatchedCalls,
+      truncated: false,
+      entries: [],
+    },
+  };
 }
 
 function notRunStage(
@@ -100,6 +113,12 @@ function notRunStage(
     returnedProvider: null,
     returnedModel: null,
     providerExposures: [],
+    settlementLedger: {
+      fromDispatchExclusive: 0,
+      throughDispatch: 0,
+      truncated: false,
+      entries: [],
+    },
     modelResolution: null,
     promptSha256: null,
     providerRequestSha256: null,
@@ -1509,6 +1528,62 @@ describe('fixed cross-provider trace suite', () => {
       'generation_cost_provenance_missing',
       'generation_provider_identity_missing',
     ]));
+  });
+
+  it('strictly binds redacted settlement receipts to their dispatched stage', () => {
+    const trace = FIXED_TRACE_SUITE.find((candidate) => candidate.category === 'knowledge')!;
+    const validFingerprint = createHash('sha256')
+      .update('adcp:addie:fixed-trace:settlement-diagnostic:v1\0', 'utf8')
+      .update('response_stream_interrupted', 'utf8')
+      .digest('hex');
+    const receipt = {
+      dispatchSequence: 1,
+      status: 'exposure_unknown' as const,
+      reason: 'response_stream_interrupted' as const,
+      errorFingerprintSha256: validFingerprint,
+    };
+    const withReceipt = () => {
+      const observation = passingObservation(trace);
+      observation.metadata.router = stage({
+        source: 'local',
+        dispatched: true,
+        returnedProvider: null,
+        returnedModel: null,
+        modelResolution: 'local',
+        usageKnown: false,
+        usage: null,
+        estimatedCostUsd: null,
+        pricingSource: null,
+        settlementLedger: {
+          fromDispatchExclusive: 0,
+          throughDispatch: 1,
+          truncated: false,
+          entries: [{ ...receipt }],
+        },
+      });
+      return observation;
+    };
+
+    expect(gradeFixedTrace(trace, withReceipt()).failures)
+      .not.toContain('router_settlement_ledger_invalid');
+
+    const rawProviderError = withReceipt();
+    (rawProviderError.metadata.router.settlementLedger!.entries[0] as Record<string, unknown>).rawProviderError = 'provider-owned detail';
+    expect(gradeFixedTrace(trace, rawProviderError).failures).toContain('router_settlement_ledger_invalid');
+
+    const arbitraryFingerprint = withReceipt();
+    arbitraryFingerprint.metadata.router.settlementLedger!.entries[0]!.errorFingerprintSha256 = HASH;
+    expect(gradeFixedTrace(trace, arbitraryFingerprint).failures).toContain('router_settlement_ledger_invalid');
+
+    const omitted = withReceipt();
+    delete omitted.metadata.router.settlementLedger;
+    expect(gradeFixedTrace(trace, omitted).failures).toContain('router_settlement_ledger_missing');
+
+    const unrelatedRange = withReceipt();
+    unrelatedRange.metadata.router.settlementLedger!.fromDispatchExclusive = 8;
+    unrelatedRange.metadata.router.settlementLedger!.throughDispatch = 9;
+    unrelatedRange.metadata.router.settlementLedger!.entries[0]!.dispatchSequence = 9;
+    expect(gradeFixedTrace(trace, unrelatedRange).failures).toContain('router_settlement_ledger_invalid');
   });
 
   it('reports omissions instead of silently shrinking the requested matrix', () => {


### PR DESCRIPTION
Retains bounded redacted settlement failure categories in fixed-trace metadata so an immutable diagnostic fails closed with actionable non-sensitive infrastructure evidence. Adds coverage for identity rejection, missing/malformed usage, interruption redaction, no-later-dispatch, and artifact finalization.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
