### PR TITLE
fix(compliance): harden target selection and escalation recovery

### DIFF
--- a/server/public/agents.html
+++ b/server/public/agents.html
@@ -1191,10 +1191,24 @@
     }
 
     async function fetchPublishers(agent) {
+        const section = document.getElementById('publishers-section');
         try {
-            const response = await fetch(`/api/public/agent-publishers?url=${encodeURIComponent(agent.url)}`);
-            const data = await response.json();
-            const section = document.getElementById('publishers-section');
+            // Use AgenticAdvertising.org's indexed authorization data. Calling the
+            // agent live here made this public page depend on each agent's
+            // auth and uptime, and non-JSON gateway errors broke rendering.
+            const response = await fetch(`/v1/agents/${encodeURIComponent(agent.url)}/publishers?status=authorized&status=revoked&limit=1000`);
+            const raw = await response.text();
+            let data;
+            try {
+                data = JSON.parse(raw);
+            } catch {
+                throw new Error(`Directory returned an invalid response (${response.status})`);
+            }
+
+            if (response.status === 404) {
+                section.innerHTML = '<div class="property-section-small">No indexed publisher authorizations are available for this agent yet.</div>';
+                return;
+            }
 
             if (!response.ok || data.error) {
                 const message = data.error?.message || data.message || data.error || 'Unknown error';
@@ -1204,64 +1218,31 @@
                 return;
             }
 
-            if (data.properties && data.properties.length > 0) {
-                const verified = data.properties.filter(p => p.verified === true);
-                const unverified = data.properties.filter(p => p.verified === false);
-                const unchecked = data.properties.filter(p => p.verified === undefined);
+            const publishers = Array.isArray(data.publishers) ? data.publishers : [];
+            if (publishers.length > 0) {
+                const authorized = publishers.filter(p => p.status === 'authorized');
+                const revoked = publishers.filter(p => p.status === 'revoked');
 
                 let html = '';
 
-                if (verified.length > 0) {
+                if (authorized.length > 0) {
                     html += '<div class="publishers-group">';
-                    html += '<h4 class="publishers-group__title publishers-group__title--verified">Verified properties</h4>';
+                    html += '<h4 class="publishers-group__title publishers-group__title--verified">Authorized publishers</h4>';
                     html += '<div class="publishers-grid">' +
-                        verified.map(p => `
+                        authorized.map(p => `
                             <div class="publisher-item publisher-item--verified">
-                                <div style="display: flex; justify-content: between; align-items: start; gap: var(--space-2);">
-                                    <div style="flex: 1;">
-                                        <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
-                                        <div class="property-section-small" style="margin-top: var(--space-1);">
-                                            <strong>Type:</strong> ${escapeHtml(p.type || 'domain')}
-                                            ${p.country ? ` | <strong>Country:</strong> ${escapeHtml(p.country)}` : ''}
-                                        </div>
-                                    </div>
-                                    ${safeHttpsUrl(p.verification_url) ? `<a href="${escapeHtml(safeHttpsUrl(p.verification_url))}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link" title="View adagents.json">
-                                        Verified
-                                    </a>` : '<span class="publisher-verify-link">Verified</span>'}
-                                </div>
-                                ${p.description ? `<div class="property-section-small" style="margin-top: var(--space-2);">${escapeHtml(p.description)}</div>` : ''}
-                                ${p.tags && p.tags.length > 0 ? `
-                                    <div class="property-tags" style="margin-top: var(--space-3);">
-                                        ${p.tags.map(tag => `<span class="property-tag">${escapeHtml(tag)}</span>`).join('')}
-                                    </div>
-                                ` : ''}
-                                ${p.metadata ? `<details class="property-metadata-toggle">
-                                    <summary>Additional metadata</summary>
-                                    <pre class="property-metadata-pre">${escapeHtml(JSON.stringify(p.metadata, null, 2))}</pre>
-                                </details>` : ''}
-                            </div>
-                        `).join('') +
-                    '</div>';
-                    html += '</div>';
-                }
-
-                if (unverified.length > 0) {
-                    html += '<div class="publishers-group">';
-                    html += '<h4 class="publishers-group__title publishers-group__title--unverified">Unverified properties (claims not authorized)</h4>';
-                    html += '<div class="publishers-grid">' +
-                        unverified.map(p => `
-                            <div class="publisher-item publisher-item--unverified">
                                 <div style="display: flex; justify-content: space-between; align-items: start; gap: var(--space-2);">
                                     <div style="flex: 1;">
-                                        <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
-                                        <div class="property-section-small" style="margin-top: var(--space-1);">${escapeHtml(p.type || 'domain')}</div>
+                                        <div class="publisher-domain">${escapeHtml(p.publisher_domain || 'Unknown')}</div>
+                                        <div class="property-section-small" style="margin-top: var(--space-1);">
+                                            <strong>Authorized properties:</strong> ${escapeHtml(String(p.properties_authorized ?? 0))} of ${escapeHtml(String(p.properties_total ?? 0))}
+                                        </div>
                                     </div>
-                                    ${safeHttpsUrl(p.verification_url) ? `<a href="${escapeHtml(safeHttpsUrl(p.verification_url))}" target="_blank" rel="noopener noreferrer" class="publisher-verify-link publisher-verify-link--error" title="Check adagents.json">
-                                        Check
-                                    </a>` : ''}
+                                    <span class="publisher-verify-link">Authorized</span>
                                 </div>
-                                <div class="publisher-warning">
-                                    <strong>Warning:</strong> ${escapeHtml(p.verification_error || 'This agent is not listed in the domain\'s .well-known/adagents.json file')}
+                                <div class="property-section-small" style="margin-top: var(--space-2);">
+                                    Discovered via ${escapeHtml(String(p.discovery_method || 'directory'))}
+                                    ${p.manager_domain ? ` | <strong>Manager:</strong> ${escapeHtml(p.manager_domain)}` : ''}
                                 </div>
                             </div>
                         `).join('') +
@@ -1269,26 +1250,31 @@
                     html += '</div>';
                 }
 
-                if (unchecked.length > 0) {
+                if (revoked.length > 0) {
                     html += '<div class="publishers-group">';
-                    html += '<h4 class="publishers-group__title publishers-group__title--unchecked">Unchecked properties</h4>';
+                    html += '<h4 class="publishers-group__title publishers-group__title--unverified">Revoked publishers</h4>';
                     html += '<div class="publishers-grid">' +
-                        unchecked.map(p => `
-                            <div class="publisher-item publisher-item--unchecked">
-                                <div class="publisher-domain">${escapeHtml(p.identifier || p.domain || 'Unknown')}</div>
-                                <div class="property-section-small" style="margin-top: var(--space-1);">${escapeHtml(p.type || 'domain')}</div>
+                        revoked.map(p => `
+                            <div class="publisher-item publisher-item--unverified">
+                                <div class="publisher-domain">${escapeHtml(p.publisher_domain || 'Unknown')}</div>
+                                <div class="publisher-warning">
+                                    <strong>Revoked:</strong> This publisher no longer authorizes the agent.
+                                </div>
                             </div>
                         `).join('') +
                     '</div>';
                     html += '</div>';
                 }
 
+                if (data.next_cursor) {
+                    html += '<div class="ds-alert ds-alert-info"><p class="ds-alert__desc">Showing the first 1,000 publisher authorizations. Additional results are available from the directory API.</p></div>';
+                }
                 section.innerHTML = html;
             } else {
-                section.innerHTML = `<div class="property-section-small">No properties available from this agent yet.</div>`;
+                section.innerHTML = '<div class="property-section-small">No indexed publisher authorizations are available for this agent yet.</div>';
             }
         } catch (error) {
-            document.getElementById('publishers-section').innerHTML = `<div class="error-text">Failed to load publishers: ${escapeHtml(error.message)}</div>`;
+            section.innerHTML = `<div class="error-text">Failed to load publishers: ${escapeHtml(error.message)}</div>`;
         }
     }
 

--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -15,7 +15,7 @@ import {
   hasTrustworthyComplianceTarget,
   HOSTED_TARGET_DISCOVERY_TIMEOUT_MS,
   selectComplianceTargetForAgentSelection,
-  storedComplianceTargetMatchesObservedProfile,
+  selectedComplianceTargetMatchesObservedProfile,
   type ComplyOptions,
   type ComplianceTargetSelection,
 } from '../services/compliance-testing.js';
@@ -177,7 +177,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
         userAgent: AAO_UA_COMPLIANCE,
         storyboard_start_offset: storyboardStartOffset,
       };
-      const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agent.agent_url);
+      const seededSupportedVersions = await complianceDb.getLastKnownSupportedVersions(agent.agent_url);
 
       runTargetSelection = await selectComplianceTargetForAgentSelection(
         agent.agent_url,
@@ -200,14 +200,14 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
       assertExecutionFence();
       const complianceResult = await comply(agent.agent_url, complyOptions, runTarget);
       assertExecutionFence();
-      if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complianceResult.agent_profile)) {
+      if (!selectedComplianceTargetMatchesObservedProfile(runTargetSelection, complianceResult.agent_profile)) {
         logger.warn(
           {
             agentUrl: agent.agent_url,
             selectedTarget: runTarget.requested,
             observedSupportedVersions: complianceResult.agent_profile?.adcp_supported_versions,
           },
-          'Compliance heartbeat skipped because the live run superseded its stored target',
+          'Compliance heartbeat skipped because the completed run superseded its selected target',
         );
         await complianceDb.deferComplianceCheckAfterInconclusiveTarget(agent.agent_url);
         result.skipped++;

--- a/server/src/addie/mcp/member-tools.ts
+++ b/server/src/addie/mcp/member-tools.ts
@@ -54,7 +54,7 @@ import {
   hasTrustworthyComplianceTarget,
   selectComplianceTargetForAgent,
   selectComplianceTargetForAgentSelection,
-  storedComplianceTargetMatchesObservedProfile,
+  selectedComplianceTargetMatchesObservedProfile,
   UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
   type ComplyOptions,
   type CapabilityResolutionErrorInfo,
@@ -222,7 +222,7 @@ function explicitTargetProbeFailureMessage(
   return [
     `**Error:** compliance_target \`${target.requested}\` resolves to \`${target.version}\`, but I could not verify this agent advertises support for that target.`,
     `Capability discovery failed${safeProbeError ? ` with agent-reported error ${safeProbeError}` : ''}.`,
-    'Fix capability discovery or authentication, then retry the prerelease diagnostic.',
+    'Fix capability discovery or authentication, then retry the requested compliance diagnostic.',
   ].join('\n');
 }
 
@@ -272,9 +272,12 @@ async function explicitTargetSupportErrorFromAgent(
   if (!hasExplicitComplianceTarget(input) || !requiresAdvertisedHostedComplianceSupport(target)) return undefined;
 
   try {
-    const caps = await testCapabilityDiscovery(agentUrl, withSdkSafeTransport({
-      ...(auth && { auth }),
-    }));
+    const caps = await testCapabilityDiscovery(
+      agentUrl,
+      withSdkSafeTransport(withHostedTestOptions({
+        ...(auth && { auth }),
+      }, target)),
+    );
     const oauthError = capabilityDiscoveryOAuthError(caps);
     if (oauthError) return explicitTargetOAuthRequiredMessage(agentUrl, organizationId);
 
@@ -282,7 +285,7 @@ async function explicitTargetSupportErrorFromAgent(
     if (probeFailure) return probeFailure;
     return explicitTargetSupportError(input, target, caps.profile);
   } catch (error) {
-    logger.warn({ err: error, agentUrl }, 'Could not verify explicit prerelease compliance target support');
+    logger.warn({ err: error, agentUrl }, 'Could not verify explicit compliance target support');
     return [
       `**Error:** cannot run compliance_target \`${target.requested}\` because the agent's advertised supported versions could not be verified.`,
       'Retry after `get_adcp_capabilities` is reachable, or use `3.0`.',
@@ -4662,7 +4665,7 @@ export function createMemberToolHandlers(
     const authOption = buildAuthOption(resolved);
 
     if (!hasExplicitComplianceTarget(input)) {
-      const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(resolved.resolvedUrl);
+      const seededSupportedVersions = await complianceDb.getLastKnownSupportedVersions(resolved.resolvedUrl);
       runTargetSelection = await selectComplianceTargetForAgentSelection(
         resolved.resolvedUrl,
         { auth: authOption },
@@ -4697,7 +4700,7 @@ export function createMemberToolHandlers(
 
     try {
       const result = await comply(resolved.resolvedUrl, complyOptions, runTarget);
-      if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, result.agent_profile)) {
+      if (!selectedComplianceTargetMatchesObservedProfile(runTargetSelection, result.agent_profile)) {
         return (
           `**Compliance target unavailable**\n\n${UNRESOLVED_COMPLIANCE_TARGET_MESSAGE} ` +
           `The agent's live profile changed after the diagnostic target was selected; retry the evaluation.`

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -30,6 +30,7 @@ import {
   selectCanonicalHostedComplianceTargetForProfile,
   selectHostedComplianceTargetForProfile,
   withHostedComplianceRunOptions,
+  withHostedTestOptions,
   type HostedComplianceTarget,
 } from '../../services/hosted-compliance-version.js';
 import { getStoryboard } from '../../services/storyboards.js';
@@ -58,22 +59,25 @@ export interface ComplianceTargetSelection {
 }
 
 export const UNRESOLVED_COMPLIANCE_TARGET_MESSAGE =
-  'Could not determine a compatible compliance target from live capabilities or recent compliance history.';
+  'Could not determine a compatible compliance target from live capabilities or compliance history.';
 
 export function hasTrustworthyComplianceTarget(selection: ComplianceTargetSelection): boolean {
   return selection.source !== 'default';
 }
 
 /**
- * A stored profile may choose a safe target for a diagnostic attempt, but the
- * profile observed by that attempt is newer evidence. Refuse to publish the
- * result if the agent no longer advertises the stored target.
+ * Pre-discovery or a stored profile may choose a safe target for a diagnostic
+ * attempt, but the profile observed by that attempt is newer evidence. Refuse
+ * to publish if the agent no longer advertises the automatically selected target.
  */
-export function storedComplianceTargetMatchesObservedProfile(
+export function selectedComplianceTargetMatchesObservedProfile(
   selection: ComplianceTargetSelection,
   profile?: { adcp_supported_versions?: readonly string[] },
 ): boolean {
-  if (selection.source !== 'stored') return true;
+  // Explicit diagnostics keep their caller-selected target semantics. For
+  // automatically selected targets, the completed run is newer evidence than
+  // either pre-discovery or history and must still advertise that target.
+  if (selection.source !== 'stored' && selection.source !== 'live') return true;
   return agentAdvertisesHostedComplianceTarget(
     profile?.adcp_supported_versions,
     selection.target,
@@ -272,12 +276,42 @@ export async function selectComplianceTargetForAgentSelection(
   mode: 'preferred' | 'canonical' = 'preferred',
   seededSupportedVersions?: readonly string[],
 ): Promise<ComplianceTargetSelection> {
+  const seededVersions = [...new Set(
+    (seededSupportedVersions ?? []).map(version => version.trim()).filter(Boolean),
+  )];
+  const seededProfile = { adcp_supported_versions: seededVersions };
+  const seededTarget = seededVersions.length > 0
+    ? (mode === 'canonical'
+        ? selectCanonicalHostedComplianceTargetForProfile(seededProfile, fallback)
+        : selectHostedComplianceTargetForProfile(seededProfile, fallback))
+    : undefined;
+  const compatibleSeededTarget = seededTarget
+    && agentAdvertisesHostedComplianceTarget(seededVersions, seededTarget)
+    ? seededTarget
+    : undefined;
+
   try {
-    const discovery = await discoverCapabilitiesWithDeadline(agentUrl, options);
+    // The SDK's default pre-discovery target can be newer than the agent's
+    // declared range. Pin a last-known compatible target when available so
+    // the probe can recover the current profile instead of failing before it
+    // gets a chance to report supported_versions.
+    const discovery = await discoverCapabilitiesWithDeadline(
+      agentUrl,
+      compatibleSeededTarget
+        ? withHostedTestOptions(options, compatibleSeededTarget)
+        : options,
+    );
     const target = mode === 'canonical'
       ? selectCanonicalHostedComplianceTargetForProfile(discovery.profile, fallback)
       : selectHostedComplianceTargetForProfile(discovery.profile, fallback);
     const supportedVersions = discovery.profile?.adcp_supported_versions;
+    if ((!supportedVersions || supportedVersions.length === 0) && compatibleSeededTarget) {
+      logger.warn(
+        { agentUrl, seededVersions, selectedTarget: compatibleSeededTarget.requested },
+        'Live capability discovery returned no supported versions; using last-known compatible target',
+      );
+      return { target: compatibleSeededTarget, confirmed: false, source: 'stored' };
+    }
     if (!agentAdvertisesHostedComplianceTarget(supportedVersions, target)) {
       logger.warn(
         { agentUrl, supportedVersions },
@@ -291,29 +325,22 @@ export async function selectComplianceTargetForAgentSelection(
       throw abortReason(options.signal, 'Hosted compliance target pre-discovery aborted');
     }
 
-    const supportedVersions = [...new Set(
-      (seededSupportedVersions ?? []).filter(version => version.trim().length > 0),
-    )];
-    if (supportedVersions.length > 0) {
-      const profile = { adcp_supported_versions: supportedVersions };
-      const target = mode === 'canonical'
-        ? selectCanonicalHostedComplianceTargetForProfile(profile, fallback)
-        : selectHostedComplianceTargetForProfile(profile, fallback);
-      if (!agentAdvertisesHostedComplianceTarget(supportedVersions, target)) {
+    if (seededVersions.length > 0) {
+      if (!compatibleSeededTarget) {
         logger.warn(
-          { err, agentUrl, supportedVersions },
-          'Could not match recent stored profile to a hosted compliance target; using default fallback',
+          { err, agentUrl, seededVersions },
+          'Could not match last-known profile to a hosted compliance target; using default fallback',
         );
         return { target: fallback, confirmed: false, source: 'default' };
       }
       logger.warn(
-        { err, agentUrl, supportedVersions, selectedTarget: target.requested },
-        'Could not pre-discover hosted compliance target; using recent stored profile',
+        { err, agentUrl, seededVersions, selectedTarget: compatibleSeededTarget.requested },
+        'Could not pre-discover hosted compliance target; using last-known profile',
       );
       // The stored profile is safe for choosing which grader to attempt, but
       // must not flow into badge eligibility. Only a profile observed during
       // the current run may support issuing or retaining public badges.
-      return { target, confirmed: false, source: 'stored' };
+      return { target: compatibleSeededTarget, confirmed: false, source: 'stored' };
     }
 
     logger.warn({ err, agentUrl }, 'Could not pre-discover hosted compliance target; using default fallback');
@@ -345,7 +372,6 @@ export function badgeEligibleVersionsForTargetSelection(
   if (!hasTrustworthyComplianceTarget(selection)) return [];
   const versions = badgeEligibleVersionsForHostedComplianceTarget(selection.target);
   if (versions.length === 0) return [];
-  if (selection.confirmed) return versions;
   return agentAdvertisesBadgeEligibleHostedComplianceTarget(
     profile?.adcp_supported_versions ?? selection.supportedVersions,
     selection.target,

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -1169,11 +1169,6 @@ export class ComplianceDatabase {
   }
 
   /**
-   * Return the most recently observed supported AdCP versions within a bounded
-   * window. This is a warm fallback for transient capability-discovery
-   * failures; live discovery remains authoritative whenever it succeeds.
-   */
-  /**
    * Number of recorded compliance runs for an agent (all-time, including
    * dry runs). Used as the persisted per-agent `storyboard_start_offset`
    * for budget-limited heartbeat assessments (adcp#6632 /
@@ -1192,20 +1187,22 @@ export class ComplianceDatabase {
     return Number.isFinite(n) && n > 0 ? n : 0;
   }
 
-  async getRecentSupportedVersions(agentUrl: string, maxAgeHours = 7 * 24): Promise<string[]> {
-    if (!Number.isInteger(maxAgeHours) || maxAgeHours <= 0) {
-      throw new Error('maxAgeHours must be a positive integer');
-    }
-
+  /**
+   * Return the last observed supported AdCP versions. Historical values are
+   * only a target-selection hint: the subsequent live compliance run must
+   * advertise the selected target before its result can be published.
+   * Keeping the hint beyond seven days lets stalled agents recover instead of
+   * permanently losing the only compatible version needed to probe them.
+   */
+  async getLastKnownSupportedVersions(agentUrl: string): Promise<string[]> {
     const result = await query(
       `SELECT agent_profile_json->'adcp_supported_versions' AS supported_versions
        FROM agent_compliance_runs
        WHERE agent_url = $1
-         AND tested_at >= NOW() - make_interval(hours => $2)
          AND jsonb_typeof(agent_profile_json->'adcp_supported_versions') = 'array'
        ORDER BY tested_at DESC
        LIMIT 1`,
-      [agentUrl, maxAgeHours],
+      [agentUrl],
     );
     const versions = result.rows[0]?.supported_versions;
     if (!Array.isArray(versions)) return [];

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -50,7 +50,7 @@ import {
   hasTrustworthyComplianceTarget,
   selectComplianceTargetForAgent,
   selectComplianceTargetForAgentSelection,
-  storedComplianceTargetMatchesObservedProfile,
+  selectedComplianceTargetMatchesObservedProfile,
   UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
 } from "../addie/services/compliance-testing.js";
 import { getPublicJwks } from "../services/verification-token.js";
@@ -8010,7 +8010,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
           storyboard_start_offset: storyboardStartOffset,
           ...(complianceAuth && { auth: complianceAuth }),
         };
-        const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);
+        const seededSupportedVersions = await complianceDb.getLastKnownSupportedVersions(agentUrl);
         const runTargetSelection = await selectComplianceTargetForAgentSelection(
           agentUrl,
           complyOptions,
@@ -8025,7 +8025,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
         lease.assertValid();
         const complyResult = await comply(agentUrl, complyOptions, runTarget);
         lease.assertValid();
-        if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
+        if (!selectedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
           throw new Error(UNRESOLVED_COMPLIANCE_TARGET_MESSAGE);
         }
         const runBadgeEligibleVersions = [
@@ -9155,7 +9155,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
           storyboards: [req.params.storyboardId],
           ...(sdkAuth && { auth: sdkAuth }),
         };
-        const seededSupportedVersions = await complianceDb.getRecentSupportedVersions(agentUrl);
+        const seededSupportedVersions = await complianceDb.getLastKnownSupportedVersions(agentUrl);
         const runTargetSelection = await selectComplianceTargetForAgentSelection(
           agentUrl,
           complyOptions,
@@ -9186,7 +9186,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
             ...(agentContextId && { agent_context_id: agentContextId }),
           });
         }
-        if (!storedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
+        if (!selectedComplianceTargetMatchesObservedProfile(runTargetSelection, complyResult.agent_profile)) {
           return res.status(422).json({
             error: UNRESOLVED_COMPLIANCE_TARGET_MESSAGE,
             error_kind: 'unresolved_compliance_target',

--- a/server/src/services/escalation-resolution-guard.ts
+++ b/server/src/services/escalation-resolution-guard.ts
@@ -1,5 +1,5 @@
 import type { Pool } from 'pg';
-import { getDomain } from 'tldts';
+import { parse } from 'tldts';
 import { getPool } from '../db/client.js';
 import type { Escalation, EscalationStatus } from '../db/escalation-db.js';
 import { checkAgentHostnameAgainstDomains } from './agent-hostname-verification.js';
@@ -31,7 +31,8 @@ interface DomainRow {
   subscription_status: string | null;
 }
 
-const REGISTRY_SETUP_RE = /\b(registry|member:\s*null|domain verification|verify_brand_domain_challenge|save_agent|brand manifest|adagents|agent registration|pending sync|propagation)\b/i;
+const REGISTRY_SETUP_RE = /\b(registry|member:\s*null|domain verification|verify_brand_domain_challenge|save_agent|agent registration|pending sync|propagation)\b/i;
+const REGISTRY_FILE_OPERATION_RE = /(?:\b(?:adagents(?:\.json)?|brand manifest)\b[^\n]{0,80}\b(?:setup|publish|crawl|sync|propagation|registration|domain|verify|blocked|failure)\b|\b(?:setup|publish|crawl|sync|propagation|registration|domain|verify|blocked|failure)\b[^\n]{0,80}\b(?:adagents(?:\.json)?|brand manifest)\b)/i;
 const DOMAIN_RE = /\b(?:https?:\/\/)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi;
 const URL_RE = /\bhttps?:\/\/[^\s)>'"]+/gi;
 const IGNORED_DOMAINS = new Set([
@@ -52,7 +53,8 @@ function escalationText(escalation: Escalation): string {
 }
 
 export function isRegistrySetupEscalation(escalation: Escalation): boolean {
-  return REGISTRY_SETUP_RE.test(escalationText(escalation));
+  const text = escalationText(escalation);
+  return REGISTRY_SETUP_RE.test(text) || REGISTRY_FILE_OPERATION_RE.test(text);
 }
 
 function toBaseDomain(hostname: string): string | null {
@@ -61,7 +63,12 @@ function toBaseDomain(hostname: string): string | null {
     .split('/')[0]
     .split(':')[0]
     .toLowerCase();
-  return getDomain(normalized, { allowPrivateDomains: true });
+  const parsed = parse(normalized, { allowPrivateDomains: true });
+  // Unknown pseudo-TLDs make ordinary documentation filenames such as
+  // adagents.json and brand.json look like domains. Only registry-qualified
+  // public/private suffixes are actionable organization-domain evidence.
+  if (!parsed.isIcann && !parsed.isPrivate) return null;
+  return parsed.domain;
 }
 
 export function extractEscalationDomains(escalation: Escalation): string[] {

--- a/server/tests/unit/compliance-db-supported-versions.test.ts
+++ b/server/tests/unit/compliance-db-supported-versions.test.ts
@@ -16,37 +16,32 @@ import { query } from '../../src/db/client.js';
 
 const mockedQuery = vi.mocked(query);
 
-describe('ComplianceDatabase.getRecentSupportedVersions', () => {
+describe('ComplianceDatabase.getLastKnownSupportedVersions', () => {
   const db = new ComplianceDatabase();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns string versions from the most recent profile inside the default seven-day window', async () => {
+  it('returns string versions from the most recent profile without expiring the recovery hint', async () => {
     mockedQuery.mockResolvedValueOnce({
       rows: [{ supported_versions: ['3.1', null, '', '3.0'] }],
       rowCount: 1,
     } as never);
 
-    await expect(db.getRecentSupportedVersions('https://agent.example/mcp'))
+    await expect(db.getLastKnownSupportedVersions('https://agent.example/mcp'))
       .resolves.toEqual(['3.1', '3.0']);
     expect(mockedQuery).toHaveBeenCalledWith(
       expect.stringContaining("jsonb_typeof(agent_profile_json->'adcp_supported_versions') = 'array'"),
-      ['https://agent.example/mcp', 168],
+      ['https://agent.example/mcp'],
     );
+    expect(mockedQuery.mock.calls[0]?.[0]).not.toContain('make_interval');
   });
 
-  it('returns an empty list when no recent stored profile exists', async () => {
+  it('returns an empty list when no stored profile exists', async () => {
     mockedQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
 
-    await expect(db.getRecentSupportedVersions('https://agent.example/mcp')).resolves.toEqual([]);
-  });
-
-  it('rejects an invalid recency window before querying', async () => {
-    await expect(db.getRecentSupportedVersions('https://agent.example/mcp', 0))
-      .rejects.toThrow('maxAgeHours must be a positive integer');
-    expect(mockedQuery).not.toHaveBeenCalled();
+    await expect(db.getLastKnownSupportedVersions('https://agent.example/mcp')).resolves.toEqual([]);
   });
 
   it('defers an inconclusive check only while its future heartbeat lock is still held', async () => {

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getAgentsDueForCheck: vi.fn(),
-  getRecentSupportedVersions: vi.fn(),
+  getLastKnownSupportedVersions: vi.fn(),
   countComplianceRuns: vi.fn(),
   deferComplianceCheckAfterInconclusiveTarget: vi.fn(),
   resolveOwnerAuth: vi.fn(),
@@ -49,7 +49,7 @@ vi.mock('../../src/logger.js', () => ({
 vi.mock('../../src/db/compliance-db.js', () => ({
   ComplianceDatabase: class {
     getAgentsDueForCheck = mocks.getAgentsDueForCheck;
-    getRecentSupportedVersions = mocks.getRecentSupportedVersions;
+    getLastKnownSupportedVersions = mocks.getLastKnownSupportedVersions;
     countComplianceRuns = mocks.countComplianceRuns;
     deferComplianceCheckAfterInconclusiveTarget = mocks.deferComplianceCheckAfterInconclusiveTarget;
     resolveOwnerAuth = mocks.resolveOwnerAuth;
@@ -79,10 +79,10 @@ vi.mock('../../src/addie/services/compliance-testing.js', () => ({
   presentCapabilityResolutionError: mocks.presentCapabilityResolutionError,
   badgeEligibleVersionsForTargetSelection: mocks.badgeEligibleVersionsForTargetSelection,
   hasTrustworthyComplianceTarget: (selection: { source?: string }) => selection.source !== 'default',
-  storedComplianceTargetMatchesObservedProfile: (
+  selectedComplianceTargetMatchesObservedProfile: (
     selection: { source?: string; target?: { requested?: string } },
     profile?: { adcp_supported_versions?: string[] },
-  ) => selection.source !== 'stored'
+  ) => !['stored', 'live'].includes(selection.source ?? '')
     || Boolean(profile?.adcp_supported_versions?.includes(selection.target?.requested ?? '')),
   selectComplianceTargetForAgentSelection: mocks.selectComplianceTargetForAgentSelection,
 }));
@@ -140,7 +140,7 @@ describe('runComplianceHeartbeatJob', () => {
     mocks.query.mockResolvedValue({ rows: [], rowCount: 0 });
     mocks.withDatabaseDeadline.mockImplementation(async (_deadline, operation) => operation());
     mocks.resolveOwnerAuth.mockResolvedValue(undefined);
-    mocks.getRecentSupportedVersions.mockResolvedValue(['3.1']);
+    mocks.getLastKnownSupportedVersions.mockResolvedValue(['3.1']);
     mocks.countComplianceRuns.mockResolvedValue(4);
     mocks.adaptAuthForSdk.mockResolvedValue(undefined);
     mocks.selectComplianceTargetForAgentSelection.mockResolvedValue({ target, confirmed: false, source: 'stored' });
@@ -523,7 +523,7 @@ describe('runComplianceHeartbeatJob', () => {
     mocks.getAgentsDueForCheck.mockResolvedValueOnce([
       { agent_url: 'https://agent.example.com/mcp', lifecycle_stage: 'testing', last_checked_at: null },
     ]);
-    mocks.getRecentSupportedVersions.mockResolvedValueOnce([]);
+    mocks.getLastKnownSupportedVersions.mockResolvedValueOnce([]);
     mocks.selectComplianceTargetForAgentSelection.mockResolvedValueOnce({
       target,
       confirmed: false,

--- a/server/tests/unit/compliance-target-discovery.test.ts
+++ b/server/tests/unit/compliance-target-discovery.test.ts
@@ -43,7 +43,14 @@ vi.mock('../../src/services/hosted-compliance-version.js', () => ({
       : mocks.fallbackTarget,
   agentAdvertisesHostedComplianceTarget: (versions: string[] | undefined, target: { requested: string }) =>
     Boolean(versions?.includes(target.requested)),
-  withHostedComplianceRunOptions: (options: unknown) => options,
+  withHostedComplianceRunOptions: (options: Record<string, unknown>, target: { version: string }) => ({
+    ...options,
+    version: target.version,
+  }),
+  withHostedTestOptions: (options: Record<string, unknown>, target: { version: string }) => ({
+    ...options,
+    adcpVersion: target.version,
+  }),
 }));
 
 vi.mock('../../src/utils/sdk-safe-fetch.js', () => ({
@@ -185,6 +192,30 @@ describe('hosted compliance target discovery deadline', () => {
       confirmed: false,
       source: 'stored',
     });
+    expect(mocks.discovery).toHaveBeenCalledWith(
+      'https://agent.example/mcp',
+      expect.objectContaining({ adcpVersion: mocks.selectedTarget.version }),
+    );
+  });
+
+  it('uses a pinned last-known target when discovery returns a partial profile', async () => {
+    mocks.discovery.mockResolvedValue({ profile: { name: 'Older agent' }, steps: [] });
+
+    await expect(selectComplianceTargetForAgentSelection(
+      'https://agent.example/mcp',
+      {},
+      mocks.fallbackTarget,
+      'canonical',
+      ['3.1'],
+    )).resolves.toEqual({
+      target: mocks.selectedTarget,
+      confirmed: false,
+      source: 'stored',
+    });
+    expect(mocks.discovery).toHaveBeenCalledWith(
+      'https://agent.example/mcp',
+      expect.objectContaining({ adcpVersion: mocks.selectedTarget.version }),
+    );
   });
 
   it('rejects recent stored versions that do not match a hosted target', async () => {

--- a/server/tests/unit/escalation-resolution-guard.test.ts
+++ b/server/tests/unit/escalation-resolution-guard.test.ts
@@ -56,6 +56,24 @@ describe('escalation-resolution-guard', () => {
     expect(extractEscalationAgentUrls(esc)).toEqual(['https://sales.latinxctv.com/mcp']);
   });
 
+  it('does not treat registry documentation filenames as organization domains', async () => {
+    const pool = { query: vi.fn() };
+    const esc = escalation({
+      summary: 'Checkpoint tool failed while discussing adagents.json',
+      original_request: 'Learner also explained brand.json version negotiation.',
+      addie_context: null,
+    });
+
+    expect(isRegistrySetupEscalation(esc)).toBe(false);
+    expect(extractEscalationDomains(esc)).toEqual([]);
+    await expect(guardEscalationResolution({
+      escalation: esc,
+      status: 'resolved',
+      pool: pool as any,
+    })).resolves.toEqual({ ok: true, checked: false });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
   it('does not guard non-registry escalations', async () => {
     const pool = { query: vi.fn() };
     const result = await guardEscalationResolution({

--- a/server/tests/unit/public-agent-registry-ui.test.ts
+++ b/server/tests/unit/public-agent-registry-ui.test.ts
@@ -7,8 +7,19 @@ describe('public agent registry UI', () => {
   it('uses the public discovery proxy routes instead of the removed MCP helpers', () => {
     expect(agentsHtml).toContain('/api/public/agent-products?url=');
     expect(agentsHtml).toContain('/api/public/agent-formats?url=');
-    expect(agentsHtml).toContain('/api/public/agent-publishers?url=');
+    expect(agentsHtml).toContain('/v1/agents/${encodeURIComponent(agent.url)}/publishers?status=authorized&status=revoked&limit=1000');
+    expect(agentsHtml).not.toContain('/api/public/agent-publishers?url=');
     expect(agentsHtml).not.toContain("fetch(`/mcp`");
+  });
+
+  it('renders indexed publisher authorization records and handles non-JSON responses', () => {
+    expect(agentsHtml).toContain('const raw = await response.text()');
+    expect(agentsHtml).toContain('data = JSON.parse(raw)');
+    expect(agentsHtml).toContain('p.publisher_domain');
+    expect(agentsHtml).toContain('p.properties_authorized');
+    expect(agentsHtml).toContain('response.status === 404');
+    expect(agentsHtml).toContain('if (data.next_cursor)');
+    expect(agentsHtml).toContain('Showing the first 1,000 publisher authorizations');
   });
 
   it('renders the complete discovered tool catalog count', () => {

--- a/server/tests/unit/storyboards.test.ts
+++ b/server/tests/unit/storyboards.test.ts
@@ -29,6 +29,7 @@ import {
   selectHostedComplianceTargetForSupportedVersions,
   withHostedAuthTestKit,
   withHostedComplianceOptions,
+  withHostedTestOptions,
 } from '../../src/services/hosted-compliance-version.js';
 import {
   isComplianceVersionSupported,
@@ -37,7 +38,7 @@ import {
 } from '@adcp/sdk/testing';
 import {
   badgeEligibleVersionsForTargetSelection,
-  storedComplianceTargetMatchesObservedProfile,
+  selectedComplianceTargetMatchesObservedProfile,
 } from '../../src/addie/services/compliance-testing.js';
 
 /**
@@ -307,19 +308,35 @@ describe('wrapper contract', () => {
       { target: stable, confirmed: false, source: 'explicit' },
       { adcp_supported_versions: ['3.0'] },
     )).toEqual(['3.0']);
-    expect(badgeEligibleVersionsForTargetSelection({ target: stable, confirmed: true, source: 'live' })).toEqual(['3.0']);
+    expect(badgeEligibleVersionsForTargetSelection(
+      { target: stable, confirmed: true, source: 'live', supportedVersions: ['3.0'] },
+    )).toEqual(['3.0']);
+    expect(badgeEligibleVersionsForTargetSelection(
+      { target: stable, confirmed: true, source: 'live', supportedVersions: ['3.0'] },
+      { adcp_supported_versions: ['3.1'] },
+    )).toEqual([]);
   });
 
   it('lets the live run profile supersede a stored compliance target before publication', () => {
     const stable = hostedComplianceTarget('3.0');
     const storedSelection = { target: stable, confirmed: false, source: 'stored' as const };
 
-    expect(storedComplianceTargetMatchesObservedProfile(
+    expect(selectedComplianceTargetMatchesObservedProfile(
       storedSelection,
       { adcp_supported_versions: ['3.0'] },
     )).toBe(true);
-    expect(storedComplianceTargetMatchesObservedProfile(
+    expect(selectedComplianceTargetMatchesObservedProfile(
       storedSelection,
+      { adcp_supported_versions: ['3.1'] },
+    )).toBe(false);
+
+    const liveSelection = { target: stable, confirmed: true, source: 'live' as const };
+    expect(selectedComplianceTargetMatchesObservedProfile(
+      liveSelection,
+      { adcp_supported_versions: ['3.0'] },
+    )).toBe(true);
+    expect(selectedComplianceTargetMatchesObservedProfile(
+      liveSelection,
       { adcp_supported_versions: ['3.1'] },
     )).toBe(false);
   });
@@ -334,6 +351,14 @@ describe('wrapper contract', () => {
     const options = withHostedComplianceOptions({ version: '3.0' }, target);
     expect(options.version).toBe(target.version);
     expect(options.complianceDir).toContain(target.version);
+  });
+
+  it('keeps an exact stable diagnostic target pinned for capability discovery', () => {
+    const target = hostedComplianceTarget('3.1.20');
+    const options = withHostedTestOptions({}, target);
+
+    expect(target.version).toBe('3.1.20');
+    expect(options.adcpVersion).toBe('3.1.20');
   });
 
   it('threads bearer auth into the hosted runtime test kit', () => {


### PR DESCRIPTION
## Summary

- recover hosted compliance target discovery by pinning compatible last-known versions
- require the completed profile to confirm automatically selected targets before DB or badge publication
- use indexed publisher authorization data in the public registry UI with bounded pagination and safe 404/error handling
- prevent escalation recovery from treating `.json` filenames as registrable domains

## Verification

- `npm run typecheck`
- focused server suite: 94/94 tests passed
- independent code, protocol, and security expert re-reviews: no remaining findings
- full server suite baseline: 8,998 passed, 3 skipped, 7 failures reproduced independently in untouched router/auth/billing tests

No protocol changeset is required; this PR changes application and operational behavior only.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ae3ad7cc-ab93-45d8-be8b-32a053a90a08)
