### PR TITLE
fix(addie): settle reviewed architecture router aliases

### DIFF
--- a/server/src/addie/eval/fixed-trace-architecture-diagnostic-execution.ts
+++ b/server/src/addie/eval/fixed-trace-architecture-diagnostic-execution.ts
@@ -18,6 +18,7 @@ import {
   BudgetedFixedTraceProvider,
   FixedTraceBudget,
   claimFixedTraceBudgetDiagnosticLease,
+  fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy,
   fixedTraceResponsePricingPolicy,
   isTrustedBudgetedFixedTraceProvider,
 } from './fixed-trace-budget.js';
@@ -63,12 +64,19 @@ function stage(provider: ModelProvider, kind: 'router' | 'generation'): FixedTra
 function requireStageProvider(
   stageConfig: FixedTraceProviderStageConfig,
   budget: FixedTraceBudget,
+  kind: 'router' | 'generation',
 ): void {
-  const policy = fixedTraceResponsePricingPolicy(
-    stageConfig.provider.id,
-    stageConfig.model,
-    stageConfig.pricing,
-  );
+  const policy = kind === 'router'
+    ? fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
+      stageConfig.provider.id,
+      stageConfig.model,
+      stageConfig.pricing,
+    )
+    : fixedTraceResponsePricingPolicy(
+      stageConfig.provider.id,
+      stageConfig.model,
+      stageConfig.pricing,
+    );
   if (!isTrustedBudgetedFixedTraceProvider(stageConfig.provider, budget, stageConfig.pricing, policy)) {
     throw new Error('Fixed trace architecture diagnostic requires authenticated budgeted Anthropic stages');
   }
@@ -93,7 +101,7 @@ export function fixedTraceArchitectureDiagnosticCostCeiling(): FixedTraceArchite
   const router = datedPricingProfilesForFixedTrace().find((entry) => entry.profileId === controls.router.pricing.profileId);
   const generation = datedPricingProfilesForFixedTrace().find((entry) => entry.profileId === controls.generation.pricing.profileId);
   if (!router || !generation) throw new Error('Fixed trace architecture diagnostic pricing is unavailable');
-  fixedTraceResponsePricingPolicy('anthropic', controls.router.model, router);
+  fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy('anthropic', controls.router.model, router);
   fixedTraceResponsePricingPolicy('anthropic', controls.generation.model, generation);
   const routerReservationUsd = 40 * datedPricingReservationCostUsd(
     router,
@@ -288,8 +296,8 @@ function authenticatedAdmission(
       || !config.router
     ) return rejectAdmission(record, 'Fixed trace architecture diagnostic admitted config is invalid');
     try {
-      requireStageProvider(config.router, record.budget);
-      requireStageProvider(config.generation, record.budget);
+      requireStageProvider(config.router, record.budget, 'router');
+      requireStageProvider(config.generation, record.budget, 'generation');
       preflightFixedTraceRunnerConfig(config);
     } catch (error) {
       return rejectAdmission(record, error instanceof Error ? error.message : String(error));
@@ -330,8 +338,8 @@ export function admitFixedTraceArchitectureDiagnostic(input: Readonly<{
     ...input, runId: `${input.runRootId}:${architectureArm}`, architectureArm,
   }));
   for (const config of requested) {
-    requireStageProvider(config.router!, input.budget);
-    requireStageProvider(config.generation, input.budget);
+    requireStageProvider(config.router!, input.budget, 'router');
+    requireStageProvider(config.generation, input.budget, 'generation');
     preflightFixedTraceRunnerConfig(config);
   }
   const lease = claimFixedTraceBudgetDiagnosticLease(

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -193,6 +193,34 @@ export function fixedTraceDirectFullSuiteResponsePricingPolicy(
   );
 }
 
+/**
+ * The architecture diagnostic's router is the one additional dated Anthropic
+ * receipt surface. Keep this separate from the direct-suite constructor: this
+ * admission is bound to the reviewed Haiku router profile, not to an arbitrary
+ * Anthropic stage which happens to use a dated identifier.
+ */
+export function fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
+  expectedProvider: ModelProvider['id'],
+  expectedModel: string,
+  pricing: FixedTraceBudgetPricing & { readonly profileId: string },
+): FixedTraceResponsePricingPolicy {
+  const isReviewedRouterProfile = FIXED_TRACE_APPROVED_PRICING.some((entry) => (
+    entry.candidateId === 'anthropic-router'
+    && entry.expectedProvider === expectedProvider
+    && entry.expectedModel === expectedModel
+    && sameApprovedPricing(entry, pricing)
+  ));
+  if (!isReviewedRouterProfile) {
+    throw new Error('Fixed trace architecture diagnostic router pricing profile is not evaluator approved');
+  }
+  return fixedTraceResponsePricingPolicyForResolution(
+    expectedProvider,
+    expectedModel,
+    pricing,
+    'anthropic_dated_revision_v1',
+  );
+}
+
 function fixedTraceResponsePricingPolicyForResolution(
   expectedProvider: ModelProvider['id'],
   expectedModel: string,

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -45,6 +45,7 @@ import {
 } from './fixed-trace-tool-loop.js';
 import {
   FixedTraceBudgetAdmissionError,
+  fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy,
   fixedTraceDirectFullSuiteResponsePricingPolicy,
   fixedTraceEstimatedCostUsd,
   fixedTraceModelResolutionPolicy as fixedTraceBudgetModelResolutionPolicy,
@@ -874,9 +875,14 @@ export function fixedTraceModelResolutionPolicy(
   return fixedTraceBudgetModelResolutionPolicy(provider, model, allowDatedAnthropicRevision);
 }
 
+type FixedTraceReturnedModelPricingMode =
+  | 'exact'
+  | 'direct_full_suite'
+  | 'architecture_diagnostic_router';
+
 function cohortStageControl(
   config: FixedTraceProviderStageConfig,
-  allowDatedAnthropicRevision = false,
+  returnedModelPricingMode: FixedTraceReturnedModelPricingMode = 'exact',
 ): FixedTraceCohortStageControl {
   return {
     requestedProvider: config.provider.id,
@@ -888,7 +894,13 @@ function cohortStageControl(
     transportRetries: config.transportRetries,
     samplingMode: config.samplingMode,
     temperature: config.temperature,
-    modelResolutionPolicy: fixedTraceModelResolutionPolicy(config.provider.id, config.model, allowDatedAnthropicRevision),
+    modelResolutionPolicy: returnedModelPricingMode === 'architecture_diagnostic_router'
+      ? 'anthropic_dated_revision_v1'
+      : fixedTraceModelResolutionPolicy(
+        config.provider.id,
+        config.model,
+        returnedModelPricingMode === 'direct_full_suite',
+      ),
     pricing: { ...config.pricing },
   };
 }
@@ -896,7 +908,12 @@ function cohortStageControl(
 function routerControlForConfig(config: FixedTraceRunnerConfig): FixedTraceCohortStageControl | { readonly status: 'not_run' } {
   if (isDirectModelScreen(config) || isDirectFullSuiteComparison(config)) return { status: 'not_run' };
   if (config.router === null) throw new Error('Fixed trace runner router is required outside direct-model-screen mode');
-  return cohortStageControl(config.router);
+  return cohortStageControl(
+    config.router,
+    config.architectureDiagnosticMode === 'synthetic_sonnet_full_pack_v1'
+      ? 'architecture_diagnostic_router'
+      : 'exact',
+  );
 }
 
 function reasoningRequest(effort: ModelReasoningEffort): Pick<ModelRequest, 'reasoning'> | Record<string, never> {
@@ -917,19 +934,25 @@ function modelResolution(
 function returnedModelUsesRecordedPricing(
   config: FixedTraceProviderStageConfig,
   response: Pick<ModelResponse, 'provider' | 'model'>,
-  allowDatedAnthropicRevision = false,
+  returnedModelPricingMode: FixedTraceReturnedModelPricingMode = 'exact',
 ): boolean {
-  const policy = allowDatedAnthropicRevision
-    ? fixedTraceDirectFullSuiteResponsePricingPolicy(
+  const policy = returnedModelPricingMode === 'architecture_diagnostic_router'
+    ? fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
       config.provider.id,
       config.model,
       config.pricing,
     )
-    : fixedTraceResponsePricingPolicy(
-    config.provider.id,
-    config.model,
-    config.pricing,
-    );
+    : returnedModelPricingMode === 'direct_full_suite'
+      ? fixedTraceDirectFullSuiteResponsePricingPolicy(
+      config.provider.id,
+      config.model,
+      config.pricing,
+    )
+      : fixedTraceResponsePricingPolicy(
+        config.provider.id,
+        config.model,
+        config.pricing,
+      );
   return fixedTraceResponseUsesPricingPolicy(policy, response);
 }
 
@@ -940,13 +963,13 @@ function providerStageMetadata(
   usage: ModelUsage,
   state: StageInvocationState,
   recordedExposures?: NonNullable<FixedTraceModelStageMetadata["providerExposures"]>,
-  allowDatedAnthropicRevision = false,
+  returnedModelPricingMode: FixedTraceReturnedModelPricingMode = 'exact',
 ): FixedTraceModelStageMetadata {
   // Provider responses are outside evaluator ownership. Retaining their usage
   // object would let a later provider turn mutate already-recorded cost and
   // usage evidence after this case has completed.
   const recordedUsage = deepFreeze(structuredClone(usage));
-  const resolvedPricing = returnedModelUsesRecordedPricing(config, response, allowDatedAnthropicRevision);
+  const resolvedPricing = returnedModelUsesRecordedPricing(config, response, returnedModelPricingMode);
   return {
     source: 'provider',
     dispatched: state.dispatched,
@@ -1190,7 +1213,10 @@ export function fixedTraceArchitectureConfigSha256(
       : fixedTraceExecutionEnvelopeProvenance(arm.id),
     requestThreadFacts: fixedTraceRequestThreadFactsProvenance(config.traceSuite, arm.id),
     routerControl: routerControlForConfig(config),
-    generationControl: cohortStageControl(config.generation, isDirectFullSuiteComparison(config)),
+    generationControl: cohortStageControl(
+      config.generation,
+      isDirectFullSuiteComparison(config) ? 'direct_full_suite' : 'exact',
+    ),
     providerDegradationInjectionEnabled: config.injectProviderDegradation !== false,
     architectureDiagnosticMode: config.architectureDiagnosticMode ?? null,
     directModelScreenMode: config.directModelScreen?.mode ?? config.directFullSuiteComparison?.mode ?? null,
@@ -1334,7 +1360,10 @@ function baseMetadata(
     directArmAdmission: admission,
     caseControl: trace.caseControl ?? null,
     routerControl: routerControlForConfig(config),
-    generationControl: cohortStageControl(config.generation, isDirectFullSuiteComparison(config)),
+    generationControl: cohortStageControl(
+      config.generation,
+      isDirectFullSuiteComparison(config) ? 'direct_full_suite' : 'exact',
+    ),
     router,
     generation,
   };
@@ -1750,7 +1779,7 @@ function directModelScreenProviderExposuresMatch(
       ? returnedModelUsesRecordedPricing(config.generation, {
           provider: exposure.returnedProvider,
           model: exposure.returnedModel,
-        }, true)
+        }, 'direct_full_suite')
       : exposure.returnedProvider === config.generation.provider.id
         && exposure.returnedModel === config.generation.model)
   ));
@@ -1825,9 +1854,21 @@ async function executeRouter(
       },
     }), config.provider.id);
     const state = { invocations, dispatched, dispatchedCalls, latencyMs: Date.now() - startedAt, settlementDiagnosticCursor };
-    const metadata = providerStageMetadata(request, config, response, response.usage, state);
+    const returnedModelPricingMode = architectureDiagnosticMode === 'synthetic_sonnet_full_pack_v1'
+      ? 'architecture_diagnostic_router' as const
+      : 'exact' as const;
+    const metadata = providerStageMetadata(
+      request,
+      config,
+      response,
+      response.usage,
+      state,
+      undefined,
+      returnedModelPricingMode,
+    );
     const output = extractRouterResponseText(response.content);
     const status = hasCompleteReturnedProviderIdentities(state, response)
+      && returnedModelUsesRecordedPricing(config, response, returnedModelPricingMode)
       ? terminalStatusForFinishReason(response.finishReason, output)
       : 'unknown_exposure';
     if (status !== 'complete') return { request, response, plan: null, output, status, metadata, failureDiagnostic: null };
@@ -2151,7 +2192,7 @@ export async function runFixedTraceCase(
       result.usage,
       state,
       result.providerExposures,
-      isDirectFullSuiteComparison(executionConfig),
+      isDirectFullSuiteComparison(executionConfig) ? 'direct_full_suite' : 'exact',
     );
     const completeProviderIdentities = hasCompleteReturnedProviderIdentities(
       state,
@@ -2161,7 +2202,7 @@ export async function runFixedTraceCase(
     const responseUsesRecordedPricing = returnedModelUsesRecordedPricing(
       generationConfig,
       result.response,
-      isDirectFullSuiteComparison(executionConfig),
+      isDirectFullSuiteComparison(executionConfig) ? 'direct_full_suite' : 'exact',
     );
     const exposureIdentitiesMatch = directModelScreenProviderExposuresMatch(executionConfig, result.providerExposures);
     const terminalStatus = completeProviderIdentities && responseUsesRecordedPricing && exposureIdentitiesMatch

--- a/server/src/addie/eval/fixed-trace-suite.ts
+++ b/server/src/addie/eval/fixed-trace-suite.ts
@@ -7,6 +7,7 @@ import {
   fixedTraceRequestThreadFactsProvenance,
 } from './fixed-trace-architecture.js';
 import {
+  fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy,
   fixedTraceEstimatedCostUsd,
   fixedTraceDirectFullSuiteResponsePricingPolicy,
   fixedTraceModelResolutionPolicy,
@@ -2936,7 +2937,7 @@ function stageMetadataFailures(
   stage: FixedTraceModelStageMetadata,
   control: FixedTraceCohortStageControl | FixedTraceNotRunCohortStageControl,
   expectedEffectiveMaxOutputTokens: number | null,
-  allowDatedAnthropicRevision = false,
+  returnedModelPricingMode: 'exact' | 'direct_full_suite' | 'architecture_diagnostic_router' = 'exact',
 ): string[] {
   const failures: string[] = [];
   const fail = (reason: string) => failures.push(`${stageName}_${reason}`);
@@ -3086,9 +3087,11 @@ function stageMetadataFailures(
         && stage.returnedModel !== null) {
         try {
           canonicalizedIdentityApproved = fixedTraceResponseUsesPricingPolicy(
-            allowDatedAnthropicRevision
-              ? fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing)
-              : fixedTraceResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing),
+            returnedModelPricingMode === 'architecture_diagnostic_router'
+              ? fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing)
+              : returnedModelPricingMode === 'direct_full_suite'
+                ? fixedTraceDirectFullSuiteResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing)
+                : fixedTraceResponsePricingPolicy(control.requestedProvider, control.requestedModel, control.pricing),
             { provider: stage.returnedProvider, model: stage.returnedModel },
           );
         } catch {
@@ -3367,13 +3370,16 @@ function metadataFailures(
     'router', metadata.router, metadata.routerControl, metadata.router.source === 'not_run' || 'status' in metadata.routerControl
       ? null
       : metadata.routerControl.configuredMaxOutputTokens,
+    metadata.architectureDiagnosticMode === 'synthetic_sonnet_full_pack_v1'
+      ? 'architecture_diagnostic_router'
+      : 'exact',
   ));
   if (!(directModelScreenMode === 'direct_full_suite_model_comparison_v1' && ['ignore', 'react'].includes(trace.routing.action))) {
     failures.push(...stageMetadataFailures(
       'generation', metadata.generation, metadata.generationControl, metadata.generation.source === 'not_run'
         ? null
         : caseControl?.maxOutputTokens ?? metadata.generationControl.configuredMaxOutputTokens,
-      directModelScreenMode === 'direct_full_suite_model_comparison_v1',
+      directModelScreenMode === 'direct_full_suite_model_comparison_v1' ? 'direct_full_suite' : 'exact',
     ));
   }
   return failures;

--- a/server/tests/manual/fixed-trace-architecture-diagnostic-eval.ts
+++ b/server/tests/manual/fixed-trace-architecture-diagnostic-eval.ts
@@ -109,7 +109,11 @@ const router = new budgetModule.BudgetedFixedTraceProvider(
   rawProvider,
   budget,
   controls.router.pricing,
-  budgetModule.fixedTraceResponsePricingPolicy('anthropic', controls.router.model, controls.router.pricing),
+  budgetModule.fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
+    'anthropic',
+    controls.router.model,
+    controls.router.pricing,
+  ),
 );
 const generation = new budgetModule.BudgetedFixedTraceProvider(
   rawProvider,

--- a/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
@@ -188,6 +188,8 @@ describe('fixed-trace architecture diagnostic execution', () => {
       observation.metadata.routerControl.modelResolutionPolicy === 'anthropic_dated_revision_v1'
     ))).toBe(true);
     expect(artifact).toMatchObject({ complete: true });
+    expect((artifact.runs as Array<{ summary?: { metadataPassRate?: number } }>)
+      .every((run) => run.summary?.metadataPassRate === 1)).toBe(true);
     expect(budget.snapshot()).toMatchObject({
       reservedUsd: 0,
       dispatchedCalls: 104,
@@ -223,6 +225,7 @@ describe('fixed-trace architecture diagnostic execution', () => {
         },
       },
     });
+    expect(artifact).toMatchObject({ complete: false });
     expect(routerDispatch).toBeGreaterThanOrEqual(0);
     expect(raw.calls.slice(routerDispatch + 1)).toEqual([]);
     expect(budget.snapshot()).toMatchObject({ exposureUnknown: true, reservedUsd: 0 });

--- a/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
+++ b/server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts
@@ -16,6 +16,7 @@ import { fixedTraceArchitectureDiagnosticPilotStageControls } from '../../../src
 import {
   BudgetedFixedTraceProvider,
   FixedTraceBudget,
+  fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy,
   fixedTraceResponsePricingPolicy,
 } from '../../../src/addie/eval/fixed-trace-budget.js';
 import type {
@@ -42,6 +43,7 @@ class ScriptedAnthropicProvider implements ModelProvider {
   constructor(
     private readonly unknownGenerationModel = false,
     private readonly failAfterCalls: number | null = null,
+    private readonly routerModel = 'claude-haiku-4-5',
   ) {}
 
   prepare(request: ModelRequest): PreparedModelInvocation {
@@ -63,7 +65,7 @@ class ScriptedAnthropicProvider implements ModelProvider {
     const router = request.requestMetadata?.purpose === 'fixed_trace_router';
     const response: ModelResponse = {
       provider: this.id,
-      model: router ? 'claude-haiku-4-5' : this.unknownGenerationModel ? 'unapproved-model' : 'claude-sonnet-5',
+      model: router ? this.routerModel : this.unknownGenerationModel ? 'unapproved-model' : 'claude-sonnet-5',
       id: `synthetic-${this.calls.length}`,
       content: [{ type: 'text', text: router
         ? JSON.stringify({ action: 'respond', tool_sets: [], confidence: 'high', requires_depth: false, reason: 'Synthetic route.' })
@@ -78,14 +80,22 @@ class ScriptedAnthropicProvider implements ModelProvider {
 
 const RUN_STARTED_AT = '2026-09-07T00:00:00.000Z';
 
-function admitted(unknownGenerationModel = false, failAfterCalls: number | null = null) {
+function admitted(
+  unknownGenerationModel = false,
+  failAfterCalls: number | null = null,
+  routerModel = 'claude-haiku-4-5',
+) {
   const ceiling = fixedTraceArchitectureDiagnosticCostCeiling();
   const budget = new FixedTraceBudget(ceiling.requiredSoftMaxUsd);
-  const raw = new ScriptedAnthropicProvider(unknownGenerationModel, failAfterCalls);
+  const raw = new ScriptedAnthropicProvider(unknownGenerationModel, failAfterCalls, routerModel);
   const controls = fixedTraceArchitectureDiagnosticPilotStageControls();
   const router = new BudgetedFixedTraceProvider(
     raw, budget, controls.router.pricing,
-    fixedTraceResponsePricingPolicy('anthropic', controls.router.model, controls.router.pricing),
+    fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
+      'anthropic',
+      controls.router.model,
+      controls.router.pricing,
+    ),
   );
   const generation = new BudgetedFixedTraceProvider(
     raw, budget, controls.generation.pricing,
@@ -146,6 +156,85 @@ describe('fixed-trace architecture diagnostic execution', () => {
       }
     }
     expect(budget.snapshot()).toMatchObject({ reservedUsd: 0, dispatchedCalls: 104, completedCalls: 104, exposureUnknown: false });
+  });
+
+  it('settles the reviewed dated Haiku router alias at its explicit profile rate', async () => {
+    const datedHaiku = 'claude-haiku-4-5-20251001';
+    const { admission, budget, raw } = admitted(false, null, datedHaiku);
+    const artifact = await runFixedTraceArchitectureDiagnosticArtifact({
+      admission, budget, runRootId: 'architecture-test-root', runStartedAt: RUN_STARTED_AT, plan: plan(),
+    });
+    const routerObservations = (artifact.runs as Array<{ observations: Array<{
+      metadata: {
+        architectureArm: { id: string };
+        router: { source: string; returnedModel: string | null; estimatedCostUsd: number | null; pricingProfileId: string | null };
+        routerControl?: { modelResolutionPolicy: string };
+      };
+    }> }>)
+      .flatMap((run) => run.observations)
+      .filter((observation) => (
+        observation.metadata.architectureArm.id === 'two_stage_llm_router'
+        && observation.metadata.router.source === 'provider'
+        && observation.metadata.routerControl !== undefined
+      ));
+
+    expect(routerObservations.length).toBeGreaterThan(0);
+    expect(routerObservations.every((observation) => (
+      observation.metadata.router.returnedModel === datedHaiku
+      && observation.metadata.router.estimatedCostUsd !== null
+      && observation.metadata.router.pricingProfileId === 'anthropic-standard-2026-09:claude-haiku-4-5'
+    ))).toBe(true);
+    expect(routerObservations.every((observation) => (
+      observation.metadata.routerControl.modelResolutionPolicy === 'anthropic_dated_revision_v1'
+    ))).toBe(true);
+    expect(artifact).toMatchObject({ complete: true });
+    expect(budget.snapshot()).toMatchObject({
+      reservedUsd: 0,
+      dispatchedCalls: 104,
+      completedCalls: 104,
+      exposureUnknown: false,
+    });
+    expect(raw.calls.some((call) => call.requestMetadata?.purpose === 'fixed_trace_router')).toBe(true);
+  });
+
+  it.each([
+    ['unknown', 'claude-unreviewed-20990101'],
+    ['cross-family', 'claude-sonnet-5-20250901'],
+  ])('rejects a %s router model without charging it or dispatching a later stage', async (_kind, routerModel) => {
+    const { admission, budget, raw } = admitted(false, null, routerModel);
+    const artifact = await runFixedTraceArchitectureDiagnosticArtifact({
+      admission, budget, runRootId: 'architecture-test-root', runStartedAt: RUN_STARTED_AT, plan: plan(),
+    });
+    const observations = (artifact.runs as Array<{ observations: Array<{
+      terminalStage: string;
+      terminalStatus: string;
+      metadata: { router: { source: string; estimatedCostUsd: number | null; settlementLedger: { entries: Array<{ reason: string }> } } };
+    }> }>).flatMap((run) => run.observations);
+    const rejected = observations.find((observation) => observation.metadata.router.source === 'provider');
+    const routerDispatch = raw.calls.findIndex((call) => call.requestMetadata?.purpose === 'fixed_trace_router');
+
+    expect(rejected).toMatchObject({
+      terminalStage: 'router',
+      terminalStatus: 'unknown_exposure',
+      metadata: {
+        router: {
+          estimatedCostUsd: null,
+          settlementLedger: { entries: [expect.objectContaining({ reason: 'identity_policy_rejected' })] },
+        },
+      },
+    });
+    expect(routerDispatch).toBeGreaterThanOrEqual(0);
+    expect(raw.calls.slice(routerDispatch + 1)).toEqual([]);
+    expect(budget.snapshot()).toMatchObject({ exposureUnknown: true, reservedUsd: 0 });
+  });
+
+  it('does not grant the dated router policy to the generation profile', () => {
+    const controls = fixedTraceArchitectureDiagnosticPilotStageControls();
+    expect(() => fixedTraceArchitectureDiagnosticRouterResponsePricingPolicy(
+      'anthropic',
+      controls.generation.model,
+      controls.generation.pricing,
+    )).toThrow('router pricing profile is not evaluator approved');
   });
 
   it('preserves unknown provider exposure in a finalized diagnostic artifact instead of inventing cost certainty', async () => {


### PR DESCRIPTION
## Summary
- settle only the evaluator-approved dated Haiku alias on the architecture diagnostic router path
- preserve fail-closed unknown/cross-family behavior and sealed cost evidence
- add dated-alias and rejection regressions

## Validation
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie/fixed-trace-architecture-diagnostic-execution.test.ts server/tests/unit/addie/fixed-trace-budget.test.ts` (31 passed)
- `npm run typecheck`

No provider calls and no immutable evidence artifacts were changed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9766c02-b837-4e9c-b98d-512958e5320b)
