### PR TITLE
feat(registry-sync): produce agent.profile_updated on crawl diff

### DIFF
--- a/server/src/crawler.ts
+++ b/server/src/crawler.ts
@@ -25,7 +25,12 @@ import { AAO_HOST } from "./config/aao.js";
 import { AAO_UA_DISCOVERY } from "./config/user-agents.js";
 import { createLogger } from "./logger.js";
 import type { CatalogEventsDatabase, WriteEventInput } from "./db/catalog-events-db.js";
-import type { AgentInventoryProfilesDatabase, ProfileUpsertInput } from "./db/agent-inventory-profiles-db.js";
+import {
+  agentProfileChangedFields,
+  type AgentInventoryProfile,
+  type AgentInventoryProfilesDatabase,
+  type ProfileUpsertInput,
+} from "./db/agent-inventory-profiles-db.js";
 import { getDedicatedClient, query, withDatabaseDeadline } from "./db/client.js";
 import { PropertyDatabase } from "./db/property-db.js";
 import { verifyHostedPropertyOrigin } from "./services/hosted-property-origin-verifier.js";
@@ -706,6 +711,14 @@ export class CrawlerService {
 
       // Snapshot pre-crawl state for diffing
       const preCrawlAgents = await this.snapshotAgentState();
+      // Capture previously-persisted profiles BEFORE buildInventoryProfiles()
+      // overwrites them via upsertProfiles() — this is the only point in the
+      // crawl where the "before" values are still readable (see
+      // agentProfileChangedFields).
+      const previousProfiles = this.profilesDb
+        ? await this.profilesDb.getProfilesByUrls([...preCrawlAgents.keys()])
+        : [];
+      const previousProfilesByUrl = new Map(previousProfiles.map(profile => [profile.agent_url, profile]));
       assertExecutionLock();
 
       // Populate federated index from PropertyIndex and adagents.json files,
@@ -743,7 +756,7 @@ export class CrawlerService {
 
       // Diff and produce events (after profiles are built so discovery events include profile data)
       assertExecutionLock();
-      await this.produceEventsFromDiff(preCrawlAgents, builtProfiles);
+      await this.produceEventsFromDiff(preCrawlAgents, builtProfiles, previousProfilesByUrl);
 
       // Scan brand.json for all crawled domains + all hosted brand domains
       const hostedDomains = await this.brandDb.listAllHostedBrandDomains();
@@ -2435,7 +2448,8 @@ export class CrawlerService {
 
   private async produceEventsFromDiff(
     preCrawlAgents: Map<string, { domains: Set<string> }>,
-    profiles: Map<string, ProfileUpsertInput>
+    profiles: Map<string, ProfileUpsertInput>,
+    previousProfilesByUrl: Map<string, AgentInventoryProfile> = new Map()
   ): Promise<void> {
     if (!this.eventsDb) return;
 
@@ -2514,6 +2528,39 @@ export class CrawlerService {
           });
         }
       }
+    }
+
+    // Detect profile changes for already-known agents that are still present.
+    // Newly discovered agents are covered by agent.discovered above (their
+    // full profile ships there instead); removed agents have no new profile
+    // to diff against.
+    for (const [url] of postCrawlAgents) {
+      if (!preCrawlAgents.has(url)) continue;
+      const profile = profiles.get(url);
+      if (!profile) continue;
+      const changedFields = agentProfileChangedFields(previousProfilesByUrl.get(url), profile);
+      if (changedFields.length === 0) continue;
+      events.push({
+        event_type: 'agent.profile_updated',
+        entity_type: 'agent',
+        entity_id: url,
+        payload: {
+          agent_url: url,
+          channels: profile.channels,
+          property_types: profile.property_types,
+          markets: profile.markets,
+          categories: profile.categories,
+          tags: profile.tags,
+          delivery_types: profile.delivery_types,
+          format_kinds: profile.format_kinds,
+          property_count: profile.property_count,
+          publisher_count: profile.publisher_count,
+          has_tmp: profile.has_tmp,
+          category_taxonomy: profile.category_taxonomy ?? null,
+          changed_fields: changedFields,
+        },
+        actor: 'pipeline:crawler',
+      });
     }
 
     if (events.length > 0) {

--- a/server/src/db/agent-inventory-profiles-db.ts
+++ b/server/src/db/agent-inventory-profiles-db.ts
@@ -86,6 +86,44 @@ const ARRAY_FILTER_COLUMNS = [
 
 type ArrayFilterColumn = typeof ARRAY_FILTER_COLUMNS[number];
 
+// ─── Profile diffing (registry-sync agent.profile_updated producer) ──────────
+
+// Same set as ARRAY_FILTER_COLUMNS, reused directly: these are exactly the
+// array-typed fields a crawl can change on an existing profile.
+const PROFILE_ARRAY_FIELDS = ARRAY_FILTER_COLUMNS;
+
+/** Order-independent (set-based) comparison string for an array field. */
+function stableArrayValue(value: string[] | undefined): string {
+  return JSON.stringify([...(value ?? [])].sort());
+}
+
+/**
+ * Top-level AgentInventoryProfile fields changed between a previously-
+ * persisted profile and a freshly built one. Mirrors adagentsChangedFields'
+ * set-based approach (publisher-db.ts) rather than reference/order-sensitive
+ * equality, since array fields here are built from Sets whose insertion
+ * order isn't semantically meaningful (see buildInventoryProfiles).
+ *
+ * Returns [] when `previous` is absent (no prior persisted row) — an agent
+ * gaining its first profile isn't a "change" this helper reports; that case
+ * is covered by the agent.discovered event path instead.
+ */
+export function agentProfileChangedFields(
+  previous: AgentInventoryProfile | undefined,
+  next: ProfileUpsertInput,
+): string[] {
+  if (!previous) return [];
+  const changed: string[] = [];
+  for (const field of PROFILE_ARRAY_FIELDS) {
+    if (stableArrayValue(previous[field]) !== stableArrayValue(next[field])) changed.push(field);
+  }
+  if ((previous.property_count ?? 0) !== (next.property_count ?? 0)) changed.push('property_count');
+  if ((previous.publisher_count ?? 0) !== (next.publisher_count ?? 0)) changed.push('publisher_count');
+  if ((previous.has_tmp ?? false) !== (next.has_tmp ?? false)) changed.push('has_tmp');
+  if ((previous.category_taxonomy ?? null) !== (next.category_taxonomy ?? null)) changed.push('category_taxonomy');
+  return changed;
+}
+
 // ─── Database ────────────────────────────────────────────────────────────────
 
 export class AgentInventoryProfilesDatabase {
@@ -231,6 +269,24 @@ export class AgentInventoryProfilesDatabase {
       [agentUrl]
     );
     return result.rows[0] ?? null;
+  }
+
+  /**
+   * Bulk-read persisted profiles for a set of agents in a single round trip,
+   * in the same single-query spirit as
+   * FederatedIndexService.getAllAgentDomainPairs() (used by
+   * CrawlerService.snapshotAgentState() to avoid O(N) per-agent queries).
+   * Callers that need a pre-crawl "previous profile" snapshot for diffing
+   * (see agentProfileChangedFields) MUST call this before upsertProfiles()
+   * overwrites the rows.
+   */
+  async getProfilesByUrls(agentUrls: string[]): Promise<AgentInventoryProfile[]> {
+    if (agentUrls.length === 0) return [];
+    const result = await query<AgentInventoryProfile>(
+      'SELECT * FROM agent_inventory_profiles WHERE agent_url = ANY($1)',
+      [agentUrls]
+    );
+    return result.rows;
   }
 
   /**

--- a/server/tests/unit/crawler-format-kind-events.test.ts
+++ b/server/tests/unit/crawler-format-kind-events.test.ts
@@ -54,6 +54,125 @@ describe('CrawlerService canonical format-kind events', () => {
     );
   });
 
+  it('emits agent.profile_updated for an already-known agent whose profile changed', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const writeEvents = vi.fn().mockResolvedValue(undefined);
+    const agentUrl = 'https://creative.example.com/mcp';
+
+    Object.assign(ctx, {
+      // produceEventsFromDiff calls snapshotAgentState() internally to get
+      // post-crawl state, which re-derives from this same source.
+      federatedIndex: {
+        getAllAgentDomainPairs: vi.fn().mockResolvedValue(
+          new Map([[agentUrl, new Set(['publisher.example.com'])]]),
+        ),
+      },
+      eventsDb: { writeEvents },
+    });
+
+    const preCrawlAgents = new Map([[agentUrl, { domains: new Set(['publisher.example.com']) }]]);
+    const previousProfile = {
+      agent_url: agentUrl,
+      channels: ['display'],
+      property_types: ['website'],
+      markets: ['US'],
+      categories: [],
+      tags: [],
+      delivery_types: [],
+      format_ids: [],
+      format_kinds: ['image'],
+      property_count: 1,
+      publisher_count: 1,
+      has_tmp: false,
+      category_taxonomy: null,
+      updated_at: new Date('2026-01-01'),
+    };
+    const newProfile: any = {
+      agent_url: agentUrl,
+      channels: ['display', 'ctv'],
+      property_types: ['website', 'ctv_app'],
+      markets: ['US'],
+      categories: [],
+      tags: [],
+      delivery_types: [],
+      format_kinds: ['image'],
+      property_count: 2,
+      publisher_count: 1,
+      has_tmp: false,
+      category_taxonomy: null,
+    };
+
+    await ctx.produceEventsFromDiff(
+      preCrawlAgents,
+      new Map([[agentUrl, newProfile]]),
+      new Map([[agentUrl, previousProfile]]),
+    );
+
+    expect(writeEvents).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: 'agent.profile_updated',
+          entity_type: 'agent',
+          entity_id: agentUrl,
+          payload: expect.objectContaining({
+            agent_url: agentUrl,
+            channels: ['display', 'ctv'],
+            property_types: ['website', 'ctv_app'],
+            property_count: 2,
+            changed_fields: expect.arrayContaining(['channels', 'property_types', 'property_count']),
+          }),
+        }),
+      ]),
+    );
+    // Nothing else should have fired: the agent is neither newly discovered
+    // nor removed, and its authorizations are unchanged.
+    expect(writeEvents).toHaveBeenCalledWith([
+      expect.objectContaining({ event_type: 'agent.profile_updated' }),
+    ]);
+  });
+
+  it('does not emit agent.profile_updated when the built profile is unchanged', async () => {
+    const { CrawlerService } = await import('../../src/crawler.js');
+    const ctx = Object.create((CrawlerService as any).prototype);
+    const writeEvents = vi.fn().mockResolvedValue(undefined);
+    const agentUrl = 'https://stable.example.com/mcp';
+
+    Object.assign(ctx, {
+      federatedIndex: {
+        getAllAgentDomainPairs: vi.fn().mockResolvedValue(
+          new Map([[agentUrl, new Set(['publisher.example.com'])]]),
+        ),
+      },
+      eventsDb: { writeEvents },
+    });
+
+    const preCrawlAgents = new Map([[agentUrl, { domains: new Set(['publisher.example.com']) }]]);
+    const profile: any = {
+      agent_url: agentUrl,
+      channels: ['display'],
+      property_types: ['website'],
+      markets: ['US'],
+      categories: [],
+      tags: [],
+      delivery_types: [],
+      format_kinds: ['image'],
+      property_count: 1,
+      publisher_count: 1,
+      has_tmp: false,
+      category_taxonomy: null,
+    };
+    const previousProfile = { ...profile, format_ids: [], updated_at: new Date('2026-01-01') };
+
+    await ctx.produceEventsFromDiff(
+      preCrawlAgents,
+      new Map([[agentUrl, profile]]),
+      new Map([[agentUrl, previousProfile]]),
+    );
+
+    expect(writeEvents).not.toHaveBeenCalled();
+  });
+
   it('preserves a high-fanout agent profile during full-crawl stale cleanup', async () => {
     const { CrawlerService } = await import('../../src/crawler.js');
     const ctx = Object.create((CrawlerService as any).prototype);


### PR DESCRIPTION
Producer-side companion to #7093 (merged consumer-side `applyEvent` fix), per #7095.

## Problem
`buildInventoryProfiles()` overwrites `agent_inventory_profiles` via `upsertProfiles()` before any diff could read the "previous" value, so the crawler never actually emitted the `agent.profile_updated` event #7093's consumer logic exists to handle — the round-trip was one-sided even after #7093 landed.

## Change
- Added `AgentInventoryProfilesDatabase.getProfilesByUrls()` — bulk previous-profile read, mirroring `getAllAgentDomainPairs()`'s single-query pattern.
- Added `agentProfileChangedFields()` — order-independent field diff, mirroring `adagentsChangedFields()` in `publisher-db.ts`.
- Wired into `crawler.ts`: `previousProfilesByUrl` is captured right after `snapshotAgentState()`, before `buildInventoryProfiles()` overwrites it, then passed into `produceEventsFromDiff()` to emit `agent.profile_updated` for any already-known, still-present agent whose profile changed. Payload matches PR #7093's whitelisted fields.

## Testing
Added two tests to `crawler-format-kind-events.test.ts` covering the changed-profile and unchanged-profile cases. Verified via revert-and-reconfirm: with the source change stashed, the positive test fails (`writeEvents` never called); restored, both new tests plus the file's existing 4 pass.

- `npx tsc --project server/tsconfig.json --noEmit`: clean.
- `node scripts/check-changeset-protocol-scope.cjs`: no changeset needed (server logic, not protocol-scoped — matches #7093's own precedent).
- Full `npm run precommit` (unit suite + storyboard matrix + typecheck): green.

Progresses #7095.