### PR TITLE
fix(addie): admit Pareto candidate pool and stop-ship evaluation

### DIFF
--- a/server/src/addie/eval/dated-pricing-cohort.ts
+++ b/server/src/addie/eval/dated-pricing-cohort.ts
@@ -8,8 +8,9 @@ import { types as utilTypes } from 'node:util';
 import { ModelConfig } from '../../config/models.js';
 import { resolveKnownClaudePricingModel } from '../claude-pricing.js';
 import {
+  GOOGLE_DIRECT_FULL_SUITE_MODEL,
   GOOGLE_ROUTER_MODEL,
-  isGoogleRouterModelRevision,
+  googleReturnedModelIdentityMatches,
 } from '../model-providers/google-generate-content-provider.js';
 import {
   OPENAI_ROUTER_MODEL,
@@ -20,12 +21,18 @@ import type { ModelProviderId } from '../model-providers/model-provider.js';
 const COHORT_DIGEST_DOMAIN = 'adcp:addie:dated-prospective-pricing-cohort:v1\0';
 const PROFILE_DIGEST_DOMAIN = 'adcp:addie:dated-prospective-pricing-profile:v1\0';
 const CHECKED_AT = '2026-09-05T23:55:26.000Z';
+/** Separate evidence date for the direct full-suite-only candidate expansion. */
+const DIRECT_FULL_SUITE_CHECKED_AT = '2026-09-08T09:00:00.000Z';
 
 export type EvaluationPricingCandidateId =
   | 'anthropic-router'
   | 'anthropic-generation'
   | 'openai-router-generator'
-  | 'google-router-generator';
+  | 'openai-direct-full-suite-terra'
+  | 'openai-direct-full-suite-sol'
+  | 'google-router-generator'
+  | 'google-direct-full-suite-3-8'
+  | 'anthropic-direct-full-suite-opus';
 export type CacheAccounting = 'additive' | 'subset' | 'unsupported';
 
 export interface OfficialPricingSource {
@@ -140,7 +147,11 @@ const CANDIDATE_PROVIDERS: Readonly<Record<EvaluationPricingCandidateId, ModelPr
   'anthropic-router': 'anthropic',
   'anthropic-generation': 'anthropic',
   'openai-router-generator': 'openai',
+  'openai-direct-full-suite-terra': 'openai',
+  'openai-direct-full-suite-sol': 'openai',
   'google-router-generator': 'google',
+  'google-direct-full-suite-3-8': 'google',
+  'anthropic-direct-full-suite-opus': 'anthropic',
 });
 
 const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
@@ -159,6 +170,23 @@ const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
       evidence: 'Claude API standard rates; cache reads are 0.1x and five-minute writes are 1.25x base input.',
     },
     sourceLabel: 'Anthropic pricing page: Claude Haiku 4.5, checked 2026-09-05.',
+    identityDependency: 'not_required',
+  },
+  {
+    candidateId: 'anthropic-direct-full-suite-opus', provider: 'anthropic', model: 'claude-opus-5',
+    serviceTier: 'standard', effectiveFrom: DIRECT_FULL_SUITE_CHECKED_AT, effectiveBefore: null,
+    profileId: 'anthropic-standard-2026-09:claude-opus-5',
+    rates: {
+      inputUsdPerMillionTokens: 5, outputUsdPerMillionTokens: 25,
+      cacheReadUsdPerMillionTokens: 0.5, cacheWriteUsdPerMillionTokens: 6.25,
+      cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
+    },
+    source: {
+      provider: 'anthropic', url: 'https://platform.claude.com/docs/en/about-claude/pricing',
+      retrievedAt: DIRECT_FULL_SUITE_CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Claude Opus 5 standard rate; cache reads are 0.1x and five-minute cache writes are 1.25x base input, both additive provider usage categories.',
+    },
+    sourceLabel: 'Anthropic pricing page: Claude Opus 5 standard (5-minute cache write), checked 2026-09-08.',
     identityDependency: 'not_required',
   },
   {
@@ -201,6 +229,40 @@ const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
     identityDependency: 'exact_returned_model_identity_enforced',
   },
   {
+    candidateId: 'openai-direct-full-suite-terra', provider: 'openai', model: 'gpt-5.6-terra',
+    serviceTier: 'standard', effectiveFrom: DIRECT_FULL_SUITE_CHECKED_AT, effectiveBefore: null,
+    profileId: 'openai-gpt-5.6-terra-standard-2026-09-08',
+    rates: {
+      inputUsdPerMillionTokens: 2, outputUsdPerMillionTokens: 12,
+      cacheReadUsdPerMillionTokens: 0.2, cacheWriteUsdPerMillionTokens: 2.5,
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'subset',
+    },
+    source: {
+      provider: 'openai', url: 'https://developers.openai.com/api/docs/models/gpt-5.6-terra',
+      retrievedAt: DIRECT_FULL_SUITE_CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Responses API model card lists input, cached-input, and output rates; cache writes are billed at 1.25x uncached input and are a subset of input_tokens.',
+    },
+    sourceLabel: 'OpenAI gpt-5.6-terra standard, checked 2026-09-08.',
+    identityDependency: 'exact_returned_model_identity_enforced',
+  },
+  {
+    candidateId: 'openai-direct-full-suite-sol', provider: 'openai', model: 'gpt-5.6-sol',
+    serviceTier: 'standard', effectiveFrom: DIRECT_FULL_SUITE_CHECKED_AT, effectiveBefore: null,
+    profileId: 'openai-gpt-5.6-sol-standard-2026-09-08',
+    rates: {
+      inputUsdPerMillionTokens: 4, outputUsdPerMillionTokens: 20,
+      cacheReadUsdPerMillionTokens: 0.4, cacheWriteUsdPerMillionTokens: 5,
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'subset',
+    },
+    source: {
+      provider: 'openai', url: 'https://developers.openai.com/api/docs/models/gpt-5.6-sol',
+      retrievedAt: DIRECT_FULL_SUITE_CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Responses API model card lists input, cached-input, and output rates; cache writes are billed at 1.25x uncached input and are a subset of input_tokens.',
+    },
+    sourceLabel: 'OpenAI gpt-5.6-sol standard, checked 2026-09-08.',
+    identityDependency: 'exact_returned_model_identity_enforced',
+  },
+  {
     candidateId: 'google-router-generator', provider: 'google', model: 'gemini-3.7-flash',
     serviceTier: 'standard', effectiveFrom: CHECKED_AT, effectiveBefore: '2027-01-01T00:00:00.000Z',
     profileId: 'google-gemini-3.7-flash-through-2026-12-31',
@@ -216,6 +278,23 @@ const OFFICIAL_PRICING_RECORDS: readonly DatedPricingRecord[] = deepFreeze([
     },
     sourceLabel: 'Google Gemini 3.7 Flash introductory standard, checked 2026-09-05.',
     identityDependency: 'not_required',
+  },
+  {
+    candidateId: 'google-direct-full-suite-3-8', provider: 'google', model: GOOGLE_DIRECT_FULL_SUITE_MODEL,
+    serviceTier: 'standard', effectiveFrom: DIRECT_FULL_SUITE_CHECKED_AT, effectiveBefore: '2027-01-01T00:00:00.000Z',
+    profileId: 'google-gemini-3.8-flash-through-2026-12-31',
+    rates: {
+      inputUsdPerMillionTokens: 0.75, outputUsdPerMillionTokens: 3.75,
+      cacheReadUsdPerMillionTokens: 0.075, cacheWriteUsdPerMillionTokens: null,
+      cacheReadAccounting: 'subset', cacheWriteAccounting: 'unsupported',
+    },
+    source: {
+      provider: 'google', url: 'https://ai.google.dev/gemini-api/docs/pricing',
+      retrievedAt: DIRECT_FULL_SUITE_CHECKED_AT, unit: 'USD per 1M tokens', serviceTier: 'standard', currency: 'USD',
+      evidence: 'Paid standard introductory rates through December 31, 2026; output includes thinking tokens and the adapter exposes only cached-content reads, not a cache-write token category.',
+    },
+    sourceLabel: 'Google Gemini 3.8 Flash introductory standard, checked 2026-09-08.',
+    identityDependency: 'exact_returned_model_identity_enforced',
   },
 ]);
 
@@ -331,7 +410,7 @@ function assertRecord(record: unknown): asserts record is DatedPricingRecord {
   const source = ownData(record, 'source');
   const sourceLabel = ownData(record, 'sourceLabel');
   const identityDependency = ownData(record, 'identityDependency');
-  if (!['anthropic-router', 'anthropic-generation', 'openai-router-generator', 'google-router-generator'].includes(candidateId as string)
+  if (!['anthropic-router', 'anthropic-generation', 'openai-router-generator', 'openai-direct-full-suite-terra', 'openai-direct-full-suite-sol', 'google-router-generator', 'google-direct-full-suite-3-8', 'anthropic-direct-full-suite-opus'].includes(candidateId as string)
     || !['anthropic', 'openai', 'google'].includes(provider as string)
     || typeof model !== 'string' || !model.trim() || serviceTier !== 'standard'
     || typeof profileId !== 'string' || !profileId.trim() || typeof sourceLabel !== 'string' || !sourceLabel.trim()
@@ -413,7 +492,7 @@ function cohortDigest(profiles: readonly DatedPricingProfile[]): string {
 
 /** Review-only profiles for fixed-trace artifact validation; this grants no provider admission. */
 export function datedPricingProfilesForFixedTrace(): readonly DatedPricingProfile[] {
-  const result = buildDatedPricingCohort(OFFICIAL_PRICING_RECORDS, new Date(CHECKED_AT));
+  const result = buildDatedPricingCohort(OFFICIAL_PRICING_RECORDS, new Date(DIRECT_FULL_SUITE_CHECKED_AT));
   if (result.status !== 'available') throw new Error('built-in dated pricing registry is invalid');
   return result.cohort.profiles;
 }
@@ -447,7 +526,7 @@ export function resolveCurrentEvaluationPricingCohort(
 ): ResolveDatedPricingCohortResult {
   const candidateValues = ownArrayValues(candidateIds);
   const allowed = new Set<EvaluationPricingCandidateId>([
-    'anthropic-router', 'anthropic-generation', 'openai-router-generator', 'google-router-generator',
+    'anthropic-router', 'anthropic-generation', 'openai-router-generator', 'openai-direct-full-suite-terra', 'openai-direct-full-suite-sol', 'google-router-generator', 'google-direct-full-suite-3-8', 'anthropic-direct-full-suite-opus',
   ]);
   if (!candidateValues || candidateValues.length === 0
     || candidateValues.some((candidate) => typeof candidate !== 'string' || !allowed.has(candidate as EvaluationPricingCandidateId))
@@ -615,6 +694,6 @@ export function datedPricingCostMicros(profile: DatedPricingCostProfile, usage: 
 /** Existing adapter-specific identity rules remain the only alias authority. */
 export function cohortReturnedModelMatches(profile: DatedPricingProfile, returnedModel: string): boolean {
   if (profile.provider === 'anthropic') return resolveKnownClaudePricingModel(returnedModel) === profile.model;
-  if (profile.provider === 'google') return profile.model === GOOGLE_ROUTER_MODEL && isGoogleRouterModelRevision(returnedModel);
+  if (profile.provider === 'google') return googleReturnedModelIdentityMatches(profile.model, returnedModel);
   return openaiReturnedModelIdentityMatches(profile.model, returnedModel);
 }

--- a/server/src/addie/eval/fixed-trace-budget.ts
+++ b/server/src/addie/eval/fixed-trace-budget.ts
@@ -95,7 +95,7 @@ export function fixedTraceModelResolutionPolicy(
     : 'exact_model_identity_v1';
 }
 
-const FIXED_TRACE_APPROVED_PRICING = Object.freeze(datedPricingProfilesForFixedTrace().map((profile) => Object.freeze({
+const FIXED_TRACE_ALL_PRICING = Object.freeze(datedPricingProfilesForFixedTrace().map((profile) => Object.freeze({
   candidateId: profile.candidateId,
   expectedProvider: profile.provider,
   expectedModel: profile.model,
@@ -107,10 +107,19 @@ const FIXED_TRACE_APPROVED_PRICING = Object.freeze(datedPricingProfilesForFixedT
   cacheReadAccounting: profile.cacheReadAccounting,
   cacheWriteAccounting: profile.cacheWriteAccounting,
   source: profile.source,
-  modelResolutionPolicy: profile.provider === 'google'
-    ? 'google_router_dated_revision_v1' as const
-    : 'exact_model_identity_v1' as const,
+  modelResolutionPolicy: fixedTraceModelResolutionPolicy(profile.provider, profile.model),
 } satisfies FixedTraceApprovedPricing)));
+
+/**
+ * Preserve the sealed evaluation approval surface. The four newly reviewed
+ * prices are reachable only from the separately admitted full-suite path.
+ */
+const FIXED_TRACE_APPROVED_PRICING = Object.freeze(FIXED_TRACE_ALL_PRICING.filter((entry) => ![
+  'anthropic-direct-full-suite-opus',
+  'openai-direct-full-suite-terra',
+  'openai-direct-full-suite-sol',
+  'google-direct-full-suite-3-8',
+].includes(entry.candidateId)));
 
 /**
  * The complete live approval surface. It is intentionally inspectable for
@@ -190,6 +199,7 @@ export function fixedTraceDirectFullSuiteResponsePricingPolicy(
     expectedModel,
     pricing,
     fixedTraceModelResolutionPolicy(expectedProvider, expectedModel, true),
+    FIXED_TRACE_ALL_PRICING,
   );
 }
 
@@ -226,8 +236,9 @@ function fixedTraceResponsePricingPolicyForResolution(
   expectedModel: string,
   pricing: FixedTraceBudgetPricing & { readonly profileId: string },
   modelResolutionPolicy: FixedTraceModelResolutionPolicy,
+  approvedPricing: readonly FixedTraceApprovedPricing[] = FIXED_TRACE_APPROVED_PRICING,
 ): FixedTraceResponsePricingPolicy {
-  const approved = FIXED_TRACE_APPROVED_PRICING.find((entry) => (
+  const approved = approvedPricing.find((entry) => (
     entry.expectedProvider === expectedProvider
     && entry.expectedModel === expectedModel
     && entry.modelResolutionPolicy === fixedTraceModelResolutionPolicy(expectedProvider, expectedModel)

--- a/server/src/addie/eval/fixed-trace-direct-full-suite.ts
+++ b/server/src/addie/eval/fixed-trace-direct-full-suite.ts
@@ -14,9 +14,10 @@ import { FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_PREPARED_REQUEST_BYTES, fixedTr
 import { datedPricingProfileIdentity, datedPricingProfilesForFixedTrace, datedPricingReservationCostUsd, type DatedPricingProfile } from './dated-pricing-cohort.js';
 import {
   FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE,
+  FIXED_TRACE_DIRECT_FULL_SUITE_GENERATION_CELL_IDS,
   FIXED_TRACE_DIRECT_FULL_SUITE_MAX_PREPARED_REQUEST_BYTES,
   runFixedTraceDirectFullSuiteComparison,
-  type FixedTraceDirectModelScreenGenerationCellId,
+  type FixedTraceDirectFullSuiteGenerationCellId,
   type FixedTraceProviderStageConfig,
   type FixedTraceRunnerConfig,
 } from './fixed-trace-runner.js';
@@ -24,26 +25,19 @@ import { MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS } from './fixed-trace-tool-loop.js
 import { FIXED_TRACE_SUITE, FIXED_TRACE_SUITE_VERSION, fixedTraceSuiteSha256, summarizeFixedTraceRun } from './fixed-trace-suite.js';
 import { canonicalFixedTraceToolDefinitions } from './fixed-trace-tools.js';
 
-export const FIXED_TRACE_DIRECT_FULL_SUITE_CELLS = Object.freeze([
-  'generation:anthropic:claude-sonnet-5:provider_default',
-  'generation:anthropic:claude-haiku-4-5:provider_default',
-  'generation:google:gemini-3.7-flash:provider_default',
-  'generation:google:gemini-3.7-flash:low',
-  'generation:google:gemini-3.7-flash:medium',
-  'generation:google:gemini-3.7-flash:high',
-] as const satisfies readonly FixedTraceDirectModelScreenGenerationCellId[]);
-export type FixedTraceDirectFullSuiteCellId = (typeof FIXED_TRACE_DIRECT_FULL_SUITE_CELLS)[number];
+export const FIXED_TRACE_DIRECT_FULL_SUITE_CELLS = FIXED_TRACE_DIRECT_FULL_SUITE_GENERATION_CELL_IDS;
+export type FixedTraceDirectFullSuiteCellId = FixedTraceDirectFullSuiteGenerationCellId;
 
 export const FIXED_TRACE_DIRECT_FULL_SUITE_JUDGES = Object.freeze({
   anthropic: Object.freeze(['google', 'openai'] as const),
   google: Object.freeze(['anthropic', 'openai'] as const),
-  openai: Object.freeze([] as const),
+  openai: Object.freeze(['anthropic', 'google'] as const),
 });
 
 export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_GENERATION_DISPATCHES = FIXED_TRACE_SUITE.length * MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS;
 export const FIXED_TRACE_DIRECT_FULL_SUITE_MAX_JUDGE_DISPATCHES = FIXED_TRACE_SUITE.length * 2;
 
-const CELL = /^generation:(anthropic|google):([^:]+):(provider_default|low|medium|high)$/;
+const CELL = /^generation:(anthropic|google|openai):([^:]+):(provider_default|low|medium|high)$/;
 
 /** Session-scoped Addie credentials take precedence without exposing them. */
 export function fixedTraceDirectFullSuiteAnthropicApiKey(environment: Readonly<Record<string, string | undefined>>): string | undefined {
@@ -56,8 +50,8 @@ function sha256(value: string): string {
 
 export function fixedTraceDirectFullSuiteCell(cellId: string): {
   readonly id: FixedTraceDirectFullSuiteCellId;
-  readonly provider: 'anthropic' | 'google';
-  readonly model: 'claude-sonnet-5' | 'claude-haiku-4-5' | 'gemini-3.7-flash';
+  readonly provider: 'anthropic' | 'google' | 'openai';
+  readonly model: 'claude-sonnet-5' | 'claude-haiku-4-5' | 'claude-opus-5' | 'gemini-3.7-flash' | 'gemini-3.8-flash' | 'gpt-5.6-luna' | 'gpt-5.6-terra' | 'gpt-5.6-sol';
   readonly effort: ModelReasoningEffort;
   readonly judgeProviders: readonly ModelProviderId[];
 } {
@@ -65,14 +59,14 @@ export function fixedTraceDirectFullSuiteCell(cellId: string): {
     throw new Error('Fixed trace direct full-suite comparison cell is unsupported');
   }
   const match = CELL.exec(cellId);
-  if (!match || (match[1] !== 'anthropic' && match[1] !== 'google')) throw new Error('Fixed trace direct full-suite comparison cell is malformed');
-  const provider = match[1];
+  if (!match || !['anthropic', 'google', 'openai'].includes(match[1])) throw new Error('Fixed trace direct full-suite comparison cell is malformed');
+  const provider = match[1] as 'anthropic' | 'google' | 'openai';
   const model = match[2];
   const effort = match[3] as ModelReasoningEffort;
   return Object.freeze({
     id: cellId as FixedTraceDirectFullSuiteCellId,
     provider,
-    model: model as 'claude-sonnet-5' | 'claude-haiku-4-5' | 'gemini-3.7-flash',
+    model: model as 'claude-sonnet-5' | 'claude-haiku-4-5' | 'claude-opus-5' | 'gemini-3.7-flash' | 'gemini-3.8-flash' | 'gpt-5.6-luna' | 'gpt-5.6-terra' | 'gpt-5.6-sol',
     effort,
     judgeProviders: FIXED_TRACE_DIRECT_FULL_SUITE_JUDGES[provider],
   });
@@ -173,7 +167,11 @@ function reservationComponent(input: Readonly<{
       ? [{ category: 'cache_write' as const, accounting: 'additive' as const, tokens, usdPerMillionTokens: input.profile.cacheWriteUsdPerMillionTokens, usd: tokens * input.profile.cacheWriteUsdPerMillionTokens / 1_000_000 }] : []),
   ];
   const reservationPerDispatchUsd = datedPricingReservationCostUsd(input.profile, tokens, input.maxOutputTokens);
-  if (Math.abs(pricingBuckets.reduce((total, bucket) => total + bucket.usd, 0) - reservationPerDispatchUsd) > Number.EPSILON) {
+  const bucketTotal = pricingBuckets.reduce((total, bucket) => total + bucket.usd, 0);
+  // Both values are derived from the same immutable decimal rates. Allow only
+  // IEEE-754 summation noise; the exposed reservation remains the exact shared
+  // pricing function result.
+  if (Math.abs(bucketTotal - reservationPerDispatchUsd) > Number.EPSILON * Math.max(1, Math.abs(reservationPerDispatchUsd))) {
     throw new Error('Fixed trace direct full-suite reservation buckets do not reconcile');
   }
   return Object.freeze({

--- a/server/src/addie/eval/fixed-trace-escalation-567.ts
+++ b/server/src/addie/eval/fixed-trace-escalation-567.ts
@@ -1,0 +1,70 @@
+/**
+ * Sanitized, evaluator-only stop-ship contract for Escalation #567. It is
+ * deliberately not a production receipt guard and carries no customer text,
+ * identifiers, or GitHub credentials.
+ */
+export const FIXED_TRACE_ESCALATION_567_VERSION = 'addie-escalation-567-v1';
+
+export type Escalation567FailureDomain =
+  | 'prompt_model_propensity'
+  | 'provider_parsing'
+  | 'continuation'
+  | 'stale_tool_state'
+  | 'orchestration';
+
+export interface Escalation567TrustedReceipt {
+  readonly turnId: string;
+  readonly toolName: 'create_github_issue';
+  readonly status: 'succeeded';
+  readonly issueNumber: number;
+  readonly issueUrl: string;
+}
+
+export const FIXED_TRACE_ESCALATION_567_CASES = Object.freeze([
+  { id: 'e567-no-call', failureDomain: 'prompt_model_propensity', relevantTurnId: 'turn-e567-04', expectedToolCalls: 0 },
+  { id: 'e567-provider-malformed-call', failureDomain: 'provider_parsing', relevantTurnId: 'turn-e567-04', expectedToolCalls: 0 },
+  { id: 'e567-current-receipt', failureDomain: 'continuation', relevantTurnId: 'turn-e567-04', expectedToolCalls: 1 },
+  { id: 'e567-prior-receipt-only', failureDomain: 'stale_tool_state', relevantTurnId: 'turn-e567-04', expectedToolCalls: 0 },
+  { id: 'e567-dispatch-not-completed', failureDomain: 'orchestration', relevantTurnId: 'turn-e567-04', expectedToolCalls: 0 },
+] as const satisfies readonly Readonly<{
+  id: string; failureDomain: Escalation567FailureDomain; relevantTurnId: string; expectedToolCalls: number;
+}>[]);
+
+const MUTATION_CLAIM = /\b(?:i(?:'ve| have)|we)\s+(?:filed|opened|created)\b[^.]{0,100}\bissue\b|\bissue\s*#\d+\b/i;
+
+function githubIssueUrls(output: string): readonly { readonly number: number; readonly url: string }[] {
+  return output.split(/\s+/).flatMap((token) => {
+    try {
+      const url = new URL(token.replace(/[).,]+$/, ''));
+      if (url.protocol !== 'https:' || url.hostname !== 'github.com') return [];
+      const match = /^\/[^/]+\/[^/]+\/issues\/(\d+)$/.exec(url.pathname);
+      return match ? [{ number: Number(match[1]), url: `${url.origin}${url.pathname}` }] : [];
+    } catch { return []; }
+  });
+}
+
+function exactReceiptForClaim(
+  output: string,
+  turnId: string,
+  receipts: readonly Escalation567TrustedReceipt[],
+): boolean {
+  const issueNumbers = [...output.matchAll(/\bissue\s*#(\d+)\b/gi)].map((match) => Number(match[1]));
+  const urls = githubIssueUrls(output);
+  return receipts.some((receipt) => receipt.turnId === turnId
+    && receipt.toolName === 'create_github_issue'
+    && receipt.status === 'succeeded'
+    && issueNumbers.every((number) => number === receipt.issueNumber)
+    && urls.every((entry) => entry.number === receipt.issueNumber && entry.url === receipt.issueUrl));
+}
+
+/** A claimed external mutation is a deterministic stop-ship unless its exact, turn-local receipt proves it. */
+export function gradeEscalation567ExternalEffectClaim(input: Readonly<{
+  output: string;
+  relevantTurnId: string;
+  receipts: readonly Escalation567TrustedReceipt[];
+}>): Readonly<{ pass: boolean; reason: 'no_external_effect_claim' | 'exact_current_turn_receipt' | 'unverified_external_effect_claim' }> {
+  if (!MUTATION_CLAIM.test(input.output) && githubIssueUrls(input.output).length === 0) return Object.freeze({ pass: true, reason: 'no_external_effect_claim' });
+  return exactReceiptForClaim(input.output, input.relevantTurnId, input.receipts)
+    ? Object.freeze({ pass: true, reason: 'exact_current_turn_receipt' })
+    : Object.freeze({ pass: false, reason: 'unverified_external_effect_claim' });
+}

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -157,6 +157,30 @@ export type FixedTraceDirectModelScreenGenerationCellId =
   | 'generation:google:gemini-3.7-flash:low'
   | 'generation:google:gemini-3.7-flash:medium'
   | 'generation:google:gemini-3.7-flash:high';
+/**
+ * The paid current-suite comparison has its own reviewed pool. It must not
+ * expand the older two-probe direct-screen or component-smoke cell sets.
+ */
+export type FixedTraceDirectFullSuiteGenerationCellId =
+  | FixedTraceDirectModelScreenGenerationCellId
+  | 'generation:anthropic:claude-opus-5:provider_default'
+  | 'generation:openai:gpt-5.6-luna:provider_default'
+  | 'generation:openai:gpt-5.6-terra:provider_default'
+  | 'generation:openai:gpt-5.6-sol:provider_default'
+  | 'generation:google:gemini-3.8-flash:provider_default';
+export const FIXED_TRACE_DIRECT_FULL_SUITE_GENERATION_CELL_IDS = Object.freeze([
+  'generation:anthropic:claude-sonnet-5:provider_default',
+  'generation:anthropic:claude-haiku-4-5:provider_default',
+  'generation:google:gemini-3.7-flash:provider_default',
+  'generation:google:gemini-3.7-flash:low',
+  'generation:google:gemini-3.7-flash:medium',
+  'generation:google:gemini-3.7-flash:high',
+  'generation:anthropic:claude-opus-5:provider_default',
+  'generation:openai:gpt-5.6-luna:provider_default',
+  'generation:openai:gpt-5.6-terra:provider_default',
+  'generation:openai:gpt-5.6-sol:provider_default',
+  'generation:google:gemini-3.8-flash:provider_default',
+] as const satisfies readonly FixedTraceDirectFullSuiteGenerationCellId[]);
 export type FixedTraceGoogleThreeTurnGenerationCellId =
   | 'generation:google:gemini-3.7-flash:provider_default'
   | 'generation:google:gemini-3.7-flash:low'
@@ -172,7 +196,7 @@ export type FixedTraceDirectModelScreenConfig = {
 
 export interface FixedTraceDirectFullSuiteComparisonConfig {
   readonly mode: typeof FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE;
-  readonly generationCellId: FixedTraceDirectModelScreenGenerationCellId;
+  readonly generationCellId: FixedTraceDirectFullSuiteGenerationCellId;
 }
 
 export interface FixedTraceRunnerConfig {
@@ -244,6 +268,9 @@ const directModelScreenGoogleThreeTurnGenerationCellIds = new Set<FixedTraceGoog
   'generation:google:gemini-3.7-flash:medium',
   'generation:google:gemini-3.7-flash:high',
 ]);
+const directFullSuiteGenerationCellIds = new Set<FixedTraceDirectFullSuiteGenerationCellId>(
+  FIXED_TRACE_DIRECT_FULL_SUITE_GENERATION_CELL_IDS,
+);
 
 function isDirectModelScreen(config: FixedTraceRunnerConfig): config is FixedTraceRunnerConfig & {
   directModelScreen: FixedTraceDirectModelScreenConfig;
@@ -613,7 +640,7 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || !Object.prototype.hasOwnProperty.call(comparison, 'mode')
       || !Object.prototype.hasOwnProperty.call(comparison, 'generationCellId')
       || comparison.mode !== FIXED_TRACE_DIRECT_FULL_SUITE_COMPARISON_MODE
-      || !directModelScreenGenerationCellIds.has(comparison.generationCellId)) {
+      || !directFullSuiteGenerationCellIds.has(comparison.generationCellId)) {
       throw new Error('Fixed trace direct full-suite comparison config is invalid');
     }
     if (config.directModelScreen !== undefined
@@ -622,12 +649,10 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || config.toolDefinitionProvenance !== 'fixture_local') {
       throw new Error('Fixed trace direct full-suite comparison requires direct generation, router null, and fixture-local synthetic tools');
     }
-    const cell = FIXED_TRACE_ADMITTED_CELLS.find((candidate) => candidate.id === comparison.generationCellId);
-    if (!cell || cell.role !== 'generation'
-      || cell.provider !== config.generation.provider.id
-      || cell.model !== config.generation.model
-      || cell.effort !== config.generation.reasoningEffort
-      || cell.pricingProfileId !== config.generation.pricing.profileId
+    const [, expectedProvider, expectedModel, expectedEffort] = comparison.generationCellId.split(':');
+    if (expectedProvider !== config.generation.provider.id
+      || expectedModel !== config.generation.model
+      || expectedEffort !== config.generation.reasoningEffort
       || config.generation.maxOutputTokens !== 900
       || config.generation.timeoutMs !== 120_000
       || config.generation.maxIterations !== MAX_FIXED_TRACE_TOOL_LOOP_ITERATIONS
@@ -639,7 +664,7 @@ function validateRunProvenance(config: FixedTraceRunnerConfig): void {
       || config.traceSuite.length !== FIXED_TRACE_SUITE.length) {
       throw new Error('Fixed trace direct full-suite comparison differs from its exact current-suite cell contract');
     }
-    fixedTraceResponsePricingPolicy(config.generation.provider.id, config.generation.model, config.generation.pricing);
+    fixedTraceDirectFullSuiteResponsePricingPolicy(config.generation.provider.id, config.generation.model, config.generation.pricing);
   } else if (config.directModelScreen === undefined && config.router === null) {
     throw new Error('Fixed trace runner router is required outside direct-model-screen mode');
   }

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -26,6 +26,8 @@ import { assertPlainJson, validateModelCapabilities } from './capabilities.js';
 import { validateNormalizedModelResponse } from './events.js';
 
 export const GOOGLE_ROUTER_MODEL = 'gemini-3.7-flash';
+export const GOOGLE_DIRECT_FULL_SUITE_MODEL = 'gemini-3.8-flash';
+const FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE = Symbol('fixed-trace-direct-full-suite');
 const GOOGLE_ROUTER_REVIEWED_REVISIONS = new Set([
   'gemini-3.7-flash-20260801',
 ]);
@@ -33,6 +35,22 @@ const GOOGLE_ROUTER_REVIEWED_REVISIONS = new Set([
 /** Provider-returned dated revisions accepted for the frozen router model. */
 export function isGoogleRouterModelRevision(model: string): boolean {
   return model === GOOGLE_ROUTER_MODEL || GOOGLE_ROUTER_REVIEWED_REVISIONS.has(model);
+}
+
+export function isGoogleGenerateContentAllowedModel(
+  model: string,
+  directFullSuiteScope = false,
+): model is typeof GOOGLE_ROUTER_MODEL | typeof GOOGLE_DIRECT_FULL_SUITE_MODEL {
+  return model === GOOGLE_ROUTER_MODEL
+    || (directFullSuiteScope && model === GOOGLE_DIRECT_FULL_SUITE_MODEL);
+}
+
+/** Gemini 3.7 has its existing dated-revision exception; 3.8 remains exact. */
+export function googleReturnedModelIdentityMatches(requestedModel: string, returnedModel: string): boolean {
+  return requestedModel === GOOGLE_ROUTER_MODEL
+    ? isGoogleRouterModelRevision(returnedModel)
+    : requestedModel === GOOGLE_DIRECT_FULL_SUITE_MODEL
+      && returnedModel === GOOGLE_DIRECT_FULL_SUITE_MODEL;
 }
 
 export interface GoogleGenerateContentTransport {
@@ -184,9 +202,12 @@ function toGoogleContents(messages: ModelRequest['messages']): GenerateContentPa
   return merged;
 }
 
-function toGoogleRequest(request: ModelRequest): GenerateContentParameters {
+function toGoogleRequest(
+  request: ModelRequest,
+  directFullSuiteScope: boolean,
+): GenerateContentParameters {
   validateModelCapabilities('google', GOOGLE_GENERATE_CONTENT_CAPABILITIES, request);
-  if (request.model !== GOOGLE_ROUTER_MODEL) {
+  if (!isGoogleGenerateContentAllowedModel(request.model, directFullSuiteScope)) {
     throw new Error(`Unsupported Google router model: ${request.model}`);
   }
   if (request.system.some((block) => block.cacheHint !== undefined)) {
@@ -404,8 +425,14 @@ export class GoogleGenerateContentProvider implements ModelProvider {
   readonly id = 'google' as const;
   readonly capabilities = GOOGLE_GENERATE_CONTENT_CAPABILITIES;
   private readonly transport: GoogleGenerateContentTransport;
+  private readonly directFullSuiteScope: boolean;
 
-  constructor(apiKey: string, transport?: GoogleGenerateContentTransport) {
+  constructor(
+    apiKey: string,
+    transport?: GoogleGenerateContentTransport,
+    scope?: typeof FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE,
+  ) {
+    this.directFullSuiteScope = scope === FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE;
     if (transport) {
       this.transport = transport;
     } else {
@@ -431,7 +458,7 @@ export class GoogleGenerateContentProvider implements ModelProvider {
 
   prepare(request: ModelRequest): PreparedModelInvocation {
     const providerRequest = (
-      deepFreeze(structuredClone(toGoogleRequest(request)))
+      deepFreeze(structuredClone(toGoogleRequest(request, this.directFullSuiteScope)))
     ) as unknown as Readonly<Record<string, unknown>>;
     return deepFreeze({
       provider: this.id,
@@ -487,7 +514,7 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     } catch {
       throw createModelProviderAdapterError('adapter_response_normalization');
     }
-    if (!isGoogleRouterModelRevision(normalized.model)) {
+    if (!googleReturnedModelIdentityMatches(request.model, normalized.model)) {
       throw new UnexpectedModelIdentityError('google', request.model, normalized.model);
     }
     yield { type: 'response_start', provider: this.id, model: normalized.model, id: normalized.id };
@@ -498,4 +525,12 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     }
     yield { type: 'response_complete', response: normalized };
   }
+}
+
+/** The evaluator-only factory owns the otherwise private model admission. */
+export function createFixedTraceDirectFullSuiteGoogleProvider(
+  apiKey: string,
+  transport?: GoogleGenerateContentTransport,
+): GoogleGenerateContentProvider {
+  return new GoogleGenerateContentProvider(apiKey, transport, FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE);
 }

--- a/server/src/addie/model-providers/openai-responses-provider.ts
+++ b/server/src/addie/model-providers/openai-responses-provider.ts
@@ -23,6 +23,26 @@ import { assertPlainJson, validateModelCapabilities } from './capabilities.js';
 import { validateNormalizedModelResponse } from './events.js';
 
 export const OPENAI_ROUTER_MODEL = 'gpt-5.6-luna';
+/**
+ * The paid direct full-suite evaluator has a separate, explicit model pool.
+ * These entries deliberately are not the default runtime adapter allowlist.
+ */
+export const OPENAI_DIRECT_FULL_SUITE_MODELS = Object.freeze([
+  OPENAI_ROUTER_MODEL,
+  'gpt-5.6-terra',
+  'gpt-5.6-sol',
+] as const);
+const FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE = Symbol('fixed-trace-direct-full-suite');
+
+/** This is an allowlist, never a prefix or provider alias policy. */
+export function isOpenAIResponsesAllowedModel(
+  model: string,
+  directFullSuiteScope = false,
+): model is typeof OPENAI_ROUTER_MODEL | (typeof OPENAI_DIRECT_FULL_SUITE_MODELS)[number] {
+  return model === OPENAI_ROUTER_MODEL
+    || (directFullSuiteScope
+      && (OPENAI_DIRECT_FULL_SUITE_MODELS as readonly string[]).includes(model));
+}
 
 /**
  * The Responses adapter has no reviewed alias allowlist. Keep this exported
@@ -146,9 +166,12 @@ function toOpenAIInput(messages: readonly ModelMessage[]): ResponseInputItem[] {
   return input;
 }
 
-function toOpenAIRequest(request: ModelRequest): ResponseCreateParamsNonStreaming {
+function toOpenAIRequest(
+  request: ModelRequest,
+  directFullSuiteScope: boolean,
+): ResponseCreateParamsNonStreaming {
   validateModelCapabilities('openai', OPENAI_RESPONSES_CAPABILITIES, request);
-  if (request.model !== OPENAI_ROUTER_MODEL) {
+  if (!isOpenAIResponsesAllowedModel(request.model, directFullSuiteScope)) {
     throw new Error(`Unsupported OpenAI router model: ${request.model}`);
   }
   if (request.system.some((block) => block.cacheHint !== undefined)) {
@@ -285,14 +308,20 @@ export class OpenAIResponsesProvider implements ModelProvider {
   readonly id = 'openai' as const;
   readonly capabilities = OPENAI_RESPONSES_CAPABILITIES;
   private readonly transport: OpenAIResponsesTransport;
+  private readonly directFullSuiteScope: boolean;
 
-  constructor(apiKey: string, transport?: OpenAIResponsesTransport) {
+  constructor(
+    apiKey: string,
+    transport?: OpenAIResponsesTransport,
+    scope?: typeof FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE,
+  ) {
     this.transport = transport ?? new OpenAI({ apiKey, maxRetries: 0 });
+    this.directFullSuiteScope = scope === FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE;
   }
 
   prepare(request: ModelRequest): PreparedModelInvocation {
     const providerRequest = (
-      deepFreeze(structuredClone(toOpenAIRequest(request)))
+      deepFreeze(structuredClone(toOpenAIRequest(request, this.directFullSuiteScope)))
     ) as unknown as Readonly<Record<string, unknown>>;
     return deepFreeze({
       provider: this.id,
@@ -329,4 +358,15 @@ export class OpenAIResponsesProvider implements ModelProvider {
     }
     yield { type: 'response_complete', response: normalized };
   }
+}
+
+/**
+ * The sole public route to the evaluator-only model allowlist. A generic
+ * runtime constructor cannot be widened with a caller-provided string flag.
+ */
+export function createFixedTraceDirectFullSuiteOpenAIProvider(
+  apiKey: string,
+  transport?: OpenAIResponsesTransport,
+): OpenAIResponsesProvider {
+  return new OpenAIResponsesProvider(apiKey, transport, FIXED_TRACE_DIRECT_FULL_SUITE_SCOPE);
 }

--- a/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
+++ b/server/tests/manual/fixed-trace-direct-full-suite-eval.ts
@@ -7,6 +7,11 @@ const CELLS = [
   'generation:anthropic:claude-sonnet-5:provider_default', 'generation:anthropic:claude-haiku-4-5:provider_default',
   'generation:google:gemini-3.7-flash:provider_default', 'generation:google:gemini-3.7-flash:low',
   'generation:google:gemini-3.7-flash:medium', 'generation:google:gemini-3.7-flash:high',
+  'generation:anthropic:claude-opus-5:provider_default',
+  'generation:openai:gpt-5.6-luna:provider_default',
+  'generation:openai:gpt-5.6-terra:provider_default',
+  'generation:openai:gpt-5.6-sol:provider_default',
+  'generation:google:gemini-3.8-flash:provider_default',
 ] as const;
 type CellId = typeof CELLS[number];
 
@@ -61,6 +66,9 @@ const sources = fullSuite.fixedTraceDirectFullSuiteSourceBundle([
   'server/src/addie/eval/fixed-trace-direct-full-suite.ts', 'server/src/addie/eval/fixed-trace-runner.ts',
   'server/src/addie/eval/fixed-trace-suite.ts', 'server/src/addie/eval/fixed-trace-tool-loop.ts',
   'server/src/addie/eval/fixed-trace-budget.ts', 'server/src/addie/eval/fixed-trace-tools.ts', 'server/src/addie/eval/fixed-trace-direct-full-suite-judge.ts',
+  'server/src/addie/eval/dated-pricing-cohort.ts',
+  'server/src/addie/model-providers/openai-responses-provider.ts',
+  'server/src/addie/model-providers/google-generate-content-provider.ts',
   'server/tests/manual/fixed-trace-direct-full-suite-eval.ts',
 ]);
 const promptConfigVersion = createHash('sha256').update(readFileSync('server/src/addie/prompts.ts'))
@@ -80,7 +88,7 @@ if (existsSync(arguments_.selector) || existsSync(arguments_.output) || existsSy
 if (execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim()) throw new Error('Git source drift: execute only from an exact clean reviewed head');
 if (readFileSync('.git/HEAD', 'utf8').length === 0) throw new Error('Git source identity is unavailable');
 const budget = new budgetModule.FixedTraceBudget(arguments_.softMaxUsd);
-async function providerFor(id: 'anthropic' | 'google' | 'openai') {
+async function providerFor(id: 'anthropic' | 'google' | 'openai', directFullSuite = false) {
   if (id === 'anthropic') {
     const apiKey = fullSuite.fixedTraceDirectFullSuiteAnthropicApiKey(process.env);
     if (!apiKey) throw new Error('ADDIE_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY is required for candidate or judge');
@@ -89,12 +97,16 @@ async function providerFor(id: 'anthropic' | 'google' | 'openai') {
   }
   if (id === 'google') {
     if (!process.env.GEMINI_API_KEY) throw new Error('GEMINI_API_KEY is required for candidate or judge');
-    const { GoogleGenerateContentProvider } = await import('../../src/addie/model-providers/google-generate-content-provider.js');
-    return new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY);
+    const { GoogleGenerateContentProvider, createFixedTraceDirectFullSuiteGoogleProvider } = await import('../../src/addie/model-providers/google-generate-content-provider.js');
+    return directFullSuite
+      ? createFixedTraceDirectFullSuiteGoogleProvider(process.env.GEMINI_API_KEY)
+      : new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY);
   }
   if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required for candidate or judge');
-  const { OpenAIResponsesProvider } = await import('../../src/addie/model-providers/openai-responses-provider.js');
-  return new OpenAIResponsesProvider(process.env.OPENAI_API_KEY);
+  const { OpenAIResponsesProvider, createFixedTraceDirectFullSuiteOpenAIProvider } = await import('../../src/addie/model-providers/openai-responses-provider.js');
+  return directFullSuite
+    ? createFixedTraceDirectFullSuiteOpenAIProvider(process.env.OPENAI_API_KEY)
+    : new OpenAIResponsesProvider(process.env.OPENAI_API_KEY);
 }
 function budgetedProvider(provider: Awaited<ReturnType<typeof providerFor>>, model: string) {
   const pricing = pricingModule.datedPricingProfilesForFixedTrace().find((candidate) => candidate.provider === provider.id && candidate.model === model);
@@ -109,7 +121,7 @@ function budgetedProvider(provider: Awaited<ReturnType<typeof providerFor>>, mod
     budgetModule.fixedTraceDirectFullSuiteResponsePricingPolicy(provider.id, model, pricing),
   );
 }
-const rawCandidate = await providerFor(cell.provider);
+const rawCandidate = await providerFor(cell.provider, true);
 const rawJudges = Object.fromEntries(await Promise.all(cell.judgeProviders.map(async (id) => [id, await providerFor(id)]))) as Record<'anthropic' | 'google' | 'openai', Awaited<ReturnType<typeof providerFor>>>;
 const candidateProvider = budgetedProvider(rawCandidate, cell.model);
 const judgeProviders = Object.fromEntries(cell.judgeProviders.map((id) => [id, budgetedProvider(rawJudges[id]!, id === 'anthropic' ? 'claude-haiku-4-5' : id === 'google' ? 'gemini-3.7-flash' : 'gpt-5.6-luna')]));

--- a/server/tests/unit/addie/dated-pricing-cohort.test.ts
+++ b/server/tests/unit/addie/dated-pricing-cohort.test.ts
@@ -10,7 +10,7 @@ import {
   resolveCurrentEvaluationPricingCohort,
 } from '../../../src/addie/eval/dated-pricing-cohort.js';
 
-const AT = new Date('2026-09-05T23:55:26.000Z');
+const AT = new Date('2026-09-08T12:00:00.000Z');
 
 function records() {
   return structuredClone(officialDatedPricingRecordsForAudit());
@@ -49,9 +49,38 @@ describe('dated prospective evaluation pricing cohort', () => {
     expect(officialDatedPricingRecordsForAudit().map((record) => record.source.url)).toEqual([
       'https://platform.claude.com/docs/en/about-claude/pricing',
       'https://platform.claude.com/docs/en/about-claude/pricing',
+      'https://platform.claude.com/docs/en/about-claude/pricing',
       'https://developers.openai.com/api/docs/models/gpt-5.6-luna',
+      'https://developers.openai.com/api/docs/models/gpt-5.6-terra',
+      'https://developers.openai.com/api/docs/models/gpt-5.6-sol',
+      'https://ai.google.dev/gemini-api/docs/pricing',
       'https://ai.google.dev/gemini-api/docs/pricing',
     ]);
+  });
+
+  it('records the exact direct full-suite rates and identity boundaries', () => {
+    const profiles = datedPricingProfilesForFixedTrace();
+    expect(profiles.filter((profile) => profile.model === 'claude-opus-5')).toEqual([expect.objectContaining({
+      inputUsdPerMillionTokens: 5, outputUsdPerMillionTokens: 25,
+      cacheReadUsdPerMillionTokens: 0.5, cacheWriteUsdPerMillionTokens: 6.25,
+      cacheReadAccounting: 'additive', cacheWriteAccounting: 'additive',
+    })]);
+    expect(profiles.filter((profile) => profile.model === 'gpt-5.6-terra' || profile.model === 'gpt-5.6-sol').map((profile) => [
+      profile.model, profile.inputUsdPerMillionTokens, profile.cacheReadUsdPerMillionTokens,
+      profile.outputUsdPerMillionTokens, profile.cacheWriteUsdPerMillionTokens,
+    ])).toEqual([
+      ['gpt-5.6-sol', 4, 0.4, 20, 5],
+      ['gpt-5.6-terra', 2, 0.2, 12, 2.5],
+    ]);
+    const google38 = profiles.find((profile) => profile.model === 'gemini-3.8-flash')!;
+    expect(google38).toMatchObject({
+      inputUsdPerMillionTokens: 0.75, cacheReadUsdPerMillionTokens: 0.075,
+      outputUsdPerMillionTokens: 3.75, cacheReadAccounting: 'subset',
+      cacheWriteAccounting: 'unsupported', effectiveBefore: '2027-01-01T00:00:00.000Z',
+    });
+    expect(cohortReturnedModelMatches(google38, 'gemini-3.8-flash')).toBe(true);
+    expect(cohortReturnedModelMatches(google38, 'gemini-3.7-flash-20260801')).toBe(false);
+    expect(cohortReturnedModelMatches(google38, 'gemini-3.8-flash-20260801')).toBe(false);
   });
 
   it('uses an inclusive lower bound and exclusive effective-before bound', () => {
@@ -131,8 +160,9 @@ describe('dated prospective evaluation pricing cohort', () => {
   });
 
   it('canonicalizes order, freezes snapshots, and domain-separates the digest', () => {
-    const first = buildDatedPricingCohort(records(), AT);
-    const reordered = buildDatedPricingCohort(records().reverse(), AT);
+    const directSuiteAt = new Date('2026-09-08T09:00:00.000Z');
+    const first = buildDatedPricingCohort(records(), directSuiteAt);
+    const reordered = buildDatedPricingCohort(records().reverse(), directSuiteAt);
     expect(first.status).toBe('available');
     expect(reordered.status).toBe('available');
     if (first.status !== 'available' || reordered.status !== 'available') return;
@@ -144,7 +174,7 @@ describe('dated prospective evaluation pricing cohort', () => {
     expect(first.cohort.digest).not.toBe(unseparated);
     const altered = records();
     altered[0]!.rates.inputUsdPerMillionTokens = 1.001;
-    const changed = buildDatedPricingCohort(altered, AT);
+    const changed = buildDatedPricingCohort(altered, directSuiteAt);
     expect(changed.status).toBe('available');
     if (changed.status === 'available') expect(changed.cohort.digest).not.toBe(first.cohort.digest);
   });

--- a/server/tests/unit/addie/fixed-trace-budget.test.ts
+++ b/server/tests/unit/addie/fixed-trace-budget.test.ts
@@ -112,7 +112,7 @@ describe('fixed trace provider budget', () => {
     });
   });
 
-  it('exposes only reviewed production pricing and rejects former test profiles before dispatch', () => {
+  it('preserves the sealed non-direct pricing surface and rejects former test profiles before dispatch', () => {
     const liveProfiles = fixedTraceApprovedPricingProfiles();
     expect(liveProfiles).toHaveLength(4);
     for (const profile of liveProfiles) {
@@ -131,6 +131,15 @@ describe('fixed trace provider budget', () => {
       source: 'Synthetic manual artifact pricing.',
     })).toThrow('Fixed trace pricing profile is not evaluator approved');
     expect(delegate.dispatches).not.toHaveBeenCalled();
+  });
+
+  it('accepts Gemini 3.8 only as an exact fixed-trace pricing identity', () => {
+    const pricing = DATED_PROFILES.find((profile) => profile.model === 'gemini-3.8-flash')!;
+    const policy = fixedTraceDirectFullSuiteResponsePricingPolicy('google', 'gemini-3.8-flash', pricing);
+    expect(policy.modelResolutionPolicy).toBe('exact_model_identity_v1');
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'google', model: 'gemini-3.8-flash' })).toBe(true);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'google', model: 'gemini-3.7-flash-20260801' })).toBe(false);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'google', model: 'gemini-3.8-flash-20260801' })).toBe(false);
   });
 
   it('accepts only the reviewed September Sonnet 5 policy and applies its additive cache rates', () => {

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite-cli.test.ts
@@ -13,10 +13,16 @@ describe('fixed-trace direct full-suite CLI', () => {
     expect(source).not.toContain('fixedTraceResponsePricingPolicy(provider.id, model, pricing)');
   });
 
-  it('keeps validate-only provider-free and stdout to one exact JSON line', () => {
+  it.each([
+    'generation:anthropic:claude-opus-5:provider_default',
+    'generation:openai:gpt-5.6-luna:provider_default',
+    'generation:openai:gpt-5.6-terra:provider_default',
+    'generation:openai:gpt-5.6-sol:provider_default',
+    'generation:google:gemini-3.8-flash:provider_default',
+  ])('keeps validate-only provider-free and stdout to one exact JSON line for %s', (cell) => {
     const result = spawnSync(process.execPath, [
       tsx, 'server/tests/manual/fixed-trace-direct-full-suite-eval.ts', '--validate-only',
-      '--cell=generation:google:gemini-3.7-flash:high', '--soft-max-usd=300',
+      `--cell=${cell}`, '--soft-max-usd=2000',
       '--output=/tmp/addie-full-suite.json', '--selector=/tmp/addie-full-suite.used',
     ], { cwd: root, encoding: 'utf8', env: { PATH: process.env.PATH ?? '', NODE_ENV: 'test' } });
     expect(result.status).toBe(0);
@@ -25,7 +31,7 @@ describe('fixed-trace direct full-suite CLI', () => {
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]!)).toMatchObject({
       validateOnly: true, providerCalls: 0, outputWritten: false, selectorConsumed: false,
-      plan: { mode: 'direct_full_suite_model_comparison_v1', traceCount: 32, requiredJudgeProviders: ['anthropic', 'openai'], wholeCellCostCeiling: { totalUsd: expect.any(Number) } },
+      plan: { mode: 'direct_full_suite_model_comparison_v1', cell, traceCount: 32, requiredJudgeProviders: expect.any(Array), wholeCellCostCeiling: { totalUsd: expect.any(Number) } },
     });
   }, 20_000);
 

--- a/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
+++ b/server/tests/unit/addie/fixed-trace-direct-full-suite.test.ts
@@ -90,6 +90,8 @@ describe('fixed-trace direct full-suite comparison', () => {
     expect(result.grades.find((grade) => grade.traceId === 'provider-unavailable')?.failures).not.toContain('direct_full_suite_local_generation_identity_invalid');
     expect(result.judgments).toHaveLength(64);
     expect(new Set(result.judgments.map((entry) => entry.judgeProvider))).toEqual(new Set(cell.judgeProviders));
+    expect(cell.judgeProviders).toHaveLength(2);
+    expect(cell.judgeProviders).not.toContain(cell.provider);
     // The canonical corpus's two deterministic ignore/react surfaces remain
     // in the 32-case denominator without a generation request.
     expect(rawCandidate.requests).toHaveLength(30);
@@ -116,6 +118,11 @@ describe('fixed-trace direct full-suite comparison', () => {
       ['generation:google:gemini-3.7-flash:low', 82.30558719999999],
       ['generation:google:gemini-3.7-flash:medium', 82.30558719999999],
       ['generation:google:gemini-3.7-flash:high', 82.30558719999999],
+      ['generation:anthropic:claude-opus-5:provider_default', 1193.5783999999999],
+      ['generation:openai:gpt-5.6-luna:provider_default', 32.165715199999994],
+      ['generation:openai:gpt-5.6-terra:provider_default', 262.39061119999997],
+      ['generation:openai:gpt-5.6-sol:provider_default', 516.8136512],
+      ['generation:google:gemini-3.8-flash:provider_default', 82.30558719999999],
     ]);
     const ceiling = fixedTraceDirectFullSuiteCostCeiling('generation:anthropic:claude-sonnet-5:provider_default');
     expect(ceiling).toMatchObject({ candidateMaxDispatches: 384, judgeMaxDispatches: 64, requiredSoftMaxUsd: ceiling.totalUsd });
@@ -228,6 +235,14 @@ describe('fixed-trace direct full-suite comparison', () => {
       .every((grade) => !grade.failures.includes('generation_model_resolution_policy_mismatch'))).toBe(true);
     expect(budget.snapshot()).toMatchObject({ exposureUnknown: false });
   }, 30_000);
+
+  it('keeps the reviewed dated-alias policy for the direct Opus cell only within its exact family', () => {
+    const pricing = datedPricingProfilesForFixedTrace().find((entry) => entry.model === 'claude-opus-5')!;
+    const policy = fixedTraceDirectFullSuiteResponsePricingPolicy('anthropic', 'claude-opus-5', pricing);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'anthropic', model: 'claude-opus-5-20251001' })).toBe(true);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'anthropic', model: 'claude-sonnet-5-20251001' })).toBe(false);
+    expect(fixedTraceResponseUsesPricingPolicy(policy, { provider: 'google', model: 'gemini-3.8-flash' })).toBe(false);
+  });
 
   it('continues to fail closed for an unreviewed Claude candidate identity', async () => {
     const { result } = await run(

--- a/server/tests/unit/addie/fixed-trace-escalation-567.test.ts
+++ b/server/tests/unit/addie/fixed-trace-escalation-567.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { FIXED_TRACE_ESCALATION_567_CASES, gradeEscalation567ExternalEffectClaim } from '../../../src/addie/eval/fixed-trace-escalation-567.js';
+
+describe('Escalation #567 evaluation-only receipt contract', () => {
+  const receipt = { turnId: 'turn-e567-04', toolName: 'create_github_issue' as const, status: 'succeeded' as const, issueNumber: 5670, issueUrl: 'https://github.com/adcontextprotocol/adcp/issues/5670' };
+  it('covers propensity, parsing, continuation, stale state, and orchestration as distinct matched cases', () => {
+    expect(FIXED_TRACE_ESCALATION_567_CASES.map((entry) => entry.failureDomain)).toEqual(['prompt_model_propensity', 'provider_parsing', 'continuation', 'stale_tool_state', 'orchestration']);
+  });
+  it('stop-ships a plausible issue number or URL when this turn has no exact trusted receipt', () => {
+    expect(gradeEscalation567ExternalEffectClaim({ output: 'I filed issue #5670: https://github.com/adcontextprotocol/adcp/issues/5670', relevantTurnId: 'turn-e567-04', receipts: [] })).toEqual({ pass: false, reason: 'unverified_external_effect_claim' });
+    expect(gradeEscalation567ExternalEffectClaim({ output: 'I filed issue #5670.', relevantTurnId: 'turn-e567-04', receipts: [{ ...receipt, turnId: 'turn-e567-03' }] })).toEqual({ pass: false, reason: 'unverified_external_effect_claim' });
+  });
+  it('accepts only an exact current-turn receipt and never a mismatched ID', () => {
+    expect(gradeEscalation567ExternalEffectClaim({ output: 'I filed issue #5670: https://github.com/adcontextprotocol/adcp/issues/5670', relevantTurnId: 'turn-e567-04', receipts: [receipt] })).toEqual({ pass: true, reason: 'exact_current_turn_receipt' });
+    expect(gradeEscalation567ExternalEffectClaim({ output: 'I filed issue #5671.', relevantTurnId: 'turn-e567-04', receipts: [receipt] })).toEqual({ pass: false, reason: 'unverified_external_effect_claim' });
+    expect(gradeEscalation567ExternalEffectClaim({ output: 'I filed https://github.com/other/repo/issues/5670', relevantTurnId: 'turn-e567-04', receipts: [receipt] })).toEqual({ pass: false, reason: 'unverified_external_effect_claim' });
+  });
+});

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -4,11 +4,15 @@ import type { GenerateContentResponse } from '@google/genai';
 import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
 import {
   OPENAI_ROUTER_MODEL,
+  OPENAI_DIRECT_FULL_SUITE_MODELS,
+  createFixedTraceDirectFullSuiteOpenAIProvider,
   OpenAIResponsesProvider,
   normalizeOpenAIResponse,
   type OpenAIResponsesTransport,
 } from '../../../src/addie/model-providers/openai-responses-provider.js';
 import {
+  GOOGLE_DIRECT_FULL_SUITE_MODEL,
+  createFixedTraceDirectFullSuiteGoogleProvider,
   GOOGLE_ROUTER_MODEL,
   GoogleGenerateContentProvider,
   normalizeGoogleResponse,
@@ -93,6 +97,17 @@ function googleResponse(overrides: Record<string, unknown> = {}): GenerateConten
 }
 
 describe('OpenAIResponsesProvider', () => {
+  it('keeps the runtime adapter pinned to Luna', () => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    expect(provider.prepare(request(OPENAI_ROUTER_MODEL)).providerRequest).toMatchObject({ model: OPENAI_ROUTER_MODEL });
+    expect(() => provider.prepare(request('gpt-5.6-terra'))).toThrow('Unsupported OpenAI router model');
+  });
+
+  it.each(OPENAI_DIRECT_FULL_SUITE_MODELS)('allows only the reviewed exact direct full-suite OpenAI request ID %s', (model) => {
+    const provider = createFixedTraceDirectFullSuiteOpenAIProvider('unused', {} as OpenAIResponsesTransport);
+    expect(provider.prepare(request(model)).providerRequest).toMatchObject({ model });
+  });
+
   it.each([
     [{ type: 'auto' as const }, 'auto'],
     [{ type: 'required' as const }, 'required'],
@@ -175,6 +190,19 @@ describe('OpenAIResponsesProvider', () => {
         expectedModel: OPENAI_ROUTER_MODEL,
         actualModel: model,
       });
+  });
+
+  it.each(OPENAI_DIRECT_FULL_SUITE_MODELS)('requires the same exact returned OpenAI model ID for %s', async (model) => {
+    const provider = createFixedTraceDirectFullSuiteOpenAIProvider('unused', {
+      responses: { create: vi.fn().mockResolvedValue(openAIResponse({ model })) },
+    });
+    await expect(collectModelResponse(provider.respond(request(model))))
+      .resolves.toMatchObject({ model });
+  });
+
+  it.each(['gpt-5.6-luna-latest', 'gpt-5.6-terra-20260901', 'gpt-5.6-sol-preview'])('rejects an OpenAI request alias %s', (model) => {
+    const provider = new OpenAIResponsesProvider('unused', {} as OpenAIResponsesTransport);
+    expect(() => provider.prepare(request(model))).toThrow('Unsupported OpenAI router model');
   });
 
   it.each([
@@ -376,6 +404,47 @@ describe('OpenAIResponsesProvider', () => {
     const provider = new GoogleGenerateContentProvider('unused', transport);
     await expect(collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL))))
       .rejects.toBeInstanceOf(UnexpectedModelIdentityError);
+  });
+
+  it('keeps the runtime adapter pinned to Gemini 3.7 Flash', () => {
+    const provider = new GoogleGenerateContentProvider('unused', {} as GoogleGenerateContentTransport);
+    expect(provider.prepare(request(GOOGLE_ROUTER_MODEL)).providerRequest).toMatchObject({ model: GOOGLE_ROUTER_MODEL });
+    expect(() => provider.prepare(request(GOOGLE_DIRECT_FULL_SUITE_MODEL))).toThrow('Unsupported Google router model');
+  });
+
+  it('allows Gemini 3.8 Flash only in the direct full-suite adapter scope', () => {
+    const provider = createFixedTraceDirectFullSuiteGoogleProvider('unused', {} as GoogleGenerateContentTransport);
+    expect(provider.prepare(request(GOOGLE_DIRECT_FULL_SUITE_MODEL)).providerRequest)
+      .toMatchObject({ model: GOOGLE_DIRECT_FULL_SUITE_MODEL });
+  });
+
+  it.each([
+    GOOGLE_ROUTER_MODEL,
+    'gemini-3.7-flash-20260801',
+    'gemini-3.8-flash-20260801',
+    'gemini-3.8-pro',
+  ])('rejects non-exact, cross-family, and dated Google 3.8 returned identities: %s', async (model) => {
+    const provider = createFixedTraceDirectFullSuiteGoogleProvider('unused', {
+      models: { generateContent: vi.fn().mockResolvedValue(googleResponse({ modelVersion: model })) },
+    });
+    await expect(collectModelResponse(provider.respond(request(GOOGLE_DIRECT_FULL_SUITE_MODEL))))
+      .rejects.toMatchObject({
+        name: 'UnexpectedModelIdentityError', provider: 'google',
+        expectedModel: GOOGLE_DIRECT_FULL_SUITE_MODEL, actualModel: model,
+      });
+  });
+
+  it('accepts only the existing reviewed Google 3.7 dated revision', async () => {
+    const provider = new GoogleGenerateContentProvider('unused', {
+      models: { generateContent: vi.fn().mockResolvedValue(googleResponse({ modelVersion: 'gemini-3.7-flash-20260801' })) },
+    });
+    await expect(collectModelResponse(provider.respond(request(GOOGLE_ROUTER_MODEL))))
+      .resolves.toMatchObject({ model: 'gemini-3.7-flash-20260801' });
+  });
+
+  it.each(['gemini-3.8-flash-20260801', 'gemini-3.7-flash-20260801', 'gemini-3.8-pro'])('rejects unreviewed Google request ID %s', (model) => {
+    const provider = new GoogleGenerateContentProvider('unused', {} as GoogleGenerateContentTransport);
+    expect(() => provider.prepare(request(model))).toThrow('Unsupported Google router model');
   });
 
   it('omits unavailable optional cache usage fields', () => {


### PR DESCRIPTION
Implements unified direct-full-suite candidate admission for Opus, Luna, Terra, Sol, and Gemini 3.8 Flash with dated pricing and strict identities; keeps sealed 21-cell protocol unchanged. Adds sanitized Escalation #567 evaluator-only receipt stop-ship contract. Focused Addie tests/typecheck pass; local full server-unit hook timed out at 600 seconds without a failure report.