### PR TITLE
fix(compliance): correct VERSION_UNSUPPORTED recovery enum value in error-compliance storyboard

### DIFF
--- a/.changeset/fix-error-compliance-recovery-enum.md
+++ b/.changeset/fix-error-compliance-recovery-enum.md
@@ -1,0 +1,11 @@
+---
+"adcontextprotocol": patch
+---
+
+Fix `VERSION_UNSUPPORTED` recovery value in `error-compliance.yaml` storyboard prose.
+
+Two occurrences of `fatal` (which is not in the `recovery` enum) have been corrected:
+- `unsupported_major_version` step `expected:` block: `recovery: fatal` → `recovery: correctable`, matching `enumMetadata.VERSION_UNSUPPORTED.recovery` across all 3.x bundles.
+- General error-shape narrative: `correctable, transient, or fatal` → `transient, correctable, or terminal`, matching the enum declaration order in `core/error.json`.
+
+The storyboard validations do not assert `recovery`, so no existing conformance test is affected. This corrects misleading prose that could cause hand-implementers to emit schema-invalid error envelopes.

--- a/static/compliance/source/universal/error-compliance.yaml
+++ b/static/compliance/source/universal/error-compliance.yaml
@@ -300,7 +300,7 @@ phases:
           Error response with:
           - code: a recognized AdCP error code
           - message: human-readable description
-          - recovery: correctable, transient, or fatal (optional)
+          - recovery: transient, correctable, or terminal (optional)
 
         sample_request:
           brand:
@@ -357,7 +357,7 @@ phases:
         expected: |
           Reject with:
           - code: VERSION_UNSUPPORTED
-          - recovery: fatal
+          - recovery: correctable
           - message referencing the buyer's requested version and the seller's supported set
 
         sample_request:


### PR DESCRIPTION
Closes #7375

Replace invalid `fatal` (not in the `recovery` enum) with the correct enum values in `static/compliance/source/universal/error-compliance.yaml`.

**Non-breaking justification:** The storyboard `expected:` blocks are informational prose — the automated compliance validations for the `unsupported_major_version` and `unsupported_release_version` steps assert only `error_code`, `field_present`, and `field_value`, never `recovery`. No existing conformance test outcome changes. The fix corrects misleading guidance without adding or removing any machine-checked assertion.

**Changes:**
- Line 360 (`unsupported_major_version` expected block): `recovery: fatal` → `recovery: correctable`, matching `enumMetadata.VERSION_UNSUPPORTED.recovery` across all 3.0 / 3.1 / 3.1.1 / 3.2.0-rc.* bundles.
- Line 303 (general error-shape narrative): `correctable, transient, or fatal (optional)` → `transient, correctable, or terminal (optional)`, matching the enum declaration order in `core/error.json` (`["transient", "correctable", "terminal"]`).

**Pre-PR review:**
- ad-tech-protocol-expert: approved — `correctable` is unambiguously correct; `fatal` is not in the recovery enum and the enumMetadata + semantics both confirm `correctable`; non-breaking patch.
- code-reviewer: approved — no build risk; both instances are correct and complete; fix belongs in one PR; `patch` changeset required (included).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01HBpEm5DvuLPLfdTAPVDPCi

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBpEm5DvuLPLfdTAPVDPCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBpEm5DvuLPLfdTAPVDPCi)_