### PR TITLE
fix(addie): use UTC accessors for LinkedIn credential share-link date

### DIFF
--- a/server/src/addie/mcp/certification-tools.ts
+++ b/server/src/addie/mcp/certification-tools.ts
@@ -607,8 +607,12 @@ function buildShareLinks(
   awardedDate: Date = new Date(),
 ): string[] {
   const lines: string[] = [];
-  const year = awardedDate.getFullYear();
-  const month = awardedDate.getMonth() + 1;
+  // awardedDate is a UTC instant (DB awarded_at / test fixtures use "...T00:00:00.000Z"
+  // literals) - the local accessors return the wrong month (and, near year boundaries, the
+  // wrong year) on any server running a timezone behind UTC, since a UTC-midnight instant is
+  // still the previous local day there.
+  const year = awardedDate.getUTCFullYear();
+  const month = awardedDate.getUTCMonth() + 1;
   let linkedInUrl = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME`
     + `&name=${encodeURIComponent(credName)}`
     + `&organizationName=${encodeURIComponent('AgenticAdvertising.org')}`


### PR DESCRIPTION
## Problem
`buildShareLinks()` computed the LinkedIn "Add to profile" `issueYear`/`issueMonth` via `awardedDate.getFullYear()`/`.getMonth()` (local server time), but `awardedDate` is always a UTC instant (the DB `awarded_at` column, and test fixtures use `"...T00:00:00.000Z"` literals). On any server running a timezone behind UTC, a UTC-midnight instant is still the previous local day, so the generated LinkedIn link silently understates the credential's issue month (and, near year boundaries, the year).

This is deterministic, not a date-drift flake: `server/tests/unit/certification-deferred-badge-membership.test.ts`'s existing fixture uses a fixed literal `awardedAt` of `2026-08-01T00:00:00.000Z` and asserts `issueMonth=8`, which fails with `issueMonth=7` on a machine in `America/Chicago` (UTC-5) before this fix — confirmed via `new Date('2026-08-01T00:00:00.000Z').getMonth() === 6` vs `.getUTCMonth() === 7`. CI runners default to UTC, which is why this was never caught there.

## Change
Switched both accessors to `getUTCFullYear()`/`getUTCMonth()`.

## Testing
Verified via revert-and-reconfirm: the existing test (which already correctly encodes `issueMonth=8` for the August fixture) fails with the local accessors and passes with the UTC ones — no new test needed, the existing fixture already covered the correct expected behavior, just not the implementation.

- `npx vitest run server/tests/unit/certification-deferred-badge-membership.test.ts`: 5/5 pass (was 4/5).
- Full `npm run precommit` (unit suite + storyboard matrix + typecheck): green.

Note: this is a different, independent defect from the one fixed in #7259 (which gated share-link *emission* behind a 24h Certifier-retry window) — this one is in the date-math *inside* `buildShareLinks` itself, in the same function #7259 also touches. No conflict; layers cleanly on top of the current `main`.