### PR TITLE
fix(addie): unblock SI certification and personal membership

### DIFF
--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -2226,6 +2226,7 @@ DO NOT USE FOR:
 - Questions you can answer with your tools or your rule files (knowledge.md, behaviors.md)
 - Community-fit questions ("would my background be a fit for the working groups?") — answer directly using the working-group mapping in knowledge.md and behaviors.md
 - Routine membership pricing, including upgrade proration for any tier on credit card or invoice — the FAQ in knowledge.md covers this; only escalate refunds, out-of-cycle credits, custom contracts, and currency changes
+- A separate self-paid membership — send signed-in users to /onboarding?mode=personal; it bills their personal workspace, not the company
 - Multi-part questions where each part is independently answerable — decompose first, answer the parts, do NOT escalate the bundle (see "Decompose bundled questions" in constraints.md)
 - "Complex" and "sensitive" are NOT magic words. Bundled or multi-domain questions are not automatically Complex; check whether each part is genuinely outside your knowledge or capability before escalating
 - Things that don't require admin attention

--- a/docs/aao/users.mdx
+++ b/docs/aao/users.mdx
@@ -14,6 +14,16 @@ This page covers what an AAO member — someone with an active membership of any
 - **Link Slack.** If you joined the AAO Slack workspace, ask Addie *"link my account"* in any DM and she'll generate a personalized sign-in link. After signing in, your Slack identity is permanently linked.
 - **Lost your link?** Ask Addie *"send me my sign-in link"* — she has a `get_account_link` tool that works in any channel.
 
+### Keep a personal membership alongside a company membership
+
+You can belong to a company organization and also maintain one separately billed personal workspace. Creating or subscribing to the personal workspace does not change the company's membership.
+
+1. Open [Create a personal workspace](https://agenticadvertising.org/onboarding?mode=personal) while signed in.
+2. Choose Individual Professional (or another individual tier) and create the workspace.
+3. The site selects the new personal workspace and opens its Membership page for checkout.
+
+If you already created a personal workspace, select it from the dashboard organization switcher before opening Membership. The organization shown in the switcher is the one Stripe will bill.
+
 ## Certification (AdCP Academy)
 
 | Tier | Price | What you get |

--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-  "profile_contract_sha256": "43de051e55ebad332933397cf5fa46684a723819a545b0a31c38168b7b3f3fe3",
+  "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {

--- a/scripts/lint-storyboard-scoping.cjs
+++ b/scripts/lint-storyboard-scoping.cjs
@@ -84,7 +84,8 @@ const TENANT_SCOPED_TASKS = new Set([
  *
  * (b) Global discovery / catalog reads. `get_adcp_capabilities`,
  *     `list_creative_formats`, `list_accounts`, `get_brand_identity`,
- *     `get_rights`, `update_rights`, `comply_test_controller`. `list_accounts`
+ *     `get_rights`, `update_rights`, `si_get_offering`,
+ *     `comply_test_controller`. `list_accounts`
  *     belongs here despite the per-tenant return shape — the request itself
  *     carries no scoping ID (it's the chicken-and-egg discovery call that
  *     produces the IDs other tasks consume), so envelope-identity routing
@@ -127,6 +128,12 @@ const EXEMPT_FROM_LINT = new Set([
   'get_adcp_capabilities',
   'list_creative_formats',
   'list_accounts',
+  'si_get_offering',
+  // (b) Sponsored Intelligence sessions are scoped to the authenticated
+  // principal; their lifecycle does not use brand/account envelope identity.
+  'si_initiate_session',
+  'si_send_message',
+  'si_terminate_session',
   // (b) Global brand/rights catalog reads
   'search_brands',
   'get_brand_identity',

--- a/server/public/onboarding.html
+++ b/server/public/onboarding.html
@@ -944,9 +944,10 @@
         }
 
         // In personal mode, check if user already has a personal workspace
-        const hasPersonalWorkspace = data.organizations && data.organizations.some(org => org.is_personal);
-        if (personalMode && hasPersonalWorkspace) {
-          window.location.href = '/dashboard';
+        const personalWorkspace = data.organizations && data.organizations.find(org => org.is_personal);
+        if (personalMode && personalWorkspace) {
+          try { localStorage.setItem('selectedOrgId', personalWorkspace.id); } catch (e) { /* storage disabled */ }
+          window.location.href = '/dashboard/membership?org=' + encodeURIComponent(personalWorkspace.id);
           return;
         }
 
@@ -1611,7 +1612,20 @@
           throw new Error(data.message || 'Failed to create workspace');
         }
 
-        window.location.href = '/dashboard';
+        // Keep the new personal workspace as the explicit billing context.
+        // Without this, a user who arrived from a company workspace lands
+        // back on that company after creation and can reasonably think the
+        // next checkout would modify the company subscription.
+        var personalOrgId = data.organization?.id || data.id;
+        if (personalOrgId) {
+          try { localStorage.setItem('selectedOrgId', personalOrgId); } catch (e) { /* storage disabled */ }
+        }
+        var destination = membershipTier && membershipTier.value
+          ? '/dashboard/membership'
+          : '/dashboard';
+        window.location.href = personalOrgId
+          ? destination + '?org=' + encodeURIComponent(personalOrgId)
+          : destination;
       } catch (error) {
         showError(error.message);
         btn.disabled = false;

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.45';
+export const CODE_VERSION = '2026.09.46';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -89,12 +89,12 @@
     "not_declared_to_router_scope": "Modern routed Slack Bolt profiles only"
   },
   "prompt": {
-    "rules_bytes": 154007,
+    "rules_bytes": 154070,
     "tool_reference_bytes": 39435,
     "complete_offline_tool_reference_bytes": 42387,
     "response_style_bytes": 9053,
-    "system_prompt_bytes": 202509,
-    "system_prompt_sha256": "12de13cc2b10f7471a3c8fb67cc3ef08d21825887a7e044226ef36034709e37e"
+    "system_prompt_bytes": 202572,
+    "system_prompt_sha256": "362d2bd7294ea6bf1ce548e4d11455da709e20bb7e52b3433f5bb855008c45e4"
   },
   "catalog": {
     "missing_runtime_tool_count": 0,
@@ -232,7 +232,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24652,
+      "wire_schema_bytes": 24793,
       "tool_reference_bytes": 6157,
       "tool_reference_sha256": "fe1ff193bf1d76fe9ce5e8cd0fae7346feab6181648dd83bca54b619f0bb7c03",
       "overridden_tool_count": 0,
@@ -273,7 +273,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "72797edb266c5688d07bd08f242c17bcc62e317351ab2324d94919dd21ce2268",
-      "wire_schema_sha256": "182a994c3a992e01089e82f5abc857061a7aa24a27cef740274507304fb2e9c6",
+      "wire_schema_sha256": "c6beca5286f029ddbb4e30d1c7171098e4ac402e56c0aa963dea86e35f332f7e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -299,7 +299,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28118,
+      "wire_schema_bytes": 28259,
       "tool_reference_bytes": 10932,
       "tool_reference_sha256": "111cd7597a76c890bb6ad724e6f2aa1e2fa01a16d8451b54572108ffc0598a80",
       "overridden_tool_count": 0,
@@ -333,7 +333,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "6a797b29e5de0a1f10dc1c3c4fcdac226883b6fe9dfcdfa6e2a3009713df8080",
-      "wire_schema_sha256": "c8c8f4eda625999f45dd6f4fd463d2ab091cfa7570db72dc698eea5e26039ae2",
+      "wire_schema_sha256": "c8889db09e254bf657fe8f8241cdfa990719d6bc65003cc004c00d3959d15c2f",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -359,7 +359,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32993,
+      "wire_schema_bytes": 33134,
       "tool_reference_bytes": 10389,
       "tool_reference_sha256": "0facc2995e2d13ee0b676e0981dec54c8e11b4b18aa2feb85756275931937a2f",
       "overridden_tool_count": 1,
@@ -398,7 +398,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7d36f54196c7f9797937fd307a1b6d6365af061a473f90a2f34735a168584e64",
-      "wire_schema_sha256": "a58fbf70267239c52565dddd7e50cdd6841e32e67328ee2b506204272319add1",
+      "wire_schema_sha256": "54e949630c48dbdcd3056f0989a59561eef4b517f39ad9e6eeae9543bb70de90",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -470,7 +470,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 22358,
+      "wire_schema_bytes": 22499,
       "tool_reference_bytes": 6089,
       "tool_reference_sha256": "2dedd93f34bb8bb96a840a2650e817f7f883931785541ffec854710e6ef68489",
       "overridden_tool_count": 0,
@@ -509,7 +509,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "a9e974b90b45f7a06c5f20a790efe7b1b48c32b69e1a546e1d30531a3a617a1a",
-      "wire_schema_sha256": "772e82bf18df11171a0929159b29a564160f9e30c383416a49a2ea4bbae32792",
+      "wire_schema_sha256": "f6440a41f9a66135dac9dfb70cdcd0938071233062b8c54937eeff50774a4187",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -535,7 +535,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25824,
+      "wire_schema_bytes": 25965,
       "tool_reference_bytes": 10864,
       "tool_reference_sha256": "c1c660ec26e128b9aedfa96fe0c1b85588c45a7221f7b9a141e2f0aa9fa0b174",
       "overridden_tool_count": 0,
@@ -567,7 +567,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bc9f123436d9760c4603abb2386e0a63c7a9f53e4c0d65adbb0041de8bf1177f",
-      "wire_schema_sha256": "7289863f271c2017a3f62f0b98b9a8d54c99fcd9a3692f0e5b6b88a842526c95",
+      "wire_schema_sha256": "7bcc5517a1af44cce605df3e17b8e10b9276c299a4cd12918c5e61226a02d0cd",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -593,7 +593,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30699,
+      "wire_schema_bytes": 30840,
       "tool_reference_bytes": 10321,
       "tool_reference_sha256": "c345073241bbb0aa78ef7366d2c97b3f776183a69a3acab73fed9bba457eb861",
       "overridden_tool_count": 1,
@@ -630,7 +630,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "9e5d653068e798450e6ec1d154f075d580807f8ca567abb56644ecefe15c3ba3",
-      "wire_schema_sha256": "56e2399081e01b8176ecba4966476a9c75b86f67b815894fe7cd25eb0c32631a",
+      "wire_schema_sha256": "83e72e59f7426d4db729dc7518aa7378fdf07fc439ac9fb1f196901c3102b23e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -702,7 +702,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 21885,
+      "wire_schema_bytes": 22026,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "0b4deb055a3bce155afee2c10f5ffa3679c5f7d61ddcf120bb4f38db95e51b2e",
       "overridden_tool_count": 0,
@@ -740,7 +740,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "eed0a10dcfdbee85651bda5b9b62b053f900f289f076d804758e827d1c6f37fc",
-      "wire_schema_sha256": "2cb796aff2c61a0b56fe61a5faedd5daa425e75da07a08339361920f37d14ded",
+      "wire_schema_sha256": "041c9603ee1df4dc902d6135f2ff14abbffd23c4c6f1a788a124bd8ed4e76673",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -766,7 +766,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25351,
+      "wire_schema_bytes": 25492,
       "tool_reference_bytes": 10846,
       "tool_reference_sha256": "cae71d21b7a57c9b000e8812ca4e216ebfab078bf8e57d9c7eee912d283bbca6",
       "overridden_tool_count": 0,
@@ -797,7 +797,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "38d30f79339ad15a17e2391466ada38f3ca0b7625d7f9a86ff778a94526a01cd",
-      "wire_schema_sha256": "b43f590a47c460c3b1bacd4fc471723e61b61a3e21bc385ebfb2a5ef33032b99",
+      "wire_schema_sha256": "cef800475dee7b2419ea8c0ffaeb98091f260e8039079121243600040699cd0b",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -823,7 +823,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30226,
+      "wire_schema_bytes": 30367,
       "tool_reference_bytes": 10303,
       "tool_reference_sha256": "0ab1524fa73fa8fb1e4b833814e017daaa7e3dea02bc532df55d3439be0e0fb7",
       "overridden_tool_count": 1,
@@ -859,7 +859,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "394038825f34d36a9462cdac8b23bb6e2fba0549ef90c1f8edd16a55d4b2f671",
-      "wire_schema_sha256": "2d9672994e09db2950fb3bbaef5aaad5c8aa96ee4972e3ec48cbc02402f17875",
+      "wire_schema_sha256": "848a56613cbfc6cfa291b8b199d0941302bed77f3ba488da88f868a617edcd32",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -931,7 +931,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 21885,
+      "wire_schema_bytes": 22026,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "0b4deb055a3bce155afee2c10f5ffa3679c5f7d61ddcf120bb4f38db95e51b2e",
       "overridden_tool_count": 0,
@@ -969,7 +969,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "eed0a10dcfdbee85651bda5b9b62b053f900f289f076d804758e827d1c6f37fc",
-      "wire_schema_sha256": "2cb796aff2c61a0b56fe61a5faedd5daa425e75da07a08339361920f37d14ded",
+      "wire_schema_sha256": "041c9603ee1df4dc902d6135f2ff14abbffd23c4c6f1a788a124bd8ed4e76673",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -995,7 +995,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25351,
+      "wire_schema_bytes": 25492,
       "tool_reference_bytes": 10846,
       "tool_reference_sha256": "cae71d21b7a57c9b000e8812ca4e216ebfab078bf8e57d9c7eee912d283bbca6",
       "overridden_tool_count": 0,
@@ -1026,7 +1026,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "38d30f79339ad15a17e2391466ada38f3ca0b7625d7f9a86ff778a94526a01cd",
-      "wire_schema_sha256": "b43f590a47c460c3b1bacd4fc471723e61b61a3e21bc385ebfb2a5ef33032b99",
+      "wire_schema_sha256": "cef800475dee7b2419ea8c0ffaeb98091f260e8039079121243600040699cd0b",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -1052,7 +1052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30226,
+      "wire_schema_bytes": 30367,
       "tool_reference_bytes": 10303,
       "tool_reference_sha256": "0ab1524fa73fa8fb1e4b833814e017daaa7e3dea02bc532df55d3439be0e0fb7",
       "overridden_tool_count": 1,
@@ -1088,7 +1088,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "394038825f34d36a9462cdac8b23bb6e2fba0549ef90c1f8edd16a55d4b2f671",
-      "wire_schema_sha256": "2d9672994e09db2950fb3bbaef5aaad5c8aa96ee4972e3ec48cbc02402f17875",
+      "wire_schema_sha256": "848a56613cbfc6cfa291b8b199d0941302bed77f3ba488da88f868a617edcd32",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -1161,7 +1161,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30867,
+      "wire_schema_bytes": 31008,
       "tool_reference_bytes": 10503,
       "tool_reference_sha256": "73434a9095de331507ba5543a5a5ba851b369d768b70a0f0cea2e7d4cd831d11",
       "overridden_tool_count": 4,
@@ -1200,7 +1200,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "21e70235e9926708cae72c4a9dc96ce633dfce1a5da5fa3afed7c9689d1994c0",
-      "wire_schema_sha256": "04edc9c62b35af5cac3e3668abdc34038616b0e865ff482f1ca9efac1f387c13",
+      "wire_schema_sha256": "7c346d80435d45e77d311d87926e87a695747134871b1abeb468a68fcfca8ce6",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -1227,7 +1227,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31770,
+      "wire_schema_bytes": 31911,
       "tool_reference_bytes": 11740,
       "tool_reference_sha256": "fd82df8cbdbdd90c9f7677e42bf4a5fd9411f1e23bd4d1f8edc00ecc778d0367",
       "overridden_tool_count": 4,
@@ -1267,7 +1267,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c3aea0dcbab6e98c77df077d96b724466d2c6987bc8bf0e5ba75fb5d286eddde",
-      "wire_schema_sha256": "fd3eadfca5fcef651eef7097748aeaff49c49487d96dd28b6b70888131753a8b",
+      "wire_schema_sha256": "d09a9cc7b101466245054fdc5e4254966982f92314c3b92e87036e1fa179a0da",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -1295,7 +1295,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 34219,
+      "wire_schema_bytes": 34360,
       "tool_reference_bytes": 13895,
       "tool_reference_sha256": "8d1eda7acbbe258a2cabc13314e87c8cba8d4c602a4a0fd545cc569d31babbf9",
       "overridden_tool_count": 4,
@@ -1338,7 +1338,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "2188ff25e360a838ca7f609753e1fa05b04925711d41dffa10d1b2c2c463af6c",
-      "wire_schema_sha256": "dd7160b51597d9a07b785bc25416528a495f6261e7c3a35ab9bc08294ff5856f",
+      "wire_schema_sha256": "dc569a392a01855f9a52dbc77e8eb261cc43e68af1b540eca7f6938ebe5cbb0c",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -1366,7 +1366,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24652,
+      "wire_schema_bytes": 24793,
       "tool_reference_bytes": 6157,
       "tool_reference_sha256": "fe1ff193bf1d76fe9ce5e8cd0fae7346feab6181648dd83bca54b619f0bb7c03",
       "overridden_tool_count": 0,
@@ -1407,7 +1407,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "72797edb266c5688d07bd08f242c17bcc62e317351ab2324d94919dd21ce2268",
-      "wire_schema_sha256": "182a994c3a992e01089e82f5abc857061a7aa24a27cef740274507304fb2e9c6",
+      "wire_schema_sha256": "c6beca5286f029ddbb4e30d1c7171098e4ac402e56c0aa963dea86e35f332f7e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -1435,7 +1435,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28118,
+      "wire_schema_bytes": 28259,
       "tool_reference_bytes": 10932,
       "tool_reference_sha256": "111cd7597a76c890bb6ad724e6f2aa1e2fa01a16d8451b54572108ffc0598a80",
       "overridden_tool_count": 0,
@@ -1469,7 +1469,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "6a797b29e5de0a1f10dc1c3c4fcdac226883b6fe9dfcdfa6e2a3009713df8080",
-      "wire_schema_sha256": "c8c8f4eda625999f45dd6f4fd463d2ab091cfa7570db72dc698eea5e26039ae2",
+      "wire_schema_sha256": "c8889db09e254bf657fe8f8241cdfa990719d6bc65003cc004c00d3959d15c2f",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -1497,7 +1497,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32993,
+      "wire_schema_bytes": 33134,
       "tool_reference_bytes": 10389,
       "tool_reference_sha256": "0facc2995e2d13ee0b676e0981dec54c8e11b4b18aa2feb85756275931937a2f",
       "overridden_tool_count": 1,
@@ -1536,7 +1536,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7d36f54196c7f9797937fd307a1b6d6365af061a473f90a2f34735a168584e64",
-      "wire_schema_sha256": "a58fbf70267239c52565dddd7e50cdd6841e32e67328ee2b506204272319add1",
+      "wire_schema_sha256": "54e949630c48dbdcd3056f0989a59561eef4b517f39ad9e6eeae9543bb70de90",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -1561,7 +1561,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15460,
+      "wire_schema_bytes": 15601,
       "tool_reference_bytes": 6330,
       "tool_reference_sha256": "6aef477bf109d821bdfa8fd07c90523f69b3a7fbe386ae353280665105de3e0f",
       "overridden_tool_count": 0,
@@ -1581,7 +1581,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ad8390526ff9af140bd7e4b0416ad3cfc4c028e44028070b95a06ae152bfa05e",
-      "wire_schema_sha256": "dc7103f30f9e621253fee5592d6b96ef643d57b5903fd0382052fff981b07d2a"
+      "wire_schema_sha256": "ca0da259992847a847763ab958007800ba2f205f075ee4881cb44a5333dc211a"
     },
     {
       "id": "slack_bolt:admin_dm:routed:adcp_task_operations",
@@ -1605,7 +1605,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13908,
+      "wire_schema_bytes": 14049,
       "tool_reference_bytes": 6378,
       "tool_reference_sha256": "6f40fffb21d3be25b7651e53dd9c9555d8b6e844e0ada398314863d004ece8c6",
       "overridden_tool_count": 0,
@@ -1624,7 +1624,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07d619635ece821a834856c3c589ae9b3fc571ad61b993c621cc54a1d488360d",
-      "wire_schema_sha256": "64851675e3c695f012343f8b9797e22e1ae9439f74b95611799e7d10029bab3a"
+      "wire_schema_sha256": "5a230a0d07bd7a8115422e4b3efe48a522cb92c8f77b8fa38a807b617d8a08a1"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_billing_account",
@@ -1648,7 +1648,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11076,
+      "wire_schema_bytes": 11217,
       "tool_reference_bytes": 4918,
       "tool_reference_sha256": "c633c81589d01cce53e416bffb362e31d3fb38c1fa7ae0be2bc1b3a89b8a30c3",
       "overridden_tool_count": 0,
@@ -1668,7 +1668,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf202ec0b5c16623f805b27e931a3423b95b24caee51e1a76dab242af5e113f2",
-      "wire_schema_sha256": "e9ded10e5ae64f63be983786276642b415b919c5a67b81f273864451863a0fbf"
+      "wire_schema_sha256": "cc2ab61e3ad19b17010c5a5c7de0eafa41a6fae2de4810a38e3808934506a57b"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_billing_discounts",
@@ -1692,7 +1692,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10390,
+      "wire_schema_bytes": 10531,
       "tool_reference_bytes": 4885,
       "tool_reference_sha256": "e6c54c011bf4113a5acfb57919b1eea144a9e2e9b037a7fa90402c91e92c4af4",
       "overridden_tool_count": 0,
@@ -1712,7 +1712,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3d5a0d9845becf4948711c6b98b82b974ad8a580d75ec4b9440d3ba0df936d28",
-      "wire_schema_sha256": "01b4c5607355c8cc879da53dc000c63d208a6c74db48dacbc300d9da16dfeba9"
+      "wire_schema_sha256": "0f0359f0ff406ae27ba491aa5346a3141b5f9c5d7d5a41e6c4c072406ff8be64"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_billing_payments",
@@ -1736,7 +1736,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11959,
+      "wire_schema_bytes": 12100,
       "tool_reference_bytes": 4873,
       "tool_reference_sha256": "beafff27d131ccfccf76c4ebf261d2ea9266a44aed3072c3e5af8b876cab4ef7",
       "overridden_tool_count": 0,
@@ -1755,7 +1755,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4658b9b7dbd4a931f13ea064882fc4fa4fdd16b52cc772c54896e65520480301",
-      "wire_schema_sha256": "c16b5a136d8ab7e05713da928b904228b45c0d43d80ca474cbae14ad0c64182f"
+      "wire_schema_sha256": "2dd912f723bb64fecdfb58f2d684ea5b45d30d38512179b7b8f1356baf188325"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_brand_logo_review",
@@ -1779,7 +1779,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10322,
+      "wire_schema_bytes": 10463,
       "tool_reference_bytes": 5103,
       "tool_reference_sha256": "18a8f680141c30fb3779c55d499734812898390dba839f7e842c5402550132d5",
       "overridden_tool_count": 0,
@@ -1798,7 +1798,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "6c9af95c4975829a7bf94aec01f35a754b8d9cdb812f5dd150c15eabac456de1",
-      "wire_schema_sha256": "c075708004e5259ded57bf7b460f7a123abf8b3c00f6327dd1f6820be35ab45b"
+      "wire_schema_sha256": "35c211082c30ee248197647c07c439c14d8c53f354fb224abdd862b433c98f55"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_brand_registry_integrity",
@@ -1822,7 +1822,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11031,
+      "wire_schema_bytes": 11172,
       "tool_reference_bytes": 5206,
       "tool_reference_sha256": "076d054efacb1b4921f34c5b4c2fa862adeb91d2c383f34ad016cb46c3ef9cdc",
       "overridden_tool_count": 0,
@@ -1843,7 +1843,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "20034d602e5fe0640db9017a31bbcfc4e1c8012b17c55022c6a86eabbe8493a1",
-      "wire_schema_sha256": "102609b8e85067acf55311c7bbfd0d7dabc1ca87f5ffd1331ea6255bd34cc26b"
+      "wire_schema_sha256": "3486e907585e59a83052d8c6fc6583648c6f45bbc5407b265fab68b761254f3b"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_conversation_review",
@@ -1867,7 +1867,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11022,
+      "wire_schema_bytes": 11163,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -1886,7 +1886,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "46c7d110ac26bd45dec3fc0870880584f46522717bd470d4e8242b1eeada4c77"
+      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_events",
@@ -1910,7 +1910,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14607,
+      "wire_schema_bytes": 14748,
       "tool_reference_bytes": 5045,
       "tool_reference_sha256": "c30cb271ee192379bdfd17da6cd5bab315e4c560f86a13f66f5192aa38ca6ed7",
       "overridden_tool_count": 0,
@@ -1931,7 +1931,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "0e315f56035f7f695f6e8b981c5b484c9802fc1b0f948e767a6bd57eb3cbafa8",
-      "wire_schema_sha256": "2b1d53f3e95f2dc8b66f3b91c52775cfb3292ed32bbf151edd33c069fdda5b20"
+      "wire_schema_sha256": "2ad96203888e13bb531d0725ed59dc9bdbc70bfebcaca69b6104225882d68f64"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_feed_curation",
@@ -1955,7 +1955,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10769,
+      "wire_schema_bytes": 10910,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "51b1859d98819b87b8cf43469c7151cee160b47dab60e0185ebbdb25b7206911",
       "overridden_tool_count": 0,
@@ -1975,7 +1975,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3dcfb69f2292cd2753faf15d02c0077a157e404763b47af52d306370c4975ea2",
-      "wire_schema_sha256": "dfe8b2570e3c6dd0470221132cebbb5c33bc6f4c95ee55c06f29bf5318fe49fa"
+      "wire_schema_sha256": "abf4e1210aaac63fb0b6abe901bb89edac2f3994ebce7572b3fd3ddfec918d56"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_feed_monitoring",
@@ -1999,7 +1999,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9556,
+      "wire_schema_bytes": 9697,
       "tool_reference_bytes": 4933,
       "tool_reference_sha256": "348f8bf0680b6697aa4db7fe642d0d2b592d98bac5ef05017653e3d5f76d1ee0",
       "overridden_tool_count": 0,
@@ -2018,7 +2018,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b1689086b33ea143c9b79edc3954c1fc9320bd7c73bf26c05d79d00a50999e6b",
-      "wire_schema_sha256": "69b08c0e33b7f5e0483b2d9faa24e71d5d8cf7a9af626b6983050b85608002dd"
+      "wire_schema_sha256": "356c5447324224f57135895bdf0755581a2b86d5bdfb0236962e92922898df10"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_followup_tasks",
@@ -2042,7 +2042,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10288,
+      "wire_schema_bytes": 10429,
       "tool_reference_bytes": 4961,
       "tool_reference_sha256": "d3b7df07a7bf17cddab315557f4db71a7e2fea4f4956d3ace06b9d96340d50d6",
       "overridden_tool_count": 0,
@@ -2062,7 +2062,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "e9891ff20b83d67e8cadb649d24df495c51f5d78064af75532944a98a14ef9e4",
-      "wire_schema_sha256": "61929aa8491fc1efa2a84b9017ac2d040d4f2e0df6893bb4939b7f0b48d01735"
+      "wire_schema_sha256": "310fa974b97a6c82109c0aac9e36fe45501e4c2acba52c730cb7dba8abe587b0"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_group_leadership",
@@ -2086,7 +2086,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10760,
+      "wire_schema_bytes": 10901,
       "tool_reference_bytes": 5041,
       "tool_reference_sha256": "90476e3b3516fa008b3063f2d55126f0c4622dfce286824afe3e33917711c10d",
       "overridden_tool_count": 0,
@@ -2107,7 +2107,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ecd5015062feb97397c759e03480c2fc6f9ef58425774b7f88d6793fc51a261a",
-      "wire_schema_sha256": "8870ff455c80a2c3ac9270a2bfaaf2fa62d4eb715f25069469a180d1523d46ac"
+      "wire_schema_sha256": "292b461d56fd3d1d6ec082dfdd8ad4b7be80323422f7d55476a2a7c50de11b62"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_group_membership",
@@ -2131,7 +2131,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10666,
+      "wire_schema_bytes": 10807,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "2388dc80f99651611a2695a01e1caaba5a3fe4d36cb4f74ef9c5443dc96b3664",
       "overridden_tool_count": 0,
@@ -2151,7 +2151,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "47db1de6135e646a948a53018f4edc8c974d39573961f5f74cf110c620b28b7d",
-      "wire_schema_sha256": "b0c37e8442437e8bf5da967213533952a688d75f9044159913740a4bb7cbc68d"
+      "wire_schema_sha256": "75cfcf4d3e182f12be3a8409b69086eb4e8395ee1eb57d6897cbe1532ffa3464"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_group_structure",
@@ -2175,7 +2175,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10729,
+      "wire_schema_bytes": 10870,
       "tool_reference_bytes": 5034,
       "tool_reference_sha256": "8f34d5a18362f50aacb64db4cba78ed35949e1ff5e47db886ea4344224766823",
       "overridden_tool_count": 0,
@@ -2196,7 +2196,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f386cc7f41b925aa66274b8f8753f1f807aab57f0b25196035c9b470d7e97e08",
-      "wire_schema_sha256": "a156969da8f3918f83e0cae37c1307567e88d7976052443702e086be3d52fa99"
+      "wire_schema_sha256": "8976f868aa83ffca02729d688267b8682dffe4bc1f3c0f75818e46c3b67208ea"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_organization_integrity",
@@ -2220,7 +2220,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10716,
+      "wire_schema_bytes": 10857,
       "tool_reference_bytes": 5263,
       "tool_reference_sha256": "2babace46b46bd3c1757a93a4fc523910763ecdc00941c9526aa723cc966057c",
       "overridden_tool_count": 0,
@@ -2240,7 +2240,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "282a96131a9d387b5b297a1798d427fb77f27935a25c03cbf2cc22b79160265d",
-      "wire_schema_sha256": "042e6ecaa3f021ea34283325da3d528e17494d89e9be9284ffadb1e84cd44dea"
+      "wire_schema_sha256": "43278aa0ec15d4cc49fd7beb7bb4ea369b7b21123737932188b480921cdd3335"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_organization_member_records",
@@ -2264,7 +2264,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13604,
+      "wire_schema_bytes": 13745,
       "tool_reference_bytes": 5279,
       "tool_reference_sha256": "3b20b9520b711943b33384fc793a5aa81c1356222e27031371fa9568fa5ddaa6",
       "overridden_tool_count": 0,
@@ -2285,7 +2285,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "fbaa28ba1001813d3f1a0cb66477a6c9b0efc4ff32214d6414c9ec478d93f373",
-      "wire_schema_sha256": "199ccde69119f622e85af6e7878095321c7af70fa6df08c2108a7db357d40f96"
+      "wire_schema_sha256": "b1827a4f4ba256571df9eb871d48d0a0822985d974b1ae9181643a2297083e8e"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_prospect_pipeline",
@@ -2309,7 +2309,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12521,
+      "wire_schema_bytes": 12662,
       "tool_reference_bytes": 4989,
       "tool_reference_sha256": "b0cd167136b0167f5271d0c640104f9e84ab19c55065b2c375ea59fd650658c6",
       "overridden_tool_count": 0,
@@ -2329,7 +2329,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "57a38e3fff723ab752525360ac09e49c8383a799c437fd7e8997db01d00d6102",
-      "wire_schema_sha256": "5c49b5d4e0419b5255b6c8f54697e65d1eb6eb15fef63635c8afd65fc5449358"
+      "wire_schema_sha256": "35a27cf6032281aba5d04bf4381436e9ebc3726f4ac1656e219c4be2bdd6ddf5"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_prospect_research",
@@ -2353,7 +2353,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10908,
+      "wire_schema_bytes": 11049,
       "tool_reference_bytes": 5007,
       "tool_reference_sha256": "1854a1b2fe6f4dc131539e2d425764f7819eea370158742211c02c1910f21338",
       "overridden_tool_count": 0,
@@ -2373,7 +2373,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "da07d5b25562ab15e7f17ce74015434853f8be2fac2917339e18cc4fb6139fd7",
-      "wire_schema_sha256": "b4cc5316fe13a05a6ed97843fecd37451808a421f1e941644f9762e268999059"
+      "wire_schema_sha256": "22bc774943369c808b85b557cdd40fc4177145a9508b613f974c1a6b37050178"
     },
     {
       "id": "slack_bolt:admin_dm:routed:agent_authentication",
@@ -2397,7 +2397,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11273,
+      "wire_schema_bytes": 11414,
       "tool_reference_bytes": 6068,
       "tool_reference_sha256": "8c5110b85f73579cbd881419b997fcc9a9d99d3b2ebdf415f4929585bd6298d5",
       "overridden_tool_count": 0,
@@ -2415,7 +2415,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07eb0de4a4c6332c5429079c33017a24205c5f3507e6399772c561ff4a092d78",
-      "wire_schema_sha256": "598a80e9d63967c72734a2a480fcc2d438cdb06af506672907ac273711905aa2"
+      "wire_schema_sha256": "c817f6a6a00ce8caeb3ceb89d2c9a6cdd34c142d48680ab1968ae85dcdd8bf32"
     },
     {
       "id": "slack_bolt:admin_dm:routed:agent_conformance",
@@ -2439,7 +2439,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9978,
+      "wire_schema_bytes": 10119,
       "tool_reference_bytes": 5792,
       "tool_reference_sha256": "182b19b64ce7302d415619c993fc24ae32136df09ef1c8ac2b89f7cc839dc266",
       "overridden_tool_count": 0,
@@ -2457,7 +2457,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "012096836c5569d43d146451a8ffb1b800f8b39a56f146da16161031ce0ac130",
-      "wire_schema_sha256": "b5943c31b2c9dd9a3a7ff21771f5b5754404e35db94bd9ec35250f2e71afbf3b"
+      "wire_schema_sha256": "b850bf84930b453a9611fc5313cb6f9348099918d6f03639cff649f85b01ad6e"
     },
     {
       "id": "slack_bolt:admin_dm:routed:agent_end_to_end",
@@ -2481,7 +2481,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19815,
+      "wire_schema_bytes": 19956,
       "tool_reference_bytes": 6636,
       "tool_reference_sha256": "d02b3eff67be7a38f952ebe0196ddb996dc932aa9e501167b0b1d71e454da1e4",
       "overridden_tool_count": 1,
@@ -2507,7 +2507,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "85c84ea52a5aa43067389e7e17605be6a93ddcf1ba596f619729779fccbe10bc",
-      "wire_schema_sha256": "4ac2625af42caf603e34700d6d4e8b1c6392a9a55f30cea92053e70ebe28a5b2",
+      "wire_schema_sha256": "6972421c67e7a20bd652da3a03d9333a6de9f05e5d2f8649e4df1d8bc23b2024",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -2532,7 +2532,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9950,
+      "wire_schema_bytes": 10091,
       "tool_reference_bytes": 5117,
       "tool_reference_sha256": "aa7e1f31ef1c683786e229c8050793d9faad83b5a5cbde309960dc4a3271a991",
       "overridden_tool_count": 4,
@@ -2552,7 +2552,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a512a4cbd9fe2e02bb76d6a1b31cd09a7638761efb4a0230834fdfb2e861159e",
-      "wire_schema_sha256": "7b05ded6a160ec1efae4e67f6132c9301be3989ba40f9ee725e1dea20d011c28"
+      "wire_schema_sha256": "a9712d8f28136b46063ae010c6e790982153087943feb2d6acaf3c7e4a4df93d"
     },
     {
       "id": "slack_bolt:admin_dm:routed:agent_quality",
@@ -2576,7 +2576,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14652,
+      "wire_schema_bytes": 14793,
       "tool_reference_bytes": 6139,
       "tool_reference_sha256": "ecf8f60600a263d6a3120321ab1f65e138a08b082a96153eed01d1968552a91f",
       "overridden_tool_count": 0,
@@ -2595,7 +2595,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f527be89fee5e5536b0b51b8c6c72924fbb8d3d9f3fee080986890437ae83065",
-      "wire_schema_sha256": "0da514e38da9e5be4280e7490b7f597ac0976df6fb9860bfd3c2abdb06f9ce69"
+      "wire_schema_sha256": "2927e76e9a88dce21cf946e0034908a0526605e5cb05f02305ffd1331cc4d91a"
     },
     {
       "id": "slack_bolt:admin_dm:routed:agent_registry",
@@ -2619,7 +2619,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11044,
+      "wire_schema_bytes": 11185,
       "tool_reference_bytes": 6701,
       "tool_reference_sha256": "25cdf10cfcafee88979211e822031ff6983a2f38b20fae8fa7088210136e135d",
       "overridden_tool_count": 1,
@@ -2640,7 +2640,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "829db1024e9ed7b56f80e74f08c79430219c661a9f7f1ca2f338268d981861c2",
-      "wire_schema_sha256": "b0d39b6c209520e8a0e3496f6c49c5ec11b5743ef88af79d479fb3857f0431de"
+      "wire_schema_sha256": "0b1af69d6704ce3c22d14b34ca20cbf5cc56fecae2ebc26ea8286f16edd6ca0e"
     },
     {
       "id": "slack_bolt:admin_dm:routed:brand_registry_identity",
@@ -2664,7 +2664,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16157,
+      "wire_schema_bytes": 16298,
       "tool_reference_bytes": 5617,
       "tool_reference_sha256": "d05f97f3dc028c1013c97a9e19feffd2796fbc23e53475e20b508a3b322b8708",
       "overridden_tool_count": 0,
@@ -2685,7 +2685,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b0cb4a01b1ab28f7ab346fe05f5d2b3fec2d73dcdc5a8309a5b0f7d902fc5758",
-      "wire_schema_sha256": "a63a1ba480dce1cc6f8abd2d0bfdf5ec25f46a84c8c73b964359f4bef911203c"
+      "wire_schema_sha256": "33ddcc81e2e2a07ee9ac86d347e32961acc9cf30088a132b1e6b54eb90f6a108"
     },
     {
       "id": "slack_bolt:admin_dm:routed:brand_registry_records",
@@ -2709,7 +2709,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11067,
+      "wire_schema_bytes": 11208,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "6e5a06f631d52e8db048ca417e593ab9731058f6ad56b3b963a13fba4576803d",
       "overridden_tool_count": 0,
@@ -2730,7 +2730,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "7fd8e61d32cf8b482ae959e5e050ee0774fb93e3ce6d39f243364659c3a81b15",
-      "wire_schema_sha256": "eacbb437559a6273d4439d0d4fc13bb39c91b2a3f6bed0d6bad7a95b7cc4778a"
+      "wire_schema_sha256": "c1381ff7692db4c526b7d5c2f55b8951be1a53daf932a2c33a083dcf80544674"
     },
     {
       "id": "slack_bolt:admin_dm:routed:certification_assessment",
@@ -2754,7 +2754,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19717,
+      "wire_schema_bytes": 19858,
       "tool_reference_bytes": 6920,
       "tool_reference_sha256": "8c278765ad621dd11f89ff7b35d60af9f51ae88d569155f91733a06a4a51aab5",
       "overridden_tool_count": 0,
@@ -2779,7 +2779,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "b8820aebc73fe700321e75a7bafc7ff346e38040ea64c833f6e87f88609e9ff2",
-      "wire_schema_sha256": "d8435d8f452b30eb17516ff8b8f2e5138a2024bd4061f07a5745c600ab834ce0",
+      "wire_schema_sha256": "a8ea168f91ead2bc224c8a1f1412249cc08892e85c7e6f1334461315bd1385b2",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -2804,7 +2804,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20620,
+      "wire_schema_bytes": 20761,
       "tool_reference_bytes": 8157,
       "tool_reference_sha256": "488a0f80dc27b82e9d7a04226a70a00d8dddb18c5801dba7d287839e9f70315d",
       "overridden_tool_count": 0,
@@ -2830,7 +2830,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "8df8d830c1370944e4768efb235cad21d4c923181157a047b167d528e599800c",
-      "wire_schema_sha256": "2de1a6ed6cd13c7c445b70447771293300a1d32460a03f3b361c108d2b930091",
+      "wire_schema_sha256": "77b48937fe7ec04b1dfe22fbd3f0d058071dffa7a646bd2333b7a6b65ae91652",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -2855,7 +2855,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10621,
+      "wire_schema_bytes": 10762,
       "tool_reference_bytes": 5714,
       "tool_reference_sha256": "ffe228a0d892df8178b8697bb3c470318c7c60e0bb97e578159b3fb4376e1674",
       "overridden_tool_count": 0,
@@ -2876,7 +2876,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "1c5d33e6479dc6e858cbaca65f2e0ac8fdef46462cfd59b9b9a1b6a958fd4c63",
-      "wire_schema_sha256": "46ffdeb02a3149cb96d8d7e99244e345f92ea243cd18a30aa51e006ca4682609"
+      "wire_schema_sha256": "a38d7b04d05b23e75862070e97a6ac3358aa1b4d4d2ee2248a4058085a275fe0"
     },
     {
       "id": "slack_bolt:admin_dm:routed:collaboration",
@@ -2900,7 +2900,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9831,
+      "wire_schema_bytes": 9972,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "e538eef1415fb4f47251a65eff930e1abb048b1440679990cff368a65814cb1b",
       "overridden_tool_count": 0,
@@ -2917,7 +2917,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "11274be30eaff96df7d3a088f1c91d7ce876a5ef74f4f65679f51f93964bb107",
-      "wire_schema_sha256": "b57a5fbf2e3185acfe0f5728d98dc166e7e8fba608ae6f79e19a91a087dfee08"
+      "wire_schema_sha256": "610a632766f98d2858732eb8d8e16fbfd1f0c23b33c6c0007909d7a33516d062"
     },
     {
       "id": "slack_bolt:admin_dm:routed:committee_co_leaders",
@@ -2941,7 +2941,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11161,
+      "wire_schema_bytes": 11302,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "a74c5c2bd2d65d9f5639a6aad516e33599b92edba4bf9cc24ff468efc9889c51",
       "overridden_tool_count": 0,
@@ -2961,7 +2961,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "bbe7d7c41eafa947c0f6456ae91b140fe2fb526a765ada057940d8283bad2d3e",
-      "wire_schema_sha256": "88e25ae1df383ca28285df07031c9b2bdd6471f2156802e8ef1c2165c884bf1c"
+      "wire_schema_sha256": "b5d99ae490ded1a4f5d20aa7753412959680237b21afe1e1faa9179927ed46d5"
     },
     {
       "id": "slack_bolt:admin_dm:routed:committee_event_planning",
@@ -2985,7 +2985,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12747,
+      "wire_schema_bytes": 12888,
       "tool_reference_bytes": 4937,
       "tool_reference_sha256": "48c146ce05f85c6d37c76ff566e74f7c5432a42f18243f0dd88c1100ffed6109",
       "overridden_tool_count": 0,
@@ -3004,7 +3004,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "4cbb76ebfc638e5e178b77ce51517e1700f437cbe07eed14ef67bc9c6d6beed1",
-      "wire_schema_sha256": "a689a1a7836d76c8570bc6da9931e3233aca3358fcd24d29b3094674a967c7b8"
+      "wire_schema_sha256": "ec641792556c5b33bada8fd491025299c5ce888240aad9e397e609d90ad96f20"
     },
     {
       "id": "slack_bolt:admin_dm:routed:committee_event_registrations",
@@ -3028,7 +3028,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11471,
+      "wire_schema_bytes": 11612,
       "tool_reference_bytes": 4994,
       "tool_reference_sha256": "e5adaa7cf86f32e770b3d2ac8ba70be81d79ad573a6e6232ec8ab514c9c512ef",
       "overridden_tool_count": 0,
@@ -3048,7 +3048,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "9c759c6159787b0bf813b405babe98af8b80fd8132ad1c292125b2998c70e9fe",
-      "wire_schema_sha256": "83042a8f9c7a4d2365e3fb6dae5f3260154fbd20283b4d0cb6a82e95f2eb866d"
+      "wire_schema_sha256": "7442c8f0343cadeaebc9fbf7b53c126800f0b4e645a77e79d1fd7b5726cf14f6"
     },
     {
       "id": "slack_bolt:admin_dm:routed:committee_full_leadership",
@@ -3072,7 +3072,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17191,
+      "wire_schema_bytes": 17332,
       "tool_reference_bytes": 5272,
       "tool_reference_sha256": "8f6e40ff2049c4b545422207ee004ad7e0d78caba7b71253994e0ebdf73978e5",
       "overridden_tool_count": 0,
@@ -3097,7 +3097,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "04ec5e8b84cc7c87cf26efc8cd7c37398baefb992eb687800a7c461a0f74b752",
-      "wire_schema_sha256": "986037ea14111776d73dad81f6c8abd2bc4ccc0b7d121343f3cb53274d06e478",
+      "wire_schema_sha256": "93e170f15266310c33b743c22b939e1f1d2b418fd332ed530e08c71a794cac1b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -3122,7 +3122,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10911,
+      "wire_schema_bytes": 11052,
       "tool_reference_bytes": 5086,
       "tool_reference_sha256": "ca6a1e66aec898732856ae10dd86e16df9ecf43c2135448665e4c4084fd6144d",
       "overridden_tool_count": 0,
@@ -3141,7 +3141,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "8b32d9e5c75ba4c1993b582b53a0dd7549dfdd37b841c2e50e6b85ef586566c9",
-      "wire_schema_sha256": "a16439b79e45c05cf7dd5f35c07a7d91c9c8eecc44c8d8032083a7fc57841132"
+      "wire_schema_sha256": "0e6fe026cfd647a67897d2c6adf7c0a3cc0ecde785a1a09b6994c64cc0dffa02"
     },
     {
       "id": "slack_bolt:admin_dm:routed:community_group_contribution",
@@ -3165,7 +3165,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10112,
+      "wire_schema_bytes": 10253,
       "tool_reference_bytes": 5314,
       "tool_reference_sha256": "ad46a2c27c92e139603118ccdda8ca72104b761f404d0e3619e2aa338331c3d2",
       "overridden_tool_count": 0,
@@ -3184,7 +3184,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "495a4a8817c854d8d9b0be45cd4c4365585ca02748a9560222f7fe7fb4498af9",
-      "wire_schema_sha256": "68a04baeb53dc384c109b00f6d6ee34f44d0c4a864bee4bc470de2f9a81e6c42"
+      "wire_schema_sha256": "48a55496c36ad8118cceda62dfc6e3f2f7512d6d4c2df52559c5b807b88487a9"
     },
     {
       "id": "slack_bolt:admin_dm:routed:community_group_discovery",
@@ -3208,7 +3208,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10155,
+      "wire_schema_bytes": 10296,
       "tool_reference_bytes": 5255,
       "tool_reference_sha256": "fd71bca33c484bb3fb934c9486a18fc1e274917ff3cc95ef90e177e47326bb7c",
       "overridden_tool_count": 0,
@@ -3228,7 +3228,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "64a3330edea439fa8fb9fdacd1f81a66133cc4f256e7f2ac470bb5f2eea00ffb",
-      "wire_schema_sha256": "37e23fe68f4983194b7eda715844651a7b67caef71aff3d641f02997d71f7689"
+      "wire_schema_sha256": "9d05198d8f6fe5f252c0dea042255b1fda4049aa7deab37bb01c0260f9ba895c"
     },
     {
       "id": "slack_bolt:admin_dm:routed:community_group_full_participation",
@@ -3252,7 +3252,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13400,
+      "wire_schema_bytes": 13541,
       "tool_reference_bytes": 5366,
       "tool_reference_sha256": "b749062fe5be6a24e2d97f9299b3264bcbd84aef9c6fbabc470dc4e186a41e3a",
       "overridden_tool_count": 0,
@@ -3279,7 +3279,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1761c6fb6a24457352ea873f301ed6c24757cb0a4fed773919c1371fb343d70c",
-      "wire_schema_sha256": "a0cc93bef80d9523deb66aad071350b6ad2cc093fed8ff770c5cf2ce7940b269",
+      "wire_schema_sha256": "ae2a4ff316eb3f6cda571b706c3d47c72b904f623fbf477450a33e9a96bd3684",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -3304,7 +3304,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10522,
+      "wire_schema_bytes": 10663,
       "tool_reference_bytes": 5288,
       "tool_reference_sha256": "60f5f1015a0888599dcff1c673ebe02a5e83258c2d048256843f2a9c791188fa",
       "overridden_tool_count": 0,
@@ -3324,7 +3324,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "c6cf0f8155798e253cad3ac0be806ac43f96ca1259a860e19d265dc255d15d91",
-      "wire_schema_sha256": "9cd71c39be1813e2691d5ea448ff001cffd85464e5ba36f812c3d0692794dedb"
+      "wire_schema_sha256": "c49379c6569c8148bfec76439fb59409ede93e45094c4b65fc2dda4c83e2c145"
     },
     {
       "id": "slack_bolt:admin_dm:routed:content",
@@ -3348,7 +3348,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11128,
+      "wire_schema_bytes": 11269,
       "tool_reference_bytes": 5083,
       "tool_reference_sha256": "282313bd3f11de63c991eb1ca9c05498a4164020624527406eb3d21ac16e72a6",
       "overridden_tool_count": 0,
@@ -3368,7 +3368,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "284c752554ad643959685c0b0fbc1b1b5221bc3c0bf42c804731caa9a351cb44",
-      "wire_schema_sha256": "b1a8d18593b12e60f70e4d7b5f04f1f171979934591eba16dc6bf63d3b58a91c"
+      "wire_schema_sha256": "22f888fa99a27d79e9434f9738fd74a67556e1f58f46e4bcdc31b8e8cdd46bfc"
     },
     {
       "id": "slack_bolt:admin_dm:routed:council_interest",
@@ -3392,7 +3392,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10156,
+      "wire_schema_bytes": 10297,
       "tool_reference_bytes": 5250,
       "tool_reference_sha256": "2a9275ce948cff4e13410aedb7932cd1483a286cb9b2f729e4b987bed296009c",
       "overridden_tool_count": 0,
@@ -3412,7 +3412,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "86286a9b99f37c50106ca5b3ab9111c7b0af4d130d68d0640ccb929363610e72",
-      "wire_schema_sha256": "117775a58f2f01975ea5b101b1f11a64957762186c77e21374cea5c666bf2af4"
+      "wire_schema_sha256": "ea7cb652802c1ee0c9b4d03ae244118218032d33579555f29bf7a97f7c665618"
     },
     {
       "id": "slack_bolt:admin_dm:routed:events",
@@ -3436,7 +3436,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11056,
+      "wire_schema_bytes": 11197,
       "tool_reference_bytes": 5090,
       "tool_reference_sha256": "ee0839be778b2e32476815c6931204145048cdaf4433bf88e0986fcf8ac24183",
       "overridden_tool_count": 0,
@@ -3456,7 +3456,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "5751ff1ac10de94ad9b147e63d707924bb971a542515ebb9a89b5cb9446451cc",
-      "wire_schema_sha256": "afedc4bd3e025df66df66083454b5b5c8113509a335eb52289ad7fd4763ab335"
+      "wire_schema_sha256": "1237e2a89f231accdbaa9e3541aedb3ae018762173d929744cf6d065596ac9b6"
     },
     {
       "id": "slack_bolt:admin_dm:routed:github",
@@ -3480,7 +3480,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12701,
+      "wire_schema_bytes": 12842,
       "tool_reference_bytes": 6073,
       "tool_reference_sha256": "17d2b9fdd26009df7efeba7b01d291553c2d578f4c4b8d2f3fa952cadd338030",
       "overridden_tool_count": 0,
@@ -3500,7 +3500,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "188b898cef2ba9447f41cdc60c27bd6433d96dd606d2c429d18247d8c752753b",
-      "wire_schema_sha256": "6457216659e15cbc7f241b6ae36b0b98c4923f7673328fba7ed8c11cfe01d23f"
+      "wire_schema_sha256": "7559b3f050430dab78f8148ddb9e83afa19514cef5de15458c7f99e9fa897512"
     },
     {
       "id": "slack_bolt:admin_dm:routed:illustrations",
@@ -3524,7 +3524,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9510,
+      "wire_schema_bytes": 9651,
       "tool_reference_bytes": 5686,
       "tool_reference_sha256": "a08ac061f8dbe6da9867b23df6239f4f64a3605e97869e827b33ebc0aca341c0",
       "overridden_tool_count": 0,
@@ -3541,7 +3541,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "eb9a928245349898452ccbb1e46caa1b7b3ce8c7b8b765cd0f9456d8b035fddd",
-      "wire_schema_sha256": "ab732b43a4caea38eb03b1634fe091c481b207d0f683f81b0802fc3862bce661"
+      "wire_schema_sha256": "69d83bb5f1e2425bfd9c041a9fd79bdf67a9e65c42f5648d1e5bf6e0c2cd700d"
     },
     {
       "id": "slack_bolt:admin_dm:routed:industry_research",
@@ -3565,7 +3565,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10752,
+      "wire_schema_bytes": 10893,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "693504dc7294e18ff4127d493c1761e8d981b96ad5405a23bcc17fe64fbdd576",
       "overridden_tool_count": 0,
@@ -3584,7 +3584,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "baa3abb17c17d41290fc3a2c47b330e0ae373019cb129abb66c429199a905dd9",
-      "wire_schema_sha256": "dd7117345ddcb9f82f4035490b6598485cb6ceee9007684286adb20de4fda617"
+      "wire_schema_sha256": "8c7049bbc7421a76d2ad3c2e3ffdc56ee8b93a90761b6414f2d52e30d2205624"
     },
     {
       "id": "slack_bolt:admin_dm:routed:knowledge",
@@ -3608,7 +3608,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11857,
+      "wire_schema_bytes": 11998,
       "tool_reference_bytes": 6272,
       "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
       "overridden_tool_count": 0,
@@ -3627,7 +3627,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
-      "wire_schema_sha256": "c19a7e8340bc410cf6849c54d43fe762ea3cde8796b90832521c4cb4cf71c713"
+      "wire_schema_sha256": "f6bf3dde92b2d28eb26b85e932e6f2b1b6bc2d5eff122ad4e571467a58f3bcd3"
     },
     {
       "id": "slack_bolt:admin_dm:routed:meeting_attendance",
@@ -3651,7 +3651,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11239,
+      "wire_schema_bytes": 11380,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "5fdc3f50ba46d26ffa75ff27538a5e7e8bcef3ea837fef8fd48705abd8624725",
       "overridden_tool_count": 0,
@@ -3672,7 +3672,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "28efbd2ca8b10c2368f967e639fd7652cd7f04960ad188392ce93fda2392bdc0",
-      "wire_schema_sha256": "f39c41b8e78c64611672126ff6b8393087a60b3cb4923b7c7d43a4ed27968343"
+      "wire_schema_sha256": "7c9f5de06def5824696babe0d384b9aa60bc3b94db3038fc4a73d7cfa6cad728"
     },
     {
       "id": "slack_bolt:admin_dm:routed:meeting_full_administration",
@@ -3696,7 +3696,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18694,
+      "wire_schema_bytes": 18835,
       "tool_reference_bytes": 5195,
       "tool_reference_sha256": "17af7be874d34d79f1adf04bfa613c4b2faa3ea2bd74ea4ad3a91bb480be9741",
       "overridden_tool_count": 0,
@@ -3723,7 +3723,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "582f87a23ce4af178918f9bb042c999466b46904c3c9f7cbfed3dd27ab8dead2",
-      "wire_schema_sha256": "59170ff943f740317737157d7a781bb80349d107c7f6f69508f9b389329e2521",
+      "wire_schema_sha256": "b70c211ed1c3c6cb49bed93c09baef38c39849ea7df747db1bffa3ffb1e9b59b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -3748,7 +3748,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14552,
+      "wire_schema_bytes": 14693,
       "tool_reference_bytes": 5046,
       "tool_reference_sha256": "fce02e48f5ad06db1fee5ed46a2a2689371e71fdceb63cc1bd3e165515ba43e6",
       "overridden_tool_count": 0,
@@ -3768,7 +3768,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "63f1c3b48687fc9d68ddd930787a7d59561f1ba9ddb8d3698f0457486829dcba",
-      "wire_schema_sha256": "19cbd7895fd5b360a6871c5b552e565ae8e2ba0439ff80de008ba76f5614e44e"
+      "wire_schema_sha256": "232dd0f7f5208d747a5c794474720434b79d43962d28c56eda22300017e1ef7c"
     },
     {
       "id": "slack_bolt:admin_dm:routed:meeting_series_topics",
@@ -3792,7 +3792,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11473,
+      "wire_schema_bytes": 11614,
       "tool_reference_bytes": 5119,
       "tool_reference_sha256": "fe9228ca48c839aefda1068097db4be03171b5d2f70101b996207477ee011b43",
       "overridden_tool_count": 0,
@@ -3812,7 +3812,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "1b799fe2a16442d418c0628fec9bdc8ae73d6c67a2f1acda08a5b99c73255258",
-      "wire_schema_sha256": "d324fb9e0c1e8b1a8df594959b9ef3a70cc3920fd1949ea7cd4606f57b8dc0ed"
+      "wire_schema_sha256": "a6ef0e4690050c165fd0cda7076be36676b0bfa48f3a72ee9fe9f689946628c6"
     },
     {
       "id": "slack_bolt:admin_dm:routed:member_billing",
@@ -3836,7 +3836,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12058,
+      "wire_schema_bytes": 12199,
       "tool_reference_bytes": 5669,
       "tool_reference_sha256": "61c7298906378b4f2f154f7275a9f56c9102bfb6247ae654a3861f7cc8895b98",
       "overridden_tool_count": 0,
@@ -3857,7 +3857,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fadd2a88b06fed26c92e0d7683ee842fc67f84dfe3c44dc3db122d8443d955cc",
-      "wire_schema_sha256": "c2c14c5784576cb740c7b6f99d57443525eae812133e1764f7c9c44e9d525a62"
+      "wire_schema_sha256": "93b1a6a28f614100aec1b9804ebf98462ed20f1705b90f5f77844b49459254a1"
     },
     {
       "id": "slack_bolt:admin_dm:routed:member_company_profile",
@@ -3881,7 +3881,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14940,
+      "wire_schema_bytes": 15081,
       "tool_reference_bytes": 7179,
       "tool_reference_sha256": "b0aa1c7af0bf4591e4177f3a8127c527154606d4587dc08756e7f18105e83bb6",
       "overridden_tool_count": 0,
@@ -3902,7 +3902,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0e1b8aa348778ebfd306f8e063d3984473a27d9aa3475eada444f6cfdba0bfea",
-      "wire_schema_sha256": "7537b15dd2395d96fda05841d4378fe5aa4357bef70d9cd7f09b2da02a47fd91"
+      "wire_schema_sha256": "7b5e7201ecfa6b413eb78c9286cf4b047ef55fc178665bc55a0bda1331a4d963"
     },
     {
       "id": "slack_bolt:admin_dm:routed:member_personal_profile",
@@ -3926,7 +3926,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9709,
+      "wire_schema_bytes": 9850,
       "tool_reference_bytes": 6603,
       "tool_reference_sha256": "1be10e69d1c2468a8f3619e586e9b7cd0fb80f57e737ceb7614f552e89795e0d",
       "overridden_tool_count": 0,
@@ -3944,7 +3944,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "278d2a60ad51f3a69b5f03330f7f2b7d3d4a8ff98509f14e558cba79fe3c6e7a",
-      "wire_schema_sha256": "ff1df39b36fdc7627c9c15607a9430d3e0ee3bc271294fbd4adfbf2c6b863edc"
+      "wire_schema_sha256": "40b3a07842f235277a229615209ef66121aef314b998e85c2d866bdc980d9f21"
     },
     {
       "id": "slack_bolt:admin_dm:routed:outreach_contact_management",
@@ -3968,7 +3968,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10589,
+      "wire_schema_bytes": 10730,
       "tool_reference_bytes": 4957,
       "tool_reference_sha256": "978d81ac4be58b4e5f0c59260b589e96a95acd041895d6e47cb238614e05642a",
       "overridden_tool_count": 0,
@@ -3988,7 +3988,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "53eb64b204251c7934442c3397a72020de3c911f9c3d29dec3d2d239591e1aa5",
-      "wire_schema_sha256": "0fed13e32364c9ec0ca1f839f71f05aa6215c616be36f94d6c5acf78200d1f5e"
+      "wire_schema_sha256": "204ec6558f12dd0ca3621e36c719d8fdf2d9d1697b4006410e380cd706a221ff"
     },
     {
       "id": "slack_bolt:admin_dm:routed:outreach_reporting",
@@ -4012,7 +4012,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10160,
+      "wire_schema_bytes": 10301,
       "tool_reference_bytes": 4949,
       "tool_reference_sha256": "deb6aeea7143042d8abb8afc908abe958eb2c6bb562fd6e31b92162b7c6e4a7a",
       "overridden_tool_count": 0,
@@ -4031,7 +4031,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "9fea2f2b6f7bd11b93a4c4b87e0034f358fccbfe72dbed4ca9c9f45d3030d677",
-      "wire_schema_sha256": "02874ad0cff3f58ac2dd0dfb07d6fcfc5fb113471151252ce1818b4002f645a7"
+      "wire_schema_sha256": "f9579b024ed866df5ee027174ee45ef12edab77db4d3adfd2988fb152b022ea4"
     },
     {
       "id": "slack_bolt:admin_dm:routed:partner_directory",
@@ -4055,7 +4055,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12140,
+      "wire_schema_bytes": 12281,
       "tool_reference_bytes": 5179,
       "tool_reference_sha256": "2f1bdba181f4d89bed5f22bf21f070d49964f094ed9aa1638220d2e53bd350bc",
       "overridden_tool_count": 2,
@@ -4076,7 +4076,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4abe43bd711dba6f2b371f991a37f3044b7efe029af19169bc8a891e3030cc0a",
-      "wire_schema_sha256": "cf87115ba620f6fd6f3045dce2a749ddbf5b0aa17006042f4f4563fae18bfa28"
+      "wire_schema_sha256": "99c51e38c04dac4354fec601c2074df2998c042d6faef38de5a38a333f6911c7"
     },
     {
       "id": "slack_bolt:admin_dm:routed:property_identifier_catalog",
@@ -4100,7 +4100,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11416,
+      "wire_schema_bytes": 11557,
       "tool_reference_bytes": 5284,
       "tool_reference_sha256": "13831dbee6b1a3c7cd6921429eec948d1b4ee446eddb9e088ed00d7939de7a8d",
       "overridden_tool_count": 0,
@@ -4119,7 +4119,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "3f40589842d92252f4c31df951f3dee47f90d694f6c84fd40cf99beeaac51b90",
-      "wire_schema_sha256": "c01fbe920fc10285094b8a60c6f6af3847a1a37b29e6c0d90fef91995259a972"
+      "wire_schema_sha256": "5ba5aa78aa1a96c657d35cb754d05923078374df5c13446e4d49c892d86f8f25"
     },
     {
       "id": "slack_bolt:admin_dm:routed:property_list_enrichment",
@@ -4143,7 +4143,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9523,
+      "wire_schema_bytes": 9664,
       "tool_reference_bytes": 5133,
       "tool_reference_sha256": "90a495e511e631244025479c57aabdaf44869fbda341849f33d6e5d82d1d4f98",
       "overridden_tool_count": 0,
@@ -4161,7 +4161,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "59cd9ba8c99ea5efc46a5ba3c8ff57fa5a02855f68171dade0e196583ed1c95d",
-      "wire_schema_sha256": "495d3ed783c97fe3e3043abb2e61ca20ff7297896a131b36bfa9d8c49de3d665"
+      "wire_schema_sha256": "fda96b55972fa731d69e54f8bd8691f6f24cb9e5ef3ee34273e2d2ebb6100bf8"
     },
     {
       "id": "slack_bolt:admin_dm:routed:property_registry_records",
@@ -4185,7 +4185,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10786,
+      "wire_schema_bytes": 10927,
       "tool_reference_bytes": 5362,
       "tool_reference_sha256": "f8db16b555a1cd7f2ed5547a7decd4a45c47a371d05b447825d9d6bdd7f1477e",
       "overridden_tool_count": 0,
@@ -4205,7 +4205,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "4efc04fd88ef1fba8495a1fffe10779d36410775b793777bff55a3dcf38d2773",
-      "wire_schema_sha256": "60bb471663c9a7f158b98d531e7f5e5842b196dc4abdd29be1bbb264f3a31f5c"
+      "wire_schema_sha256": "fd0aeac830426617253183c886b87c7620f6b8cff41d483e99ffb9bdd4009b20"
     },
     {
       "id": "slack_bolt:admin_dm:routed:publishing_assets",
@@ -4229,7 +4229,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10900,
+      "wire_schema_bytes": 11041,
       "tool_reference_bytes": 5087,
       "tool_reference_sha256": "d56011932cbd50f96ac3191be635143521775a2fcd9567d4ebfa3e8d1f9dab77",
       "overridden_tool_count": 0,
@@ -4249,7 +4249,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fdc3b16e146cb1098e8fbe4e560b521d8c72da0febb5a43e18a4ee5d4f43a2b7",
-      "wire_schema_sha256": "8a975d08f355c8c1b1a18df73015a16cd316a15fe949632eb8869510138b0785"
+      "wire_schema_sha256": "4821ac40e06fc1d64c6110ba18ecdaa9e46d7b5372cca121aaa3b140b1975a2a"
     },
     {
       "id": "slack_bolt:admin_dm:routed:publishing_promotion",
@@ -4273,7 +4273,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10385,
+      "wire_schema_bytes": 10526,
       "tool_reference_bytes": 4976,
       "tool_reference_sha256": "242b8d1ee88bacff1da83025b9e31abcd0c9fd9b15b567c26cb829ad3db59588",
       "overridden_tool_count": 0,
@@ -4291,7 +4291,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "914e5042ff5aa77185e5f5ca8e9a05f1a41124bbd8ba8b599080f70efb9c7b83",
-      "wire_schema_sha256": "b772f60aecc8ffa0350d81313e7deee857d45eca4f477455d1f4e229517b4071"
+      "wire_schema_sha256": "acd6fd57e8b76ec32feaf2bd22e8ecddee3c7bb925f8a55f8f7d7bcc670388e1"
     },
     {
       "id": "slack_bolt:admin_dm:routed:publishing_review",
@@ -4315,7 +4315,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10229,
+      "wire_schema_bytes": 10370,
       "tool_reference_bytes": 5157,
       "tool_reference_sha256": "bbd74b8e4738835551b2440b98a1ae56d7846f2d971933af09ec972ed5b40682",
       "overridden_tool_count": 0,
@@ -4335,7 +4335,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a895f645f68398d3e561173892a44e31eaa1cfdfa5dfa74cd3cdd30c833aadda",
-      "wire_schema_sha256": "c5caa7ddc47fa48618ba74b09cc76301ba5554af9e9c2df7d4a555c514b3aa19"
+      "wire_schema_sha256": "4827ac2b31737f015deea00bd512859c97ee3b6fde1b4453b02d30e6b290c16e"
     },
     {
       "id": "slack_bolt:admin_dm:routed:publishing_submission",
@@ -4359,7 +4359,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11917,
+      "wire_schema_bytes": 12058,
       "tool_reference_bytes": 5933,
       "tool_reference_sha256": "4368a4534a12db25c52e70aa2e4d45ea9f359786531bfa7a1549cb7622539813",
       "overridden_tool_count": 0,
@@ -4378,7 +4378,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0c9654e2c90afb77d7cb1482baf49531c1dbf1d6ad96e89d9065e2845f0ef290",
-      "wire_schema_sha256": "9a8526aca39c98e9fbccce4ea348015f2d50c43dfe2f91780ef55143f5e29f6b"
+      "wire_schema_sha256": "71574736fbd843f0f486ad2dc5567c674c6e7b7158fbac11a29825a3c54dddf8"
     },
     {
       "id": "slack_bolt:admin_dm:routed:schema_reference",
@@ -4402,7 +4402,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11005,
+      "wire_schema_bytes": 11146,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -4422,7 +4422,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "443689ec626f64502248bcf217d42ef60900891d9a4163e30f52dba93a237984"
+      "wire_schema_sha256": "fb719521c0abe29641c041144222f371429552b112530b64a7ada5244f864852"
     },
     {
       "id": "slack_bolt:admin_dm:routed:sponsored_intelligence_discovery",
@@ -4446,7 +4446,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
+      "wire_schema_bytes": 10334,
       "tool_reference_bytes": 5309,
       "tool_reference_sha256": "3a8d840efe998abbd5d636abcc586fe5889c3e1282e0bd5e503674461bcd0dd9",
       "overridden_tool_count": 0,
@@ -4465,7 +4465,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "273d2551a68559859045673bd43c47271fa94a6c2d964d52ea97b3ddcc82a3e1",
-      "wire_schema_sha256": "14fb233d8d227dfabb95f29858a9676478f4da482b6872205d51eae2494fc8e7"
+      "wire_schema_sha256": "50638db9f4084536bad895819c3394c83de09b7038f2177a0df409d83ff1da97"
     },
     {
       "id": "slack_bolt:admin_dm:routed:sponsored_intelligence_session",
@@ -4489,7 +4489,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9712,
+      "wire_schema_bytes": 9853,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "a6db91f7f951d33d2386aa95c8902dc13d042413c343658a7764921db30faba2",
       "overridden_tool_count": 0,
@@ -4508,7 +4508,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4374fdf27f7f4d8646711d9cd15247ada5ff2a909ed24cfbd9b847b40c6fe3e7",
-      "wire_schema_sha256": "cd9443cf3509268c019d4d7528f0a9b650efcff272b88d9653863825f1a2f41a"
+      "wire_schema_sha256": "f2795405837d1a84a8998ef506930127f587d4a073fbf730249dfd9dc989a10d"
     },
     {
       "id": "slack_bolt:admin_dm:safe_fallback",
@@ -4578,7 +4578,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15460,
+      "wire_schema_bytes": 15601,
       "tool_reference_bytes": 6330,
       "tool_reference_sha256": "6aef477bf109d821bdfa8fd07c90523f69b3a7fbe386ae353280665105de3e0f",
       "overridden_tool_count": 0,
@@ -4598,7 +4598,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ad8390526ff9af140bd7e4b0416ad3cfc4c028e44028070b95a06ae152bfa05e",
-      "wire_schema_sha256": "dc7103f30f9e621253fee5592d6b96ef643d57b5903fd0382052fff981b07d2a"
+      "wire_schema_sha256": "ca0da259992847a847763ab958007800ba2f205f075ee4881cb44a5333dc211a"
     },
     {
       "id": "slack_bolt:admin_working_group:adcp_task_operations",
@@ -4622,7 +4622,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13908,
+      "wire_schema_bytes": 14049,
       "tool_reference_bytes": 6378,
       "tool_reference_sha256": "6f40fffb21d3be25b7651e53dd9c9555d8b6e844e0ada398314863d004ece8c6",
       "overridden_tool_count": 0,
@@ -4641,7 +4641,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07d619635ece821a834856c3c589ae9b3fc571ad61b993c621cc54a1d488360d",
-      "wire_schema_sha256": "64851675e3c695f012343f8b9797e22e1ae9439f74b95611799e7d10029bab3a"
+      "wire_schema_sha256": "5a230a0d07bd7a8115422e4b3efe48a522cb92c8f77b8fa38a807b617d8a08a1"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_billing_account",
@@ -4665,7 +4665,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11076,
+      "wire_schema_bytes": 11217,
       "tool_reference_bytes": 4918,
       "tool_reference_sha256": "c633c81589d01cce53e416bffb362e31d3fb38c1fa7ae0be2bc1b3a89b8a30c3",
       "overridden_tool_count": 0,
@@ -4685,7 +4685,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf202ec0b5c16623f805b27e931a3423b95b24caee51e1a76dab242af5e113f2",
-      "wire_schema_sha256": "e9ded10e5ae64f63be983786276642b415b919c5a67b81f273864451863a0fbf"
+      "wire_schema_sha256": "cc2ab61e3ad19b17010c5a5c7de0eafa41a6fae2de4810a38e3808934506a57b"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_billing_discounts",
@@ -4709,7 +4709,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10390,
+      "wire_schema_bytes": 10531,
       "tool_reference_bytes": 4885,
       "tool_reference_sha256": "e6c54c011bf4113a5acfb57919b1eea144a9e2e9b037a7fa90402c91e92c4af4",
       "overridden_tool_count": 0,
@@ -4729,7 +4729,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3d5a0d9845becf4948711c6b98b82b974ad8a580d75ec4b9440d3ba0df936d28",
-      "wire_schema_sha256": "01b4c5607355c8cc879da53dc000c63d208a6c74db48dacbc300d9da16dfeba9"
+      "wire_schema_sha256": "0f0359f0ff406ae27ba491aa5346a3141b5f9c5d7d5a41e6c4c072406ff8be64"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_billing_payments",
@@ -4753,7 +4753,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11959,
+      "wire_schema_bytes": 12100,
       "tool_reference_bytes": 4873,
       "tool_reference_sha256": "beafff27d131ccfccf76c4ebf261d2ea9266a44aed3072c3e5af8b876cab4ef7",
       "overridden_tool_count": 0,
@@ -4772,7 +4772,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4658b9b7dbd4a931f13ea064882fc4fa4fdd16b52cc772c54896e65520480301",
-      "wire_schema_sha256": "c16b5a136d8ab7e05713da928b904228b45c0d43d80ca474cbae14ad0c64182f"
+      "wire_schema_sha256": "2dd912f723bb64fecdfb58f2d684ea5b45d30d38512179b7b8f1356baf188325"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_brand_logo_review",
@@ -4796,7 +4796,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10322,
+      "wire_schema_bytes": 10463,
       "tool_reference_bytes": 5103,
       "tool_reference_sha256": "18a8f680141c30fb3779c55d499734812898390dba839f7e842c5402550132d5",
       "overridden_tool_count": 0,
@@ -4815,7 +4815,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "6c9af95c4975829a7bf94aec01f35a754b8d9cdb812f5dd150c15eabac456de1",
-      "wire_schema_sha256": "c075708004e5259ded57bf7b460f7a123abf8b3c00f6327dd1f6820be35ab45b"
+      "wire_schema_sha256": "35c211082c30ee248197647c07c439c14d8c53f354fb224abdd862b433c98f55"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_brand_registry_integrity",
@@ -4839,7 +4839,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11031,
+      "wire_schema_bytes": 11172,
       "tool_reference_bytes": 5206,
       "tool_reference_sha256": "076d054efacb1b4921f34c5b4c2fa862adeb91d2c383f34ad016cb46c3ef9cdc",
       "overridden_tool_count": 0,
@@ -4860,7 +4860,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "20034d602e5fe0640db9017a31bbcfc4e1c8012b17c55022c6a86eabbe8493a1",
-      "wire_schema_sha256": "102609b8e85067acf55311c7bbfd0d7dabc1ca87f5ffd1331ea6255bd34cc26b"
+      "wire_schema_sha256": "3486e907585e59a83052d8c6fc6583648c6f45bbc5407b265fab68b761254f3b"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_conversation_review",
@@ -4884,7 +4884,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11022,
+      "wire_schema_bytes": 11163,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -4903,7 +4903,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "46c7d110ac26bd45dec3fc0870880584f46522717bd470d4e8242b1eeada4c77"
+      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_events",
@@ -4927,7 +4927,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14607,
+      "wire_schema_bytes": 14748,
       "tool_reference_bytes": 5045,
       "tool_reference_sha256": "c30cb271ee192379bdfd17da6cd5bab315e4c560f86a13f66f5192aa38ca6ed7",
       "overridden_tool_count": 0,
@@ -4948,7 +4948,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "0e315f56035f7f695f6e8b981c5b484c9802fc1b0f948e767a6bd57eb3cbafa8",
-      "wire_schema_sha256": "2b1d53f3e95f2dc8b66f3b91c52775cfb3292ed32bbf151edd33c069fdda5b20"
+      "wire_schema_sha256": "2ad96203888e13bb531d0725ed59dc9bdbc70bfebcaca69b6104225882d68f64"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_feed_curation",
@@ -4972,7 +4972,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10769,
+      "wire_schema_bytes": 10910,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "51b1859d98819b87b8cf43469c7151cee160b47dab60e0185ebbdb25b7206911",
       "overridden_tool_count": 0,
@@ -4992,7 +4992,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3dcfb69f2292cd2753faf15d02c0077a157e404763b47af52d306370c4975ea2",
-      "wire_schema_sha256": "dfe8b2570e3c6dd0470221132cebbb5c33bc6f4c95ee55c06f29bf5318fe49fa"
+      "wire_schema_sha256": "abf4e1210aaac63fb0b6abe901bb89edac2f3994ebce7572b3fd3ddfec918d56"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_feed_monitoring",
@@ -5016,7 +5016,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9556,
+      "wire_schema_bytes": 9697,
       "tool_reference_bytes": 4933,
       "tool_reference_sha256": "348f8bf0680b6697aa4db7fe642d0d2b592d98bac5ef05017653e3d5f76d1ee0",
       "overridden_tool_count": 0,
@@ -5035,7 +5035,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b1689086b33ea143c9b79edc3954c1fc9320bd7c73bf26c05d79d00a50999e6b",
-      "wire_schema_sha256": "69b08c0e33b7f5e0483b2d9faa24e71d5d8cf7a9af626b6983050b85608002dd"
+      "wire_schema_sha256": "356c5447324224f57135895bdf0755581a2b86d5bdfb0236962e92922898df10"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_followup_tasks",
@@ -5059,7 +5059,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10288,
+      "wire_schema_bytes": 10429,
       "tool_reference_bytes": 4961,
       "tool_reference_sha256": "d3b7df07a7bf17cddab315557f4db71a7e2fea4f4956d3ace06b9d96340d50d6",
       "overridden_tool_count": 0,
@@ -5079,7 +5079,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "e9891ff20b83d67e8cadb649d24df495c51f5d78064af75532944a98a14ef9e4",
-      "wire_schema_sha256": "61929aa8491fc1efa2a84b9017ac2d040d4f2e0df6893bb4939b7f0b48d01735"
+      "wire_schema_sha256": "310fa974b97a6c82109c0aac9e36fe45501e4c2acba52c730cb7dba8abe587b0"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_group_leadership",
@@ -5103,7 +5103,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10760,
+      "wire_schema_bytes": 10901,
       "tool_reference_bytes": 5041,
       "tool_reference_sha256": "90476e3b3516fa008b3063f2d55126f0c4622dfce286824afe3e33917711c10d",
       "overridden_tool_count": 0,
@@ -5124,7 +5124,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ecd5015062feb97397c759e03480c2fc6f9ef58425774b7f88d6793fc51a261a",
-      "wire_schema_sha256": "8870ff455c80a2c3ac9270a2bfaaf2fa62d4eb715f25069469a180d1523d46ac"
+      "wire_schema_sha256": "292b461d56fd3d1d6ec082dfdd8ad4b7be80323422f7d55476a2a7c50de11b62"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_group_membership",
@@ -5148,7 +5148,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10666,
+      "wire_schema_bytes": 10807,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "2388dc80f99651611a2695a01e1caaba5a3fe4d36cb4f74ef9c5443dc96b3664",
       "overridden_tool_count": 0,
@@ -5168,7 +5168,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "47db1de6135e646a948a53018f4edc8c974d39573961f5f74cf110c620b28b7d",
-      "wire_schema_sha256": "b0c37e8442437e8bf5da967213533952a688d75f9044159913740a4bb7cbc68d"
+      "wire_schema_sha256": "75cfcf4d3e182f12be3a8409b69086eb4e8395ee1eb57d6897cbe1532ffa3464"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_group_structure",
@@ -5192,7 +5192,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10729,
+      "wire_schema_bytes": 10870,
       "tool_reference_bytes": 5034,
       "tool_reference_sha256": "8f34d5a18362f50aacb64db4cba78ed35949e1ff5e47db886ea4344224766823",
       "overridden_tool_count": 0,
@@ -5213,7 +5213,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f386cc7f41b925aa66274b8f8753f1f807aab57f0b25196035c9b470d7e97e08",
-      "wire_schema_sha256": "a156969da8f3918f83e0cae37c1307567e88d7976052443702e086be3d52fa99"
+      "wire_schema_sha256": "8976f868aa83ffca02729d688267b8682dffe4bc1f3c0f75818e46c3b67208ea"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_organization_integrity",
@@ -5237,7 +5237,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10716,
+      "wire_schema_bytes": 10857,
       "tool_reference_bytes": 5263,
       "tool_reference_sha256": "2babace46b46bd3c1757a93a4fc523910763ecdc00941c9526aa723cc966057c",
       "overridden_tool_count": 0,
@@ -5257,7 +5257,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "282a96131a9d387b5b297a1798d427fb77f27935a25c03cbf2cc22b79160265d",
-      "wire_schema_sha256": "042e6ecaa3f021ea34283325da3d528e17494d89e9be9284ffadb1e84cd44dea"
+      "wire_schema_sha256": "43278aa0ec15d4cc49fd7beb7bb4ea369b7b21123737932188b480921cdd3335"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_organization_member_records",
@@ -5281,7 +5281,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13604,
+      "wire_schema_bytes": 13745,
       "tool_reference_bytes": 5279,
       "tool_reference_sha256": "3b20b9520b711943b33384fc793a5aa81c1356222e27031371fa9568fa5ddaa6",
       "overridden_tool_count": 0,
@@ -5302,7 +5302,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "fbaa28ba1001813d3f1a0cb66477a6c9b0efc4ff32214d6414c9ec478d93f373",
-      "wire_schema_sha256": "199ccde69119f622e85af6e7878095321c7af70fa6df08c2108a7db357d40f96"
+      "wire_schema_sha256": "b1827a4f4ba256571df9eb871d48d0a0822985d974b1ae9181643a2297083e8e"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_prospect_pipeline",
@@ -5326,7 +5326,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12521,
+      "wire_schema_bytes": 12662,
       "tool_reference_bytes": 4989,
       "tool_reference_sha256": "b0cd167136b0167f5271d0c640104f9e84ab19c55065b2c375ea59fd650658c6",
       "overridden_tool_count": 0,
@@ -5346,7 +5346,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "57a38e3fff723ab752525360ac09e49c8383a799c437fd7e8997db01d00d6102",
-      "wire_schema_sha256": "5c49b5d4e0419b5255b6c8f54697e65d1eb6eb15fef63635c8afd65fc5449358"
+      "wire_schema_sha256": "35a27cf6032281aba5d04bf4381436e9ebc3726f4ac1656e219c4be2bdd6ddf5"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_prospect_research",
@@ -5370,7 +5370,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10908,
+      "wire_schema_bytes": 11049,
       "tool_reference_bytes": 5007,
       "tool_reference_sha256": "1854a1b2fe6f4dc131539e2d425764f7819eea370158742211c02c1910f21338",
       "overridden_tool_count": 0,
@@ -5390,7 +5390,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "da07d5b25562ab15e7f17ce74015434853f8be2fac2917339e18cc4fb6139fd7",
-      "wire_schema_sha256": "b4cc5316fe13a05a6ed97843fecd37451808a421f1e941644f9762e268999059"
+      "wire_schema_sha256": "22bc774943369c808b85b557cdd40fc4177145a9508b613f974c1a6b37050178"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_authentication",
@@ -5414,7 +5414,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11273,
+      "wire_schema_bytes": 11414,
       "tool_reference_bytes": 6068,
       "tool_reference_sha256": "8c5110b85f73579cbd881419b997fcc9a9d99d3b2ebdf415f4929585bd6298d5",
       "overridden_tool_count": 0,
@@ -5432,7 +5432,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07eb0de4a4c6332c5429079c33017a24205c5f3507e6399772c561ff4a092d78",
-      "wire_schema_sha256": "598a80e9d63967c72734a2a480fcc2d438cdb06af506672907ac273711905aa2"
+      "wire_schema_sha256": "c817f6a6a00ce8caeb3ceb89d2c9a6cdd34c142d48680ab1968ae85dcdd8bf32"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_conformance",
@@ -5456,7 +5456,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9978,
+      "wire_schema_bytes": 10119,
       "tool_reference_bytes": 5792,
       "tool_reference_sha256": "182b19b64ce7302d415619c993fc24ae32136df09ef1c8ac2b89f7cc839dc266",
       "overridden_tool_count": 0,
@@ -5474,7 +5474,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "012096836c5569d43d146451a8ffb1b800f8b39a56f146da16161031ce0ac130",
-      "wire_schema_sha256": "b5943c31b2c9dd9a3a7ff21771f5b5754404e35db94bd9ec35250f2e71afbf3b"
+      "wire_schema_sha256": "b850bf84930b453a9611fc5313cb6f9348099918d6f03639cff649f85b01ad6e"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_end_to_end",
@@ -5498,7 +5498,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19815,
+      "wire_schema_bytes": 19956,
       "tool_reference_bytes": 6636,
       "tool_reference_sha256": "d02b3eff67be7a38f952ebe0196ddb996dc932aa9e501167b0b1d71e454da1e4",
       "overridden_tool_count": 1,
@@ -5524,7 +5524,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "85c84ea52a5aa43067389e7e17605be6a93ddcf1ba596f619729779fccbe10bc",
-      "wire_schema_sha256": "4ac2625af42caf603e34700d6d4e8b1c6392a9a55f30cea92053e70ebe28a5b2",
+      "wire_schema_sha256": "6972421c67e7a20bd652da3a03d9333a6de9f05e5d2f8649e4df1d8bc23b2024",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -5549,7 +5549,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9950,
+      "wire_schema_bytes": 10091,
       "tool_reference_bytes": 5117,
       "tool_reference_sha256": "aa7e1f31ef1c683786e229c8050793d9faad83b5a5cbde309960dc4a3271a991",
       "overridden_tool_count": 4,
@@ -5569,7 +5569,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a512a4cbd9fe2e02bb76d6a1b31cd09a7638761efb4a0230834fdfb2e861159e",
-      "wire_schema_sha256": "7b05ded6a160ec1efae4e67f6132c9301be3989ba40f9ee725e1dea20d011c28"
+      "wire_schema_sha256": "a9712d8f28136b46063ae010c6e790982153087943feb2d6acaf3c7e4a4df93d"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_quality",
@@ -5593,7 +5593,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14652,
+      "wire_schema_bytes": 14793,
       "tool_reference_bytes": 6139,
       "tool_reference_sha256": "ecf8f60600a263d6a3120321ab1f65e138a08b082a96153eed01d1968552a91f",
       "overridden_tool_count": 0,
@@ -5612,7 +5612,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f527be89fee5e5536b0b51b8c6c72924fbb8d3d9f3fee080986890437ae83065",
-      "wire_schema_sha256": "0da514e38da9e5be4280e7490b7f597ac0976df6fb9860bfd3c2abdb06f9ce69"
+      "wire_schema_sha256": "2927e76e9a88dce21cf946e0034908a0526605e5cb05f02305ffd1331cc4d91a"
     },
     {
       "id": "slack_bolt:admin_working_group:agent_registry",
@@ -5636,7 +5636,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11044,
+      "wire_schema_bytes": 11185,
       "tool_reference_bytes": 6701,
       "tool_reference_sha256": "25cdf10cfcafee88979211e822031ff6983a2f38b20fae8fa7088210136e135d",
       "overridden_tool_count": 1,
@@ -5657,7 +5657,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "829db1024e9ed7b56f80e74f08c79430219c661a9f7f1ca2f338268d981861c2",
-      "wire_schema_sha256": "b0d39b6c209520e8a0e3496f6c49c5ec11b5743ef88af79d479fb3857f0431de"
+      "wire_schema_sha256": "0b1af69d6704ce3c22d14b34ca20cbf5cc56fecae2ebc26ea8286f16edd6ca0e"
     },
     {
       "id": "slack_bolt:admin_working_group:all_valid_sets_maximum",
@@ -5747,7 +5747,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -5973,7 +5973,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -5998,7 +5998,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16157,
+      "wire_schema_bytes": 16298,
       "tool_reference_bytes": 5617,
       "tool_reference_sha256": "d05f97f3dc028c1013c97a9e19feffd2796fbc23e53475e20b508a3b322b8708",
       "overridden_tool_count": 0,
@@ -6019,7 +6019,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b0cb4a01b1ab28f7ab346fe05f5d2b3fec2d73dcdc5a8309a5b0f7d902fc5758",
-      "wire_schema_sha256": "a63a1ba480dce1cc6f8abd2d0bfdf5ec25f46a84c8c73b964359f4bef911203c"
+      "wire_schema_sha256": "33ddcc81e2e2a07ee9ac86d347e32961acc9cf30088a132b1e6b54eb90f6a108"
     },
     {
       "id": "slack_bolt:admin_working_group:brand_registry_records",
@@ -6043,7 +6043,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11067,
+      "wire_schema_bytes": 11208,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "6e5a06f631d52e8db048ca417e593ab9731058f6ad56b3b963a13fba4576803d",
       "overridden_tool_count": 0,
@@ -6064,7 +6064,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "7fd8e61d32cf8b482ae959e5e050ee0774fb93e3ce6d39f243364659c3a81b15",
-      "wire_schema_sha256": "eacbb437559a6273d4439d0d4fc13bb39c91b2a3f6bed0d6bad7a95b7cc4778a"
+      "wire_schema_sha256": "c1381ff7692db4c526b7d5c2f55b8951be1a53daf932a2c33a083dcf80544674"
     },
     {
       "id": "slack_bolt:admin_working_group:certification_assessment",
@@ -6088,7 +6088,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19717,
+      "wire_schema_bytes": 19858,
       "tool_reference_bytes": 6920,
       "tool_reference_sha256": "8c278765ad621dd11f89ff7b35d60af9f51ae88d569155f91733a06a4a51aab5",
       "overridden_tool_count": 0,
@@ -6113,7 +6113,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "b8820aebc73fe700321e75a7bafc7ff346e38040ea64c833f6e87f88609e9ff2",
-      "wire_schema_sha256": "d8435d8f452b30eb17516ff8b8f2e5138a2024bd4061f07a5745c600ab834ce0",
+      "wire_schema_sha256": "a8ea168f91ead2bc224c8a1f1412249cc08892e85c7e6f1334461315bd1385b2",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -6138,7 +6138,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20620,
+      "wire_schema_bytes": 20761,
       "tool_reference_bytes": 8157,
       "tool_reference_sha256": "488a0f80dc27b82e9d7a04226a70a00d8dddb18c5801dba7d287839e9f70315d",
       "overridden_tool_count": 0,
@@ -6164,7 +6164,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "8df8d830c1370944e4768efb235cad21d4c923181157a047b167d528e599800c",
-      "wire_schema_sha256": "2de1a6ed6cd13c7c445b70447771293300a1d32460a03f3b361c108d2b930091",
+      "wire_schema_sha256": "77b48937fe7ec04b1dfe22fbd3f0d058071dffa7a646bd2333b7a6b65ae91652",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -6189,7 +6189,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10621,
+      "wire_schema_bytes": 10762,
       "tool_reference_bytes": 5714,
       "tool_reference_sha256": "ffe228a0d892df8178b8697bb3c470318c7c60e0bb97e578159b3fb4376e1674",
       "overridden_tool_count": 0,
@@ -6210,7 +6210,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "1c5d33e6479dc6e858cbaca65f2e0ac8fdef46462cfd59b9b9a1b6a958fd4c63",
-      "wire_schema_sha256": "46ffdeb02a3149cb96d8d7e99244e345f92ea243cd18a30aa51e006ca4682609"
+      "wire_schema_sha256": "a38d7b04d05b23e75862070e97a6ac3358aa1b4d4d2ee2248a4058085a275fe0"
     },
     {
       "id": "slack_bolt:admin_working_group:collaboration",
@@ -6234,7 +6234,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9831,
+      "wire_schema_bytes": 9972,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "e538eef1415fb4f47251a65eff930e1abb048b1440679990cff368a65814cb1b",
       "overridden_tool_count": 0,
@@ -6251,7 +6251,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "11274be30eaff96df7d3a088f1c91d7ce876a5ef74f4f65679f51f93964bb107",
-      "wire_schema_sha256": "b57a5fbf2e3185acfe0f5728d98dc166e7e8fba608ae6f79e19a91a087dfee08"
+      "wire_schema_sha256": "610a632766f98d2858732eb8d8e16fbfd1f0c23b33c6c0007909d7a33516d062"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_co_leaders",
@@ -6275,7 +6275,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11161,
+      "wire_schema_bytes": 11302,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "a74c5c2bd2d65d9f5639a6aad516e33599b92edba4bf9cc24ff468efc9889c51",
       "overridden_tool_count": 0,
@@ -6295,7 +6295,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "bbe7d7c41eafa947c0f6456ae91b140fe2fb526a765ada057940d8283bad2d3e",
-      "wire_schema_sha256": "88e25ae1df383ca28285df07031c9b2bdd6471f2156802e8ef1c2165c884bf1c"
+      "wire_schema_sha256": "b5d99ae490ded1a4f5d20aa7753412959680237b21afe1e1faa9179927ed46d5"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_event_planning",
@@ -6319,7 +6319,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12747,
+      "wire_schema_bytes": 12888,
       "tool_reference_bytes": 4937,
       "tool_reference_sha256": "48c146ce05f85c6d37c76ff566e74f7c5432a42f18243f0dd88c1100ffed6109",
       "overridden_tool_count": 0,
@@ -6338,7 +6338,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "4cbb76ebfc638e5e178b77ce51517e1700f437cbe07eed14ef67bc9c6d6beed1",
-      "wire_schema_sha256": "a689a1a7836d76c8570bc6da9931e3233aca3358fcd24d29b3094674a967c7b8"
+      "wire_schema_sha256": "ec641792556c5b33bada8fd491025299c5ce888240aad9e397e609d90ad96f20"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_event_registrations",
@@ -6362,7 +6362,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11471,
+      "wire_schema_bytes": 11612,
       "tool_reference_bytes": 4994,
       "tool_reference_sha256": "e5adaa7cf86f32e770b3d2ac8ba70be81d79ad573a6e6232ec8ab514c9c512ef",
       "overridden_tool_count": 0,
@@ -6382,7 +6382,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "9c759c6159787b0bf813b405babe98af8b80fd8132ad1c292125b2998c70e9fe",
-      "wire_schema_sha256": "83042a8f9c7a4d2365e3fb6dae5f3260154fbd20283b4d0cb6a82e95f2eb866d"
+      "wire_schema_sha256": "7442c8f0343cadeaebc9fbf7b53c126800f0b4e645a77e79d1fd7b5726cf14f6"
     },
     {
       "id": "slack_bolt:admin_working_group:committee_full_leadership",
@@ -6406,7 +6406,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17191,
+      "wire_schema_bytes": 17332,
       "tool_reference_bytes": 5272,
       "tool_reference_sha256": "8f6e40ff2049c4b545422207ee004ad7e0d78caba7b71253994e0ebdf73978e5",
       "overridden_tool_count": 0,
@@ -6431,7 +6431,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "04ec5e8b84cc7c87cf26efc8cd7c37398baefb992eb687800a7c461a0f74b752",
-      "wire_schema_sha256": "986037ea14111776d73dad81f6c8abd2bc4ccc0b7d121343f3cb53274d06e478",
+      "wire_schema_sha256": "93e170f15266310c33b743c22b939e1f1d2b418fd332ed530e08c71a794cac1b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -6456,7 +6456,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10911,
+      "wire_schema_bytes": 11052,
       "tool_reference_bytes": 5086,
       "tool_reference_sha256": "ca6a1e66aec898732856ae10dd86e16df9ecf43c2135448665e4c4084fd6144d",
       "overridden_tool_count": 0,
@@ -6475,7 +6475,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "8b32d9e5c75ba4c1993b582b53a0dd7549dfdd37b841c2e50e6b85ef586566c9",
-      "wire_schema_sha256": "a16439b79e45c05cf7dd5f35c07a7d91c9c8eecc44c8d8032083a7fc57841132"
+      "wire_schema_sha256": "0e6fe026cfd647a67897d2c6adf7c0a3cc0ecde785a1a09b6994c64cc0dffa02"
     },
     {
       "id": "slack_bolt:admin_working_group:community_group_contribution",
@@ -6499,7 +6499,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10112,
+      "wire_schema_bytes": 10253,
       "tool_reference_bytes": 5314,
       "tool_reference_sha256": "ad46a2c27c92e139603118ccdda8ca72104b761f404d0e3619e2aa338331c3d2",
       "overridden_tool_count": 0,
@@ -6518,7 +6518,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "495a4a8817c854d8d9b0be45cd4c4365585ca02748a9560222f7fe7fb4498af9",
-      "wire_schema_sha256": "68a04baeb53dc384c109b00f6d6ee34f44d0c4a864bee4bc470de2f9a81e6c42"
+      "wire_schema_sha256": "48a55496c36ad8118cceda62dfc6e3f2f7512d6d4c2df52559c5b807b88487a9"
     },
     {
       "id": "slack_bolt:admin_working_group:community_group_discovery",
@@ -6542,7 +6542,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10155,
+      "wire_schema_bytes": 10296,
       "tool_reference_bytes": 5255,
       "tool_reference_sha256": "fd71bca33c484bb3fb934c9486a18fc1e274917ff3cc95ef90e177e47326bb7c",
       "overridden_tool_count": 0,
@@ -6562,7 +6562,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "64a3330edea439fa8fb9fdacd1f81a66133cc4f256e7f2ac470bb5f2eea00ffb",
-      "wire_schema_sha256": "37e23fe68f4983194b7eda715844651a7b67caef71aff3d641f02997d71f7689"
+      "wire_schema_sha256": "9d05198d8f6fe5f252c0dea042255b1fda4049aa7deab37bb01c0260f9ba895c"
     },
     {
       "id": "slack_bolt:admin_working_group:community_group_full_participation",
@@ -6586,7 +6586,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13400,
+      "wire_schema_bytes": 13541,
       "tool_reference_bytes": 5366,
       "tool_reference_sha256": "b749062fe5be6a24e2d97f9299b3264bcbd84aef9c6fbabc470dc4e186a41e3a",
       "overridden_tool_count": 0,
@@ -6613,7 +6613,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1761c6fb6a24457352ea873f301ed6c24757cb0a4fed773919c1371fb343d70c",
-      "wire_schema_sha256": "a0cc93bef80d9523deb66aad071350b6ad2cc093fed8ff770c5cf2ce7940b269",
+      "wire_schema_sha256": "ae2a4ff316eb3f6cda571b706c3d47c72b904f623fbf477450a33e9a96bd3684",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -6638,7 +6638,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10522,
+      "wire_schema_bytes": 10663,
       "tool_reference_bytes": 5288,
       "tool_reference_sha256": "60f5f1015a0888599dcff1c673ebe02a5e83258c2d048256843f2a9c791188fa",
       "overridden_tool_count": 0,
@@ -6658,7 +6658,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "c6cf0f8155798e253cad3ac0be806ac43f96ca1259a860e19d265dc255d15d91",
-      "wire_schema_sha256": "9cd71c39be1813e2691d5ea448ff001cffd85464e5ba36f812c3d0692794dedb"
+      "wire_schema_sha256": "c49379c6569c8148bfec76439fb59409ede93e45094c4b65fc2dda4c83e2c145"
     },
     {
       "id": "slack_bolt:admin_working_group:content",
@@ -6682,7 +6682,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11128,
+      "wire_schema_bytes": 11269,
       "tool_reference_bytes": 5083,
       "tool_reference_sha256": "282313bd3f11de63c991eb1ca9c05498a4164020624527406eb3d21ac16e72a6",
       "overridden_tool_count": 0,
@@ -6702,7 +6702,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "284c752554ad643959685c0b0fbc1b1b5221bc3c0bf42c804731caa9a351cb44",
-      "wire_schema_sha256": "b1a8d18593b12e60f70e4d7b5f04f1f171979934591eba16dc6bf63d3b58a91c"
+      "wire_schema_sha256": "22f888fa99a27d79e9434f9738fd74a67556e1f58f46e4bcdc31b8e8cdd46bfc"
     },
     {
       "id": "slack_bolt:admin_working_group:council_interest",
@@ -6726,7 +6726,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10156,
+      "wire_schema_bytes": 10297,
       "tool_reference_bytes": 5250,
       "tool_reference_sha256": "2a9275ce948cff4e13410aedb7932cd1483a286cb9b2f729e4b987bed296009c",
       "overridden_tool_count": 0,
@@ -6746,7 +6746,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "86286a9b99f37c50106ca5b3ab9111c7b0af4d130d68d0640ccb929363610e72",
-      "wire_schema_sha256": "117775a58f2f01975ea5b101b1f11a64957762186c77e21374cea5c666bf2af4"
+      "wire_schema_sha256": "ea7cb652802c1ee0c9b4d03ae244118218032d33579555f29bf7a97f7c665618"
     },
     {
       "id": "slack_bolt:admin_working_group:events",
@@ -6770,7 +6770,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11056,
+      "wire_schema_bytes": 11197,
       "tool_reference_bytes": 5090,
       "tool_reference_sha256": "ee0839be778b2e32476815c6931204145048cdaf4433bf88e0986fcf8ac24183",
       "overridden_tool_count": 0,
@@ -6790,7 +6790,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "5751ff1ac10de94ad9b147e63d707924bb971a542515ebb9a89b5cb9446451cc",
-      "wire_schema_sha256": "afedc4bd3e025df66df66083454b5b5c8113509a335eb52289ad7fd4763ab335"
+      "wire_schema_sha256": "1237e2a89f231accdbaa9e3541aedb3ae018762173d929744cf6d065596ac9b6"
     },
     {
       "id": "slack_bolt:admin_working_group:github",
@@ -6814,7 +6814,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12701,
+      "wire_schema_bytes": 12842,
       "tool_reference_bytes": 6073,
       "tool_reference_sha256": "17d2b9fdd26009df7efeba7b01d291553c2d578f4c4b8d2f3fa952cadd338030",
       "overridden_tool_count": 0,
@@ -6834,7 +6834,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "188b898cef2ba9447f41cdc60c27bd6433d96dd606d2c429d18247d8c752753b",
-      "wire_schema_sha256": "6457216659e15cbc7f241b6ae36b0b98c4923f7673328fba7ed8c11cfe01d23f"
+      "wire_schema_sha256": "7559b3f050430dab78f8148ddb9e83afa19514cef5de15458c7f99e9fa897512"
     },
     {
       "id": "slack_bolt:admin_working_group:illustrations",
@@ -6858,7 +6858,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9510,
+      "wire_schema_bytes": 9651,
       "tool_reference_bytes": 5686,
       "tool_reference_sha256": "a08ac061f8dbe6da9867b23df6239f4f64a3605e97869e827b33ebc0aca341c0",
       "overridden_tool_count": 0,
@@ -6875,7 +6875,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "eb9a928245349898452ccbb1e46caa1b7b3ce8c7b8b765cd0f9456d8b035fddd",
-      "wire_schema_sha256": "ab732b43a4caea38eb03b1634fe091c481b207d0f683f81b0802fc3862bce661"
+      "wire_schema_sha256": "69d83bb5f1e2425bfd9c041a9fd79bdf67a9e65c42f5648d1e5bf6e0c2cd700d"
     },
     {
       "id": "slack_bolt:admin_working_group:industry_research",
@@ -6899,7 +6899,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10752,
+      "wire_schema_bytes": 10893,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "693504dc7294e18ff4127d493c1761e8d981b96ad5405a23bcc17fe64fbdd576",
       "overridden_tool_count": 0,
@@ -6918,7 +6918,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "baa3abb17c17d41290fc3a2c47b330e0ae373019cb129abb66c429199a905dd9",
-      "wire_schema_sha256": "dd7117345ddcb9f82f4035490b6598485cb6ceee9007684286adb20de4fda617"
+      "wire_schema_sha256": "8c7049bbc7421a76d2ad3c2e3ffdc56ee8b93a90761b6414f2d52e30d2205624"
     },
     {
       "id": "slack_bolt:admin_working_group:knowledge",
@@ -6942,7 +6942,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11857,
+      "wire_schema_bytes": 11998,
       "tool_reference_bytes": 6272,
       "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
       "overridden_tool_count": 0,
@@ -6961,7 +6961,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
-      "wire_schema_sha256": "c19a7e8340bc410cf6849c54d43fe762ea3cde8796b90832521c4cb4cf71c713"
+      "wire_schema_sha256": "f6bf3dde92b2d28eb26b85e932e6f2b1b6bc2d5eff122ad4e571467a58f3bcd3"
     },
     {
       "id": "slack_bolt:admin_working_group:meeting_attendance",
@@ -6985,7 +6985,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11239,
+      "wire_schema_bytes": 11380,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "5fdc3f50ba46d26ffa75ff27538a5e7e8bcef3ea837fef8fd48705abd8624725",
       "overridden_tool_count": 0,
@@ -7006,7 +7006,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "28efbd2ca8b10c2368f967e639fd7652cd7f04960ad188392ce93fda2392bdc0",
-      "wire_schema_sha256": "f39c41b8e78c64611672126ff6b8393087a60b3cb4923b7c7d43a4ed27968343"
+      "wire_schema_sha256": "7c9f5de06def5824696babe0d384b9aa60bc3b94db3038fc4a73d7cfa6cad728"
     },
     {
       "id": "slack_bolt:admin_working_group:meeting_full_administration",
@@ -7030,7 +7030,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18694,
+      "wire_schema_bytes": 18835,
       "tool_reference_bytes": 5195,
       "tool_reference_sha256": "17af7be874d34d79f1adf04bfa613c4b2faa3ea2bd74ea4ad3a91bb480be9741",
       "overridden_tool_count": 0,
@@ -7057,7 +7057,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "582f87a23ce4af178918f9bb042c999466b46904c3c9f7cbfed3dd27ab8dead2",
-      "wire_schema_sha256": "59170ff943f740317737157d7a781bb80349d107c7f6f69508f9b389329e2521",
+      "wire_schema_sha256": "b70c211ed1c3c6cb49bed93c09baef38c39849ea7df747db1bffa3ffb1e9b59b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -7082,7 +7082,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14552,
+      "wire_schema_bytes": 14693,
       "tool_reference_bytes": 5046,
       "tool_reference_sha256": "fce02e48f5ad06db1fee5ed46a2a2689371e71fdceb63cc1bd3e165515ba43e6",
       "overridden_tool_count": 0,
@@ -7102,7 +7102,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "63f1c3b48687fc9d68ddd930787a7d59561f1ba9ddb8d3698f0457486829dcba",
-      "wire_schema_sha256": "19cbd7895fd5b360a6871c5b552e565ae8e2ba0439ff80de008ba76f5614e44e"
+      "wire_schema_sha256": "232dd0f7f5208d747a5c794474720434b79d43962d28c56eda22300017e1ef7c"
     },
     {
       "id": "slack_bolt:admin_working_group:meeting_series_topics",
@@ -7126,7 +7126,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11473,
+      "wire_schema_bytes": 11614,
       "tool_reference_bytes": 5119,
       "tool_reference_sha256": "fe9228ca48c839aefda1068097db4be03171b5d2f70101b996207477ee011b43",
       "overridden_tool_count": 0,
@@ -7146,7 +7146,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "1b799fe2a16442d418c0628fec9bdc8ae73d6c67a2f1acda08a5b99c73255258",
-      "wire_schema_sha256": "d324fb9e0c1e8b1a8df594959b9ef3a70cc3920fd1949ea7cd4606f57b8dc0ed"
+      "wire_schema_sha256": "a6ef0e4690050c165fd0cda7076be36676b0bfa48f3a72ee9fe9f689946628c6"
     },
     {
       "id": "slack_bolt:admin_working_group:member_billing",
@@ -7170,7 +7170,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12058,
+      "wire_schema_bytes": 12199,
       "tool_reference_bytes": 5669,
       "tool_reference_sha256": "61c7298906378b4f2f154f7275a9f56c9102bfb6247ae654a3861f7cc8895b98",
       "overridden_tool_count": 0,
@@ -7191,7 +7191,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fadd2a88b06fed26c92e0d7683ee842fc67f84dfe3c44dc3db122d8443d955cc",
-      "wire_schema_sha256": "c2c14c5784576cb740c7b6f99d57443525eae812133e1764f7c9c44e9d525a62"
+      "wire_schema_sha256": "93b1a6a28f614100aec1b9804ebf98462ed20f1705b90f5f77844b49459254a1"
     },
     {
       "id": "slack_bolt:admin_working_group:member_company_profile",
@@ -7215,7 +7215,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14940,
+      "wire_schema_bytes": 15081,
       "tool_reference_bytes": 7179,
       "tool_reference_sha256": "b0aa1c7af0bf4591e4177f3a8127c527154606d4587dc08756e7f18105e83bb6",
       "overridden_tool_count": 0,
@@ -7236,7 +7236,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0e1b8aa348778ebfd306f8e063d3984473a27d9aa3475eada444f6cfdba0bfea",
-      "wire_schema_sha256": "7537b15dd2395d96fda05841d4378fe5aa4357bef70d9cd7f09b2da02a47fd91"
+      "wire_schema_sha256": "7b5e7201ecfa6b413eb78c9286cf4b047ef55fc178665bc55a0bda1331a4d963"
     },
     {
       "id": "slack_bolt:admin_working_group:member_personal_profile",
@@ -7260,7 +7260,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9709,
+      "wire_schema_bytes": 9850,
       "tool_reference_bytes": 6603,
       "tool_reference_sha256": "1be10e69d1c2468a8f3619e586e9b7cd0fb80f57e737ceb7614f552e89795e0d",
       "overridden_tool_count": 0,
@@ -7278,7 +7278,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "278d2a60ad51f3a69b5f03330f7f2b7d3d4a8ff98509f14e558cba79fe3c6e7a",
-      "wire_schema_sha256": "ff1df39b36fdc7627c9c15607a9430d3e0ee3bc271294fbd4adfbf2c6b863edc"
+      "wire_schema_sha256": "40b3a07842f235277a229615209ef66121aef314b998e85c2d866bdc980d9f21"
     },
     {
       "id": "slack_bolt:admin_working_group:outreach_contact_management",
@@ -7302,7 +7302,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10589,
+      "wire_schema_bytes": 10730,
       "tool_reference_bytes": 4957,
       "tool_reference_sha256": "978d81ac4be58b4e5f0c59260b589e96a95acd041895d6e47cb238614e05642a",
       "overridden_tool_count": 0,
@@ -7322,7 +7322,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "53eb64b204251c7934442c3397a72020de3c911f9c3d29dec3d2d239591e1aa5",
-      "wire_schema_sha256": "0fed13e32364c9ec0ca1f839f71f05aa6215c616be36f94d6c5acf78200d1f5e"
+      "wire_schema_sha256": "204ec6558f12dd0ca3621e36c719d8fdf2d9d1697b4006410e380cd706a221ff"
     },
     {
       "id": "slack_bolt:admin_working_group:outreach_reporting",
@@ -7346,7 +7346,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10160,
+      "wire_schema_bytes": 10301,
       "tool_reference_bytes": 4949,
       "tool_reference_sha256": "deb6aeea7143042d8abb8afc908abe958eb2c6bb562fd6e31b92162b7c6e4a7a",
       "overridden_tool_count": 0,
@@ -7365,7 +7365,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "9fea2f2b6f7bd11b93a4c4b87e0034f358fccbfe72dbed4ca9c9f45d3030d677",
-      "wire_schema_sha256": "02874ad0cff3f58ac2dd0dfb07d6fcfc5fb113471151252ce1818b4002f645a7"
+      "wire_schema_sha256": "f9579b024ed866df5ee027174ee45ef12edab77db4d3adfd2988fb152b022ea4"
     },
     {
       "id": "slack_bolt:admin_working_group:partner_directory",
@@ -7389,7 +7389,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12140,
+      "wire_schema_bytes": 12281,
       "tool_reference_bytes": 5179,
       "tool_reference_sha256": "2f1bdba181f4d89bed5f22bf21f070d49964f094ed9aa1638220d2e53bd350bc",
       "overridden_tool_count": 2,
@@ -7410,7 +7410,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4abe43bd711dba6f2b371f991a37f3044b7efe029af19169bc8a891e3030cc0a",
-      "wire_schema_sha256": "cf87115ba620f6fd6f3045dce2a749ddbf5b0aa17006042f4f4563fae18bfa28"
+      "wire_schema_sha256": "99c51e38c04dac4354fec601c2074df2998c042d6faef38de5a38a333f6911c7"
     },
     {
       "id": "slack_bolt:admin_working_group:property_identifier_catalog",
@@ -7434,7 +7434,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11416,
+      "wire_schema_bytes": 11557,
       "tool_reference_bytes": 5284,
       "tool_reference_sha256": "13831dbee6b1a3c7cd6921429eec948d1b4ee446eddb9e088ed00d7939de7a8d",
       "overridden_tool_count": 0,
@@ -7453,7 +7453,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "3f40589842d92252f4c31df951f3dee47f90d694f6c84fd40cf99beeaac51b90",
-      "wire_schema_sha256": "c01fbe920fc10285094b8a60c6f6af3847a1a37b29e6c0d90fef91995259a972"
+      "wire_schema_sha256": "5ba5aa78aa1a96c657d35cb754d05923078374df5c13446e4d49c892d86f8f25"
     },
     {
       "id": "slack_bolt:admin_working_group:property_list_enrichment",
@@ -7477,7 +7477,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9523,
+      "wire_schema_bytes": 9664,
       "tool_reference_bytes": 5133,
       "tool_reference_sha256": "90a495e511e631244025479c57aabdaf44869fbda341849f33d6e5d82d1d4f98",
       "overridden_tool_count": 0,
@@ -7495,7 +7495,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "59cd9ba8c99ea5efc46a5ba3c8ff57fa5a02855f68171dade0e196583ed1c95d",
-      "wire_schema_sha256": "495d3ed783c97fe3e3043abb2e61ca20ff7297896a131b36bfa9d8c49de3d665"
+      "wire_schema_sha256": "fda96b55972fa731d69e54f8bd8691f6f24cb9e5ef3ee34273e2d2ebb6100bf8"
     },
     {
       "id": "slack_bolt:admin_working_group:property_registry_records",
@@ -7519,7 +7519,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10786,
+      "wire_schema_bytes": 10927,
       "tool_reference_bytes": 5362,
       "tool_reference_sha256": "f8db16b555a1cd7f2ed5547a7decd4a45c47a371d05b447825d9d6bdd7f1477e",
       "overridden_tool_count": 0,
@@ -7539,7 +7539,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "4efc04fd88ef1fba8495a1fffe10779d36410775b793777bff55a3dcf38d2773",
-      "wire_schema_sha256": "60bb471663c9a7f158b98d531e7f5e5842b196dc4abdd29be1bbb264f3a31f5c"
+      "wire_schema_sha256": "fd0aeac830426617253183c886b87c7620f6b8cff41d483e99ffb9bdd4009b20"
     },
     {
       "id": "slack_bolt:admin_working_group:publishing_assets",
@@ -7563,7 +7563,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10900,
+      "wire_schema_bytes": 11041,
       "tool_reference_bytes": 5087,
       "tool_reference_sha256": "d56011932cbd50f96ac3191be635143521775a2fcd9567d4ebfa3e8d1f9dab77",
       "overridden_tool_count": 0,
@@ -7583,7 +7583,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fdc3b16e146cb1098e8fbe4e560b521d8c72da0febb5a43e18a4ee5d4f43a2b7",
-      "wire_schema_sha256": "8a975d08f355c8c1b1a18df73015a16cd316a15fe949632eb8869510138b0785"
+      "wire_schema_sha256": "4821ac40e06fc1d64c6110ba18ecdaa9e46d7b5372cca121aaa3b140b1975a2a"
     },
     {
       "id": "slack_bolt:admin_working_group:publishing_promotion",
@@ -7607,7 +7607,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10385,
+      "wire_schema_bytes": 10526,
       "tool_reference_bytes": 4976,
       "tool_reference_sha256": "242b8d1ee88bacff1da83025b9e31abcd0c9fd9b15b567c26cb829ad3db59588",
       "overridden_tool_count": 0,
@@ -7625,7 +7625,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "914e5042ff5aa77185e5f5ca8e9a05f1a41124bbd8ba8b599080f70efb9c7b83",
-      "wire_schema_sha256": "b772f60aecc8ffa0350d81313e7deee857d45eca4f477455d1f4e229517b4071"
+      "wire_schema_sha256": "acd6fd57e8b76ec32feaf2bd22e8ecddee3c7bb925f8a55f8f7d7bcc670388e1"
     },
     {
       "id": "slack_bolt:admin_working_group:publishing_review",
@@ -7649,7 +7649,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10229,
+      "wire_schema_bytes": 10370,
       "tool_reference_bytes": 5157,
       "tool_reference_sha256": "bbd74b8e4738835551b2440b98a1ae56d7846f2d971933af09ec972ed5b40682",
       "overridden_tool_count": 0,
@@ -7669,7 +7669,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a895f645f68398d3e561173892a44e31eaa1cfdfa5dfa74cd3cdd30c833aadda",
-      "wire_schema_sha256": "c5caa7ddc47fa48618ba74b09cc76301ba5554af9e9c2df7d4a555c514b3aa19"
+      "wire_schema_sha256": "4827ac2b31737f015deea00bd512859c97ee3b6fde1b4453b02d30e6b290c16e"
     },
     {
       "id": "slack_bolt:admin_working_group:publishing_submission",
@@ -7693,7 +7693,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11917,
+      "wire_schema_bytes": 12058,
       "tool_reference_bytes": 5933,
       "tool_reference_sha256": "4368a4534a12db25c52e70aa2e4d45ea9f359786531bfa7a1549cb7622539813",
       "overridden_tool_count": 0,
@@ -7712,7 +7712,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0c9654e2c90afb77d7cb1482baf49531c1dbf1d6ad96e89d9065e2845f0ef290",
-      "wire_schema_sha256": "9a8526aca39c98e9fbccce4ea348015f2d50c43dfe2f91780ef55143f5e29f6b"
+      "wire_schema_sha256": "71574736fbd843f0f486ad2dc5567c674c6e7b7158fbac11a29825a3c54dddf8"
     },
     {
       "id": "slack_bolt:admin_working_group:router_unavailable",
@@ -7736,7 +7736,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18794,
+      "wire_schema_bytes": 18935,
       "tool_reference_bytes": 7427,
       "tool_reference_sha256": "8627374abce19cb49e5d04a1bb04037a237687c86a96db2f00e71947f5cb5c29",
       "overridden_tool_count": 4,
@@ -7765,7 +7765,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "868d8863be91474176cbcfd36d94f2979be7e745dd75ec1f747bf5ac0a3c9790",
+      "wire_schema_sha256": "7c7fdf09cb6dfd92d4f71b7ef4c7537c641350dd5cb7316928a139852dfbe9a0",
       "target_exception_category": "legacy_channel_router_continuity"
     },
     {
@@ -7790,7 +7790,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11005,
+      "wire_schema_bytes": 11146,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -7810,7 +7810,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "443689ec626f64502248bcf217d42ef60900891d9a4163e30f52dba93a237984"
+      "wire_schema_sha256": "fb719521c0abe29641c041144222f371429552b112530b64a7ada5244f864852"
     },
     {
       "id": "slack_bolt:admin_working_group:sponsored_intelligence_discovery",
@@ -7834,7 +7834,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
+      "wire_schema_bytes": 10334,
       "tool_reference_bytes": 5309,
       "tool_reference_sha256": "3a8d840efe998abbd5d636abcc586fe5889c3e1282e0bd5e503674461bcd0dd9",
       "overridden_tool_count": 0,
@@ -7853,7 +7853,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "273d2551a68559859045673bd43c47271fa94a6c2d964d52ea97b3ddcc82a3e1",
-      "wire_schema_sha256": "14fb233d8d227dfabb95f29858a9676478f4da482b6872205d51eae2494fc8e7"
+      "wire_schema_sha256": "50638db9f4084536bad895819c3394c83de09b7038f2177a0df409d83ff1da97"
     },
     {
       "id": "slack_bolt:admin_working_group:sponsored_intelligence_session",
@@ -7877,7 +7877,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9712,
+      "wire_schema_bytes": 9853,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "a6db91f7f951d33d2386aa95c8902dc13d042413c343658a7764921db30faba2",
       "overridden_tool_count": 0,
@@ -7896,7 +7896,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4374fdf27f7f4d8646711d9cd15247ada5ff2a909ed24cfbd9b847b40c6fe3e7",
-      "wire_schema_sha256": "cd9443cf3509268c019d4d7528f0a9b650efcff272b88d9653863825f1a2f41a"
+      "wire_schema_sha256": "f2795405837d1a84a8998ef506930127f587d4a073fbf730249dfd9dc989a10d"
     },
     {
       "id": "slack_bolt:member_dm:certification_assessment_session",
@@ -7922,7 +7922,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28573,
+      "wire_schema_bytes": 28714,
       "tool_reference_bytes": 10435,
       "tool_reference_sha256": "5c2c2d615bbec18e17501a7dddf9cafb9b8e379b3fb25a8ec8932b5a198f252e",
       "overridden_tool_count": 4,
@@ -7959,7 +7959,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "26b6cc3a42587a710c7baa1a374ce45cfe41c97040fffeebc1c464c7a8e2f415",
-      "wire_schema_sha256": "bb5f472a4e6a6f4883b2e93c987d974865339b4dae801ec3bbbde24b5f2d39af",
+      "wire_schema_sha256": "286f643899d7ae1e77013984ae0326b681f9333d597f0ba172ef8b91d55734fa",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -7986,7 +7986,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29476,
+      "wire_schema_bytes": 29617,
       "tool_reference_bytes": 11672,
       "tool_reference_sha256": "b70024ce69d5774ef0b18573e0df152dd02ee2c0cbe5cced7d1a4e638b43228c",
       "overridden_tool_count": 4,
@@ -8024,7 +8024,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "3fea176c7247ff2d3f96cfbc3bb1d8586d83c37c1dc090253111c1fa67c78d06",
-      "wire_schema_sha256": "035bf0bd619942bca6a57b3e50cc98351297014f96d70d9516138a84ff45c0b7",
+      "wire_schema_sha256": "df05265a6a3c9f4ff2db8eedab215a1c8f2301ba0141b9b08c002354903c7486",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -8052,7 +8052,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 31925,
+      "wire_schema_bytes": 32066,
       "tool_reference_bytes": 13827,
       "tool_reference_sha256": "c1d970e8a838ab127d4f716b5261ddae5690e4d0d8d643b08bd8ee7225fdce4c",
       "overridden_tool_count": 4,
@@ -8093,7 +8093,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "ecb4a361ac31c3fdca960be469fd56589b0538d5c5e135811326b45943f17cf2",
-      "wire_schema_sha256": "01a851132a69873e5c0588ccca567f628b1a1fe2ef816fbd3cececd8e699d850",
+      "wire_schema_sha256": "cbbeaef80532980bf7e8b80694e34b2e8f6adae12409f1b883b875b0cf9f779f",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -8121,7 +8121,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 22358,
+      "wire_schema_bytes": 22499,
       "tool_reference_bytes": 6089,
       "tool_reference_sha256": "2dedd93f34bb8bb96a840a2650e817f7f883931785541ffec854710e6ef68489",
       "overridden_tool_count": 0,
@@ -8160,7 +8160,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "a9e974b90b45f7a06c5f20a790efe7b1b48c32b69e1a546e1d30531a3a617a1a",
-      "wire_schema_sha256": "772e82bf18df11171a0929159b29a564160f9e30c383416a49a2ea4bbae32792",
+      "wire_schema_sha256": "f6440a41f9a66135dac9dfb70cdcd0938071233062b8c54937eeff50774a4187",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -8188,7 +8188,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25824,
+      "wire_schema_bytes": 25965,
       "tool_reference_bytes": 10864,
       "tool_reference_sha256": "c1c660ec26e128b9aedfa96fe0c1b85588c45a7221f7b9a141e2f0aa9fa0b174",
       "overridden_tool_count": 0,
@@ -8220,7 +8220,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bc9f123436d9760c4603abb2386e0a63c7a9f53e4c0d65adbb0041de8bf1177f",
-      "wire_schema_sha256": "7289863f271c2017a3f62f0b98b9a8d54c99fcd9a3692f0e5b6b88a842526c95",
+      "wire_schema_sha256": "7bcc5517a1af44cce605df3e17b8e10b9276c299a4cd12918c5e61226a02d0cd",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -8248,7 +8248,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30699,
+      "wire_schema_bytes": 30840,
       "tool_reference_bytes": 10321,
       "tool_reference_sha256": "c345073241bbb0aa78ef7366d2c97b3f776183a69a3acab73fed9bba457eb861",
       "overridden_tool_count": 1,
@@ -8285,7 +8285,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "9e5d653068e798450e6ec1d154f075d580807f8ca567abb56644ecefe15c3ba3",
-      "wire_schema_sha256": "56e2399081e01b8176ecba4966476a9c75b86f67b815894fe7cd25eb0c32631a",
+      "wire_schema_sha256": "83e72e59f7426d4db729dc7518aa7378fdf07fc439ac9fb1f196901c3102b23e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -8310,7 +8310,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13166,
+      "wire_schema_bytes": 13307,
       "tool_reference_bytes": 6262,
       "tool_reference_sha256": "3d2ccbb6aba85bd38419a3d9045f5707e4d0f0ba6be27a89a1d1fe8143715007",
       "overridden_tool_count": 0,
@@ -8328,7 +8328,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c0d2d1533050187c0d555031976948036cb84a1b937814f81af6b77701972ab0",
-      "wire_schema_sha256": "1dfd23f8107e98dd592c8c633949e3314b854147b63e602c40d3f736e0e8d047"
+      "wire_schema_sha256": "bbefddd5ad515565950049ea6a7e1ba108020755a2d9c8e58a7d489dfacfd91d"
     },
     {
       "id": "slack_bolt:member_dm:routed:adcp_task_operations",
@@ -8352,7 +8352,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11614,
+      "wire_schema_bytes": 11755,
       "tool_reference_bytes": 6310,
       "tool_reference_sha256": "04603aeb0ae569596b5ee5fd6be628303bece3bf65625633a68f9e6e2879d538",
       "overridden_tool_count": 0,
@@ -8369,7 +8369,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "29439abce5e792eca86c1ba105cd40eb03da5b67c1d77aa7808478a7f6817236",
-      "wire_schema_sha256": "010bdffef19c5bc0be999224bc9860ed0c919e0ef770efbdd235b62e4099f3b0"
+      "wire_schema_sha256": "7474c9abc30ab1714ffacdf911cf38b29cbf346e15bbf9c7c6068b6a42b14b5b"
     },
     {
       "id": "slack_bolt:member_dm:routed:agent_authentication",
@@ -8393,7 +8393,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8979,
+      "wire_schema_bytes": 9120,
       "tool_reference_bytes": 6000,
       "tool_reference_sha256": "b937948691c576fbcb7f1b179d3d84d2fd8ee5354cf0e9ec23e02728eaf9d3cc",
       "overridden_tool_count": 0,
@@ -8409,7 +8409,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "aa35268403f3b37ff1f3ae0b78bfd8f2fdbefc392a5d3546fbeeca83ca5c6ed7",
-      "wire_schema_sha256": "e616084893239a3360d038f27f027e253460b07d34eb9fa2cd3902a5c7764906"
+      "wire_schema_sha256": "c32fecfcbf637c9b547a939f7c850f3e46c387cef5a396b4193986ae68a49771"
     },
     {
       "id": "slack_bolt:member_dm:routed:agent_conformance",
@@ -8433,7 +8433,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7684,
+      "wire_schema_bytes": 7825,
       "tool_reference_bytes": 5724,
       "tool_reference_sha256": "bad9128b97000bf1d5dbea147ade01da67d7d91a01c53ae5d7664090e3060f23",
       "overridden_tool_count": 0,
@@ -8449,7 +8449,7 @@
         "run_conformance_against_my_agent"
       ],
       "ordered_tool_names_sha256": "166257c2827756df7f041cafac875520b810ea3f464f68f15502906bb3dfa3e3",
-      "wire_schema_sha256": "2290b7005932c8517950883ff3608abc713aa3ac37b382240e67ff3dfb82df96"
+      "wire_schema_sha256": "bb17e454b4e2377185654c1b61b52ebc2d55212c31c16e4d0b05355c7aa80b8f"
     },
     {
       "id": "slack_bolt:member_dm:routed:agent_end_to_end",
@@ -8473,7 +8473,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17521,
+      "wire_schema_bytes": 17662,
       "tool_reference_bytes": 6568,
       "tool_reference_sha256": "724c570df0c1afbfc5474f247fa2d289e56582171e19ca033a263bf4a38a8591",
       "overridden_tool_count": 1,
@@ -8497,7 +8497,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "01a4e47a1d56a06a49d88c67cef7541d40b7a79d196a034be57130c9182aec3a",
-      "wire_schema_sha256": "ae3d112fe6f349ce16eb5ff5bf6b45ddd72f909646f9c8ecefcaf5d21ac4e7f4",
+      "wire_schema_sha256": "6afb8588ca2c5e02009d4a1a32f0cda3e013daa9acda61c3e7f3ccd3703ae544",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -8522,7 +8522,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7656,
+      "wire_schema_bytes": 7797,
       "tool_reference_bytes": 5049,
       "tool_reference_sha256": "e864b0a33e55d3e7caf062c73af9a521bbcf2a8494a6f1c34e42fcbe54749910",
       "overridden_tool_count": 4,
@@ -8540,7 +8540,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f44279c0b16e64b09a8a1fdd183eb3b82606b5477a249986eae941d027b18aca",
-      "wire_schema_sha256": "03b93c5ac8de474e43c6586f7b8fc43fa9147b8e241dde51a8c6ea15735e3c8e"
+      "wire_schema_sha256": "6ab6dbf06b50ba07dd90c9de354c870af777499e851295d577ff9deb91d2b900"
     },
     {
       "id": "slack_bolt:member_dm:routed:agent_quality",
@@ -8564,7 +8564,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12358,
+      "wire_schema_bytes": 12499,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "815eb22df22b1d8f37c869018b9c5e49c83178001b26f1e7523ce09aec7b230e",
       "overridden_tool_count": 0,
@@ -8581,7 +8581,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "32ee638aa5b9177bbea802803498f87f715d059b195e4d0492e56312ff6c9cbe",
-      "wire_schema_sha256": "0a2850d80b2523a669874d940a93a714c73e21f8db67a61371a50c644e019815"
+      "wire_schema_sha256": "a1d8c157b5a199141179bc09a30808ecde2c99bd7975c39ef01f6aa21dc55634"
     },
     {
       "id": "slack_bolt:member_dm:routed:agent_registry",
@@ -8605,7 +8605,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8750,
+      "wire_schema_bytes": 8891,
       "tool_reference_bytes": 6633,
       "tool_reference_sha256": "e78fc94ddc9de419855cc10bf05d7a05126c4c50f23abc99d90fc08c530ccdf3",
       "overridden_tool_count": 1,
@@ -8624,7 +8624,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "173718fd9ea51f05c1519f70f4cc6eb81dfb5d82d81ebdbee0e77ccbbefc7f20",
-      "wire_schema_sha256": "78162fb4f54d37c139b4848053f9a14cc789980322d3bc746b40dec9d28f20bb"
+      "wire_schema_sha256": "19bfc0421c37c4f3a9d4840a31de433186c9fbed08527c767b8e959b88d88cab"
     },
     {
       "id": "slack_bolt:member_dm:routed:brand_registry_identity",
@@ -8648,7 +8648,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13863,
+      "wire_schema_bytes": 14004,
       "tool_reference_bytes": 5549,
       "tool_reference_sha256": "3d9e0ef13806268f909fc694acc66e88b75809de91dd343dd2282b4a731b3571",
       "overridden_tool_count": 0,
@@ -8667,7 +8667,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b183eaa3b6370d563884bbbc1e78d71e105e4b5f8090cdc9dbab0c1041ab8496",
-      "wire_schema_sha256": "cb9f26b443ec2248eb32899ea66a162d73cd3c843ce1e528ee30260bdf87dbd1"
+      "wire_schema_sha256": "98e43b568bb5469b0ff5d4acb2a842141f8bebb8f69ef79f134f7d0fc96452c6"
     },
     {
       "id": "slack_bolt:member_dm:routed:brand_registry_records",
@@ -8691,7 +8691,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8773,
+      "wire_schema_bytes": 8914,
       "tool_reference_bytes": 5212,
       "tool_reference_sha256": "7bda40be2f135095e28761f77dda59f399bd5198a9cca4cc4de885041d8207b7",
       "overridden_tool_count": 0,
@@ -8710,7 +8710,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "216e020594d4d7a8339e16df0fae6761fe628a994db86d295e96d4f3ab6f1d54",
-      "wire_schema_sha256": "9e0084841f9e18256a2159684d8c9347a23a741dd01947551450c303b0afd62d"
+      "wire_schema_sha256": "5311aeaf6c65dab26e2f453ac37453da99760b1d707b7ee420bda6d440e30bce"
     },
     {
       "id": "slack_bolt:member_dm:routed:certification_assessment",
@@ -8734,7 +8734,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17423,
+      "wire_schema_bytes": 17564,
       "tool_reference_bytes": 6852,
       "tool_reference_sha256": "414adb08a79ac4142a2967f857c3abb49345cd48daad70100e6a1762b980779a",
       "overridden_tool_count": 0,
@@ -8757,7 +8757,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "790df4634084e2fb5c430ea95d47b4aad105e5cad065f2ab1b3694405e550c02",
-      "wire_schema_sha256": "7fe9a986cef51874ba191843beabca61d9be8169bcf4c1661776f50e4627bdf5",
+      "wire_schema_sha256": "0b3889df9d691e023e2b17a45e8c42fa2bfc6e75a90db8afc0aaa43aa894a651",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -8782,7 +8782,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18326,
+      "wire_schema_bytes": 18467,
       "tool_reference_bytes": 8089,
       "tool_reference_sha256": "346659796dfa0cb862a77cb3dbe215b925a8c59aa3c0296e22a0af15cf384ba6",
       "overridden_tool_count": 0,
@@ -8806,7 +8806,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "463fa4659a702b7f1c65e0598b3c1d0340c915ba31ad3efd626031cc85c502ab",
-      "wire_schema_sha256": "224579a89b00e02213dadd0c0ee850514160d0b1de2ff70d6051fc62971c5bb2",
+      "wire_schema_sha256": "480faf32e4985700bc768db1fd7c08c691713b9ad363d36240983a299174440c",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -8831,7 +8831,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8327,
+      "wire_schema_bytes": 8468,
       "tool_reference_bytes": 5646,
       "tool_reference_sha256": "9a53ee96acd89cd57b17a1e2eefd7db0579223584a0a08c489b75fae2dd819e7",
       "overridden_tool_count": 0,
@@ -8850,7 +8850,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "cf9fc5e1f9fa1da6e4fab7287829c6367f01894d0fe2e1dad8c4ccc244ce8048",
-      "wire_schema_sha256": "8d674770df02dc173a35c04b26bda66251d51506e3aff4d0002cb5aeeaafe10b"
+      "wire_schema_sha256": "8082725b3570063223db9c483d4e4e092876bfb3e19ea38446fc764ac26d37d3"
     },
     {
       "id": "slack_bolt:member_dm:routed:collaboration",
@@ -8874,7 +8874,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7537,
+      "wire_schema_bytes": 7678,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "068dd1ae345e461198b3955d26166dcd9bf6d94102993b93f7c2c6115a642fef",
       "overridden_tool_count": 0,
@@ -8889,7 +8889,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "91b057a3704a11380e0df622192c815eb5c43e514d3701109890f421f27a6561",
-      "wire_schema_sha256": "7d56e0c735dc09c3b7c8ab8b6c4bc04dc5e489fe7b23070a35896a36fe18ae0b"
+      "wire_schema_sha256": "7bc2452f52378498e733ff13b1a665d9f6ed7fd8336e49fbba7ca91331fba0c6"
     },
     {
       "id": "slack_bolt:member_dm:routed:committee_co_leaders",
@@ -8913,7 +8913,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8867,
+      "wire_schema_bytes": 9008,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "6c3e8581decba525396c1e53df2d6afaf7aa6e9b5bf80df401e63e1cda3bc0ea",
       "overridden_tool_count": 0,
@@ -8931,7 +8931,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "063596a30c0f4e99cfdd77779d92a7145e459caff78c9dff3604043a9ae8c59c",
-      "wire_schema_sha256": "ef2df999c1e0e89e3a4d2f29e58c096f2a05db5781b97ab22681cf724593a156"
+      "wire_schema_sha256": "ab974565c5b82fadcde3f73292631edbe36a14535a1c668bb7dc19112b30549d"
     },
     {
       "id": "slack_bolt:member_dm:routed:committee_event_planning",
@@ -8955,7 +8955,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10453,
+      "wire_schema_bytes": 10594,
       "tool_reference_bytes": 4869,
       "tool_reference_sha256": "07ca352ac259a3f7ba7fc6d292b3d7651993267bcef116dd2b83d8e407d50ad0",
       "overridden_tool_count": 0,
@@ -8972,7 +8972,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "61b15f24d4412ef90e46e186ee894b94fd1934ec2c87650d4ffee7284407076a",
-      "wire_schema_sha256": "af63723c8ec93ac60a616fdbf98cf77bb6c6ec6ab539d57585bb1fa943fdb86e"
+      "wire_schema_sha256": "a3b5babe3fae195cd6181062015bebbaa2db05fe94d81f0cc7e3095c79b5a78b"
     },
     {
       "id": "slack_bolt:member_dm:routed:committee_event_registrations",
@@ -8996,7 +8996,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9177,
+      "wire_schema_bytes": 9318,
       "tool_reference_bytes": 4926,
       "tool_reference_sha256": "648cd8b0d8d84b2a2208c82f366b7ac9f4e84dab8bdfc5e72160c898d80f29a2",
       "overridden_tool_count": 0,
@@ -9014,7 +9014,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "369b9218680099ed68bc9d5552efe5f4446c5b4792ab573e9e890c507a44185f",
-      "wire_schema_sha256": "41344247ea67693b5b673df108a1a293f73e872286bcebe60e0390a5465f4480"
+      "wire_schema_sha256": "e3502e6d2b036fcd84070f1ac13a3da42fef4115deecbffa7e7deb40be149a92"
     },
     {
       "id": "slack_bolt:member_dm:routed:committee_full_leadership",
@@ -9038,7 +9038,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14897,
+      "wire_schema_bytes": 15038,
       "tool_reference_bytes": 5204,
       "tool_reference_sha256": "73a64178cee70c326c45c27854fa4b29f61c9dc4203c20deb8cdbde7d932d29b",
       "overridden_tool_count": 0,
@@ -9061,7 +9061,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "3ef51ef6c23dc0bb939300d94c013762dcc27966aecdaaa1260aa3786c167cdc",
-      "wire_schema_sha256": "904072f3004a6f52d211601a328088912734622ae51622caaaebcde80b08f731",
+      "wire_schema_sha256": "b30205b328e7ca8969df567373277d78f4729864a0c27005b635a125e754c8dc",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -9086,7 +9086,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8617,
+      "wire_schema_bytes": 8758,
       "tool_reference_bytes": 5018,
       "tool_reference_sha256": "121afdcbf592ca6eedf859b93dbc32a0d10f046be5c82a3d40caf6752209cb51",
       "overridden_tool_count": 0,
@@ -9103,7 +9103,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3b942e3d6661676eadfeadf4a6ef255eb2bf7031897813df8e9ea1e49e22bf56",
-      "wire_schema_sha256": "14006ec0e717dcc82409b234aedee5878c460c5d7ab99c4cf7a016ae32cc4b5e"
+      "wire_schema_sha256": "af8905a330bc38b22c20d974cb2bf9f4bace445e41bd3215d2a7b541e89d4c4e"
     },
     {
       "id": "slack_bolt:member_dm:routed:community_group_contribution",
@@ -9127,7 +9127,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7818,
+      "wire_schema_bytes": 7959,
       "tool_reference_bytes": 5246,
       "tool_reference_sha256": "152900bc3d9f41d32d451c4ac8be8c23f69dffadbc08ae9ca8bc2096f1afcbe8",
       "overridden_tool_count": 0,
@@ -9144,7 +9144,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d0d8e5d8794d84fcbc14242245599cfffc6efdaf2f0c95c364b38bb8d6d2d726",
-      "wire_schema_sha256": "6a8c30e0c92df59895e554df7e745d6fef443088a09d3f6cf9956611d1b3270d"
+      "wire_schema_sha256": "794be7c89294c0994e2119f91ac06b4b5e07d3dbb20efc15a4e271923e54751c"
     },
     {
       "id": "slack_bolt:member_dm:routed:community_group_discovery",
@@ -9168,7 +9168,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7861,
+      "wire_schema_bytes": 8002,
       "tool_reference_bytes": 5187,
       "tool_reference_sha256": "d0e9bd5129bd8760c05e98f921ccc95426fe90e70d6aef554bd686fdfcfa5d0e",
       "overridden_tool_count": 0,
@@ -9186,7 +9186,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3ee5d15eafe1c588bced75166f704e89aab43275266d8b47ba666388fa23ca6d",
-      "wire_schema_sha256": "44415464c14f4750bf57e001721a201670761b6beeb6d3b64e0314e6baa65682"
+      "wire_schema_sha256": "df63d6fd395cf19acf04212a86e6f017d21801bf89a1fd13cdf1488f0e991679"
     },
     {
       "id": "slack_bolt:member_dm:routed:community_group_full_participation",
@@ -9210,7 +9210,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11106,
+      "wire_schema_bytes": 11247,
       "tool_reference_bytes": 5298,
       "tool_reference_sha256": "80fe2d2700902546fe5e83a4dabb0972bd02912c7f3e4a4c30b3d63a7f11c144",
       "overridden_tool_count": 0,
@@ -9235,7 +9235,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d84555d6b82afdd6959fa75186599e3cb0eb59ba7ef4fc9bdc342620712cf0f9",
-      "wire_schema_sha256": "dec4c8306907826d97cb014172aaabc8a1813780abe21071bda8d0c09f56a48a",
+      "wire_schema_sha256": "23f519cf63cf92e41183131c60e30587cd7809627864cb4f6a6c7e0fc396ea74",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -9260,7 +9260,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8228,
+      "wire_schema_bytes": 8369,
       "tool_reference_bytes": 5220,
       "tool_reference_sha256": "24ab86bf1679054829bd2cd425f87f559118fa501aaaebd060429615a876d5a5",
       "overridden_tool_count": 0,
@@ -9278,7 +9278,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "93da32ba816b1c3678855eacc260dadf902727d23ccb7c524d29e132b1b31551",
-      "wire_schema_sha256": "f6ee5d3de237607b436dab4f7f332f67fb5fafa3b5db5ffa3db30e83fc13d06e"
+      "wire_schema_sha256": "6783b521c6665b4ae2e51a99d16dbc0a09776486e1be4d69f905d8092c700cc9"
     },
     {
       "id": "slack_bolt:member_dm:routed:content",
@@ -9302,7 +9302,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8834,
+      "wire_schema_bytes": 8975,
       "tool_reference_bytes": 5015,
       "tool_reference_sha256": "ff49e5adf006709f1a45aa0a9af51aa9f8a7f85e224c512aea4dad1fc291b2ea",
       "overridden_tool_count": 0,
@@ -9320,7 +9320,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "82ce1e649afc38958ef06db762d13fe999ee4b04095ff5d5044344ac7fce4e7a",
-      "wire_schema_sha256": "950976d1ed4068184b73e7c853f123f95d5b443b039f7872105816915d9c378b"
+      "wire_schema_sha256": "79ec89ff0a645818b29e0203efacbd531835cab5f5191ac3a88571a1d3b20b73"
     },
     {
       "id": "slack_bolt:member_dm:routed:council_interest",
@@ -9344,7 +9344,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7862,
+      "wire_schema_bytes": 8003,
       "tool_reference_bytes": 5182,
       "tool_reference_sha256": "00a0d6dd08ec9626b5f39dd01e60f62a4c0d6b052136b3cb8186188c163e9ce7",
       "overridden_tool_count": 0,
@@ -9362,7 +9362,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b6f0d8f9b4251533f855be149de6d5f265bd92f498ff458283723dcba93d547a",
-      "wire_schema_sha256": "e0224c9085f0e6f6006568a08ecf325ce6b2380cd8211a275cd65f718262085f"
+      "wire_schema_sha256": "7c4b1ed6479478e8230803c538d540f37d87d96a63fcde05e121128c60b3ff07"
     },
     {
       "id": "slack_bolt:member_dm:routed:events",
@@ -9386,7 +9386,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8762,
+      "wire_schema_bytes": 8903,
       "tool_reference_bytes": 5022,
       "tool_reference_sha256": "d0d0a800352042ec9c342399e44ba8df2453093ceb8854bcd9b2210d7d67c138",
       "overridden_tool_count": 0,
@@ -9404,7 +9404,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "dec8b1e73a67b4044e464a8ada67f64611e9cdbe2683c0e7e5fe8732aad1dd0d",
-      "wire_schema_sha256": "c66df15de10255687d4d0200d52556b0ab8b57c5c69814399ed31a74e4935b05"
+      "wire_schema_sha256": "673bb0e6c25a1321be42f8c7d4cd0ad374bd40430ffef5fdf381a20ec034a800"
     },
     {
       "id": "slack_bolt:member_dm:routed:github",
@@ -9428,7 +9428,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10407,
+      "wire_schema_bytes": 10548,
       "tool_reference_bytes": 6005,
       "tool_reference_sha256": "153b3f7994700206e694fde53f0dd0a55ff7bd73f6fbe7bbdd3133068c3a57ca",
       "overridden_tool_count": 0,
@@ -9446,7 +9446,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e7cde1aedf4ffdc3722e9b8d80a15e06e7a92767847470acbf77aaa7294c402",
-      "wire_schema_sha256": "c2e6b031ee991457569e82e13ffc2893cd2309f0eb8eed7483ee0573acc504ef"
+      "wire_schema_sha256": "665355ed88edfbec2ddf83c2070aa07e59e686d9fe64950611c7a0f80a415044"
     },
     {
       "id": "slack_bolt:member_dm:routed:illustrations",
@@ -9470,7 +9470,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7216,
+      "wire_schema_bytes": 7357,
       "tool_reference_bytes": 5618,
       "tool_reference_sha256": "623ebf79339bd5110e3c5fc552029d1dd963ec75656ee5c33d0a70ae0bb424c8",
       "overridden_tool_count": 0,
@@ -9485,7 +9485,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2262e46c9d68205fbc414bd4692d1f8c6fc2016e9e23c26a41d5f07990ca23f3",
-      "wire_schema_sha256": "01bf7d3937ebe469a34902a012f306e28554f298c7ca92ceb552a45f0a47be10"
+      "wire_schema_sha256": "c7be7227a3ed18b712471906aa926f2812b523208d79c5506c5d5e10624e8040"
     },
     {
       "id": "slack_bolt:member_dm:routed:industry_research",
@@ -9509,7 +9509,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8458,
+      "wire_schema_bytes": 8599,
       "tool_reference_bytes": 4972,
       "tool_reference_sha256": "185900837249fb365b264337b3d47582c5fc7f4f532a4cf01f420f5acc97bccd",
       "overridden_tool_count": 0,
@@ -9526,7 +9526,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c03b924580ac2b085190e3b4ae5c211b92918be3bbbf87c8c2feb40c59140deb",
-      "wire_schema_sha256": "a0ded125df614b848b41decf0b925fd49bc504cd9a9b7cbbb2839f3ac374f557"
+      "wire_schema_sha256": "c86a0caa2d0edaf672fcfb2d3afebe6d5c46c18aafe4942614eef27a874113ec"
     },
     {
       "id": "slack_bolt:member_dm:routed:knowledge",
@@ -9550,7 +9550,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9563,
+      "wire_schema_bytes": 9704,
       "tool_reference_bytes": 6204,
       "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
       "overridden_tool_count": 0,
@@ -9567,7 +9567,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
-      "wire_schema_sha256": "5438b4aa64ac11bb20f3f810fa76e1a542f6b54087b2329203de2a124311c11a"
+      "wire_schema_sha256": "ec8ac68fd4d8b0eb30babafab56ea4414f429e10dd4e22c738884a51a8c2b42d"
     },
     {
       "id": "slack_bolt:member_dm:routed:meeting_attendance",
@@ -9591,7 +9591,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8945,
+      "wire_schema_bytes": 9086,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "df3af926f99c7f9d48206b0c20048f46be655ec3881722c8be2be2db81a63acf",
       "overridden_tool_count": 0,
@@ -9610,7 +9610,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "9a66a9d3f906bd65c3235d8f9fd264d2dfc900ffc5860af19c7b5d32f99a4d8f",
-      "wire_schema_sha256": "b7ec2bfb8d39f7899e36e8d654f46802b48bd67a8bb966de97ea5b84860cb125"
+      "wire_schema_sha256": "5d0cc9b52e8442f9bbd21e684ec4837f286f6054c93f320e53db8817bfaea287"
     },
     {
       "id": "slack_bolt:member_dm:routed:meeting_full_administration",
@@ -9634,7 +9634,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16400,
+      "wire_schema_bytes": 16541,
       "tool_reference_bytes": 5127,
       "tool_reference_sha256": "000143f1682565038450ae5a74b8276cca8d354dbec76741dd85d46052760238",
       "overridden_tool_count": 0,
@@ -9659,7 +9659,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "8bcb247100605d8c2354b2fa7a9f1a2b5c349fa2aab59266996b5bcdf634fa51",
-      "wire_schema_sha256": "e9986416e30b85a45f5732568173f1a5f8b8653e4e43e9de3dbe18457134ed86",
+      "wire_schema_sha256": "25082d4bb25baffcc0880a8c99ad02c5a85d4a2b4beb22e930b1f733773fd2e1",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -9684,7 +9684,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12258,
+      "wire_schema_bytes": 12399,
       "tool_reference_bytes": 4978,
       "tool_reference_sha256": "a59255184701822e566e5691e81b78ac059fd7a5e3b90284837c2f70fed0ef1a",
       "overridden_tool_count": 0,
@@ -9702,7 +9702,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "7d975630d220603ee3b6cbf059fe22fd9783702a41ab1ed034a1728a95a3e658",
-      "wire_schema_sha256": "e99f89fb6b6000ac1fd12877cede72f3105201964c9add14836d790d9bbe128a"
+      "wire_schema_sha256": "2253c5750ed560bd5432ce9193d0311b535a4afd0204a095068dd2df77633d11"
     },
     {
       "id": "slack_bolt:member_dm:routed:meeting_series_topics",
@@ -9726,7 +9726,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9179,
+      "wire_schema_bytes": 9320,
       "tool_reference_bytes": 5051,
       "tool_reference_sha256": "41cdd27ed230ed4b8267bb4e12a4374fcbc4760641fb45cbf0b23106dfb028cf",
       "overridden_tool_count": 0,
@@ -9744,7 +9744,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "7e127221944ab98d82c8ea4c6a144d7f65081bd75d2d35700b5e4fc5219e01a6",
-      "wire_schema_sha256": "f0637992f399d4aa9f2e7a7897c476aed290bbe9d3251ec4763f586e679ee40c"
+      "wire_schema_sha256": "90d6c562f04be6f98a5915bc3f594575806d39321edb5e5d4f17e80f0eb33e99"
     },
     {
       "id": "slack_bolt:member_dm:routed:member_billing",
@@ -9768,7 +9768,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9764,
+      "wire_schema_bytes": 9905,
       "tool_reference_bytes": 5601,
       "tool_reference_sha256": "a341d5c2e105981cd5b9a59335595d0857f26c560edf48b0224c584bb832e0ff",
       "overridden_tool_count": 0,
@@ -9787,7 +9787,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8699d6181a5d508084790d0cba1a651a4bc2dcd7a4778343c1e1c74d8194805",
-      "wire_schema_sha256": "445ea8435ca1189973da1380ccfaf1f7cf92a320f874c30233584fcd0b5a3751"
+      "wire_schema_sha256": "cabd0cb631cf16d712d77eeb947de1193cb6bf7695a2915ad9e6af229261b644"
     },
     {
       "id": "slack_bolt:member_dm:routed:member_company_profile",
@@ -9811,7 +9811,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12646,
+      "wire_schema_bytes": 12787,
       "tool_reference_bytes": 7111,
       "tool_reference_sha256": "35dd65133e09a8f9a9983ac8d38e362612aed792bb65ea66fc08923a1f6a82f6",
       "overridden_tool_count": 0,
@@ -9830,7 +9830,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8f6f85c0206f418794cc44768ecd12209f1b28f37c41bb463800ef829d542c54",
-      "wire_schema_sha256": "ab5c358b264bc08aa27993a3242b5764c599d379a3bea224900bce88ea1df0fd"
+      "wire_schema_sha256": "054ab5c37e70843aba7803a8ae60dc51c77c80d99a68a9282369c441e163b23e"
     },
     {
       "id": "slack_bolt:member_dm:routed:member_personal_profile",
@@ -9854,7 +9854,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7415,
+      "wire_schema_bytes": 7556,
       "tool_reference_bytes": 6535,
       "tool_reference_sha256": "0b3ad904d581c85060bf4fcf486b2feaf130f5eb13e53a66c273d0b1628e8ed6",
       "overridden_tool_count": 0,
@@ -9870,7 +9870,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b38dbd9cdb706e4bec9988f5f79ddf06c3add5fbbb3d642d020aa47580a1c188",
-      "wire_schema_sha256": "f291ad37c42ffeeeea7c29772478a34da6482727b580d3e9d5ec17f9c61298d9"
+      "wire_schema_sha256": "26e9ba660534e07fb4c0505b280c3fe5fda36bf20c7cdab9cc1284a565178f2a"
     },
     {
       "id": "slack_bolt:member_dm:routed:partner_directory",
@@ -9894,7 +9894,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9846,
+      "wire_schema_bytes": 9987,
       "tool_reference_bytes": 5111,
       "tool_reference_sha256": "a2c31cc736db63698935549fc4cc50145d0d5620aadd13ec001b5a57a6e21a81",
       "overridden_tool_count": 2,
@@ -9913,7 +9913,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bcae4bb08bebd099c9bf9207069921d51e16f79f607ff74883ab20bd515f90f3",
-      "wire_schema_sha256": "c7ec3a0ae906c9bd8ad2c3f0fa2ccf9c85fad786463e86fa52f8047110c23071"
+      "wire_schema_sha256": "a94d80cf2ce8d7ad435c782fb11a6cc9f2a83671ed845c0071d58e1b1c9f0f9b"
     },
     {
       "id": "slack_bolt:member_dm:routed:property_identifier_catalog",
@@ -9937,7 +9937,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9122,
+      "wire_schema_bytes": 9263,
       "tool_reference_bytes": 5216,
       "tool_reference_sha256": "f601e979751136d9791f545ecd22c07a13bfe0992d57c8132a4a12236b0acaf2",
       "overridden_tool_count": 0,
@@ -9954,7 +9954,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "aab2803cfb10c48ed22433a12d597a29cfbb108da9594ba642298056510b44f2",
-      "wire_schema_sha256": "3bacda2bff63186913b51b0526b4f63aeb1e2321fb05843800566b3dc6abee4c"
+      "wire_schema_sha256": "6515b61fd8007e5748125c56512bd494fc0ed387fe4b020f2804a08b65629b29"
     },
     {
       "id": "slack_bolt:member_dm:routed:property_list_enrichment",
@@ -9978,7 +9978,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7229,
+      "wire_schema_bytes": 7370,
       "tool_reference_bytes": 5065,
       "tool_reference_sha256": "0d5b48fe7e301b593e2c037bbe63663f9b8b8657b79ab8fd08c7fa24307c2a17",
       "overridden_tool_count": 0,
@@ -9994,7 +9994,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "438911e6103584c2b1a56dc85cb88fc27a4058a972f2ada41568f97e40f118b6",
-      "wire_schema_sha256": "1df55b955f0f9894c63614ffe350252a80ee584016135d8c5f338aff86d9d220"
+      "wire_schema_sha256": "07d9f089ad797a270dee73fb19e83a6555caf8d7067249e480ed9bd738bdb97a"
     },
     {
       "id": "slack_bolt:member_dm:routed:property_registry_records",
@@ -10018,7 +10018,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8492,
+      "wire_schema_bytes": 8633,
       "tool_reference_bytes": 5294,
       "tool_reference_sha256": "9db46b41e9dcb5583694e069f64c5cfd02727e6134feebe06666e3ea8505f6e8",
       "overridden_tool_count": 0,
@@ -10036,7 +10036,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "f35d857d81802956401ab47bd71f0b06a480bb636ca347f0ae928e5af642da8a",
-      "wire_schema_sha256": "704f0a3527433030c4a3ed82a7eb4878dacb1c0d45262db00e414437e3c75144"
+      "wire_schema_sha256": "49382c593b971754422988be697c341b872061d8aef7bb996dd1860419980869"
     },
     {
       "id": "slack_bolt:member_dm:routed:publishing_assets",
@@ -10060,7 +10060,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8606,
+      "wire_schema_bytes": 8747,
       "tool_reference_bytes": 5019,
       "tool_reference_sha256": "76b5d90221f61a3b3510669dbbb83391980b917f6e01d6949205e8a669477bbd",
       "overridden_tool_count": 0,
@@ -10078,7 +10078,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b28f189dc7f1f3e9c0e3b1e8c21c782031a27af29ee92fdc774cad495f9d358d",
-      "wire_schema_sha256": "73ef5c2b385d2445dc245d4d018fc45359090ac4bd0a7df36cb3713cdc58302c"
+      "wire_schema_sha256": "3fc9213c19c46c09e85ab261d2ec3031ff2db832e33634b1323b9c003f07a9c8"
     },
     {
       "id": "slack_bolt:member_dm:routed:publishing_promotion",
@@ -10102,7 +10102,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8091,
+      "wire_schema_bytes": 8232,
       "tool_reference_bytes": 4908,
       "tool_reference_sha256": "028b475316bf9318c8daf7e8db4c2bc999f6765438191278143deaf41d83f84c",
       "overridden_tool_count": 0,
@@ -10118,7 +10118,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "12fc6a926164fc6d781582726b792bce04c0d955dcd1881fcba91cfccad46a43",
-      "wire_schema_sha256": "531a42722f29d3fec4e1b6c2db4eb62bae0ea522e050c88e9369f48c8346dad9"
+      "wire_schema_sha256": "71e143fc055ea35d849ae8031d3204717aecc703ec5a09d3eeafcf7ee47e943b"
     },
     {
       "id": "slack_bolt:member_dm:routed:publishing_review",
@@ -10142,7 +10142,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7935,
+      "wire_schema_bytes": 8076,
       "tool_reference_bytes": 5089,
       "tool_reference_sha256": "293cccb606c14259488ae08b58dd5864c1cd5cdb261ebdde177cdf71c030930d",
       "overridden_tool_count": 0,
@@ -10160,7 +10160,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "6367bb5059c34b3346ad8ffe1e3b768852a2e7389e6c2c0f4e1d97d2b006b666",
-      "wire_schema_sha256": "2f060dff5af7d527393686dc2d1e06986583280a86a15e95d4cf831c8f4384cd"
+      "wire_schema_sha256": "361f6c77be8270ad9e01ff835a9d8fed47baf1891b879ce3e6e99bb6d838b352"
     },
     {
       "id": "slack_bolt:member_dm:routed:publishing_submission",
@@ -10184,7 +10184,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9623,
+      "wire_schema_bytes": 9764,
       "tool_reference_bytes": 5865,
       "tool_reference_sha256": "c43c878587751a7b5f684d5e3b47be6f94c4bbe7ad889cf32b4713ed6ba2a924",
       "overridden_tool_count": 0,
@@ -10201,7 +10201,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "aba155c978eca98aa50d8e3397966f83f4b0b8532484458082433d8f106032f5",
-      "wire_schema_sha256": "6d5281a4edb4988ce0166404aa7043db2cc82af4f52b6b0e9ae6380c38bd9190"
+      "wire_schema_sha256": "1f600b2b4d9e9a1fb722ad9a84b946476ab263ace6dd6b0b7b6baf5e66f58dcd"
     },
     {
       "id": "slack_bolt:member_dm:routed:schema_reference",
@@ -10225,7 +10225,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8711,
+      "wire_schema_bytes": 8852,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 4,
@@ -10243,7 +10243,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "8b72f1ae05db4aeef98159092ffd8e443b623eb4e19b30bf0be9443cc739bd90"
+      "wire_schema_sha256": "b680060649c8e0fc0921e98428b53f5b567d84f31c4ecd952047679811816401"
     },
     {
       "id": "slack_bolt:member_dm:routed:sponsored_intelligence_discovery",
@@ -10267,7 +10267,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7899,
+      "wire_schema_bytes": 8040,
       "tool_reference_bytes": 5241,
       "tool_reference_sha256": "3c43d712cf42391096e4c83cfb5ce4cf7388385519d5ec966d1edc73e53a964c",
       "overridden_tool_count": 0,
@@ -10284,7 +10284,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "10dc3537f2c3b17d9f0364e80871604779981fcba52329e34b442ceee2c396b6",
-      "wire_schema_sha256": "00e9bf28f9d1e0b60747706f7a756166f8222ce66f08ab5d826b5f7437674f4b"
+      "wire_schema_sha256": "922c919dc877b18418917c7fe2a9515f8fc6661841065875779824cd1d810a80"
     },
     {
       "id": "slack_bolt:member_dm:routed:sponsored_intelligence_session",
@@ -10308,7 +10308,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7418,
+      "wire_schema_bytes": 7559,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "b0c20685f8468efe08eda7704772d86eb52c6f23de9d4af2425b8f97ffecc870",
       "overridden_tool_count": 0,
@@ -10325,7 +10325,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a57a8f996c5c03f33848a5dc74ef82c65a5d990f8ee2c9dbf85a08b8f90628b3",
-      "wire_schema_sha256": "b346004519c43ef64023ce979be1c59481536490c537b430d5c06f08e9e24b11"
+      "wire_schema_sha256": "612102c9dec28da25aa58d000a5890ccf2134cccb68a5b5f423140a609287e05"
     },
     {
       "id": "slack_bolt:member_dm:safe_fallback",
@@ -10395,7 +10395,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15460,
+      "wire_schema_bytes": 15601,
       "tool_reference_bytes": 6330,
       "tool_reference_sha256": "6aef477bf109d821bdfa8fd07c90523f69b3a7fbe386ae353280665105de3e0f",
       "overridden_tool_count": 0,
@@ -10415,7 +10415,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ad8390526ff9af140bd7e4b0416ad3cfc4c028e44028070b95a06ae152bfa05e",
-      "wire_schema_sha256": "dc7103f30f9e621253fee5592d6b96ef643d57b5903fd0382052fff981b07d2a"
+      "wire_schema_sha256": "ca0da259992847a847763ab958007800ba2f205f075ee4881cb44a5333dc211a"
     },
     {
       "id": "slack_bolt:private_channel_admin:adcp_task_operations",
@@ -10439,7 +10439,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13908,
+      "wire_schema_bytes": 14049,
       "tool_reference_bytes": 6378,
       "tool_reference_sha256": "6f40fffb21d3be25b7651e53dd9c9555d8b6e844e0ada398314863d004ece8c6",
       "overridden_tool_count": 0,
@@ -10458,7 +10458,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07d619635ece821a834856c3c589ae9b3fc571ad61b993c621cc54a1d488360d",
-      "wire_schema_sha256": "64851675e3c695f012343f8b9797e22e1ae9439f74b95611799e7d10029bab3a"
+      "wire_schema_sha256": "5a230a0d07bd7a8115422e4b3efe48a522cb92c8f77b8fa38a807b617d8a08a1"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_billing_account",
@@ -10482,7 +10482,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11076,
+      "wire_schema_bytes": 11217,
       "tool_reference_bytes": 4918,
       "tool_reference_sha256": "c633c81589d01cce53e416bffb362e31d3fb38c1fa7ae0be2bc1b3a89b8a30c3",
       "overridden_tool_count": 0,
@@ -10502,7 +10502,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf202ec0b5c16623f805b27e931a3423b95b24caee51e1a76dab242af5e113f2",
-      "wire_schema_sha256": "e9ded10e5ae64f63be983786276642b415b919c5a67b81f273864451863a0fbf"
+      "wire_schema_sha256": "cc2ab61e3ad19b17010c5a5c7de0eafa41a6fae2de4810a38e3808934506a57b"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_billing_discounts",
@@ -10526,7 +10526,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10390,
+      "wire_schema_bytes": 10531,
       "tool_reference_bytes": 4885,
       "tool_reference_sha256": "e6c54c011bf4113a5acfb57919b1eea144a9e2e9b037a7fa90402c91e92c4af4",
       "overridden_tool_count": 0,
@@ -10546,7 +10546,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3d5a0d9845becf4948711c6b98b82b974ad8a580d75ec4b9440d3ba0df936d28",
-      "wire_schema_sha256": "01b4c5607355c8cc879da53dc000c63d208a6c74db48dacbc300d9da16dfeba9"
+      "wire_schema_sha256": "0f0359f0ff406ae27ba491aa5346a3141b5f9c5d7d5a41e6c4c072406ff8be64"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_billing_payments",
@@ -10570,7 +10570,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11959,
+      "wire_schema_bytes": 12100,
       "tool_reference_bytes": 4873,
       "tool_reference_sha256": "beafff27d131ccfccf76c4ebf261d2ea9266a44aed3072c3e5af8b876cab4ef7",
       "overridden_tool_count": 0,
@@ -10589,7 +10589,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4658b9b7dbd4a931f13ea064882fc4fa4fdd16b52cc772c54896e65520480301",
-      "wire_schema_sha256": "c16b5a136d8ab7e05713da928b904228b45c0d43d80ca474cbae14ad0c64182f"
+      "wire_schema_sha256": "2dd912f723bb64fecdfb58f2d684ea5b45d30d38512179b7b8f1356baf188325"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_brand_logo_review",
@@ -10613,7 +10613,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10322,
+      "wire_schema_bytes": 10463,
       "tool_reference_bytes": 5103,
       "tool_reference_sha256": "18a8f680141c30fb3779c55d499734812898390dba839f7e842c5402550132d5",
       "overridden_tool_count": 0,
@@ -10632,7 +10632,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "6c9af95c4975829a7bf94aec01f35a754b8d9cdb812f5dd150c15eabac456de1",
-      "wire_schema_sha256": "c075708004e5259ded57bf7b460f7a123abf8b3c00f6327dd1f6820be35ab45b"
+      "wire_schema_sha256": "35c211082c30ee248197647c07c439c14d8c53f354fb224abdd862b433c98f55"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_brand_registry_integrity",
@@ -10656,7 +10656,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11031,
+      "wire_schema_bytes": 11172,
       "tool_reference_bytes": 5206,
       "tool_reference_sha256": "076d054efacb1b4921f34c5b4c2fa862adeb91d2c383f34ad016cb46c3ef9cdc",
       "overridden_tool_count": 0,
@@ -10677,7 +10677,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "20034d602e5fe0640db9017a31bbcfc4e1c8012b17c55022c6a86eabbe8493a1",
-      "wire_schema_sha256": "102609b8e85067acf55311c7bbfd0d7dabc1ca87f5ffd1331ea6255bd34cc26b"
+      "wire_schema_sha256": "3486e907585e59a83052d8c6fc6583648c6f45bbc5407b265fab68b761254f3b"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_conversation_review",
@@ -10701,7 +10701,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11022,
+      "wire_schema_bytes": 11163,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -10720,7 +10720,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "46c7d110ac26bd45dec3fc0870880584f46522717bd470d4e8242b1eeada4c77"
+      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_events",
@@ -10744,7 +10744,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14607,
+      "wire_schema_bytes": 14748,
       "tool_reference_bytes": 5045,
       "tool_reference_sha256": "c30cb271ee192379bdfd17da6cd5bab315e4c560f86a13f66f5192aa38ca6ed7",
       "overridden_tool_count": 0,
@@ -10765,7 +10765,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "0e315f56035f7f695f6e8b981c5b484c9802fc1b0f948e767a6bd57eb3cbafa8",
-      "wire_schema_sha256": "2b1d53f3e95f2dc8b66f3b91c52775cfb3292ed32bbf151edd33c069fdda5b20"
+      "wire_schema_sha256": "2ad96203888e13bb531d0725ed59dc9bdbc70bfebcaca69b6104225882d68f64"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_feed_curation",
@@ -10789,7 +10789,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10769,
+      "wire_schema_bytes": 10910,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "51b1859d98819b87b8cf43469c7151cee160b47dab60e0185ebbdb25b7206911",
       "overridden_tool_count": 0,
@@ -10809,7 +10809,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3dcfb69f2292cd2753faf15d02c0077a157e404763b47af52d306370c4975ea2",
-      "wire_schema_sha256": "dfe8b2570e3c6dd0470221132cebbb5c33bc6f4c95ee55c06f29bf5318fe49fa"
+      "wire_schema_sha256": "abf4e1210aaac63fb0b6abe901bb89edac2f3994ebce7572b3fd3ddfec918d56"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_feed_monitoring",
@@ -10833,7 +10833,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9556,
+      "wire_schema_bytes": 9697,
       "tool_reference_bytes": 4933,
       "tool_reference_sha256": "348f8bf0680b6697aa4db7fe642d0d2b592d98bac5ef05017653e3d5f76d1ee0",
       "overridden_tool_count": 0,
@@ -10852,7 +10852,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b1689086b33ea143c9b79edc3954c1fc9320bd7c73bf26c05d79d00a50999e6b",
-      "wire_schema_sha256": "69b08c0e33b7f5e0483b2d9faa24e71d5d8cf7a9af626b6983050b85608002dd"
+      "wire_schema_sha256": "356c5447324224f57135895bdf0755581a2b86d5bdfb0236962e92922898df10"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_followup_tasks",
@@ -10876,7 +10876,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10288,
+      "wire_schema_bytes": 10429,
       "tool_reference_bytes": 4961,
       "tool_reference_sha256": "d3b7df07a7bf17cddab315557f4db71a7e2fea4f4956d3ace06b9d96340d50d6",
       "overridden_tool_count": 0,
@@ -10896,7 +10896,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "e9891ff20b83d67e8cadb649d24df495c51f5d78064af75532944a98a14ef9e4",
-      "wire_schema_sha256": "61929aa8491fc1efa2a84b9017ac2d040d4f2e0df6893bb4939b7f0b48d01735"
+      "wire_schema_sha256": "310fa974b97a6c82109c0aac9e36fe45501e4c2acba52c730cb7dba8abe587b0"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_group_leadership",
@@ -10920,7 +10920,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10760,
+      "wire_schema_bytes": 10901,
       "tool_reference_bytes": 5041,
       "tool_reference_sha256": "90476e3b3516fa008b3063f2d55126f0c4622dfce286824afe3e33917711c10d",
       "overridden_tool_count": 0,
@@ -10941,7 +10941,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ecd5015062feb97397c759e03480c2fc6f9ef58425774b7f88d6793fc51a261a",
-      "wire_schema_sha256": "8870ff455c80a2c3ac9270a2bfaaf2fa62d4eb715f25069469a180d1523d46ac"
+      "wire_schema_sha256": "292b461d56fd3d1d6ec082dfdd8ad4b7be80323422f7d55476a2a7c50de11b62"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_group_membership",
@@ -10965,7 +10965,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10666,
+      "wire_schema_bytes": 10807,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "2388dc80f99651611a2695a01e1caaba5a3fe4d36cb4f74ef9c5443dc96b3664",
       "overridden_tool_count": 0,
@@ -10985,7 +10985,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "47db1de6135e646a948a53018f4edc8c974d39573961f5f74cf110c620b28b7d",
-      "wire_schema_sha256": "b0c37e8442437e8bf5da967213533952a688d75f9044159913740a4bb7cbc68d"
+      "wire_schema_sha256": "75cfcf4d3e182f12be3a8409b69086eb4e8395ee1eb57d6897cbe1532ffa3464"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_group_structure",
@@ -11009,7 +11009,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10729,
+      "wire_schema_bytes": 10870,
       "tool_reference_bytes": 5034,
       "tool_reference_sha256": "8f34d5a18362f50aacb64db4cba78ed35949e1ff5e47db886ea4344224766823",
       "overridden_tool_count": 0,
@@ -11030,7 +11030,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f386cc7f41b925aa66274b8f8753f1f807aab57f0b25196035c9b470d7e97e08",
-      "wire_schema_sha256": "a156969da8f3918f83e0cae37c1307567e88d7976052443702e086be3d52fa99"
+      "wire_schema_sha256": "8976f868aa83ffca02729d688267b8682dffe4bc1f3c0f75818e46c3b67208ea"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_organization_integrity",
@@ -11054,7 +11054,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10716,
+      "wire_schema_bytes": 10857,
       "tool_reference_bytes": 5263,
       "tool_reference_sha256": "2babace46b46bd3c1757a93a4fc523910763ecdc00941c9526aa723cc966057c",
       "overridden_tool_count": 0,
@@ -11074,7 +11074,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "282a96131a9d387b5b297a1798d427fb77f27935a25c03cbf2cc22b79160265d",
-      "wire_schema_sha256": "042e6ecaa3f021ea34283325da3d528e17494d89e9be9284ffadb1e84cd44dea"
+      "wire_schema_sha256": "43278aa0ec15d4cc49fd7beb7bb4ea369b7b21123737932188b480921cdd3335"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_organization_member_records",
@@ -11098,7 +11098,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13604,
+      "wire_schema_bytes": 13745,
       "tool_reference_bytes": 5279,
       "tool_reference_sha256": "3b20b9520b711943b33384fc793a5aa81c1356222e27031371fa9568fa5ddaa6",
       "overridden_tool_count": 0,
@@ -11119,7 +11119,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "fbaa28ba1001813d3f1a0cb66477a6c9b0efc4ff32214d6414c9ec478d93f373",
-      "wire_schema_sha256": "199ccde69119f622e85af6e7878095321c7af70fa6df08c2108a7db357d40f96"
+      "wire_schema_sha256": "b1827a4f4ba256571df9eb871d48d0a0822985d974b1ae9181643a2297083e8e"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_prospect_pipeline",
@@ -11143,7 +11143,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12521,
+      "wire_schema_bytes": 12662,
       "tool_reference_bytes": 4989,
       "tool_reference_sha256": "b0cd167136b0167f5271d0c640104f9e84ab19c55065b2c375ea59fd650658c6",
       "overridden_tool_count": 0,
@@ -11163,7 +11163,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "57a38e3fff723ab752525360ac09e49c8383a799c437fd7e8997db01d00d6102",
-      "wire_schema_sha256": "5c49b5d4e0419b5255b6c8f54697e65d1eb6eb15fef63635c8afd65fc5449358"
+      "wire_schema_sha256": "35a27cf6032281aba5d04bf4381436e9ebc3726f4ac1656e219c4be2bdd6ddf5"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_prospect_research",
@@ -11187,7 +11187,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10908,
+      "wire_schema_bytes": 11049,
       "tool_reference_bytes": 5007,
       "tool_reference_sha256": "1854a1b2fe6f4dc131539e2d425764f7819eea370158742211c02c1910f21338",
       "overridden_tool_count": 0,
@@ -11207,7 +11207,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "da07d5b25562ab15e7f17ce74015434853f8be2fac2917339e18cc4fb6139fd7",
-      "wire_schema_sha256": "b4cc5316fe13a05a6ed97843fecd37451808a421f1e941644f9762e268999059"
+      "wire_schema_sha256": "22bc774943369c808b85b557cdd40fc4177145a9508b613f974c1a6b37050178"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_authentication",
@@ -11231,7 +11231,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11273,
+      "wire_schema_bytes": 11414,
       "tool_reference_bytes": 6068,
       "tool_reference_sha256": "8c5110b85f73579cbd881419b997fcc9a9d99d3b2ebdf415f4929585bd6298d5",
       "overridden_tool_count": 0,
@@ -11249,7 +11249,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07eb0de4a4c6332c5429079c33017a24205c5f3507e6399772c561ff4a092d78",
-      "wire_schema_sha256": "598a80e9d63967c72734a2a480fcc2d438cdb06af506672907ac273711905aa2"
+      "wire_schema_sha256": "c817f6a6a00ce8caeb3ceb89d2c9a6cdd34c142d48680ab1968ae85dcdd8bf32"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_conformance",
@@ -11273,7 +11273,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9978,
+      "wire_schema_bytes": 10119,
       "tool_reference_bytes": 5792,
       "tool_reference_sha256": "182b19b64ce7302d415619c993fc24ae32136df09ef1c8ac2b89f7cc839dc266",
       "overridden_tool_count": 0,
@@ -11291,7 +11291,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "012096836c5569d43d146451a8ffb1b800f8b39a56f146da16161031ce0ac130",
-      "wire_schema_sha256": "b5943c31b2c9dd9a3a7ff21771f5b5754404e35db94bd9ec35250f2e71afbf3b"
+      "wire_schema_sha256": "b850bf84930b453a9611fc5313cb6f9348099918d6f03639cff649f85b01ad6e"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_end_to_end",
@@ -11315,7 +11315,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19815,
+      "wire_schema_bytes": 19956,
       "tool_reference_bytes": 6636,
       "tool_reference_sha256": "d02b3eff67be7a38f952ebe0196ddb996dc932aa9e501167b0b1d71e454da1e4",
       "overridden_tool_count": 1,
@@ -11341,7 +11341,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "85c84ea52a5aa43067389e7e17605be6a93ddcf1ba596f619729779fccbe10bc",
-      "wire_schema_sha256": "4ac2625af42caf603e34700d6d4e8b1c6392a9a55f30cea92053e70ebe28a5b2",
+      "wire_schema_sha256": "6972421c67e7a20bd652da3a03d9333a6de9f05e5d2f8649e4df1d8bc23b2024",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -11366,7 +11366,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9950,
+      "wire_schema_bytes": 10091,
       "tool_reference_bytes": 5117,
       "tool_reference_sha256": "aa7e1f31ef1c683786e229c8050793d9faad83b5a5cbde309960dc4a3271a991",
       "overridden_tool_count": 4,
@@ -11386,7 +11386,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a512a4cbd9fe2e02bb76d6a1b31cd09a7638761efb4a0230834fdfb2e861159e",
-      "wire_schema_sha256": "7b05ded6a160ec1efae4e67f6132c9301be3989ba40f9ee725e1dea20d011c28"
+      "wire_schema_sha256": "a9712d8f28136b46063ae010c6e790982153087943feb2d6acaf3c7e4a4df93d"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_quality",
@@ -11410,7 +11410,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14652,
+      "wire_schema_bytes": 14793,
       "tool_reference_bytes": 6139,
       "tool_reference_sha256": "ecf8f60600a263d6a3120321ab1f65e138a08b082a96153eed01d1968552a91f",
       "overridden_tool_count": 0,
@@ -11429,7 +11429,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f527be89fee5e5536b0b51b8c6c72924fbb8d3d9f3fee080986890437ae83065",
-      "wire_schema_sha256": "0da514e38da9e5be4280e7490b7f597ac0976df6fb9860bfd3c2abdb06f9ce69"
+      "wire_schema_sha256": "2927e76e9a88dce21cf946e0034908a0526605e5cb05f02305ffd1331cc4d91a"
     },
     {
       "id": "slack_bolt:private_channel_admin:agent_registry",
@@ -11453,7 +11453,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11044,
+      "wire_schema_bytes": 11185,
       "tool_reference_bytes": 6701,
       "tool_reference_sha256": "25cdf10cfcafee88979211e822031ff6983a2f38b20fae8fa7088210136e135d",
       "overridden_tool_count": 1,
@@ -11474,7 +11474,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "829db1024e9ed7b56f80e74f08c79430219c661a9f7f1ca2f338268d981861c2",
-      "wire_schema_sha256": "b0d39b6c209520e8a0e3496f6c49c5ec11b5743ef88af79d479fb3857f0431de"
+      "wire_schema_sha256": "0b1af69d6704ce3c22d14b34ca20cbf5cc56fecae2ebc26ea8286f16edd6ca0e"
     },
     {
       "id": "slack_bolt:private_channel_admin:all_valid_sets_maximum",
@@ -11564,7 +11564,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -11790,7 +11790,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -11815,7 +11815,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16157,
+      "wire_schema_bytes": 16298,
       "tool_reference_bytes": 5617,
       "tool_reference_sha256": "d05f97f3dc028c1013c97a9e19feffd2796fbc23e53475e20b508a3b322b8708",
       "overridden_tool_count": 0,
@@ -11836,7 +11836,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b0cb4a01b1ab28f7ab346fe05f5d2b3fec2d73dcdc5a8309a5b0f7d902fc5758",
-      "wire_schema_sha256": "a63a1ba480dce1cc6f8abd2d0bfdf5ec25f46a84c8c73b964359f4bef911203c"
+      "wire_schema_sha256": "33ddcc81e2e2a07ee9ac86d347e32961acc9cf30088a132b1e6b54eb90f6a108"
     },
     {
       "id": "slack_bolt:private_channel_admin:brand_registry_records",
@@ -11860,7 +11860,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11067,
+      "wire_schema_bytes": 11208,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "6e5a06f631d52e8db048ca417e593ab9731058f6ad56b3b963a13fba4576803d",
       "overridden_tool_count": 0,
@@ -11881,7 +11881,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "7fd8e61d32cf8b482ae959e5e050ee0774fb93e3ce6d39f243364659c3a81b15",
-      "wire_schema_sha256": "eacbb437559a6273d4439d0d4fc13bb39c91b2a3f6bed0d6bad7a95b7cc4778a"
+      "wire_schema_sha256": "c1381ff7692db4c526b7d5c2f55b8951be1a53daf932a2c33a083dcf80544674"
     },
     {
       "id": "slack_bolt:private_channel_admin:certification_assessment",
@@ -11905,7 +11905,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19717,
+      "wire_schema_bytes": 19858,
       "tool_reference_bytes": 6920,
       "tool_reference_sha256": "8c278765ad621dd11f89ff7b35d60af9f51ae88d569155f91733a06a4a51aab5",
       "overridden_tool_count": 0,
@@ -11930,7 +11930,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "b8820aebc73fe700321e75a7bafc7ff346e38040ea64c833f6e87f88609e9ff2",
-      "wire_schema_sha256": "d8435d8f452b30eb17516ff8b8f2e5138a2024bd4061f07a5745c600ab834ce0",
+      "wire_schema_sha256": "a8ea168f91ead2bc224c8a1f1412249cc08892e85c7e6f1334461315bd1385b2",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -11955,7 +11955,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20620,
+      "wire_schema_bytes": 20761,
       "tool_reference_bytes": 8157,
       "tool_reference_sha256": "488a0f80dc27b82e9d7a04226a70a00d8dddb18c5801dba7d287839e9f70315d",
       "overridden_tool_count": 0,
@@ -11981,7 +11981,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "8df8d830c1370944e4768efb235cad21d4c923181157a047b167d528e599800c",
-      "wire_schema_sha256": "2de1a6ed6cd13c7c445b70447771293300a1d32460a03f3b361c108d2b930091",
+      "wire_schema_sha256": "77b48937fe7ec04b1dfe22fbd3f0d058071dffa7a646bd2333b7a6b65ae91652",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -12006,7 +12006,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10621,
+      "wire_schema_bytes": 10762,
       "tool_reference_bytes": 5714,
       "tool_reference_sha256": "ffe228a0d892df8178b8697bb3c470318c7c60e0bb97e578159b3fb4376e1674",
       "overridden_tool_count": 0,
@@ -12027,7 +12027,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "1c5d33e6479dc6e858cbaca65f2e0ac8fdef46462cfd59b9b9a1b6a958fd4c63",
-      "wire_schema_sha256": "46ffdeb02a3149cb96d8d7e99244e345f92ea243cd18a30aa51e006ca4682609"
+      "wire_schema_sha256": "a38d7b04d05b23e75862070e97a6ac3358aa1b4d4d2ee2248a4058085a275fe0"
     },
     {
       "id": "slack_bolt:private_channel_admin:collaboration",
@@ -12051,7 +12051,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9831,
+      "wire_schema_bytes": 9972,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "e538eef1415fb4f47251a65eff930e1abb048b1440679990cff368a65814cb1b",
       "overridden_tool_count": 0,
@@ -12068,7 +12068,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "11274be30eaff96df7d3a088f1c91d7ce876a5ef74f4f65679f51f93964bb107",
-      "wire_schema_sha256": "b57a5fbf2e3185acfe0f5728d98dc166e7e8fba608ae6f79e19a91a087dfee08"
+      "wire_schema_sha256": "610a632766f98d2858732eb8d8e16fbfd1f0c23b33c6c0007909d7a33516d062"
     },
     {
       "id": "slack_bolt:private_channel_admin:committee_co_leaders",
@@ -12092,7 +12092,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11161,
+      "wire_schema_bytes": 11302,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "a74c5c2bd2d65d9f5639a6aad516e33599b92edba4bf9cc24ff468efc9889c51",
       "overridden_tool_count": 0,
@@ -12112,7 +12112,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "bbe7d7c41eafa947c0f6456ae91b140fe2fb526a765ada057940d8283bad2d3e",
-      "wire_schema_sha256": "88e25ae1df383ca28285df07031c9b2bdd6471f2156802e8ef1c2165c884bf1c"
+      "wire_schema_sha256": "b5d99ae490ded1a4f5d20aa7753412959680237b21afe1e1faa9179927ed46d5"
     },
     {
       "id": "slack_bolt:private_channel_admin:committee_event_planning",
@@ -12136,7 +12136,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12747,
+      "wire_schema_bytes": 12888,
       "tool_reference_bytes": 4937,
       "tool_reference_sha256": "48c146ce05f85c6d37c76ff566e74f7c5432a42f18243f0dd88c1100ffed6109",
       "overridden_tool_count": 0,
@@ -12155,7 +12155,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "4cbb76ebfc638e5e178b77ce51517e1700f437cbe07eed14ef67bc9c6d6beed1",
-      "wire_schema_sha256": "a689a1a7836d76c8570bc6da9931e3233aca3358fcd24d29b3094674a967c7b8"
+      "wire_schema_sha256": "ec641792556c5b33bada8fd491025299c5ce888240aad9e397e609d90ad96f20"
     },
     {
       "id": "slack_bolt:private_channel_admin:committee_event_registrations",
@@ -12179,7 +12179,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11471,
+      "wire_schema_bytes": 11612,
       "tool_reference_bytes": 4994,
       "tool_reference_sha256": "e5adaa7cf86f32e770b3d2ac8ba70be81d79ad573a6e6232ec8ab514c9c512ef",
       "overridden_tool_count": 0,
@@ -12199,7 +12199,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "9c759c6159787b0bf813b405babe98af8b80fd8132ad1c292125b2998c70e9fe",
-      "wire_schema_sha256": "83042a8f9c7a4d2365e3fb6dae5f3260154fbd20283b4d0cb6a82e95f2eb866d"
+      "wire_schema_sha256": "7442c8f0343cadeaebc9fbf7b53c126800f0b4e645a77e79d1fd7b5726cf14f6"
     },
     {
       "id": "slack_bolt:private_channel_admin:committee_full_leadership",
@@ -12223,7 +12223,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17191,
+      "wire_schema_bytes": 17332,
       "tool_reference_bytes": 5272,
       "tool_reference_sha256": "8f6e40ff2049c4b545422207ee004ad7e0d78caba7b71253994e0ebdf73978e5",
       "overridden_tool_count": 0,
@@ -12248,7 +12248,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "04ec5e8b84cc7c87cf26efc8cd7c37398baefb992eb687800a7c461a0f74b752",
-      "wire_schema_sha256": "986037ea14111776d73dad81f6c8abd2bc4ccc0b7d121343f3cb53274d06e478",
+      "wire_schema_sha256": "93e170f15266310c33b743c22b939e1f1d2b418fd332ed530e08c71a794cac1b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -12273,7 +12273,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10911,
+      "wire_schema_bytes": 11052,
       "tool_reference_bytes": 5086,
       "tool_reference_sha256": "ca6a1e66aec898732856ae10dd86e16df9ecf43c2135448665e4c4084fd6144d",
       "overridden_tool_count": 0,
@@ -12292,7 +12292,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "8b32d9e5c75ba4c1993b582b53a0dd7549dfdd37b841c2e50e6b85ef586566c9",
-      "wire_schema_sha256": "a16439b79e45c05cf7dd5f35c07a7d91c9c8eecc44c8d8032083a7fc57841132"
+      "wire_schema_sha256": "0e6fe026cfd647a67897d2c6adf7c0a3cc0ecde785a1a09b6994c64cc0dffa02"
     },
     {
       "id": "slack_bolt:private_channel_admin:community_group_contribution",
@@ -12316,7 +12316,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10112,
+      "wire_schema_bytes": 10253,
       "tool_reference_bytes": 5314,
       "tool_reference_sha256": "ad46a2c27c92e139603118ccdda8ca72104b761f404d0e3619e2aa338331c3d2",
       "overridden_tool_count": 0,
@@ -12335,7 +12335,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "495a4a8817c854d8d9b0be45cd4c4365585ca02748a9560222f7fe7fb4498af9",
-      "wire_schema_sha256": "68a04baeb53dc384c109b00f6d6ee34f44d0c4a864bee4bc470de2f9a81e6c42"
+      "wire_schema_sha256": "48a55496c36ad8118cceda62dfc6e3f2f7512d6d4c2df52559c5b807b88487a9"
     },
     {
       "id": "slack_bolt:private_channel_admin:community_group_discovery",
@@ -12359,7 +12359,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10155,
+      "wire_schema_bytes": 10296,
       "tool_reference_bytes": 5255,
       "tool_reference_sha256": "fd71bca33c484bb3fb934c9486a18fc1e274917ff3cc95ef90e177e47326bb7c",
       "overridden_tool_count": 0,
@@ -12379,7 +12379,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "64a3330edea439fa8fb9fdacd1f81a66133cc4f256e7f2ac470bb5f2eea00ffb",
-      "wire_schema_sha256": "37e23fe68f4983194b7eda715844651a7b67caef71aff3d641f02997d71f7689"
+      "wire_schema_sha256": "9d05198d8f6fe5f252c0dea042255b1fda4049aa7deab37bb01c0260f9ba895c"
     },
     {
       "id": "slack_bolt:private_channel_admin:community_group_full_participation",
@@ -12403,7 +12403,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13400,
+      "wire_schema_bytes": 13541,
       "tool_reference_bytes": 5366,
       "tool_reference_sha256": "b749062fe5be6a24e2d97f9299b3264bcbd84aef9c6fbabc470dc4e186a41e3a",
       "overridden_tool_count": 0,
@@ -12430,7 +12430,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1761c6fb6a24457352ea873f301ed6c24757cb0a4fed773919c1371fb343d70c",
-      "wire_schema_sha256": "a0cc93bef80d9523deb66aad071350b6ad2cc093fed8ff770c5cf2ce7940b269",
+      "wire_schema_sha256": "ae2a4ff316eb3f6cda571b706c3d47c72b904f623fbf477450a33e9a96bd3684",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -12455,7 +12455,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10522,
+      "wire_schema_bytes": 10663,
       "tool_reference_bytes": 5288,
       "tool_reference_sha256": "60f5f1015a0888599dcff1c673ebe02a5e83258c2d048256843f2a9c791188fa",
       "overridden_tool_count": 0,
@@ -12475,7 +12475,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "c6cf0f8155798e253cad3ac0be806ac43f96ca1259a860e19d265dc255d15d91",
-      "wire_schema_sha256": "9cd71c39be1813e2691d5ea448ff001cffd85464e5ba36f812c3d0692794dedb"
+      "wire_schema_sha256": "c49379c6569c8148bfec76439fb59409ede93e45094c4b65fc2dda4c83e2c145"
     },
     {
       "id": "slack_bolt:private_channel_admin:content",
@@ -12499,7 +12499,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11128,
+      "wire_schema_bytes": 11269,
       "tool_reference_bytes": 5083,
       "tool_reference_sha256": "282313bd3f11de63c991eb1ca9c05498a4164020624527406eb3d21ac16e72a6",
       "overridden_tool_count": 0,
@@ -12519,7 +12519,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "284c752554ad643959685c0b0fbc1b1b5221bc3c0bf42c804731caa9a351cb44",
-      "wire_schema_sha256": "b1a8d18593b12e60f70e4d7b5f04f1f171979934591eba16dc6bf63d3b58a91c"
+      "wire_schema_sha256": "22f888fa99a27d79e9434f9738fd74a67556e1f58f46e4bcdc31b8e8cdd46bfc"
     },
     {
       "id": "slack_bolt:private_channel_admin:council_interest",
@@ -12543,7 +12543,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10156,
+      "wire_schema_bytes": 10297,
       "tool_reference_bytes": 5250,
       "tool_reference_sha256": "2a9275ce948cff4e13410aedb7932cd1483a286cb9b2f729e4b987bed296009c",
       "overridden_tool_count": 0,
@@ -12563,7 +12563,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "86286a9b99f37c50106ca5b3ab9111c7b0af4d130d68d0640ccb929363610e72",
-      "wire_schema_sha256": "117775a58f2f01975ea5b101b1f11a64957762186c77e21374cea5c666bf2af4"
+      "wire_schema_sha256": "ea7cb652802c1ee0c9b4d03ae244118218032d33579555f29bf7a97f7c665618"
     },
     {
       "id": "slack_bolt:private_channel_admin:events",
@@ -12587,7 +12587,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11056,
+      "wire_schema_bytes": 11197,
       "tool_reference_bytes": 5090,
       "tool_reference_sha256": "ee0839be778b2e32476815c6931204145048cdaf4433bf88e0986fcf8ac24183",
       "overridden_tool_count": 0,
@@ -12607,7 +12607,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "5751ff1ac10de94ad9b147e63d707924bb971a542515ebb9a89b5cb9446451cc",
-      "wire_schema_sha256": "afedc4bd3e025df66df66083454b5b5c8113509a335eb52289ad7fd4763ab335"
+      "wire_schema_sha256": "1237e2a89f231accdbaa9e3541aedb3ae018762173d929744cf6d065596ac9b6"
     },
     {
       "id": "slack_bolt:private_channel_admin:github",
@@ -12631,7 +12631,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12701,
+      "wire_schema_bytes": 12842,
       "tool_reference_bytes": 6073,
       "tool_reference_sha256": "17d2b9fdd26009df7efeba7b01d291553c2d578f4c4b8d2f3fa952cadd338030",
       "overridden_tool_count": 0,
@@ -12651,7 +12651,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "188b898cef2ba9447f41cdc60c27bd6433d96dd606d2c429d18247d8c752753b",
-      "wire_schema_sha256": "6457216659e15cbc7f241b6ae36b0b98c4923f7673328fba7ed8c11cfe01d23f"
+      "wire_schema_sha256": "7559b3f050430dab78f8148ddb9e83afa19514cef5de15458c7f99e9fa897512"
     },
     {
       "id": "slack_bolt:private_channel_admin:illustrations",
@@ -12675,7 +12675,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9510,
+      "wire_schema_bytes": 9651,
       "tool_reference_bytes": 5686,
       "tool_reference_sha256": "a08ac061f8dbe6da9867b23df6239f4f64a3605e97869e827b33ebc0aca341c0",
       "overridden_tool_count": 0,
@@ -12692,7 +12692,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "eb9a928245349898452ccbb1e46caa1b7b3ce8c7b8b765cd0f9456d8b035fddd",
-      "wire_schema_sha256": "ab732b43a4caea38eb03b1634fe091c481b207d0f683f81b0802fc3862bce661"
+      "wire_schema_sha256": "69d83bb5f1e2425bfd9c041a9fd79bdf67a9e65c42f5648d1e5bf6e0c2cd700d"
     },
     {
       "id": "slack_bolt:private_channel_admin:industry_research",
@@ -12716,7 +12716,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10752,
+      "wire_schema_bytes": 10893,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "693504dc7294e18ff4127d493c1761e8d981b96ad5405a23bcc17fe64fbdd576",
       "overridden_tool_count": 0,
@@ -12735,7 +12735,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "baa3abb17c17d41290fc3a2c47b330e0ae373019cb129abb66c429199a905dd9",
-      "wire_schema_sha256": "dd7117345ddcb9f82f4035490b6598485cb6ceee9007684286adb20de4fda617"
+      "wire_schema_sha256": "8c7049bbc7421a76d2ad3c2e3ffdc56ee8b93a90761b6414f2d52e30d2205624"
     },
     {
       "id": "slack_bolt:private_channel_admin:knowledge",
@@ -12759,7 +12759,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11857,
+      "wire_schema_bytes": 11998,
       "tool_reference_bytes": 6272,
       "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
       "overridden_tool_count": 0,
@@ -12778,7 +12778,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
-      "wire_schema_sha256": "c19a7e8340bc410cf6849c54d43fe762ea3cde8796b90832521c4cb4cf71c713"
+      "wire_schema_sha256": "f6bf3dde92b2d28eb26b85e932e6f2b1b6bc2d5eff122ad4e571467a58f3bcd3"
     },
     {
       "id": "slack_bolt:private_channel_admin:meeting_attendance",
@@ -12802,7 +12802,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11239,
+      "wire_schema_bytes": 11380,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "5fdc3f50ba46d26ffa75ff27538a5e7e8bcef3ea837fef8fd48705abd8624725",
       "overridden_tool_count": 0,
@@ -12823,7 +12823,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "28efbd2ca8b10c2368f967e639fd7652cd7f04960ad188392ce93fda2392bdc0",
-      "wire_schema_sha256": "f39c41b8e78c64611672126ff6b8393087a60b3cb4923b7c7d43a4ed27968343"
+      "wire_schema_sha256": "7c9f5de06def5824696babe0d384b9aa60bc3b94db3038fc4a73d7cfa6cad728"
     },
     {
       "id": "slack_bolt:private_channel_admin:meeting_full_administration",
@@ -12847,7 +12847,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18694,
+      "wire_schema_bytes": 18835,
       "tool_reference_bytes": 5195,
       "tool_reference_sha256": "17af7be874d34d79f1adf04bfa613c4b2faa3ea2bd74ea4ad3a91bb480be9741",
       "overridden_tool_count": 0,
@@ -12874,7 +12874,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "582f87a23ce4af178918f9bb042c999466b46904c3c9f7cbfed3dd27ab8dead2",
-      "wire_schema_sha256": "59170ff943f740317737157d7a781bb80349d107c7f6f69508f9b389329e2521",
+      "wire_schema_sha256": "b70c211ed1c3c6cb49bed93c09baef38c39849ea7df747db1bffa3ffb1e9b59b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -12899,7 +12899,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14552,
+      "wire_schema_bytes": 14693,
       "tool_reference_bytes": 5046,
       "tool_reference_sha256": "fce02e48f5ad06db1fee5ed46a2a2689371e71fdceb63cc1bd3e165515ba43e6",
       "overridden_tool_count": 0,
@@ -12919,7 +12919,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "63f1c3b48687fc9d68ddd930787a7d59561f1ba9ddb8d3698f0457486829dcba",
-      "wire_schema_sha256": "19cbd7895fd5b360a6871c5b552e565ae8e2ba0439ff80de008ba76f5614e44e"
+      "wire_schema_sha256": "232dd0f7f5208d747a5c794474720434b79d43962d28c56eda22300017e1ef7c"
     },
     {
       "id": "slack_bolt:private_channel_admin:meeting_series_topics",
@@ -12943,7 +12943,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11473,
+      "wire_schema_bytes": 11614,
       "tool_reference_bytes": 5119,
       "tool_reference_sha256": "fe9228ca48c839aefda1068097db4be03171b5d2f70101b996207477ee011b43",
       "overridden_tool_count": 0,
@@ -12963,7 +12963,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "1b799fe2a16442d418c0628fec9bdc8ae73d6c67a2f1acda08a5b99c73255258",
-      "wire_schema_sha256": "d324fb9e0c1e8b1a8df594959b9ef3a70cc3920fd1949ea7cd4606f57b8dc0ed"
+      "wire_schema_sha256": "a6ef0e4690050c165fd0cda7076be36676b0bfa48f3a72ee9fe9f689946628c6"
     },
     {
       "id": "slack_bolt:private_channel_admin:member_billing",
@@ -12987,7 +12987,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12058,
+      "wire_schema_bytes": 12199,
       "tool_reference_bytes": 5669,
       "tool_reference_sha256": "61c7298906378b4f2f154f7275a9f56c9102bfb6247ae654a3861f7cc8895b98",
       "overridden_tool_count": 0,
@@ -13008,7 +13008,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fadd2a88b06fed26c92e0d7683ee842fc67f84dfe3c44dc3db122d8443d955cc",
-      "wire_schema_sha256": "c2c14c5784576cb740c7b6f99d57443525eae812133e1764f7c9c44e9d525a62"
+      "wire_schema_sha256": "93b1a6a28f614100aec1b9804ebf98462ed20f1705b90f5f77844b49459254a1"
     },
     {
       "id": "slack_bolt:private_channel_admin:member_company_profile",
@@ -13032,7 +13032,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14940,
+      "wire_schema_bytes": 15081,
       "tool_reference_bytes": 7179,
       "tool_reference_sha256": "b0aa1c7af0bf4591e4177f3a8127c527154606d4587dc08756e7f18105e83bb6",
       "overridden_tool_count": 0,
@@ -13053,7 +13053,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0e1b8aa348778ebfd306f8e063d3984473a27d9aa3475eada444f6cfdba0bfea",
-      "wire_schema_sha256": "7537b15dd2395d96fda05841d4378fe5aa4357bef70d9cd7f09b2da02a47fd91"
+      "wire_schema_sha256": "7b5e7201ecfa6b413eb78c9286cf4b047ef55fc178665bc55a0bda1331a4d963"
     },
     {
       "id": "slack_bolt:private_channel_admin:member_personal_profile",
@@ -13077,7 +13077,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9709,
+      "wire_schema_bytes": 9850,
       "tool_reference_bytes": 6603,
       "tool_reference_sha256": "1be10e69d1c2468a8f3619e586e9b7cd0fb80f57e737ceb7614f552e89795e0d",
       "overridden_tool_count": 0,
@@ -13095,7 +13095,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "278d2a60ad51f3a69b5f03330f7f2b7d3d4a8ff98509f14e558cba79fe3c6e7a",
-      "wire_schema_sha256": "ff1df39b36fdc7627c9c15607a9430d3e0ee3bc271294fbd4adfbf2c6b863edc"
+      "wire_schema_sha256": "40b3a07842f235277a229615209ef66121aef314b998e85c2d866bdc980d9f21"
     },
     {
       "id": "slack_bolt:private_channel_admin:outreach_contact_management",
@@ -13119,7 +13119,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10589,
+      "wire_schema_bytes": 10730,
       "tool_reference_bytes": 4957,
       "tool_reference_sha256": "978d81ac4be58b4e5f0c59260b589e96a95acd041895d6e47cb238614e05642a",
       "overridden_tool_count": 0,
@@ -13139,7 +13139,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "53eb64b204251c7934442c3397a72020de3c911f9c3d29dec3d2d239591e1aa5",
-      "wire_schema_sha256": "0fed13e32364c9ec0ca1f839f71f05aa6215c616be36f94d6c5acf78200d1f5e"
+      "wire_schema_sha256": "204ec6558f12dd0ca3621e36c719d8fdf2d9d1697b4006410e380cd706a221ff"
     },
     {
       "id": "slack_bolt:private_channel_admin:outreach_reporting",
@@ -13163,7 +13163,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10160,
+      "wire_schema_bytes": 10301,
       "tool_reference_bytes": 4949,
       "tool_reference_sha256": "deb6aeea7143042d8abb8afc908abe958eb2c6bb562fd6e31b92162b7c6e4a7a",
       "overridden_tool_count": 0,
@@ -13182,7 +13182,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "9fea2f2b6f7bd11b93a4c4b87e0034f358fccbfe72dbed4ca9c9f45d3030d677",
-      "wire_schema_sha256": "02874ad0cff3f58ac2dd0dfb07d6fcfc5fb113471151252ce1818b4002f645a7"
+      "wire_schema_sha256": "f9579b024ed866df5ee027174ee45ef12edab77db4d3adfd2988fb152b022ea4"
     },
     {
       "id": "slack_bolt:private_channel_admin:partner_directory",
@@ -13206,7 +13206,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12140,
+      "wire_schema_bytes": 12281,
       "tool_reference_bytes": 5179,
       "tool_reference_sha256": "2f1bdba181f4d89bed5f22bf21f070d49964f094ed9aa1638220d2e53bd350bc",
       "overridden_tool_count": 2,
@@ -13227,7 +13227,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4abe43bd711dba6f2b371f991a37f3044b7efe029af19169bc8a891e3030cc0a",
-      "wire_schema_sha256": "cf87115ba620f6fd6f3045dce2a749ddbf5b0aa17006042f4f4563fae18bfa28"
+      "wire_schema_sha256": "99c51e38c04dac4354fec601c2074df2998c042d6faef38de5a38a333f6911c7"
     },
     {
       "id": "slack_bolt:private_channel_admin:property_identifier_catalog",
@@ -13251,7 +13251,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11416,
+      "wire_schema_bytes": 11557,
       "tool_reference_bytes": 5284,
       "tool_reference_sha256": "13831dbee6b1a3c7cd6921429eec948d1b4ee446eddb9e088ed00d7939de7a8d",
       "overridden_tool_count": 0,
@@ -13270,7 +13270,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "3f40589842d92252f4c31df951f3dee47f90d694f6c84fd40cf99beeaac51b90",
-      "wire_schema_sha256": "c01fbe920fc10285094b8a60c6f6af3847a1a37b29e6c0d90fef91995259a972"
+      "wire_schema_sha256": "5ba5aa78aa1a96c657d35cb754d05923078374df5c13446e4d49c892d86f8f25"
     },
     {
       "id": "slack_bolt:private_channel_admin:property_list_enrichment",
@@ -13294,7 +13294,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9523,
+      "wire_schema_bytes": 9664,
       "tool_reference_bytes": 5133,
       "tool_reference_sha256": "90a495e511e631244025479c57aabdaf44869fbda341849f33d6e5d82d1d4f98",
       "overridden_tool_count": 0,
@@ -13312,7 +13312,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "59cd9ba8c99ea5efc46a5ba3c8ff57fa5a02855f68171dade0e196583ed1c95d",
-      "wire_schema_sha256": "495d3ed783c97fe3e3043abb2e61ca20ff7297896a131b36bfa9d8c49de3d665"
+      "wire_schema_sha256": "fda96b55972fa731d69e54f8bd8691f6f24cb9e5ef3ee34273e2d2ebb6100bf8"
     },
     {
       "id": "slack_bolt:private_channel_admin:property_registry_records",
@@ -13336,7 +13336,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10786,
+      "wire_schema_bytes": 10927,
       "tool_reference_bytes": 5362,
       "tool_reference_sha256": "f8db16b555a1cd7f2ed5547a7decd4a45c47a371d05b447825d9d6bdd7f1477e",
       "overridden_tool_count": 0,
@@ -13356,7 +13356,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "4efc04fd88ef1fba8495a1fffe10779d36410775b793777bff55a3dcf38d2773",
-      "wire_schema_sha256": "60bb471663c9a7f158b98d531e7f5e5842b196dc4abdd29be1bbb264f3a31f5c"
+      "wire_schema_sha256": "fd0aeac830426617253183c886b87c7620f6b8cff41d483e99ffb9bdd4009b20"
     },
     {
       "id": "slack_bolt:private_channel_admin:publishing_assets",
@@ -13380,7 +13380,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10900,
+      "wire_schema_bytes": 11041,
       "tool_reference_bytes": 5087,
       "tool_reference_sha256": "d56011932cbd50f96ac3191be635143521775a2fcd9567d4ebfa3e8d1f9dab77",
       "overridden_tool_count": 0,
@@ -13400,7 +13400,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fdc3b16e146cb1098e8fbe4e560b521d8c72da0febb5a43e18a4ee5d4f43a2b7",
-      "wire_schema_sha256": "8a975d08f355c8c1b1a18df73015a16cd316a15fe949632eb8869510138b0785"
+      "wire_schema_sha256": "4821ac40e06fc1d64c6110ba18ecdaa9e46d7b5372cca121aaa3b140b1975a2a"
     },
     {
       "id": "slack_bolt:private_channel_admin:publishing_promotion",
@@ -13424,7 +13424,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10385,
+      "wire_schema_bytes": 10526,
       "tool_reference_bytes": 4976,
       "tool_reference_sha256": "242b8d1ee88bacff1da83025b9e31abcd0c9fd9b15b567c26cb829ad3db59588",
       "overridden_tool_count": 0,
@@ -13442,7 +13442,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "914e5042ff5aa77185e5f5ca8e9a05f1a41124bbd8ba8b599080f70efb9c7b83",
-      "wire_schema_sha256": "b772f60aecc8ffa0350d81313e7deee857d45eca4f477455d1f4e229517b4071"
+      "wire_schema_sha256": "acd6fd57e8b76ec32feaf2bd22e8ecddee3c7bb925f8a55f8f7d7bcc670388e1"
     },
     {
       "id": "slack_bolt:private_channel_admin:publishing_review",
@@ -13466,7 +13466,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10229,
+      "wire_schema_bytes": 10370,
       "tool_reference_bytes": 5157,
       "tool_reference_sha256": "bbd74b8e4738835551b2440b98a1ae56d7846f2d971933af09ec972ed5b40682",
       "overridden_tool_count": 0,
@@ -13486,7 +13486,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a895f645f68398d3e561173892a44e31eaa1cfdfa5dfa74cd3cdd30c833aadda",
-      "wire_schema_sha256": "c5caa7ddc47fa48618ba74b09cc76301ba5554af9e9c2df7d4a555c514b3aa19"
+      "wire_schema_sha256": "4827ac2b31737f015deea00bd512859c97ee3b6fde1b4453b02d30e6b290c16e"
     },
     {
       "id": "slack_bolt:private_channel_admin:publishing_submission",
@@ -13510,7 +13510,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11917,
+      "wire_schema_bytes": 12058,
       "tool_reference_bytes": 5933,
       "tool_reference_sha256": "4368a4534a12db25c52e70aa2e4d45ea9f359786531bfa7a1549cb7622539813",
       "overridden_tool_count": 0,
@@ -13529,7 +13529,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0c9654e2c90afb77d7cb1482baf49531c1dbf1d6ad96e89d9065e2845f0ef290",
-      "wire_schema_sha256": "9a8526aca39c98e9fbccce4ea348015f2d50c43dfe2f91780ef55143f5e29f6b"
+      "wire_schema_sha256": "71574736fbd843f0f486ad2dc5567c674c6e7b7158fbac11a29825a3c54dddf8"
     },
     {
       "id": "slack_bolt:private_channel_admin:router_unavailable",
@@ -13553,7 +13553,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18794,
+      "wire_schema_bytes": 18935,
       "tool_reference_bytes": 7427,
       "tool_reference_sha256": "8627374abce19cb49e5d04a1bb04037a237687c86a96db2f00e71947f5cb5c29",
       "overridden_tool_count": 4,
@@ -13582,7 +13582,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "be35c37cdf3779929cd70ee957c150514f115ff0796c9a44eeb2a326a5b1d862",
-      "wire_schema_sha256": "868d8863be91474176cbcfd36d94f2979be7e745dd75ec1f747bf5ac0a3c9790",
+      "wire_schema_sha256": "7c7fdf09cb6dfd92d4f71b7ef4c7537c641350dd5cb7316928a139852dfbe9a0",
       "target_exception_category": "legacy_channel_router_continuity"
     },
     {
@@ -13607,7 +13607,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11005,
+      "wire_schema_bytes": 11146,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -13627,7 +13627,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "443689ec626f64502248bcf217d42ef60900891d9a4163e30f52dba93a237984"
+      "wire_schema_sha256": "fb719521c0abe29641c041144222f371429552b112530b64a7ada5244f864852"
     },
     {
       "id": "slack_bolt:private_channel_admin:sponsored_intelligence_discovery",
@@ -13651,7 +13651,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
+      "wire_schema_bytes": 10334,
       "tool_reference_bytes": 5309,
       "tool_reference_sha256": "3a8d840efe998abbd5d636abcc586fe5889c3e1282e0bd5e503674461bcd0dd9",
       "overridden_tool_count": 0,
@@ -13670,7 +13670,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "273d2551a68559859045673bd43c47271fa94a6c2d964d52ea97b3ddcc82a3e1",
-      "wire_schema_sha256": "14fb233d8d227dfabb95f29858a9676478f4da482b6872205d51eae2494fc8e7"
+      "wire_schema_sha256": "50638db9f4084536bad895819c3394c83de09b7038f2177a0df409d83ff1da97"
     },
     {
       "id": "slack_bolt:private_channel_admin:sponsored_intelligence_session",
@@ -13694,7 +13694,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9712,
+      "wire_schema_bytes": 9853,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "a6db91f7f951d33d2386aa95c8902dc13d042413c343658a7764921db30faba2",
       "overridden_tool_count": 0,
@@ -13713,7 +13713,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4374fdf27f7f4d8646711d9cd15247ada5ff2a909ed24cfbd9b847b40c6fe3e7",
-      "wire_schema_sha256": "cd9443cf3509268c019d4d7528f0a9b650efcff272b88d9653863825f1a2f41a"
+      "wire_schema_sha256": "f2795405837d1a84a8998ef506930127f587d4a073fbf730249dfd9dc989a10d"
     },
     {
       "id": "slack_bolt:private_channel_member:adcp_agent_management",
@@ -13737,7 +13737,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13166,
+      "wire_schema_bytes": 13307,
       "tool_reference_bytes": 6262,
       "tool_reference_sha256": "3d2ccbb6aba85bd38419a3d9045f5707e4d0f0ba6be27a89a1d1fe8143715007",
       "overridden_tool_count": 0,
@@ -13755,7 +13755,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c0d2d1533050187c0d555031976948036cb84a1b937814f81af6b77701972ab0",
-      "wire_schema_sha256": "1dfd23f8107e98dd592c8c633949e3314b854147b63e602c40d3f736e0e8d047"
+      "wire_schema_sha256": "bbefddd5ad515565950049ea6a7e1ba108020755a2d9c8e58a7d489dfacfd91d"
     },
     {
       "id": "slack_bolt:private_channel_member:adcp_task_operations",
@@ -13779,7 +13779,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11614,
+      "wire_schema_bytes": 11755,
       "tool_reference_bytes": 6310,
       "tool_reference_sha256": "04603aeb0ae569596b5ee5fd6be628303bece3bf65625633a68f9e6e2879d538",
       "overridden_tool_count": 0,
@@ -13796,7 +13796,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "29439abce5e792eca86c1ba105cd40eb03da5b67c1d77aa7808478a7f6817236",
-      "wire_schema_sha256": "010bdffef19c5bc0be999224bc9860ed0c919e0ef770efbdd235b62e4099f3b0"
+      "wire_schema_sha256": "7474c9abc30ab1714ffacdf911cf38b29cbf346e15bbf9c7c6068b6a42b14b5b"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_authentication",
@@ -13820,7 +13820,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8979,
+      "wire_schema_bytes": 9120,
       "tool_reference_bytes": 6000,
       "tool_reference_sha256": "b937948691c576fbcb7f1b179d3d84d2fd8ee5354cf0e9ec23e02728eaf9d3cc",
       "overridden_tool_count": 0,
@@ -13836,7 +13836,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "aa35268403f3b37ff1f3ae0b78bfd8f2fdbefc392a5d3546fbeeca83ca5c6ed7",
-      "wire_schema_sha256": "e616084893239a3360d038f27f027e253460b07d34eb9fa2cd3902a5c7764906"
+      "wire_schema_sha256": "c32fecfcbf637c9b547a939f7c850f3e46c387cef5a396b4193986ae68a49771"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_conformance",
@@ -13860,7 +13860,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7684,
+      "wire_schema_bytes": 7825,
       "tool_reference_bytes": 5724,
       "tool_reference_sha256": "bad9128b97000bf1d5dbea147ade01da67d7d91a01c53ae5d7664090e3060f23",
       "overridden_tool_count": 0,
@@ -13876,7 +13876,7 @@
         "run_conformance_against_my_agent"
       ],
       "ordered_tool_names_sha256": "166257c2827756df7f041cafac875520b810ea3f464f68f15502906bb3dfa3e3",
-      "wire_schema_sha256": "2290b7005932c8517950883ff3608abc713aa3ac37b382240e67ff3dfb82df96"
+      "wire_schema_sha256": "bb17e454b4e2377185654c1b61b52ebc2d55212c31c16e4d0b05355c7aa80b8f"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_end_to_end",
@@ -13900,7 +13900,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17521,
+      "wire_schema_bytes": 17662,
       "tool_reference_bytes": 6568,
       "tool_reference_sha256": "724c570df0c1afbfc5474f247fa2d289e56582171e19ca033a263bf4a38a8591",
       "overridden_tool_count": 1,
@@ -13924,7 +13924,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "01a4e47a1d56a06a49d88c67cef7541d40b7a79d196a034be57130c9182aec3a",
-      "wire_schema_sha256": "ae3d112fe6f349ce16eb5ff5bf6b45ddd72f909646f9c8ecefcaf5d21ac4e7f4",
+      "wire_schema_sha256": "6afb8588ca2c5e02009d4a1a32f0cda3e013daa9acda61c3e7f3ccd3703ae544",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -13949,7 +13949,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7656,
+      "wire_schema_bytes": 7797,
       "tool_reference_bytes": 5049,
       "tool_reference_sha256": "e864b0a33e55d3e7caf062c73af9a521bbcf2a8494a6f1c34e42fcbe54749910",
       "overridden_tool_count": 4,
@@ -13967,7 +13967,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f44279c0b16e64b09a8a1fdd183eb3b82606b5477a249986eae941d027b18aca",
-      "wire_schema_sha256": "03b93c5ac8de474e43c6586f7b8fc43fa9147b8e241dde51a8c6ea15735e3c8e"
+      "wire_schema_sha256": "6ab6dbf06b50ba07dd90c9de354c870af777499e851295d577ff9deb91d2b900"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_quality",
@@ -13991,7 +13991,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12358,
+      "wire_schema_bytes": 12499,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "815eb22df22b1d8f37c869018b9c5e49c83178001b26f1e7523ce09aec7b230e",
       "overridden_tool_count": 0,
@@ -14008,7 +14008,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "32ee638aa5b9177bbea802803498f87f715d059b195e4d0492e56312ff6c9cbe",
-      "wire_schema_sha256": "0a2850d80b2523a669874d940a93a714c73e21f8db67a61371a50c644e019815"
+      "wire_schema_sha256": "a1d8c157b5a199141179bc09a30808ecde2c99bd7975c39ef01f6aa21dc55634"
     },
     {
       "id": "slack_bolt:private_channel_member:agent_registry",
@@ -14032,7 +14032,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8750,
+      "wire_schema_bytes": 8891,
       "tool_reference_bytes": 6633,
       "tool_reference_sha256": "e78fc94ddc9de419855cc10bf05d7a05126c4c50f23abc99d90fc08c530ccdf3",
       "overridden_tool_count": 1,
@@ -14051,7 +14051,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "173718fd9ea51f05c1519f70f4cc6eb81dfb5d82d81ebdbee0e77ccbbefc7f20",
-      "wire_schema_sha256": "78162fb4f54d37c139b4848053f9a14cc789980322d3bc746b40dec9d28f20bb"
+      "wire_schema_sha256": "19bfc0421c37c4f3a9d4840a31de433186c9fbed08527c767b8e959b88d88cab"
     },
     {
       "id": "slack_bolt:private_channel_member:all_valid_sets_maximum",
@@ -14122,7 +14122,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 129080,
+      "wire_schema_bytes": 129221,
       "tool_reference_bytes": 34728,
       "tool_reference_sha256": "1f0f5d10364550b671d8936d3f68c7745c5b31053ee6df30f2e88b75455363bb",
       "overridden_tool_count": 11,
@@ -14282,7 +14282,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c6682221c1906cd860a8f531bc24d25e520ac556a05f70976ca3d7b839740866",
-      "wire_schema_sha256": "db95e410e7e99c76f56f7c27c25bdbfbaa4ac634da475e6b495e2d0d0425b048",
+      "wire_schema_sha256": "7c21bbd5802e853ae93d933fd8461d4060faadf25977f3ab18de698df0cde873",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -14307,7 +14307,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13863,
+      "wire_schema_bytes": 14004,
       "tool_reference_bytes": 5549,
       "tool_reference_sha256": "3d9e0ef13806268f909fc694acc66e88b75809de91dd343dd2282b4a731b3571",
       "overridden_tool_count": 0,
@@ -14326,7 +14326,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b183eaa3b6370d563884bbbc1e78d71e105e4b5f8090cdc9dbab0c1041ab8496",
-      "wire_schema_sha256": "cb9f26b443ec2248eb32899ea66a162d73cd3c843ce1e528ee30260bdf87dbd1"
+      "wire_schema_sha256": "98e43b568bb5469b0ff5d4acb2a842141f8bebb8f69ef79f134f7d0fc96452c6"
     },
     {
       "id": "slack_bolt:private_channel_member:brand_registry_records",
@@ -14350,7 +14350,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8773,
+      "wire_schema_bytes": 8914,
       "tool_reference_bytes": 5212,
       "tool_reference_sha256": "7bda40be2f135095e28761f77dda59f399bd5198a9cca4cc4de885041d8207b7",
       "overridden_tool_count": 0,
@@ -14369,7 +14369,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "216e020594d4d7a8339e16df0fae6761fe628a994db86d295e96d4f3ab6f1d54",
-      "wire_schema_sha256": "9e0084841f9e18256a2159684d8c9347a23a741dd01947551450c303b0afd62d"
+      "wire_schema_sha256": "5311aeaf6c65dab26e2f453ac37453da99760b1d707b7ee420bda6d440e30bce"
     },
     {
       "id": "slack_bolt:private_channel_member:certification_assessment",
@@ -14393,7 +14393,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17423,
+      "wire_schema_bytes": 17564,
       "tool_reference_bytes": 6852,
       "tool_reference_sha256": "414adb08a79ac4142a2967f857c3abb49345cd48daad70100e6a1762b980779a",
       "overridden_tool_count": 0,
@@ -14416,7 +14416,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "790df4634084e2fb5c430ea95d47b4aad105e5cad065f2ab1b3694405e550c02",
-      "wire_schema_sha256": "7fe9a986cef51874ba191843beabca61d9be8169bcf4c1661776f50e4627bdf5",
+      "wire_schema_sha256": "0b3889df9d691e023e2b17a45e8c42fa2bfc6e75a90db8afc0aaa43aa894a651",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -14441,7 +14441,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18326,
+      "wire_schema_bytes": 18467,
       "tool_reference_bytes": 8089,
       "tool_reference_sha256": "346659796dfa0cb862a77cb3dbe215b925a8c59aa3c0296e22a0af15cf384ba6",
       "overridden_tool_count": 0,
@@ -14465,7 +14465,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "463fa4659a702b7f1c65e0598b3c1d0340c915ba31ad3efd626031cc85c502ab",
-      "wire_schema_sha256": "224579a89b00e02213dadd0c0ee850514160d0b1de2ff70d6051fc62971c5bb2",
+      "wire_schema_sha256": "480faf32e4985700bc768db1fd7c08c691713b9ad363d36240983a299174440c",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -14490,7 +14490,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8327,
+      "wire_schema_bytes": 8468,
       "tool_reference_bytes": 5646,
       "tool_reference_sha256": "9a53ee96acd89cd57b17a1e2eefd7db0579223584a0a08c489b75fae2dd819e7",
       "overridden_tool_count": 0,
@@ -14509,7 +14509,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "cf9fc5e1f9fa1da6e4fab7287829c6367f01894d0fe2e1dad8c4ccc244ce8048",
-      "wire_schema_sha256": "8d674770df02dc173a35c04b26bda66251d51506e3aff4d0002cb5aeeaafe10b"
+      "wire_schema_sha256": "8082725b3570063223db9c483d4e4e092876bfb3e19ea38446fc764ac26d37d3"
     },
     {
       "id": "slack_bolt:private_channel_member:collaboration",
@@ -14533,7 +14533,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7537,
+      "wire_schema_bytes": 7678,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "068dd1ae345e461198b3955d26166dcd9bf6d94102993b93f7c2c6115a642fef",
       "overridden_tool_count": 0,
@@ -14548,7 +14548,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "91b057a3704a11380e0df622192c815eb5c43e514d3701109890f421f27a6561",
-      "wire_schema_sha256": "7d56e0c735dc09c3b7c8ab8b6c4bc04dc5e489fe7b23070a35896a36fe18ae0b"
+      "wire_schema_sha256": "7bc2452f52378498e733ff13b1a665d9f6ed7fd8336e49fbba7ca91331fba0c6"
     },
     {
       "id": "slack_bolt:private_channel_member:committee_co_leaders",
@@ -14572,7 +14572,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8867,
+      "wire_schema_bytes": 9008,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "6c3e8581decba525396c1e53df2d6afaf7aa6e9b5bf80df401e63e1cda3bc0ea",
       "overridden_tool_count": 0,
@@ -14590,7 +14590,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "063596a30c0f4e99cfdd77779d92a7145e459caff78c9dff3604043a9ae8c59c",
-      "wire_schema_sha256": "ef2df999c1e0e89e3a4d2f29e58c096f2a05db5781b97ab22681cf724593a156"
+      "wire_schema_sha256": "ab974565c5b82fadcde3f73292631edbe36a14535a1c668bb7dc19112b30549d"
     },
     {
       "id": "slack_bolt:private_channel_member:committee_event_planning",
@@ -14614,7 +14614,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10453,
+      "wire_schema_bytes": 10594,
       "tool_reference_bytes": 4869,
       "tool_reference_sha256": "07ca352ac259a3f7ba7fc6d292b3d7651993267bcef116dd2b83d8e407d50ad0",
       "overridden_tool_count": 0,
@@ -14631,7 +14631,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "61b15f24d4412ef90e46e186ee894b94fd1934ec2c87650d4ffee7284407076a",
-      "wire_schema_sha256": "af63723c8ec93ac60a616fdbf98cf77bb6c6ec6ab539d57585bb1fa943fdb86e"
+      "wire_schema_sha256": "a3b5babe3fae195cd6181062015bebbaa2db05fe94d81f0cc7e3095c79b5a78b"
     },
     {
       "id": "slack_bolt:private_channel_member:committee_event_registrations",
@@ -14655,7 +14655,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9177,
+      "wire_schema_bytes": 9318,
       "tool_reference_bytes": 4926,
       "tool_reference_sha256": "648cd8b0d8d84b2a2208c82f366b7ac9f4e84dab8bdfc5e72160c898d80f29a2",
       "overridden_tool_count": 0,
@@ -14673,7 +14673,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "369b9218680099ed68bc9d5552efe5f4446c5b4792ab573e9e890c507a44185f",
-      "wire_schema_sha256": "41344247ea67693b5b673df108a1a293f73e872286bcebe60e0390a5465f4480"
+      "wire_schema_sha256": "e3502e6d2b036fcd84070f1ac13a3da42fef4115deecbffa7e7deb40be149a92"
     },
     {
       "id": "slack_bolt:private_channel_member:committee_full_leadership",
@@ -14697,7 +14697,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14897,
+      "wire_schema_bytes": 15038,
       "tool_reference_bytes": 5204,
       "tool_reference_sha256": "73a64178cee70c326c45c27854fa4b29f61c9dc4203c20deb8cdbde7d932d29b",
       "overridden_tool_count": 0,
@@ -14720,7 +14720,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "3ef51ef6c23dc0bb939300d94c013762dcc27966aecdaaa1260aa3786c167cdc",
-      "wire_schema_sha256": "904072f3004a6f52d211601a328088912734622ae51622caaaebcde80b08f731",
+      "wire_schema_sha256": "b30205b328e7ca8969df567373277d78f4729864a0c27005b635a125e754c8dc",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -14745,7 +14745,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8617,
+      "wire_schema_bytes": 8758,
       "tool_reference_bytes": 5018,
       "tool_reference_sha256": "121afdcbf592ca6eedf859b93dbc32a0d10f046be5c82a3d40caf6752209cb51",
       "overridden_tool_count": 0,
@@ -14762,7 +14762,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3b942e3d6661676eadfeadf4a6ef255eb2bf7031897813df8e9ea1e49e22bf56",
-      "wire_schema_sha256": "14006ec0e717dcc82409b234aedee5878c460c5d7ab99c4cf7a016ae32cc4b5e"
+      "wire_schema_sha256": "af8905a330bc38b22c20d974cb2bf9f4bace445e41bd3215d2a7b541e89d4c4e"
     },
     {
       "id": "slack_bolt:private_channel_member:community_group_contribution",
@@ -14786,7 +14786,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7818,
+      "wire_schema_bytes": 7959,
       "tool_reference_bytes": 5246,
       "tool_reference_sha256": "152900bc3d9f41d32d451c4ac8be8c23f69dffadbc08ae9ca8bc2096f1afcbe8",
       "overridden_tool_count": 0,
@@ -14803,7 +14803,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d0d8e5d8794d84fcbc14242245599cfffc6efdaf2f0c95c364b38bb8d6d2d726",
-      "wire_schema_sha256": "6a8c30e0c92df59895e554df7e745d6fef443088a09d3f6cf9956611d1b3270d"
+      "wire_schema_sha256": "794be7c89294c0994e2119f91ac06b4b5e07d3dbb20efc15a4e271923e54751c"
     },
     {
       "id": "slack_bolt:private_channel_member:community_group_discovery",
@@ -14827,7 +14827,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7861,
+      "wire_schema_bytes": 8002,
       "tool_reference_bytes": 5187,
       "tool_reference_sha256": "d0e9bd5129bd8760c05e98f921ccc95426fe90e70d6aef554bd686fdfcfa5d0e",
       "overridden_tool_count": 0,
@@ -14845,7 +14845,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3ee5d15eafe1c588bced75166f704e89aab43275266d8b47ba666388fa23ca6d",
-      "wire_schema_sha256": "44415464c14f4750bf57e001721a201670761b6beeb6d3b64e0314e6baa65682"
+      "wire_schema_sha256": "df63d6fd395cf19acf04212a86e6f017d21801bf89a1fd13cdf1488f0e991679"
     },
     {
       "id": "slack_bolt:private_channel_member:community_group_full_participation",
@@ -14869,7 +14869,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11106,
+      "wire_schema_bytes": 11247,
       "tool_reference_bytes": 5298,
       "tool_reference_sha256": "80fe2d2700902546fe5e83a4dabb0972bd02912c7f3e4a4c30b3d63a7f11c144",
       "overridden_tool_count": 0,
@@ -14894,7 +14894,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d84555d6b82afdd6959fa75186599e3cb0eb59ba7ef4fc9bdc342620712cf0f9",
-      "wire_schema_sha256": "dec4c8306907826d97cb014172aaabc8a1813780abe21071bda8d0c09f56a48a",
+      "wire_schema_sha256": "23f519cf63cf92e41183131c60e30587cd7809627864cb4f6a6c7e0fc396ea74",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -14919,7 +14919,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8228,
+      "wire_schema_bytes": 8369,
       "tool_reference_bytes": 5220,
       "tool_reference_sha256": "24ab86bf1679054829bd2cd425f87f559118fa501aaaebd060429615a876d5a5",
       "overridden_tool_count": 0,
@@ -14937,7 +14937,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "93da32ba816b1c3678855eacc260dadf902727d23ccb7c524d29e132b1b31551",
-      "wire_schema_sha256": "f6ee5d3de237607b436dab4f7f332f67fb5fafa3b5db5ffa3db30e83fc13d06e"
+      "wire_schema_sha256": "6783b521c6665b4ae2e51a99d16dbc0a09776486e1be4d69f905d8092c700cc9"
     },
     {
       "id": "slack_bolt:private_channel_member:content",
@@ -14961,7 +14961,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8834,
+      "wire_schema_bytes": 8975,
       "tool_reference_bytes": 5015,
       "tool_reference_sha256": "ff49e5adf006709f1a45aa0a9af51aa9f8a7f85e224c512aea4dad1fc291b2ea",
       "overridden_tool_count": 0,
@@ -14979,7 +14979,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "82ce1e649afc38958ef06db762d13fe999ee4b04095ff5d5044344ac7fce4e7a",
-      "wire_schema_sha256": "950976d1ed4068184b73e7c853f123f95d5b443b039f7872105816915d9c378b"
+      "wire_schema_sha256": "79ec89ff0a645818b29e0203efacbd531835cab5f5191ac3a88571a1d3b20b73"
     },
     {
       "id": "slack_bolt:private_channel_member:council_interest",
@@ -15003,7 +15003,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7862,
+      "wire_schema_bytes": 8003,
       "tool_reference_bytes": 5182,
       "tool_reference_sha256": "00a0d6dd08ec9626b5f39dd01e60f62a4c0d6b052136b3cb8186188c163e9ce7",
       "overridden_tool_count": 0,
@@ -15021,7 +15021,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b6f0d8f9b4251533f855be149de6d5f265bd92f498ff458283723dcba93d547a",
-      "wire_schema_sha256": "e0224c9085f0e6f6006568a08ecf325ce6b2380cd8211a275cd65f718262085f"
+      "wire_schema_sha256": "7c4b1ed6479478e8230803c538d540f37d87d96a63fcde05e121128c60b3ff07"
     },
     {
       "id": "slack_bolt:private_channel_member:events",
@@ -15045,7 +15045,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8762,
+      "wire_schema_bytes": 8903,
       "tool_reference_bytes": 5022,
       "tool_reference_sha256": "d0d0a800352042ec9c342399e44ba8df2453093ceb8854bcd9b2210d7d67c138",
       "overridden_tool_count": 0,
@@ -15063,7 +15063,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "dec8b1e73a67b4044e464a8ada67f64611e9cdbe2683c0e7e5fe8732aad1dd0d",
-      "wire_schema_sha256": "c66df15de10255687d4d0200d52556b0ab8b57c5c69814399ed31a74e4935b05"
+      "wire_schema_sha256": "673bb0e6c25a1321be42f8c7d4cd0ad374bd40430ffef5fdf381a20ec034a800"
     },
     {
       "id": "slack_bolt:private_channel_member:github",
@@ -15087,7 +15087,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10407,
+      "wire_schema_bytes": 10548,
       "tool_reference_bytes": 6005,
       "tool_reference_sha256": "153b3f7994700206e694fde53f0dd0a55ff7bd73f6fbe7bbdd3133068c3a57ca",
       "overridden_tool_count": 0,
@@ -15105,7 +15105,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e7cde1aedf4ffdc3722e9b8d80a15e06e7a92767847470acbf77aaa7294c402",
-      "wire_schema_sha256": "c2e6b031ee991457569e82e13ffc2893cd2309f0eb8eed7483ee0573acc504ef"
+      "wire_schema_sha256": "665355ed88edfbec2ddf83c2070aa07e59e686d9fe64950611c7a0f80a415044"
     },
     {
       "id": "slack_bolt:private_channel_member:illustrations",
@@ -15129,7 +15129,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7216,
+      "wire_schema_bytes": 7357,
       "tool_reference_bytes": 5618,
       "tool_reference_sha256": "623ebf79339bd5110e3c5fc552029d1dd963ec75656ee5c33d0a70ae0bb424c8",
       "overridden_tool_count": 0,
@@ -15144,7 +15144,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2262e46c9d68205fbc414bd4692d1f8c6fc2016e9e23c26a41d5f07990ca23f3",
-      "wire_schema_sha256": "01bf7d3937ebe469a34902a012f306e28554f298c7ca92ceb552a45f0a47be10"
+      "wire_schema_sha256": "c7be7227a3ed18b712471906aa926f2812b523208d79c5506c5d5e10624e8040"
     },
     {
       "id": "slack_bolt:private_channel_member:industry_research",
@@ -15168,7 +15168,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8458,
+      "wire_schema_bytes": 8599,
       "tool_reference_bytes": 4972,
       "tool_reference_sha256": "185900837249fb365b264337b3d47582c5fc7f4f532a4cf01f420f5acc97bccd",
       "overridden_tool_count": 0,
@@ -15185,7 +15185,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c03b924580ac2b085190e3b4ae5c211b92918be3bbbf87c8c2feb40c59140deb",
-      "wire_schema_sha256": "a0ded125df614b848b41decf0b925fd49bc504cd9a9b7cbbb2839f3ac374f557"
+      "wire_schema_sha256": "c86a0caa2d0edaf672fcfb2d3afebe6d5c46c18aafe4942614eef27a874113ec"
     },
     {
       "id": "slack_bolt:private_channel_member:knowledge",
@@ -15209,7 +15209,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9563,
+      "wire_schema_bytes": 9704,
       "tool_reference_bytes": 6204,
       "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
       "overridden_tool_count": 0,
@@ -15226,7 +15226,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
-      "wire_schema_sha256": "5438b4aa64ac11bb20f3f810fa76e1a542f6b54087b2329203de2a124311c11a"
+      "wire_schema_sha256": "ec8ac68fd4d8b0eb30babafab56ea4414f429e10dd4e22c738884a51a8c2b42d"
     },
     {
       "id": "slack_bolt:private_channel_member:meeting_attendance",
@@ -15250,7 +15250,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8945,
+      "wire_schema_bytes": 9086,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "df3af926f99c7f9d48206b0c20048f46be655ec3881722c8be2be2db81a63acf",
       "overridden_tool_count": 0,
@@ -15269,7 +15269,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "9a66a9d3f906bd65c3235d8f9fd264d2dfc900ffc5860af19c7b5d32f99a4d8f",
-      "wire_schema_sha256": "b7ec2bfb8d39f7899e36e8d654f46802b48bd67a8bb966de97ea5b84860cb125"
+      "wire_schema_sha256": "5d0cc9b52e8442f9bbd21e684ec4837f286f6054c93f320e53db8817bfaea287"
     },
     {
       "id": "slack_bolt:private_channel_member:meeting_full_administration",
@@ -15293,7 +15293,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16400,
+      "wire_schema_bytes": 16541,
       "tool_reference_bytes": 5127,
       "tool_reference_sha256": "000143f1682565038450ae5a74b8276cca8d354dbec76741dd85d46052760238",
       "overridden_tool_count": 0,
@@ -15318,7 +15318,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "8bcb247100605d8c2354b2fa7a9f1a2b5c349fa2aab59266996b5bcdf634fa51",
-      "wire_schema_sha256": "e9986416e30b85a45f5732568173f1a5f8b8653e4e43e9de3dbe18457134ed86",
+      "wire_schema_sha256": "25082d4bb25baffcc0880a8c99ad02c5a85d4a2b4beb22e930b1f733773fd2e1",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -15343,7 +15343,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12258,
+      "wire_schema_bytes": 12399,
       "tool_reference_bytes": 4978,
       "tool_reference_sha256": "a59255184701822e566e5691e81b78ac059fd7a5e3b90284837c2f70fed0ef1a",
       "overridden_tool_count": 0,
@@ -15361,7 +15361,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "7d975630d220603ee3b6cbf059fe22fd9783702a41ab1ed034a1728a95a3e658",
-      "wire_schema_sha256": "e99f89fb6b6000ac1fd12877cede72f3105201964c9add14836d790d9bbe128a"
+      "wire_schema_sha256": "2253c5750ed560bd5432ce9193d0311b535a4afd0204a095068dd2df77633d11"
     },
     {
       "id": "slack_bolt:private_channel_member:meeting_series_topics",
@@ -15385,7 +15385,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9179,
+      "wire_schema_bytes": 9320,
       "tool_reference_bytes": 5051,
       "tool_reference_sha256": "41cdd27ed230ed4b8267bb4e12a4374fcbc4760641fb45cbf0b23106dfb028cf",
       "overridden_tool_count": 0,
@@ -15403,7 +15403,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "7e127221944ab98d82c8ea4c6a144d7f65081bd75d2d35700b5e4fc5219e01a6",
-      "wire_schema_sha256": "f0637992f399d4aa9f2e7a7897c476aed290bbe9d3251ec4763f586e679ee40c"
+      "wire_schema_sha256": "90d6c562f04be6f98a5915bc3f594575806d39321edb5e5d4f17e80f0eb33e99"
     },
     {
       "id": "slack_bolt:private_channel_member:member_billing",
@@ -15427,7 +15427,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9764,
+      "wire_schema_bytes": 9905,
       "tool_reference_bytes": 5601,
       "tool_reference_sha256": "a341d5c2e105981cd5b9a59335595d0857f26c560edf48b0224c584bb832e0ff",
       "overridden_tool_count": 0,
@@ -15446,7 +15446,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8699d6181a5d508084790d0cba1a651a4bc2dcd7a4778343c1e1c74d8194805",
-      "wire_schema_sha256": "445ea8435ca1189973da1380ccfaf1f7cf92a320f874c30233584fcd0b5a3751"
+      "wire_schema_sha256": "cabd0cb631cf16d712d77eeb947de1193cb6bf7695a2915ad9e6af229261b644"
     },
     {
       "id": "slack_bolt:private_channel_member:member_company_profile",
@@ -15470,7 +15470,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12646,
+      "wire_schema_bytes": 12787,
       "tool_reference_bytes": 7111,
       "tool_reference_sha256": "35dd65133e09a8f9a9983ac8d38e362612aed792bb65ea66fc08923a1f6a82f6",
       "overridden_tool_count": 0,
@@ -15489,7 +15489,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8f6f85c0206f418794cc44768ecd12209f1b28f37c41bb463800ef829d542c54",
-      "wire_schema_sha256": "ab5c358b264bc08aa27993a3242b5764c599d379a3bea224900bce88ea1df0fd"
+      "wire_schema_sha256": "054ab5c37e70843aba7803a8ae60dc51c77c80d99a68a9282369c441e163b23e"
     },
     {
       "id": "slack_bolt:private_channel_member:member_personal_profile",
@@ -15513,7 +15513,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7415,
+      "wire_schema_bytes": 7556,
       "tool_reference_bytes": 6535,
       "tool_reference_sha256": "0b3ad904d581c85060bf4fcf486b2feaf130f5eb13e53a66c273d0b1628e8ed6",
       "overridden_tool_count": 0,
@@ -15529,7 +15529,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b38dbd9cdb706e4bec9988f5f79ddf06c3add5fbbb3d642d020aa47580a1c188",
-      "wire_schema_sha256": "f291ad37c42ffeeeea7c29772478a34da6482727b580d3e9d5ec17f9c61298d9"
+      "wire_schema_sha256": "26e9ba660534e07fb4c0505b280c3fe5fda36bf20c7cdab9cc1284a565178f2a"
     },
     {
       "id": "slack_bolt:private_channel_member:partner_directory",
@@ -15553,7 +15553,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9846,
+      "wire_schema_bytes": 9987,
       "tool_reference_bytes": 5111,
       "tool_reference_sha256": "a2c31cc736db63698935549fc4cc50145d0d5620aadd13ec001b5a57a6e21a81",
       "overridden_tool_count": 2,
@@ -15572,7 +15572,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bcae4bb08bebd099c9bf9207069921d51e16f79f607ff74883ab20bd515f90f3",
-      "wire_schema_sha256": "c7ec3a0ae906c9bd8ad2c3f0fa2ccf9c85fad786463e86fa52f8047110c23071"
+      "wire_schema_sha256": "a94d80cf2ce8d7ad435c782fb11a6cc9f2a83671ed845c0071d58e1b1c9f0f9b"
     },
     {
       "id": "slack_bolt:private_channel_member:property_identifier_catalog",
@@ -15596,7 +15596,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9122,
+      "wire_schema_bytes": 9263,
       "tool_reference_bytes": 5216,
       "tool_reference_sha256": "f601e979751136d9791f545ecd22c07a13bfe0992d57c8132a4a12236b0acaf2",
       "overridden_tool_count": 0,
@@ -15613,7 +15613,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "aab2803cfb10c48ed22433a12d597a29cfbb108da9594ba642298056510b44f2",
-      "wire_schema_sha256": "3bacda2bff63186913b51b0526b4f63aeb1e2321fb05843800566b3dc6abee4c"
+      "wire_schema_sha256": "6515b61fd8007e5748125c56512bd494fc0ed387fe4b020f2804a08b65629b29"
     },
     {
       "id": "slack_bolt:private_channel_member:property_list_enrichment",
@@ -15637,7 +15637,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7229,
+      "wire_schema_bytes": 7370,
       "tool_reference_bytes": 5065,
       "tool_reference_sha256": "0d5b48fe7e301b593e2c037bbe63663f9b8b8657b79ab8fd08c7fa24307c2a17",
       "overridden_tool_count": 0,
@@ -15653,7 +15653,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "438911e6103584c2b1a56dc85cb88fc27a4058a972f2ada41568f97e40f118b6",
-      "wire_schema_sha256": "1df55b955f0f9894c63614ffe350252a80ee584016135d8c5f338aff86d9d220"
+      "wire_schema_sha256": "07d9f089ad797a270dee73fb19e83a6555caf8d7067249e480ed9bd738bdb97a"
     },
     {
       "id": "slack_bolt:private_channel_member:property_registry_records",
@@ -15677,7 +15677,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8492,
+      "wire_schema_bytes": 8633,
       "tool_reference_bytes": 5294,
       "tool_reference_sha256": "9db46b41e9dcb5583694e069f64c5cfd02727e6134feebe06666e3ea8505f6e8",
       "overridden_tool_count": 0,
@@ -15695,7 +15695,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "f35d857d81802956401ab47bd71f0b06a480bb636ca347f0ae928e5af642da8a",
-      "wire_schema_sha256": "704f0a3527433030c4a3ed82a7eb4878dacb1c0d45262db00e414437e3c75144"
+      "wire_schema_sha256": "49382c593b971754422988be697c341b872061d8aef7bb996dd1860419980869"
     },
     {
       "id": "slack_bolt:private_channel_member:publishing_assets",
@@ -15719,7 +15719,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8606,
+      "wire_schema_bytes": 8747,
       "tool_reference_bytes": 5019,
       "tool_reference_sha256": "76b5d90221f61a3b3510669dbbb83391980b917f6e01d6949205e8a669477bbd",
       "overridden_tool_count": 0,
@@ -15737,7 +15737,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b28f189dc7f1f3e9c0e3b1e8c21c782031a27af29ee92fdc774cad495f9d358d",
-      "wire_schema_sha256": "73ef5c2b385d2445dc245d4d018fc45359090ac4bd0a7df36cb3713cdc58302c"
+      "wire_schema_sha256": "3fc9213c19c46c09e85ab261d2ec3031ff2db832e33634b1323b9c003f07a9c8"
     },
     {
       "id": "slack_bolt:private_channel_member:publishing_promotion",
@@ -15761,7 +15761,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8091,
+      "wire_schema_bytes": 8232,
       "tool_reference_bytes": 4908,
       "tool_reference_sha256": "028b475316bf9318c8daf7e8db4c2bc999f6765438191278143deaf41d83f84c",
       "overridden_tool_count": 0,
@@ -15777,7 +15777,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "12fc6a926164fc6d781582726b792bce04c0d955dcd1881fcba91cfccad46a43",
-      "wire_schema_sha256": "531a42722f29d3fec4e1b6c2db4eb62bae0ea522e050c88e9369f48c8346dad9"
+      "wire_schema_sha256": "71e143fc055ea35d849ae8031d3204717aecc703ec5a09d3eeafcf7ee47e943b"
     },
     {
       "id": "slack_bolt:private_channel_member:publishing_review",
@@ -15801,7 +15801,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7935,
+      "wire_schema_bytes": 8076,
       "tool_reference_bytes": 5089,
       "tool_reference_sha256": "293cccb606c14259488ae08b58dd5864c1cd5cdb261ebdde177cdf71c030930d",
       "overridden_tool_count": 0,
@@ -15819,7 +15819,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "6367bb5059c34b3346ad8ffe1e3b768852a2e7389e6c2c0f4e1d97d2b006b666",
-      "wire_schema_sha256": "2f060dff5af7d527393686dc2d1e06986583280a86a15e95d4cf831c8f4384cd"
+      "wire_schema_sha256": "361f6c77be8270ad9e01ff835a9d8fed47baf1891b879ce3e6e99bb6d838b352"
     },
     {
       "id": "slack_bolt:private_channel_member:publishing_submission",
@@ -15843,7 +15843,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9623,
+      "wire_schema_bytes": 9764,
       "tool_reference_bytes": 5865,
       "tool_reference_sha256": "c43c878587751a7b5f684d5e3b47be6f94c4bbe7ad889cf32b4713ed6ba2a924",
       "overridden_tool_count": 0,
@@ -15860,7 +15860,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "aba155c978eca98aa50d8e3397966f83f4b0b8532484458082433d8f106032f5",
-      "wire_schema_sha256": "6d5281a4edb4988ce0166404aa7043db2cc82af4f52b6b0e9ae6380c38bd9190"
+      "wire_schema_sha256": "1f600b2b4d9e9a1fb722ad9a84b946476ab263ace6dd6b0b7b6baf5e66f58dcd"
     },
     {
       "id": "slack_bolt:private_channel_member:router_unavailable",
@@ -15884,7 +15884,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16500,
+      "wire_schema_bytes": 16641,
       "tool_reference_bytes": 7359,
       "tool_reference_sha256": "f1fcadd9c4dfa7e3fcf67f4f050227bb0a7e37b5d30d8d812c1b04ec50c27b2e",
       "overridden_tool_count": 4,
@@ -15911,7 +15911,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "7771bc4ccaf1f93b1c16b3e86054c10b50ce447dd631c5e161eb035c1462741a",
-      "wire_schema_sha256": "5697462203306cef0764272c5fb0bb53718b506ab5d81b9b465466323b0f5cc6",
+      "wire_schema_sha256": "caa40b18639f2a8798052bfb132cefc1046312df55508c2006b97f3a12bcb577",
       "target_exception_category": "legacy_channel_router_continuity"
     },
     {
@@ -15936,7 +15936,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8711,
+      "wire_schema_bytes": 8852,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 4,
@@ -15954,7 +15954,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "8b72f1ae05db4aeef98159092ffd8e443b623eb4e19b30bf0be9443cc739bd90"
+      "wire_schema_sha256": "b680060649c8e0fc0921e98428b53f5b567d84f31c4ecd952047679811816401"
     },
     {
       "id": "slack_bolt:private_channel_member:sponsored_intelligence_discovery",
@@ -15978,7 +15978,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7899,
+      "wire_schema_bytes": 8040,
       "tool_reference_bytes": 5241,
       "tool_reference_sha256": "3c43d712cf42391096e4c83cfb5ce4cf7388385519d5ec966d1edc73e53a964c",
       "overridden_tool_count": 0,
@@ -15995,7 +15995,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "10dc3537f2c3b17d9f0364e80871604779981fcba52329e34b442ceee2c396b6",
-      "wire_schema_sha256": "00e9bf28f9d1e0b60747706f7a756166f8222ce66f08ab5d826b5f7437674f4b"
+      "wire_schema_sha256": "922c919dc877b18418917c7fe2a9515f8fc6661841065875779824cd1d810a80"
     },
     {
       "id": "slack_bolt:private_channel_member:sponsored_intelligence_session",
@@ -16019,7 +16019,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7418,
+      "wire_schema_bytes": 7559,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "b0c20685f8468efe08eda7704772d86eb52c6f23de9d4af2425b8f97ffecc870",
       "overridden_tool_count": 0,
@@ -16036,7 +16036,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a57a8f996c5c03f33848a5dc74ef82c65a5d990f8ee2c9dbf85a08b8f90628b3",
-      "wire_schema_sha256": "b346004519c43ef64023ce979be1c59481536490c537b430d5c06f08e9e24b11"
+      "wire_schema_sha256": "612102c9dec28da25aa58d000a5890ccf2134cccb68a5b5f423140a609287e05"
     },
     {
       "id": "slack_bolt:private_mention_admin:maximum",
@@ -16063,7 +16063,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24652,
+      "wire_schema_bytes": 24793,
       "tool_reference_bytes": 6157,
       "tool_reference_sha256": "fe1ff193bf1d76fe9ce5e8cd0fae7346feab6181648dd83bca54b619f0bb7c03",
       "overridden_tool_count": 0,
@@ -16104,7 +16104,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "72797edb266c5688d07bd08f242c17bcc62e317351ab2324d94919dd21ce2268",
-      "wire_schema_sha256": "182a994c3a992e01089e82f5abc857061a7aa24a27cef740274507304fb2e9c6",
+      "wire_schema_sha256": "c6beca5286f029ddbb4e30d1c7171098e4ac402e56c0aa963dea86e35f332f7e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -16132,7 +16132,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28118,
+      "wire_schema_bytes": 28259,
       "tool_reference_bytes": 10932,
       "tool_reference_sha256": "111cd7597a76c890bb6ad724e6f2aa1e2fa01a16d8451b54572108ffc0598a80",
       "overridden_tool_count": 0,
@@ -16166,7 +16166,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "6a797b29e5de0a1f10dc1c3c4fcdac226883b6fe9dfcdfa6e2a3009713df8080",
-      "wire_schema_sha256": "c8c8f4eda625999f45dd6f4fd463d2ab091cfa7570db72dc698eea5e26039ae2",
+      "wire_schema_sha256": "c8889db09e254bf657fe8f8241cdfa990719d6bc65003cc004c00d3959d15c2f",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -16194,7 +16194,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32993,
+      "wire_schema_bytes": 33134,
       "tool_reference_bytes": 10389,
       "tool_reference_sha256": "0facc2995e2d13ee0b676e0981dec54c8e11b4b18aa2feb85756275931937a2f",
       "overridden_tool_count": 1,
@@ -16233,7 +16233,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7d36f54196c7f9797937fd307a1b6d6365af061a473f90a2f34735a168584e64",
-      "wire_schema_sha256": "a58fbf70267239c52565dddd7e50cdd6841e32e67328ee2b506204272319add1",
+      "wire_schema_sha256": "54e949630c48dbdcd3056f0989a59561eef4b517f39ad9e6eeae9543bb70de90",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -16258,7 +16258,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15460,
+      "wire_schema_bytes": 15601,
       "tool_reference_bytes": 6330,
       "tool_reference_sha256": "6aef477bf109d821bdfa8fd07c90523f69b3a7fbe386ae353280665105de3e0f",
       "overridden_tool_count": 0,
@@ -16278,7 +16278,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ad8390526ff9af140bd7e4b0416ad3cfc4c028e44028070b95a06ae152bfa05e",
-      "wire_schema_sha256": "dc7103f30f9e621253fee5592d6b96ef643d57b5903fd0382052fff981b07d2a"
+      "wire_schema_sha256": "ca0da259992847a847763ab958007800ba2f205f075ee4881cb44a5333dc211a"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:adcp_task_operations",
@@ -16302,7 +16302,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13908,
+      "wire_schema_bytes": 14049,
       "tool_reference_bytes": 6378,
       "tool_reference_sha256": "6f40fffb21d3be25b7651e53dd9c9555d8b6e844e0ada398314863d004ece8c6",
       "overridden_tool_count": 0,
@@ -16321,7 +16321,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07d619635ece821a834856c3c589ae9b3fc571ad61b993c621cc54a1d488360d",
-      "wire_schema_sha256": "64851675e3c695f012343f8b9797e22e1ae9439f74b95611799e7d10029bab3a"
+      "wire_schema_sha256": "5a230a0d07bd7a8115422e4b3efe48a522cb92c8f77b8fa38a807b617d8a08a1"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_billing_account",
@@ -16345,7 +16345,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11076,
+      "wire_schema_bytes": 11217,
       "tool_reference_bytes": 4918,
       "tool_reference_sha256": "c633c81589d01cce53e416bffb362e31d3fb38c1fa7ae0be2bc1b3a89b8a30c3",
       "overridden_tool_count": 0,
@@ -16365,7 +16365,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf202ec0b5c16623f805b27e931a3423b95b24caee51e1a76dab242af5e113f2",
-      "wire_schema_sha256": "e9ded10e5ae64f63be983786276642b415b919c5a67b81f273864451863a0fbf"
+      "wire_schema_sha256": "cc2ab61e3ad19b17010c5a5c7de0eafa41a6fae2de4810a38e3808934506a57b"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_billing_discounts",
@@ -16389,7 +16389,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10390,
+      "wire_schema_bytes": 10531,
       "tool_reference_bytes": 4885,
       "tool_reference_sha256": "e6c54c011bf4113a5acfb57919b1eea144a9e2e9b037a7fa90402c91e92c4af4",
       "overridden_tool_count": 0,
@@ -16409,7 +16409,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3d5a0d9845becf4948711c6b98b82b974ad8a580d75ec4b9440d3ba0df936d28",
-      "wire_schema_sha256": "01b4c5607355c8cc879da53dc000c63d208a6c74db48dacbc300d9da16dfeba9"
+      "wire_schema_sha256": "0f0359f0ff406ae27ba491aa5346a3141b5f9c5d7d5a41e6c4c072406ff8be64"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_billing_payments",
@@ -16433,7 +16433,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11959,
+      "wire_schema_bytes": 12100,
       "tool_reference_bytes": 4873,
       "tool_reference_sha256": "beafff27d131ccfccf76c4ebf261d2ea9266a44aed3072c3e5af8b876cab4ef7",
       "overridden_tool_count": 0,
@@ -16452,7 +16452,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4658b9b7dbd4a931f13ea064882fc4fa4fdd16b52cc772c54896e65520480301",
-      "wire_schema_sha256": "c16b5a136d8ab7e05713da928b904228b45c0d43d80ca474cbae14ad0c64182f"
+      "wire_schema_sha256": "2dd912f723bb64fecdfb58f2d684ea5b45d30d38512179b7b8f1356baf188325"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_brand_logo_review",
@@ -16476,7 +16476,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10322,
+      "wire_schema_bytes": 10463,
       "tool_reference_bytes": 5103,
       "tool_reference_sha256": "18a8f680141c30fb3779c55d499734812898390dba839f7e842c5402550132d5",
       "overridden_tool_count": 0,
@@ -16495,7 +16495,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "6c9af95c4975829a7bf94aec01f35a754b8d9cdb812f5dd150c15eabac456de1",
-      "wire_schema_sha256": "c075708004e5259ded57bf7b460f7a123abf8b3c00f6327dd1f6820be35ab45b"
+      "wire_schema_sha256": "35c211082c30ee248197647c07c439c14d8c53f354fb224abdd862b433c98f55"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_brand_registry_integrity",
@@ -16519,7 +16519,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11031,
+      "wire_schema_bytes": 11172,
       "tool_reference_bytes": 5206,
       "tool_reference_sha256": "076d054efacb1b4921f34c5b4c2fa862adeb91d2c383f34ad016cb46c3ef9cdc",
       "overridden_tool_count": 0,
@@ -16540,7 +16540,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "20034d602e5fe0640db9017a31bbcfc4e1c8012b17c55022c6a86eabbe8493a1",
-      "wire_schema_sha256": "102609b8e85067acf55311c7bbfd0d7dabc1ca87f5ffd1331ea6255bd34cc26b"
+      "wire_schema_sha256": "3486e907585e59a83052d8c6fc6583648c6f45bbc5407b265fab68b761254f3b"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_conversation_review",
@@ -16564,7 +16564,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11022,
+      "wire_schema_bytes": 11163,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -16583,7 +16583,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "46c7d110ac26bd45dec3fc0870880584f46522717bd470d4e8242b1eeada4c77"
+      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_events",
@@ -16607,7 +16607,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14607,
+      "wire_schema_bytes": 14748,
       "tool_reference_bytes": 5045,
       "tool_reference_sha256": "c30cb271ee192379bdfd17da6cd5bab315e4c560f86a13f66f5192aa38ca6ed7",
       "overridden_tool_count": 0,
@@ -16628,7 +16628,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "0e315f56035f7f695f6e8b981c5b484c9802fc1b0f948e767a6bd57eb3cbafa8",
-      "wire_schema_sha256": "2b1d53f3e95f2dc8b66f3b91c52775cfb3292ed32bbf151edd33c069fdda5b20"
+      "wire_schema_sha256": "2ad96203888e13bb531d0725ed59dc9bdbc70bfebcaca69b6104225882d68f64"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_feed_curation",
@@ -16652,7 +16652,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10769,
+      "wire_schema_bytes": 10910,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "51b1859d98819b87b8cf43469c7151cee160b47dab60e0185ebbdb25b7206911",
       "overridden_tool_count": 0,
@@ -16672,7 +16672,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3dcfb69f2292cd2753faf15d02c0077a157e404763b47af52d306370c4975ea2",
-      "wire_schema_sha256": "dfe8b2570e3c6dd0470221132cebbb5c33bc6f4c95ee55c06f29bf5318fe49fa"
+      "wire_schema_sha256": "abf4e1210aaac63fb0b6abe901bb89edac2f3994ebce7572b3fd3ddfec918d56"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_feed_monitoring",
@@ -16696,7 +16696,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9556,
+      "wire_schema_bytes": 9697,
       "tool_reference_bytes": 4933,
       "tool_reference_sha256": "348f8bf0680b6697aa4db7fe642d0d2b592d98bac5ef05017653e3d5f76d1ee0",
       "overridden_tool_count": 0,
@@ -16715,7 +16715,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b1689086b33ea143c9b79edc3954c1fc9320bd7c73bf26c05d79d00a50999e6b",
-      "wire_schema_sha256": "69b08c0e33b7f5e0483b2d9faa24e71d5d8cf7a9af626b6983050b85608002dd"
+      "wire_schema_sha256": "356c5447324224f57135895bdf0755581a2b86d5bdfb0236962e92922898df10"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_followup_tasks",
@@ -16739,7 +16739,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10288,
+      "wire_schema_bytes": 10429,
       "tool_reference_bytes": 4961,
       "tool_reference_sha256": "d3b7df07a7bf17cddab315557f4db71a7e2fea4f4956d3ace06b9d96340d50d6",
       "overridden_tool_count": 0,
@@ -16759,7 +16759,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "e9891ff20b83d67e8cadb649d24df495c51f5d78064af75532944a98a14ef9e4",
-      "wire_schema_sha256": "61929aa8491fc1efa2a84b9017ac2d040d4f2e0df6893bb4939b7f0b48d01735"
+      "wire_schema_sha256": "310fa974b97a6c82109c0aac9e36fe45501e4c2acba52c730cb7dba8abe587b0"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_group_leadership",
@@ -16783,7 +16783,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10760,
+      "wire_schema_bytes": 10901,
       "tool_reference_bytes": 5041,
       "tool_reference_sha256": "90476e3b3516fa008b3063f2d55126f0c4622dfce286824afe3e33917711c10d",
       "overridden_tool_count": 0,
@@ -16804,7 +16804,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ecd5015062feb97397c759e03480c2fc6f9ef58425774b7f88d6793fc51a261a",
-      "wire_schema_sha256": "8870ff455c80a2c3ac9270a2bfaaf2fa62d4eb715f25069469a180d1523d46ac"
+      "wire_schema_sha256": "292b461d56fd3d1d6ec082dfdd8ad4b7be80323422f7d55476a2a7c50de11b62"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_group_membership",
@@ -16828,7 +16828,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10666,
+      "wire_schema_bytes": 10807,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "2388dc80f99651611a2695a01e1caaba5a3fe4d36cb4f74ef9c5443dc96b3664",
       "overridden_tool_count": 0,
@@ -16848,7 +16848,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "47db1de6135e646a948a53018f4edc8c974d39573961f5f74cf110c620b28b7d",
-      "wire_schema_sha256": "b0c37e8442437e8bf5da967213533952a688d75f9044159913740a4bb7cbc68d"
+      "wire_schema_sha256": "75cfcf4d3e182f12be3a8409b69086eb4e8395ee1eb57d6897cbe1532ffa3464"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_group_structure",
@@ -16872,7 +16872,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10729,
+      "wire_schema_bytes": 10870,
       "tool_reference_bytes": 5034,
       "tool_reference_sha256": "8f34d5a18362f50aacb64db4cba78ed35949e1ff5e47db886ea4344224766823",
       "overridden_tool_count": 0,
@@ -16893,7 +16893,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f386cc7f41b925aa66274b8f8753f1f807aab57f0b25196035c9b470d7e97e08",
-      "wire_schema_sha256": "a156969da8f3918f83e0cae37c1307567e88d7976052443702e086be3d52fa99"
+      "wire_schema_sha256": "8976f868aa83ffca02729d688267b8682dffe4bc1f3c0f75818e46c3b67208ea"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_organization_integrity",
@@ -16917,7 +16917,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10716,
+      "wire_schema_bytes": 10857,
       "tool_reference_bytes": 5263,
       "tool_reference_sha256": "2babace46b46bd3c1757a93a4fc523910763ecdc00941c9526aa723cc966057c",
       "overridden_tool_count": 0,
@@ -16937,7 +16937,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "282a96131a9d387b5b297a1798d427fb77f27935a25c03cbf2cc22b79160265d",
-      "wire_schema_sha256": "042e6ecaa3f021ea34283325da3d528e17494d89e9be9284ffadb1e84cd44dea"
+      "wire_schema_sha256": "43278aa0ec15d4cc49fd7beb7bb4ea369b7b21123737932188b480921cdd3335"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_organization_member_records",
@@ -16961,7 +16961,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13604,
+      "wire_schema_bytes": 13745,
       "tool_reference_bytes": 5279,
       "tool_reference_sha256": "3b20b9520b711943b33384fc793a5aa81c1356222e27031371fa9568fa5ddaa6",
       "overridden_tool_count": 0,
@@ -16982,7 +16982,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "fbaa28ba1001813d3f1a0cb66477a6c9b0efc4ff32214d6414c9ec478d93f373",
-      "wire_schema_sha256": "199ccde69119f622e85af6e7878095321c7af70fa6df08c2108a7db357d40f96"
+      "wire_schema_sha256": "b1827a4f4ba256571df9eb871d48d0a0822985d974b1ae9181643a2297083e8e"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_prospect_pipeline",
@@ -17006,7 +17006,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12521,
+      "wire_schema_bytes": 12662,
       "tool_reference_bytes": 4989,
       "tool_reference_sha256": "b0cd167136b0167f5271d0c640104f9e84ab19c55065b2c375ea59fd650658c6",
       "overridden_tool_count": 0,
@@ -17026,7 +17026,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "57a38e3fff723ab752525360ac09e49c8383a799c437fd7e8997db01d00d6102",
-      "wire_schema_sha256": "5c49b5d4e0419b5255b6c8f54697e65d1eb6eb15fef63635c8afd65fc5449358"
+      "wire_schema_sha256": "35a27cf6032281aba5d04bf4381436e9ebc3726f4ac1656e219c4be2bdd6ddf5"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_prospect_research",
@@ -17050,7 +17050,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10908,
+      "wire_schema_bytes": 11049,
       "tool_reference_bytes": 5007,
       "tool_reference_sha256": "1854a1b2fe6f4dc131539e2d425764f7819eea370158742211c02c1910f21338",
       "overridden_tool_count": 0,
@@ -17070,7 +17070,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "da07d5b25562ab15e7f17ce74015434853f8be2fac2917339e18cc4fb6139fd7",
-      "wire_schema_sha256": "b4cc5316fe13a05a6ed97843fecd37451808a421f1e941644f9762e268999059"
+      "wire_schema_sha256": "22bc774943369c808b85b557cdd40fc4177145a9508b613f974c1a6b37050178"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:agent_authentication",
@@ -17094,7 +17094,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11273,
+      "wire_schema_bytes": 11414,
       "tool_reference_bytes": 6068,
       "tool_reference_sha256": "8c5110b85f73579cbd881419b997fcc9a9d99d3b2ebdf415f4929585bd6298d5",
       "overridden_tool_count": 0,
@@ -17112,7 +17112,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07eb0de4a4c6332c5429079c33017a24205c5f3507e6399772c561ff4a092d78",
-      "wire_schema_sha256": "598a80e9d63967c72734a2a480fcc2d438cdb06af506672907ac273711905aa2"
+      "wire_schema_sha256": "c817f6a6a00ce8caeb3ceb89d2c9a6cdd34c142d48680ab1968ae85dcdd8bf32"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:agent_conformance",
@@ -17136,7 +17136,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9978,
+      "wire_schema_bytes": 10119,
       "tool_reference_bytes": 5792,
       "tool_reference_sha256": "182b19b64ce7302d415619c993fc24ae32136df09ef1c8ac2b89f7cc839dc266",
       "overridden_tool_count": 0,
@@ -17154,7 +17154,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "012096836c5569d43d146451a8ffb1b800f8b39a56f146da16161031ce0ac130",
-      "wire_schema_sha256": "b5943c31b2c9dd9a3a7ff21771f5b5754404e35db94bd9ec35250f2e71afbf3b"
+      "wire_schema_sha256": "b850bf84930b453a9611fc5313cb6f9348099918d6f03639cff649f85b01ad6e"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:agent_end_to_end",
@@ -17178,7 +17178,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19815,
+      "wire_schema_bytes": 19956,
       "tool_reference_bytes": 6636,
       "tool_reference_sha256": "d02b3eff67be7a38f952ebe0196ddb996dc932aa9e501167b0b1d71e454da1e4",
       "overridden_tool_count": 1,
@@ -17204,7 +17204,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "85c84ea52a5aa43067389e7e17605be6a93ddcf1ba596f619729779fccbe10bc",
-      "wire_schema_sha256": "4ac2625af42caf603e34700d6d4e8b1c6392a9a55f30cea92053e70ebe28a5b2",
+      "wire_schema_sha256": "6972421c67e7a20bd652da3a03d9333a6de9f05e5d2f8649e4df1d8bc23b2024",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -17229,7 +17229,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9950,
+      "wire_schema_bytes": 10091,
       "tool_reference_bytes": 5117,
       "tool_reference_sha256": "aa7e1f31ef1c683786e229c8050793d9faad83b5a5cbde309960dc4a3271a991",
       "overridden_tool_count": 4,
@@ -17249,7 +17249,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a512a4cbd9fe2e02bb76d6a1b31cd09a7638761efb4a0230834fdfb2e861159e",
-      "wire_schema_sha256": "7b05ded6a160ec1efae4e67f6132c9301be3989ba40f9ee725e1dea20d011c28"
+      "wire_schema_sha256": "a9712d8f28136b46063ae010c6e790982153087943feb2d6acaf3c7e4a4df93d"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:agent_quality",
@@ -17273,7 +17273,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14652,
+      "wire_schema_bytes": 14793,
       "tool_reference_bytes": 6139,
       "tool_reference_sha256": "ecf8f60600a263d6a3120321ab1f65e138a08b082a96153eed01d1968552a91f",
       "overridden_tool_count": 0,
@@ -17292,7 +17292,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f527be89fee5e5536b0b51b8c6c72924fbb8d3d9f3fee080986890437ae83065",
-      "wire_schema_sha256": "0da514e38da9e5be4280e7490b7f597ac0976df6fb9860bfd3c2abdb06f9ce69"
+      "wire_schema_sha256": "2927e76e9a88dce21cf946e0034908a0526605e5cb05f02305ffd1331cc4d91a"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:agent_registry",
@@ -17316,7 +17316,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11044,
+      "wire_schema_bytes": 11185,
       "tool_reference_bytes": 6701,
       "tool_reference_sha256": "25cdf10cfcafee88979211e822031ff6983a2f38b20fae8fa7088210136e135d",
       "overridden_tool_count": 1,
@@ -17337,7 +17337,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "829db1024e9ed7b56f80e74f08c79430219c661a9f7f1ca2f338268d981861c2",
-      "wire_schema_sha256": "b0d39b6c209520e8a0e3496f6c49c5ec11b5743ef88af79d479fb3857f0431de"
+      "wire_schema_sha256": "0b1af69d6704ce3c22d14b34ca20cbf5cc56fecae2ebc26ea8286f16edd6ca0e"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:brand_registry_identity",
@@ -17361,7 +17361,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16157,
+      "wire_schema_bytes": 16298,
       "tool_reference_bytes": 5617,
       "tool_reference_sha256": "d05f97f3dc028c1013c97a9e19feffd2796fbc23e53475e20b508a3b322b8708",
       "overridden_tool_count": 0,
@@ -17382,7 +17382,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b0cb4a01b1ab28f7ab346fe05f5d2b3fec2d73dcdc5a8309a5b0f7d902fc5758",
-      "wire_schema_sha256": "a63a1ba480dce1cc6f8abd2d0bfdf5ec25f46a84c8c73b964359f4bef911203c"
+      "wire_schema_sha256": "33ddcc81e2e2a07ee9ac86d347e32961acc9cf30088a132b1e6b54eb90f6a108"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:brand_registry_records",
@@ -17406,7 +17406,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11067,
+      "wire_schema_bytes": 11208,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "6e5a06f631d52e8db048ca417e593ab9731058f6ad56b3b963a13fba4576803d",
       "overridden_tool_count": 0,
@@ -17427,7 +17427,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "7fd8e61d32cf8b482ae959e5e050ee0774fb93e3ce6d39f243364659c3a81b15",
-      "wire_schema_sha256": "eacbb437559a6273d4439d0d4fc13bb39c91b2a3f6bed0d6bad7a95b7cc4778a"
+      "wire_schema_sha256": "c1381ff7692db4c526b7d5c2f55b8951be1a53daf932a2c33a083dcf80544674"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:certification_assessment",
@@ -17451,7 +17451,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19717,
+      "wire_schema_bytes": 19858,
       "tool_reference_bytes": 6920,
       "tool_reference_sha256": "8c278765ad621dd11f89ff7b35d60af9f51ae88d569155f91733a06a4a51aab5",
       "overridden_tool_count": 0,
@@ -17476,7 +17476,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "b8820aebc73fe700321e75a7bafc7ff346e38040ea64c833f6e87f88609e9ff2",
-      "wire_schema_sha256": "d8435d8f452b30eb17516ff8b8f2e5138a2024bd4061f07a5745c600ab834ce0",
+      "wire_schema_sha256": "a8ea168f91ead2bc224c8a1f1412249cc08892e85c7e6f1334461315bd1385b2",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -17501,7 +17501,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20620,
+      "wire_schema_bytes": 20761,
       "tool_reference_bytes": 8157,
       "tool_reference_sha256": "488a0f80dc27b82e9d7a04226a70a00d8dddb18c5801dba7d287839e9f70315d",
       "overridden_tool_count": 0,
@@ -17527,7 +17527,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "8df8d830c1370944e4768efb235cad21d4c923181157a047b167d528e599800c",
-      "wire_schema_sha256": "2de1a6ed6cd13c7c445b70447771293300a1d32460a03f3b361c108d2b930091",
+      "wire_schema_sha256": "77b48937fe7ec04b1dfe22fbd3f0d058071dffa7a646bd2333b7a6b65ae91652",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -17552,7 +17552,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10621,
+      "wire_schema_bytes": 10762,
       "tool_reference_bytes": 5714,
       "tool_reference_sha256": "ffe228a0d892df8178b8697bb3c470318c7c60e0bb97e578159b3fb4376e1674",
       "overridden_tool_count": 0,
@@ -17573,7 +17573,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "1c5d33e6479dc6e858cbaca65f2e0ac8fdef46462cfd59b9b9a1b6a958fd4c63",
-      "wire_schema_sha256": "46ffdeb02a3149cb96d8d7e99244e345f92ea243cd18a30aa51e006ca4682609"
+      "wire_schema_sha256": "a38d7b04d05b23e75862070e97a6ac3358aa1b4d4d2ee2248a4058085a275fe0"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:collaboration",
@@ -17597,7 +17597,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9831,
+      "wire_schema_bytes": 9972,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "e538eef1415fb4f47251a65eff930e1abb048b1440679990cff368a65814cb1b",
       "overridden_tool_count": 0,
@@ -17614,7 +17614,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "11274be30eaff96df7d3a088f1c91d7ce876a5ef74f4f65679f51f93964bb107",
-      "wire_schema_sha256": "b57a5fbf2e3185acfe0f5728d98dc166e7e8fba608ae6f79e19a91a087dfee08"
+      "wire_schema_sha256": "610a632766f98d2858732eb8d8e16fbfd1f0c23b33c6c0007909d7a33516d062"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:committee_co_leaders",
@@ -17638,7 +17638,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11161,
+      "wire_schema_bytes": 11302,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "a74c5c2bd2d65d9f5639a6aad516e33599b92edba4bf9cc24ff468efc9889c51",
       "overridden_tool_count": 0,
@@ -17658,7 +17658,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "bbe7d7c41eafa947c0f6456ae91b140fe2fb526a765ada057940d8283bad2d3e",
-      "wire_schema_sha256": "88e25ae1df383ca28285df07031c9b2bdd6471f2156802e8ef1c2165c884bf1c"
+      "wire_schema_sha256": "b5d99ae490ded1a4f5d20aa7753412959680237b21afe1e1faa9179927ed46d5"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:committee_event_planning",
@@ -17682,7 +17682,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12747,
+      "wire_schema_bytes": 12888,
       "tool_reference_bytes": 4937,
       "tool_reference_sha256": "48c146ce05f85c6d37c76ff566e74f7c5432a42f18243f0dd88c1100ffed6109",
       "overridden_tool_count": 0,
@@ -17701,7 +17701,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "4cbb76ebfc638e5e178b77ce51517e1700f437cbe07eed14ef67bc9c6d6beed1",
-      "wire_schema_sha256": "a689a1a7836d76c8570bc6da9931e3233aca3358fcd24d29b3094674a967c7b8"
+      "wire_schema_sha256": "ec641792556c5b33bada8fd491025299c5ce888240aad9e397e609d90ad96f20"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:committee_event_registrations",
@@ -17725,7 +17725,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11471,
+      "wire_schema_bytes": 11612,
       "tool_reference_bytes": 4994,
       "tool_reference_sha256": "e5adaa7cf86f32e770b3d2ac8ba70be81d79ad573a6e6232ec8ab514c9c512ef",
       "overridden_tool_count": 0,
@@ -17745,7 +17745,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "9c759c6159787b0bf813b405babe98af8b80fd8132ad1c292125b2998c70e9fe",
-      "wire_schema_sha256": "83042a8f9c7a4d2365e3fb6dae5f3260154fbd20283b4d0cb6a82e95f2eb866d"
+      "wire_schema_sha256": "7442c8f0343cadeaebc9fbf7b53c126800f0b4e645a77e79d1fd7b5726cf14f6"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:committee_full_leadership",
@@ -17769,7 +17769,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17191,
+      "wire_schema_bytes": 17332,
       "tool_reference_bytes": 5272,
       "tool_reference_sha256": "8f6e40ff2049c4b545422207ee004ad7e0d78caba7b71253994e0ebdf73978e5",
       "overridden_tool_count": 0,
@@ -17794,7 +17794,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "04ec5e8b84cc7c87cf26efc8cd7c37398baefb992eb687800a7c461a0f74b752",
-      "wire_schema_sha256": "986037ea14111776d73dad81f6c8abd2bc4ccc0b7d121343f3cb53274d06e478",
+      "wire_schema_sha256": "93e170f15266310c33b743c22b939e1f1d2b418fd332ed530e08c71a794cac1b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -17819,7 +17819,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10911,
+      "wire_schema_bytes": 11052,
       "tool_reference_bytes": 5086,
       "tool_reference_sha256": "ca6a1e66aec898732856ae10dd86e16df9ecf43c2135448665e4c4084fd6144d",
       "overridden_tool_count": 0,
@@ -17838,7 +17838,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "8b32d9e5c75ba4c1993b582b53a0dd7549dfdd37b841c2e50e6b85ef586566c9",
-      "wire_schema_sha256": "a16439b79e45c05cf7dd5f35c07a7d91c9c8eecc44c8d8032083a7fc57841132"
+      "wire_schema_sha256": "0e6fe026cfd647a67897d2c6adf7c0a3cc0ecde785a1a09b6994c64cc0dffa02"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:community_group_contribution",
@@ -17862,7 +17862,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10112,
+      "wire_schema_bytes": 10253,
       "tool_reference_bytes": 5314,
       "tool_reference_sha256": "ad46a2c27c92e139603118ccdda8ca72104b761f404d0e3619e2aa338331c3d2",
       "overridden_tool_count": 0,
@@ -17881,7 +17881,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "495a4a8817c854d8d9b0be45cd4c4365585ca02748a9560222f7fe7fb4498af9",
-      "wire_schema_sha256": "68a04baeb53dc384c109b00f6d6ee34f44d0c4a864bee4bc470de2f9a81e6c42"
+      "wire_schema_sha256": "48a55496c36ad8118cceda62dfc6e3f2f7512d6d4c2df52559c5b807b88487a9"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:community_group_discovery",
@@ -17905,7 +17905,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10155,
+      "wire_schema_bytes": 10296,
       "tool_reference_bytes": 5255,
       "tool_reference_sha256": "fd71bca33c484bb3fb934c9486a18fc1e274917ff3cc95ef90e177e47326bb7c",
       "overridden_tool_count": 0,
@@ -17925,7 +17925,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "64a3330edea439fa8fb9fdacd1f81a66133cc4f256e7f2ac470bb5f2eea00ffb",
-      "wire_schema_sha256": "37e23fe68f4983194b7eda715844651a7b67caef71aff3d641f02997d71f7689"
+      "wire_schema_sha256": "9d05198d8f6fe5f252c0dea042255b1fda4049aa7deab37bb01c0260f9ba895c"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:community_group_full_participation",
@@ -17949,7 +17949,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13400,
+      "wire_schema_bytes": 13541,
       "tool_reference_bytes": 5366,
       "tool_reference_sha256": "b749062fe5be6a24e2d97f9299b3264bcbd84aef9c6fbabc470dc4e186a41e3a",
       "overridden_tool_count": 0,
@@ -17976,7 +17976,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1761c6fb6a24457352ea873f301ed6c24757cb0a4fed773919c1371fb343d70c",
-      "wire_schema_sha256": "a0cc93bef80d9523deb66aad071350b6ad2cc093fed8ff770c5cf2ce7940b269",
+      "wire_schema_sha256": "ae2a4ff316eb3f6cda571b706c3d47c72b904f623fbf477450a33e9a96bd3684",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -18001,7 +18001,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10522,
+      "wire_schema_bytes": 10663,
       "tool_reference_bytes": 5288,
       "tool_reference_sha256": "60f5f1015a0888599dcff1c673ebe02a5e83258c2d048256843f2a9c791188fa",
       "overridden_tool_count": 0,
@@ -18021,7 +18021,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "c6cf0f8155798e253cad3ac0be806ac43f96ca1259a860e19d265dc255d15d91",
-      "wire_schema_sha256": "9cd71c39be1813e2691d5ea448ff001cffd85464e5ba36f812c3d0692794dedb"
+      "wire_schema_sha256": "c49379c6569c8148bfec76439fb59409ede93e45094c4b65fc2dda4c83e2c145"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:content",
@@ -18045,7 +18045,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11128,
+      "wire_schema_bytes": 11269,
       "tool_reference_bytes": 5083,
       "tool_reference_sha256": "282313bd3f11de63c991eb1ca9c05498a4164020624527406eb3d21ac16e72a6",
       "overridden_tool_count": 0,
@@ -18065,7 +18065,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "284c752554ad643959685c0b0fbc1b1b5221bc3c0bf42c804731caa9a351cb44",
-      "wire_schema_sha256": "b1a8d18593b12e60f70e4d7b5f04f1f171979934591eba16dc6bf63d3b58a91c"
+      "wire_schema_sha256": "22f888fa99a27d79e9434f9738fd74a67556e1f58f46e4bcdc31b8e8cdd46bfc"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:council_interest",
@@ -18089,7 +18089,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10156,
+      "wire_schema_bytes": 10297,
       "tool_reference_bytes": 5250,
       "tool_reference_sha256": "2a9275ce948cff4e13410aedb7932cd1483a286cb9b2f729e4b987bed296009c",
       "overridden_tool_count": 0,
@@ -18109,7 +18109,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "86286a9b99f37c50106ca5b3ab9111c7b0af4d130d68d0640ccb929363610e72",
-      "wire_schema_sha256": "117775a58f2f01975ea5b101b1f11a64957762186c77e21374cea5c666bf2af4"
+      "wire_schema_sha256": "ea7cb652802c1ee0c9b4d03ae244118218032d33579555f29bf7a97f7c665618"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:events",
@@ -18133,7 +18133,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11056,
+      "wire_schema_bytes": 11197,
       "tool_reference_bytes": 5090,
       "tool_reference_sha256": "ee0839be778b2e32476815c6931204145048cdaf4433bf88e0986fcf8ac24183",
       "overridden_tool_count": 0,
@@ -18153,7 +18153,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "5751ff1ac10de94ad9b147e63d707924bb971a542515ebb9a89b5cb9446451cc",
-      "wire_schema_sha256": "afedc4bd3e025df66df66083454b5b5c8113509a335eb52289ad7fd4763ab335"
+      "wire_schema_sha256": "1237e2a89f231accdbaa9e3541aedb3ae018762173d929744cf6d065596ac9b6"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:github",
@@ -18177,7 +18177,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12701,
+      "wire_schema_bytes": 12842,
       "tool_reference_bytes": 6073,
       "tool_reference_sha256": "17d2b9fdd26009df7efeba7b01d291553c2d578f4c4b8d2f3fa952cadd338030",
       "overridden_tool_count": 0,
@@ -18197,7 +18197,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "188b898cef2ba9447f41cdc60c27bd6433d96dd606d2c429d18247d8c752753b",
-      "wire_schema_sha256": "6457216659e15cbc7f241b6ae36b0b98c4923f7673328fba7ed8c11cfe01d23f"
+      "wire_schema_sha256": "7559b3f050430dab78f8148ddb9e83afa19514cef5de15458c7f99e9fa897512"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:illustrations",
@@ -18221,7 +18221,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9510,
+      "wire_schema_bytes": 9651,
       "tool_reference_bytes": 5686,
       "tool_reference_sha256": "a08ac061f8dbe6da9867b23df6239f4f64a3605e97869e827b33ebc0aca341c0",
       "overridden_tool_count": 0,
@@ -18238,7 +18238,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "eb9a928245349898452ccbb1e46caa1b7b3ce8c7b8b765cd0f9456d8b035fddd",
-      "wire_schema_sha256": "ab732b43a4caea38eb03b1634fe091c481b207d0f683f81b0802fc3862bce661"
+      "wire_schema_sha256": "69d83bb5f1e2425bfd9c041a9fd79bdf67a9e65c42f5648d1e5bf6e0c2cd700d"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:industry_research",
@@ -18262,7 +18262,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10752,
+      "wire_schema_bytes": 10893,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "693504dc7294e18ff4127d493c1761e8d981b96ad5405a23bcc17fe64fbdd576",
       "overridden_tool_count": 0,
@@ -18281,7 +18281,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "baa3abb17c17d41290fc3a2c47b330e0ae373019cb129abb66c429199a905dd9",
-      "wire_schema_sha256": "dd7117345ddcb9f82f4035490b6598485cb6ceee9007684286adb20de4fda617"
+      "wire_schema_sha256": "8c7049bbc7421a76d2ad3c2e3ffdc56ee8b93a90761b6414f2d52e30d2205624"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:knowledge",
@@ -18305,7 +18305,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11857,
+      "wire_schema_bytes": 11998,
       "tool_reference_bytes": 6272,
       "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
       "overridden_tool_count": 0,
@@ -18324,7 +18324,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
-      "wire_schema_sha256": "c19a7e8340bc410cf6849c54d43fe762ea3cde8796b90832521c4cb4cf71c713"
+      "wire_schema_sha256": "f6bf3dde92b2d28eb26b85e932e6f2b1b6bc2d5eff122ad4e571467a58f3bcd3"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:meeting_attendance",
@@ -18348,7 +18348,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11239,
+      "wire_schema_bytes": 11380,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "5fdc3f50ba46d26ffa75ff27538a5e7e8bcef3ea837fef8fd48705abd8624725",
       "overridden_tool_count": 0,
@@ -18369,7 +18369,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "28efbd2ca8b10c2368f967e639fd7652cd7f04960ad188392ce93fda2392bdc0",
-      "wire_schema_sha256": "f39c41b8e78c64611672126ff6b8393087a60b3cb4923b7c7d43a4ed27968343"
+      "wire_schema_sha256": "7c9f5de06def5824696babe0d384b9aa60bc3b94db3038fc4a73d7cfa6cad728"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:meeting_full_administration",
@@ -18393,7 +18393,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18694,
+      "wire_schema_bytes": 18835,
       "tool_reference_bytes": 5195,
       "tool_reference_sha256": "17af7be874d34d79f1adf04bfa613c4b2faa3ea2bd74ea4ad3a91bb480be9741",
       "overridden_tool_count": 0,
@@ -18420,7 +18420,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "582f87a23ce4af178918f9bb042c999466b46904c3c9f7cbfed3dd27ab8dead2",
-      "wire_schema_sha256": "59170ff943f740317737157d7a781bb80349d107c7f6f69508f9b389329e2521",
+      "wire_schema_sha256": "b70c211ed1c3c6cb49bed93c09baef38c39849ea7df747db1bffa3ffb1e9b59b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -18445,7 +18445,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14552,
+      "wire_schema_bytes": 14693,
       "tool_reference_bytes": 5046,
       "tool_reference_sha256": "fce02e48f5ad06db1fee5ed46a2a2689371e71fdceb63cc1bd3e165515ba43e6",
       "overridden_tool_count": 0,
@@ -18465,7 +18465,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "63f1c3b48687fc9d68ddd930787a7d59561f1ba9ddb8d3698f0457486829dcba",
-      "wire_schema_sha256": "19cbd7895fd5b360a6871c5b552e565ae8e2ba0439ff80de008ba76f5614e44e"
+      "wire_schema_sha256": "232dd0f7f5208d747a5c794474720434b79d43962d28c56eda22300017e1ef7c"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:meeting_series_topics",
@@ -18489,7 +18489,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11473,
+      "wire_schema_bytes": 11614,
       "tool_reference_bytes": 5119,
       "tool_reference_sha256": "fe9228ca48c839aefda1068097db4be03171b5d2f70101b996207477ee011b43",
       "overridden_tool_count": 0,
@@ -18509,7 +18509,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "1b799fe2a16442d418c0628fec9bdc8ae73d6c67a2f1acda08a5b99c73255258",
-      "wire_schema_sha256": "d324fb9e0c1e8b1a8df594959b9ef3a70cc3920fd1949ea7cd4606f57b8dc0ed"
+      "wire_schema_sha256": "a6ef0e4690050c165fd0cda7076be36676b0bfa48f3a72ee9fe9f689946628c6"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:member_billing",
@@ -18533,7 +18533,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12058,
+      "wire_schema_bytes": 12199,
       "tool_reference_bytes": 5669,
       "tool_reference_sha256": "61c7298906378b4f2f154f7275a9f56c9102bfb6247ae654a3861f7cc8895b98",
       "overridden_tool_count": 0,
@@ -18554,7 +18554,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fadd2a88b06fed26c92e0d7683ee842fc67f84dfe3c44dc3db122d8443d955cc",
-      "wire_schema_sha256": "c2c14c5784576cb740c7b6f99d57443525eae812133e1764f7c9c44e9d525a62"
+      "wire_schema_sha256": "93b1a6a28f614100aec1b9804ebf98462ed20f1705b90f5f77844b49459254a1"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:member_company_profile",
@@ -18578,7 +18578,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14940,
+      "wire_schema_bytes": 15081,
       "tool_reference_bytes": 7179,
       "tool_reference_sha256": "b0aa1c7af0bf4591e4177f3a8127c527154606d4587dc08756e7f18105e83bb6",
       "overridden_tool_count": 0,
@@ -18599,7 +18599,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0e1b8aa348778ebfd306f8e063d3984473a27d9aa3475eada444f6cfdba0bfea",
-      "wire_schema_sha256": "7537b15dd2395d96fda05841d4378fe5aa4357bef70d9cd7f09b2da02a47fd91"
+      "wire_schema_sha256": "7b5e7201ecfa6b413eb78c9286cf4b047ef55fc178665bc55a0bda1331a4d963"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:member_personal_profile",
@@ -18623,7 +18623,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9709,
+      "wire_schema_bytes": 9850,
       "tool_reference_bytes": 6603,
       "tool_reference_sha256": "1be10e69d1c2468a8f3619e586e9b7cd0fb80f57e737ceb7614f552e89795e0d",
       "overridden_tool_count": 0,
@@ -18641,7 +18641,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "278d2a60ad51f3a69b5f03330f7f2b7d3d4a8ff98509f14e558cba79fe3c6e7a",
-      "wire_schema_sha256": "ff1df39b36fdc7627c9c15607a9430d3e0ee3bc271294fbd4adfbf2c6b863edc"
+      "wire_schema_sha256": "40b3a07842f235277a229615209ef66121aef314b998e85c2d866bdc980d9f21"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:outreach_contact_management",
@@ -18665,7 +18665,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10589,
+      "wire_schema_bytes": 10730,
       "tool_reference_bytes": 4957,
       "tool_reference_sha256": "978d81ac4be58b4e5f0c59260b589e96a95acd041895d6e47cb238614e05642a",
       "overridden_tool_count": 0,
@@ -18685,7 +18685,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "53eb64b204251c7934442c3397a72020de3c911f9c3d29dec3d2d239591e1aa5",
-      "wire_schema_sha256": "0fed13e32364c9ec0ca1f839f71f05aa6215c616be36f94d6c5acf78200d1f5e"
+      "wire_schema_sha256": "204ec6558f12dd0ca3621e36c719d8fdf2d9d1697b4006410e380cd706a221ff"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:outreach_reporting",
@@ -18709,7 +18709,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10160,
+      "wire_schema_bytes": 10301,
       "tool_reference_bytes": 4949,
       "tool_reference_sha256": "deb6aeea7143042d8abb8afc908abe958eb2c6bb562fd6e31b92162b7c6e4a7a",
       "overridden_tool_count": 0,
@@ -18728,7 +18728,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "9fea2f2b6f7bd11b93a4c4b87e0034f358fccbfe72dbed4ca9c9f45d3030d677",
-      "wire_schema_sha256": "02874ad0cff3f58ac2dd0dfb07d6fcfc5fb113471151252ce1818b4002f645a7"
+      "wire_schema_sha256": "f9579b024ed866df5ee027174ee45ef12edab77db4d3adfd2988fb152b022ea4"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:partner_directory",
@@ -18752,7 +18752,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12140,
+      "wire_schema_bytes": 12281,
       "tool_reference_bytes": 5179,
       "tool_reference_sha256": "2f1bdba181f4d89bed5f22bf21f070d49964f094ed9aa1638220d2e53bd350bc",
       "overridden_tool_count": 2,
@@ -18773,7 +18773,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4abe43bd711dba6f2b371f991a37f3044b7efe029af19169bc8a891e3030cc0a",
-      "wire_schema_sha256": "cf87115ba620f6fd6f3045dce2a749ddbf5b0aa17006042f4f4563fae18bfa28"
+      "wire_schema_sha256": "99c51e38c04dac4354fec601c2074df2998c042d6faef38de5a38a333f6911c7"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:property_identifier_catalog",
@@ -18797,7 +18797,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11416,
+      "wire_schema_bytes": 11557,
       "tool_reference_bytes": 5284,
       "tool_reference_sha256": "13831dbee6b1a3c7cd6921429eec948d1b4ee446eddb9e088ed00d7939de7a8d",
       "overridden_tool_count": 0,
@@ -18816,7 +18816,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "3f40589842d92252f4c31df951f3dee47f90d694f6c84fd40cf99beeaac51b90",
-      "wire_schema_sha256": "c01fbe920fc10285094b8a60c6f6af3847a1a37b29e6c0d90fef91995259a972"
+      "wire_schema_sha256": "5ba5aa78aa1a96c657d35cb754d05923078374df5c13446e4d49c892d86f8f25"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:property_list_enrichment",
@@ -18840,7 +18840,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9523,
+      "wire_schema_bytes": 9664,
       "tool_reference_bytes": 5133,
       "tool_reference_sha256": "90a495e511e631244025479c57aabdaf44869fbda341849f33d6e5d82d1d4f98",
       "overridden_tool_count": 0,
@@ -18858,7 +18858,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "59cd9ba8c99ea5efc46a5ba3c8ff57fa5a02855f68171dade0e196583ed1c95d",
-      "wire_schema_sha256": "495d3ed783c97fe3e3043abb2e61ca20ff7297896a131b36bfa9d8c49de3d665"
+      "wire_schema_sha256": "fda96b55972fa731d69e54f8bd8691f6f24cb9e5ef3ee34273e2d2ebb6100bf8"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:property_registry_records",
@@ -18882,7 +18882,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10786,
+      "wire_schema_bytes": 10927,
       "tool_reference_bytes": 5362,
       "tool_reference_sha256": "f8db16b555a1cd7f2ed5547a7decd4a45c47a371d05b447825d9d6bdd7f1477e",
       "overridden_tool_count": 0,
@@ -18902,7 +18902,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "4efc04fd88ef1fba8495a1fffe10779d36410775b793777bff55a3dcf38d2773",
-      "wire_schema_sha256": "60bb471663c9a7f158b98d531e7f5e5842b196dc4abdd29be1bbb264f3a31f5c"
+      "wire_schema_sha256": "fd0aeac830426617253183c886b87c7620f6b8cff41d483e99ffb9bdd4009b20"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:publishing_assets",
@@ -18926,7 +18926,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10900,
+      "wire_schema_bytes": 11041,
       "tool_reference_bytes": 5087,
       "tool_reference_sha256": "d56011932cbd50f96ac3191be635143521775a2fcd9567d4ebfa3e8d1f9dab77",
       "overridden_tool_count": 0,
@@ -18946,7 +18946,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "fdc3b16e146cb1098e8fbe4e560b521d8c72da0febb5a43e18a4ee5d4f43a2b7",
-      "wire_schema_sha256": "8a975d08f355c8c1b1a18df73015a16cd316a15fe949632eb8869510138b0785"
+      "wire_schema_sha256": "4821ac40e06fc1d64c6110ba18ecdaa9e46d7b5372cca121aaa3b140b1975a2a"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:publishing_promotion",
@@ -18970,7 +18970,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10385,
+      "wire_schema_bytes": 10526,
       "tool_reference_bytes": 4976,
       "tool_reference_sha256": "242b8d1ee88bacff1da83025b9e31abcd0c9fd9b15b567c26cb829ad3db59588",
       "overridden_tool_count": 0,
@@ -18988,7 +18988,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "914e5042ff5aa77185e5f5ca8e9a05f1a41124bbd8ba8b599080f70efb9c7b83",
-      "wire_schema_sha256": "b772f60aecc8ffa0350d81313e7deee857d45eca4f477455d1f4e229517b4071"
+      "wire_schema_sha256": "acd6fd57e8b76ec32feaf2bd22e8ecddee3c7bb925f8a55f8f7d7bcc670388e1"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:publishing_review",
@@ -19012,7 +19012,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10229,
+      "wire_schema_bytes": 10370,
       "tool_reference_bytes": 5157,
       "tool_reference_sha256": "bbd74b8e4738835551b2440b98a1ae56d7846f2d971933af09ec972ed5b40682",
       "overridden_tool_count": 0,
@@ -19032,7 +19032,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a895f645f68398d3e561173892a44e31eaa1cfdfa5dfa74cd3cdd30c833aadda",
-      "wire_schema_sha256": "c5caa7ddc47fa48618ba74b09cc76301ba5554af9e9c2df7d4a555c514b3aa19"
+      "wire_schema_sha256": "4827ac2b31737f015deea00bd512859c97ee3b6fde1b4453b02d30e6b290c16e"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:publishing_submission",
@@ -19056,7 +19056,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11917,
+      "wire_schema_bytes": 12058,
       "tool_reference_bytes": 5933,
       "tool_reference_sha256": "4368a4534a12db25c52e70aa2e4d45ea9f359786531bfa7a1549cb7622539813",
       "overridden_tool_count": 0,
@@ -19075,7 +19075,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0c9654e2c90afb77d7cb1482baf49531c1dbf1d6ad96e89d9065e2845f0ef290",
-      "wire_schema_sha256": "9a8526aca39c98e9fbccce4ea348015f2d50c43dfe2f91780ef55143f5e29f6b"
+      "wire_schema_sha256": "71574736fbd843f0f486ad2dc5567c674c6e7b7158fbac11a29825a3c54dddf8"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:schema_reference",
@@ -19099,7 +19099,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11005,
+      "wire_schema_bytes": 11146,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 4,
@@ -19119,7 +19119,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "443689ec626f64502248bcf217d42ef60900891d9a4163e30f52dba93a237984"
+      "wire_schema_sha256": "fb719521c0abe29641c041144222f371429552b112530b64a7ada5244f864852"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:sponsored_intelligence_discovery",
@@ -19143,7 +19143,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
+      "wire_schema_bytes": 10334,
       "tool_reference_bytes": 5309,
       "tool_reference_sha256": "3a8d840efe998abbd5d636abcc586fe5889c3e1282e0bd5e503674461bcd0dd9",
       "overridden_tool_count": 0,
@@ -19162,7 +19162,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "273d2551a68559859045673bd43c47271fa94a6c2d964d52ea97b3ddcc82a3e1",
-      "wire_schema_sha256": "14fb233d8d227dfabb95f29858a9676478f4da482b6872205d51eae2494fc8e7"
+      "wire_schema_sha256": "50638db9f4084536bad895819c3394c83de09b7038f2177a0df409d83ff1da97"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:sponsored_intelligence_session",
@@ -19186,7 +19186,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9712,
+      "wire_schema_bytes": 9853,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "a6db91f7f951d33d2386aa95c8902dc13d042413c343658a7764921db30faba2",
       "overridden_tool_count": 0,
@@ -19205,7 +19205,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4374fdf27f7f4d8646711d9cd15247ada5ff2a909ed24cfbd9b847b40c6fe3e7",
-      "wire_schema_sha256": "cd9443cf3509268c019d4d7528f0a9b650efcff272b88d9653863825f1a2f41a"
+      "wire_schema_sha256": "f2795405837d1a84a8998ef506930127f587d4a073fbf730249dfd9dc989a10d"
     },
     {
       "id": "slack_bolt:private_mention_admin:safe_fallback",
@@ -19278,7 +19278,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 22358,
+      "wire_schema_bytes": 22499,
       "tool_reference_bytes": 6089,
       "tool_reference_sha256": "2dedd93f34bb8bb96a840a2650e817f7f883931785541ffec854710e6ef68489",
       "overridden_tool_count": 0,
@@ -19317,7 +19317,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "a9e974b90b45f7a06c5f20a790efe7b1b48c32b69e1a546e1d30531a3a617a1a",
-      "wire_schema_sha256": "772e82bf18df11171a0929159b29a564160f9e30c383416a49a2ea4bbae32792",
+      "wire_schema_sha256": "f6440a41f9a66135dac9dfb70cdcd0938071233062b8c54937eeff50774a4187",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -19345,7 +19345,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25824,
+      "wire_schema_bytes": 25965,
       "tool_reference_bytes": 10864,
       "tool_reference_sha256": "c1c660ec26e128b9aedfa96fe0c1b85588c45a7221f7b9a141e2f0aa9fa0b174",
       "overridden_tool_count": 0,
@@ -19377,7 +19377,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bc9f123436d9760c4603abb2386e0a63c7a9f53e4c0d65adbb0041de8bf1177f",
-      "wire_schema_sha256": "7289863f271c2017a3f62f0b98b9a8d54c99fcd9a3692f0e5b6b88a842526c95",
+      "wire_schema_sha256": "7bcc5517a1af44cce605df3e17b8e10b9276c299a4cd12918c5e61226a02d0cd",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -19405,7 +19405,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30699,
+      "wire_schema_bytes": 30840,
       "tool_reference_bytes": 10321,
       "tool_reference_sha256": "c345073241bbb0aa78ef7366d2c97b3f776183a69a3acab73fed9bba457eb861",
       "overridden_tool_count": 1,
@@ -19442,7 +19442,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "9e5d653068e798450e6ec1d154f075d580807f8ca567abb56644ecefe15c3ba3",
-      "wire_schema_sha256": "56e2399081e01b8176ecba4966476a9c75b86f67b815894fe7cd25eb0c32631a",
+      "wire_schema_sha256": "83e72e59f7426d4db729dc7518aa7378fdf07fc439ac9fb1f196901c3102b23e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -19467,7 +19467,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13166,
+      "wire_schema_bytes": 13307,
       "tool_reference_bytes": 6262,
       "tool_reference_sha256": "3d2ccbb6aba85bd38419a3d9045f5707e4d0f0ba6be27a89a1d1fe8143715007",
       "overridden_tool_count": 0,
@@ -19485,7 +19485,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c0d2d1533050187c0d555031976948036cb84a1b937814f81af6b77701972ab0",
-      "wire_schema_sha256": "1dfd23f8107e98dd592c8c633949e3314b854147b63e602c40d3f736e0e8d047"
+      "wire_schema_sha256": "bbefddd5ad515565950049ea6a7e1ba108020755a2d9c8e58a7d489dfacfd91d"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:adcp_task_operations",
@@ -19509,7 +19509,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11614,
+      "wire_schema_bytes": 11755,
       "tool_reference_bytes": 6310,
       "tool_reference_sha256": "04603aeb0ae569596b5ee5fd6be628303bece3bf65625633a68f9e6e2879d538",
       "overridden_tool_count": 0,
@@ -19526,7 +19526,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "29439abce5e792eca86c1ba105cd40eb03da5b67c1d77aa7808478a7f6817236",
-      "wire_schema_sha256": "010bdffef19c5bc0be999224bc9860ed0c919e0ef770efbdd235b62e4099f3b0"
+      "wire_schema_sha256": "7474c9abc30ab1714ffacdf911cf38b29cbf346e15bbf9c7c6068b6a42b14b5b"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:agent_authentication",
@@ -19550,7 +19550,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8979,
+      "wire_schema_bytes": 9120,
       "tool_reference_bytes": 6000,
       "tool_reference_sha256": "b937948691c576fbcb7f1b179d3d84d2fd8ee5354cf0e9ec23e02728eaf9d3cc",
       "overridden_tool_count": 0,
@@ -19566,7 +19566,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "aa35268403f3b37ff1f3ae0b78bfd8f2fdbefc392a5d3546fbeeca83ca5c6ed7",
-      "wire_schema_sha256": "e616084893239a3360d038f27f027e253460b07d34eb9fa2cd3902a5c7764906"
+      "wire_schema_sha256": "c32fecfcbf637c9b547a939f7c850f3e46c387cef5a396b4193986ae68a49771"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:agent_conformance",
@@ -19590,7 +19590,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7684,
+      "wire_schema_bytes": 7825,
       "tool_reference_bytes": 5724,
       "tool_reference_sha256": "bad9128b97000bf1d5dbea147ade01da67d7d91a01c53ae5d7664090e3060f23",
       "overridden_tool_count": 0,
@@ -19606,7 +19606,7 @@
         "run_conformance_against_my_agent"
       ],
       "ordered_tool_names_sha256": "166257c2827756df7f041cafac875520b810ea3f464f68f15502906bb3dfa3e3",
-      "wire_schema_sha256": "2290b7005932c8517950883ff3608abc713aa3ac37b382240e67ff3dfb82df96"
+      "wire_schema_sha256": "bb17e454b4e2377185654c1b61b52ebc2d55212c31c16e4d0b05355c7aa80b8f"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:agent_end_to_end",
@@ -19630,7 +19630,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17521,
+      "wire_schema_bytes": 17662,
       "tool_reference_bytes": 6568,
       "tool_reference_sha256": "724c570df0c1afbfc5474f247fa2d289e56582171e19ca033a263bf4a38a8591",
       "overridden_tool_count": 1,
@@ -19654,7 +19654,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "01a4e47a1d56a06a49d88c67cef7541d40b7a79d196a034be57130c9182aec3a",
-      "wire_schema_sha256": "ae3d112fe6f349ce16eb5ff5bf6b45ddd72f909646f9c8ecefcaf5d21ac4e7f4",
+      "wire_schema_sha256": "6afb8588ca2c5e02009d4a1a32f0cda3e013daa9acda61c3e7f3ccd3703ae544",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -19679,7 +19679,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7656,
+      "wire_schema_bytes": 7797,
       "tool_reference_bytes": 5049,
       "tool_reference_sha256": "e864b0a33e55d3e7caf062c73af9a521bbcf2a8494a6f1c34e42fcbe54749910",
       "overridden_tool_count": 4,
@@ -19697,7 +19697,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f44279c0b16e64b09a8a1fdd183eb3b82606b5477a249986eae941d027b18aca",
-      "wire_schema_sha256": "03b93c5ac8de474e43c6586f7b8fc43fa9147b8e241dde51a8c6ea15735e3c8e"
+      "wire_schema_sha256": "6ab6dbf06b50ba07dd90c9de354c870af777499e851295d577ff9deb91d2b900"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:agent_quality",
@@ -19721,7 +19721,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12358,
+      "wire_schema_bytes": 12499,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "815eb22df22b1d8f37c869018b9c5e49c83178001b26f1e7523ce09aec7b230e",
       "overridden_tool_count": 0,
@@ -19738,7 +19738,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "32ee638aa5b9177bbea802803498f87f715d059b195e4d0492e56312ff6c9cbe",
-      "wire_schema_sha256": "0a2850d80b2523a669874d940a93a714c73e21f8db67a61371a50c644e019815"
+      "wire_schema_sha256": "a1d8c157b5a199141179bc09a30808ecde2c99bd7975c39ef01f6aa21dc55634"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:agent_registry",
@@ -19762,7 +19762,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8750,
+      "wire_schema_bytes": 8891,
       "tool_reference_bytes": 6633,
       "tool_reference_sha256": "e78fc94ddc9de419855cc10bf05d7a05126c4c50f23abc99d90fc08c530ccdf3",
       "overridden_tool_count": 1,
@@ -19781,7 +19781,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "173718fd9ea51f05c1519f70f4cc6eb81dfb5d82d81ebdbee0e77ccbbefc7f20",
-      "wire_schema_sha256": "78162fb4f54d37c139b4848053f9a14cc789980322d3bc746b40dec9d28f20bb"
+      "wire_schema_sha256": "19bfc0421c37c4f3a9d4840a31de433186c9fbed08527c767b8e959b88d88cab"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:brand_registry_identity",
@@ -19805,7 +19805,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13863,
+      "wire_schema_bytes": 14004,
       "tool_reference_bytes": 5549,
       "tool_reference_sha256": "3d9e0ef13806268f909fc694acc66e88b75809de91dd343dd2282b4a731b3571",
       "overridden_tool_count": 0,
@@ -19824,7 +19824,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "b183eaa3b6370d563884bbbc1e78d71e105e4b5f8090cdc9dbab0c1041ab8496",
-      "wire_schema_sha256": "cb9f26b443ec2248eb32899ea66a162d73cd3c843ce1e528ee30260bdf87dbd1"
+      "wire_schema_sha256": "98e43b568bb5469b0ff5d4acb2a842141f8bebb8f69ef79f134f7d0fc96452c6"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:brand_registry_records",
@@ -19848,7 +19848,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8773,
+      "wire_schema_bytes": 8914,
       "tool_reference_bytes": 5212,
       "tool_reference_sha256": "7bda40be2f135095e28761f77dda59f399bd5198a9cca4cc4de885041d8207b7",
       "overridden_tool_count": 0,
@@ -19867,7 +19867,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "216e020594d4d7a8339e16df0fae6761fe628a994db86d295e96d4f3ab6f1d54",
-      "wire_schema_sha256": "9e0084841f9e18256a2159684d8c9347a23a741dd01947551450c303b0afd62d"
+      "wire_schema_sha256": "5311aeaf6c65dab26e2f453ac37453da99760b1d707b7ee420bda6d440e30bce"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:certification_assessment",
@@ -19891,7 +19891,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17423,
+      "wire_schema_bytes": 17564,
       "tool_reference_bytes": 6852,
       "tool_reference_sha256": "414adb08a79ac4142a2967f857c3abb49345cd48daad70100e6a1762b980779a",
       "overridden_tool_count": 0,
@@ -19914,7 +19914,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "790df4634084e2fb5c430ea95d47b4aad105e5cad065f2ab1b3694405e550c02",
-      "wire_schema_sha256": "7fe9a986cef51874ba191843beabca61d9be8169bcf4c1661776f50e4627bdf5",
+      "wire_schema_sha256": "0b3889df9d691e023e2b17a45e8c42fa2bfc6e75a90db8afc0aaa43aa894a651",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -19939,7 +19939,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18326,
+      "wire_schema_bytes": 18467,
       "tool_reference_bytes": 8089,
       "tool_reference_sha256": "346659796dfa0cb862a77cb3dbe215b925a8c59aa3c0296e22a0af15cf384ba6",
       "overridden_tool_count": 0,
@@ -19963,7 +19963,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "463fa4659a702b7f1c65e0598b3c1d0340c915ba31ad3efd626031cc85c502ab",
-      "wire_schema_sha256": "224579a89b00e02213dadd0c0ee850514160d0b1de2ff70d6051fc62971c5bb2",
+      "wire_schema_sha256": "480faf32e4985700bc768db1fd7c08c691713b9ad363d36240983a299174440c",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -19988,7 +19988,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8327,
+      "wire_schema_bytes": 8468,
       "tool_reference_bytes": 5646,
       "tool_reference_sha256": "9a53ee96acd89cd57b17a1e2eefd7db0579223584a0a08c489b75fae2dd819e7",
       "overridden_tool_count": 0,
@@ -20007,7 +20007,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "cf9fc5e1f9fa1da6e4fab7287829c6367f01894d0fe2e1dad8c4ccc244ce8048",
-      "wire_schema_sha256": "8d674770df02dc173a35c04b26bda66251d51506e3aff4d0002cb5aeeaafe10b"
+      "wire_schema_sha256": "8082725b3570063223db9c483d4e4e092876bfb3e19ea38446fc764ac26d37d3"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:collaboration",
@@ -20031,7 +20031,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7537,
+      "wire_schema_bytes": 7678,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "068dd1ae345e461198b3955d26166dcd9bf6d94102993b93f7c2c6115a642fef",
       "overridden_tool_count": 0,
@@ -20046,7 +20046,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "91b057a3704a11380e0df622192c815eb5c43e514d3701109890f421f27a6561",
-      "wire_schema_sha256": "7d56e0c735dc09c3b7c8ab8b6c4bc04dc5e489fe7b23070a35896a36fe18ae0b"
+      "wire_schema_sha256": "7bc2452f52378498e733ff13b1a665d9f6ed7fd8336e49fbba7ca91331fba0c6"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:committee_co_leaders",
@@ -20070,7 +20070,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8867,
+      "wire_schema_bytes": 9008,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "6c3e8581decba525396c1e53df2d6afaf7aa6e9b5bf80df401e63e1cda3bc0ea",
       "overridden_tool_count": 0,
@@ -20088,7 +20088,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "063596a30c0f4e99cfdd77779d92a7145e459caff78c9dff3604043a9ae8c59c",
-      "wire_schema_sha256": "ef2df999c1e0e89e3a4d2f29e58c096f2a05db5781b97ab22681cf724593a156"
+      "wire_schema_sha256": "ab974565c5b82fadcde3f73292631edbe36a14535a1c668bb7dc19112b30549d"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:committee_event_planning",
@@ -20112,7 +20112,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10453,
+      "wire_schema_bytes": 10594,
       "tool_reference_bytes": 4869,
       "tool_reference_sha256": "07ca352ac259a3f7ba7fc6d292b3d7651993267bcef116dd2b83d8e407d50ad0",
       "overridden_tool_count": 0,
@@ -20129,7 +20129,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "61b15f24d4412ef90e46e186ee894b94fd1934ec2c87650d4ffee7284407076a",
-      "wire_schema_sha256": "af63723c8ec93ac60a616fdbf98cf77bb6c6ec6ab539d57585bb1fa943fdb86e"
+      "wire_schema_sha256": "a3b5babe3fae195cd6181062015bebbaa2db05fe94d81f0cc7e3095c79b5a78b"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:committee_event_registrations",
@@ -20153,7 +20153,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9177,
+      "wire_schema_bytes": 9318,
       "tool_reference_bytes": 4926,
       "tool_reference_sha256": "648cd8b0d8d84b2a2208c82f366b7ac9f4e84dab8bdfc5e72160c898d80f29a2",
       "overridden_tool_count": 0,
@@ -20171,7 +20171,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "369b9218680099ed68bc9d5552efe5f4446c5b4792ab573e9e890c507a44185f",
-      "wire_schema_sha256": "41344247ea67693b5b673df108a1a293f73e872286bcebe60e0390a5465f4480"
+      "wire_schema_sha256": "e3502e6d2b036fcd84070f1ac13a3da42fef4115deecbffa7e7deb40be149a92"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:committee_full_leadership",
@@ -20195,7 +20195,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14897,
+      "wire_schema_bytes": 15038,
       "tool_reference_bytes": 5204,
       "tool_reference_sha256": "73a64178cee70c326c45c27854fa4b29f61c9dc4203c20deb8cdbde7d932d29b",
       "overridden_tool_count": 0,
@@ -20218,7 +20218,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "3ef51ef6c23dc0bb939300d94c013762dcc27966aecdaaa1260aa3786c167cdc",
-      "wire_schema_sha256": "904072f3004a6f52d211601a328088912734622ae51622caaaebcde80b08f731",
+      "wire_schema_sha256": "b30205b328e7ca8969df567373277d78f4729864a0c27005b635a125e754c8dc",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -20243,7 +20243,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8617,
+      "wire_schema_bytes": 8758,
       "tool_reference_bytes": 5018,
       "tool_reference_sha256": "121afdcbf592ca6eedf859b93dbc32a0d10f046be5c82a3d40caf6752209cb51",
       "overridden_tool_count": 0,
@@ -20260,7 +20260,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3b942e3d6661676eadfeadf4a6ef255eb2bf7031897813df8e9ea1e49e22bf56",
-      "wire_schema_sha256": "14006ec0e717dcc82409b234aedee5878c460c5d7ab99c4cf7a016ae32cc4b5e"
+      "wire_schema_sha256": "af8905a330bc38b22c20d974cb2bf9f4bace445e41bd3215d2a7b541e89d4c4e"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:community_group_contribution",
@@ -20284,7 +20284,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7818,
+      "wire_schema_bytes": 7959,
       "tool_reference_bytes": 5246,
       "tool_reference_sha256": "152900bc3d9f41d32d451c4ac8be8c23f69dffadbc08ae9ca8bc2096f1afcbe8",
       "overridden_tool_count": 0,
@@ -20301,7 +20301,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d0d8e5d8794d84fcbc14242245599cfffc6efdaf2f0c95c364b38bb8d6d2d726",
-      "wire_schema_sha256": "6a8c30e0c92df59895e554df7e745d6fef443088a09d3f6cf9956611d1b3270d"
+      "wire_schema_sha256": "794be7c89294c0994e2119f91ac06b4b5e07d3dbb20efc15a4e271923e54751c"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:community_group_discovery",
@@ -20325,7 +20325,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7861,
+      "wire_schema_bytes": 8002,
       "tool_reference_bytes": 5187,
       "tool_reference_sha256": "d0e9bd5129bd8760c05e98f921ccc95426fe90e70d6aef554bd686fdfcfa5d0e",
       "overridden_tool_count": 0,
@@ -20343,7 +20343,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3ee5d15eafe1c588bced75166f704e89aab43275266d8b47ba666388fa23ca6d",
-      "wire_schema_sha256": "44415464c14f4750bf57e001721a201670761b6beeb6d3b64e0314e6baa65682"
+      "wire_schema_sha256": "df63d6fd395cf19acf04212a86e6f017d21801bf89a1fd13cdf1488f0e991679"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:community_group_full_participation",
@@ -20367,7 +20367,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11106,
+      "wire_schema_bytes": 11247,
       "tool_reference_bytes": 5298,
       "tool_reference_sha256": "80fe2d2700902546fe5e83a4dabb0972bd02912c7f3e4a4c30b3d63a7f11c144",
       "overridden_tool_count": 0,
@@ -20392,7 +20392,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d84555d6b82afdd6959fa75186599e3cb0eb59ba7ef4fc9bdc342620712cf0f9",
-      "wire_schema_sha256": "dec4c8306907826d97cb014172aaabc8a1813780abe21071bda8d0c09f56a48a",
+      "wire_schema_sha256": "23f519cf63cf92e41183131c60e30587cd7809627864cb4f6a6c7e0fc396ea74",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -20417,7 +20417,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8228,
+      "wire_schema_bytes": 8369,
       "tool_reference_bytes": 5220,
       "tool_reference_sha256": "24ab86bf1679054829bd2cd425f87f559118fa501aaaebd060429615a876d5a5",
       "overridden_tool_count": 0,
@@ -20435,7 +20435,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "93da32ba816b1c3678855eacc260dadf902727d23ccb7c524d29e132b1b31551",
-      "wire_schema_sha256": "f6ee5d3de237607b436dab4f7f332f67fb5fafa3b5db5ffa3db30e83fc13d06e"
+      "wire_schema_sha256": "6783b521c6665b4ae2e51a99d16dbc0a09776486e1be4d69f905d8092c700cc9"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:content",
@@ -20459,7 +20459,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8834,
+      "wire_schema_bytes": 8975,
       "tool_reference_bytes": 5015,
       "tool_reference_sha256": "ff49e5adf006709f1a45aa0a9af51aa9f8a7f85e224c512aea4dad1fc291b2ea",
       "overridden_tool_count": 0,
@@ -20477,7 +20477,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "82ce1e649afc38958ef06db762d13fe999ee4b04095ff5d5044344ac7fce4e7a",
-      "wire_schema_sha256": "950976d1ed4068184b73e7c853f123f95d5b443b039f7872105816915d9c378b"
+      "wire_schema_sha256": "79ec89ff0a645818b29e0203efacbd531835cab5f5191ac3a88571a1d3b20b73"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:council_interest",
@@ -20501,7 +20501,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7862,
+      "wire_schema_bytes": 8003,
       "tool_reference_bytes": 5182,
       "tool_reference_sha256": "00a0d6dd08ec9626b5f39dd01e60f62a4c0d6b052136b3cb8186188c163e9ce7",
       "overridden_tool_count": 0,
@@ -20519,7 +20519,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b6f0d8f9b4251533f855be149de6d5f265bd92f498ff458283723dcba93d547a",
-      "wire_schema_sha256": "e0224c9085f0e6f6006568a08ecf325ce6b2380cd8211a275cd65f718262085f"
+      "wire_schema_sha256": "7c4b1ed6479478e8230803c538d540f37d87d96a63fcde05e121128c60b3ff07"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:events",
@@ -20543,7 +20543,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8762,
+      "wire_schema_bytes": 8903,
       "tool_reference_bytes": 5022,
       "tool_reference_sha256": "d0d0a800352042ec9c342399e44ba8df2453093ceb8854bcd9b2210d7d67c138",
       "overridden_tool_count": 0,
@@ -20561,7 +20561,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "dec8b1e73a67b4044e464a8ada67f64611e9cdbe2683c0e7e5fe8732aad1dd0d",
-      "wire_schema_sha256": "c66df15de10255687d4d0200d52556b0ab8b57c5c69814399ed31a74e4935b05"
+      "wire_schema_sha256": "673bb0e6c25a1321be42f8c7d4cd0ad374bd40430ffef5fdf381a20ec034a800"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:github",
@@ -20585,7 +20585,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10407,
+      "wire_schema_bytes": 10548,
       "tool_reference_bytes": 6005,
       "tool_reference_sha256": "153b3f7994700206e694fde53f0dd0a55ff7bd73f6fbe7bbdd3133068c3a57ca",
       "overridden_tool_count": 0,
@@ -20603,7 +20603,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e7cde1aedf4ffdc3722e9b8d80a15e06e7a92767847470acbf77aaa7294c402",
-      "wire_schema_sha256": "c2e6b031ee991457569e82e13ffc2893cd2309f0eb8eed7483ee0573acc504ef"
+      "wire_schema_sha256": "665355ed88edfbec2ddf83c2070aa07e59e686d9fe64950611c7a0f80a415044"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:illustrations",
@@ -20627,7 +20627,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7216,
+      "wire_schema_bytes": 7357,
       "tool_reference_bytes": 5618,
       "tool_reference_sha256": "623ebf79339bd5110e3c5fc552029d1dd963ec75656ee5c33d0a70ae0bb424c8",
       "overridden_tool_count": 0,
@@ -20642,7 +20642,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2262e46c9d68205fbc414bd4692d1f8c6fc2016e9e23c26a41d5f07990ca23f3",
-      "wire_schema_sha256": "01bf7d3937ebe469a34902a012f306e28554f298c7ca92ceb552a45f0a47be10"
+      "wire_schema_sha256": "c7be7227a3ed18b712471906aa926f2812b523208d79c5506c5d5e10624e8040"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:industry_research",
@@ -20666,7 +20666,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8458,
+      "wire_schema_bytes": 8599,
       "tool_reference_bytes": 4972,
       "tool_reference_sha256": "185900837249fb365b264337b3d47582c5fc7f4f532a4cf01f420f5acc97bccd",
       "overridden_tool_count": 0,
@@ -20683,7 +20683,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c03b924580ac2b085190e3b4ae5c211b92918be3bbbf87c8c2feb40c59140deb",
-      "wire_schema_sha256": "a0ded125df614b848b41decf0b925fd49bc504cd9a9b7cbbb2839f3ac374f557"
+      "wire_schema_sha256": "c86a0caa2d0edaf672fcfb2d3afebe6d5c46c18aafe4942614eef27a874113ec"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:knowledge",
@@ -20707,7 +20707,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9563,
+      "wire_schema_bytes": 9704,
       "tool_reference_bytes": 6204,
       "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
       "overridden_tool_count": 0,
@@ -20724,7 +20724,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
-      "wire_schema_sha256": "5438b4aa64ac11bb20f3f810fa76e1a542f6b54087b2329203de2a124311c11a"
+      "wire_schema_sha256": "ec8ac68fd4d8b0eb30babafab56ea4414f429e10dd4e22c738884a51a8c2b42d"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:meeting_attendance",
@@ -20748,7 +20748,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8945,
+      "wire_schema_bytes": 9086,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "df3af926f99c7f9d48206b0c20048f46be655ec3881722c8be2be2db81a63acf",
       "overridden_tool_count": 0,
@@ -20767,7 +20767,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "9a66a9d3f906bd65c3235d8f9fd264d2dfc900ffc5860af19c7b5d32f99a4d8f",
-      "wire_schema_sha256": "b7ec2bfb8d39f7899e36e8d654f46802b48bd67a8bb966de97ea5b84860cb125"
+      "wire_schema_sha256": "5d0cc9b52e8442f9bbd21e684ec4837f286f6054c93f320e53db8817bfaea287"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:meeting_full_administration",
@@ -20791,7 +20791,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16400,
+      "wire_schema_bytes": 16541,
       "tool_reference_bytes": 5127,
       "tool_reference_sha256": "000143f1682565038450ae5a74b8276cca8d354dbec76741dd85d46052760238",
       "overridden_tool_count": 0,
@@ -20816,7 +20816,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "8bcb247100605d8c2354b2fa7a9f1a2b5c349fa2aab59266996b5bcdf634fa51",
-      "wire_schema_sha256": "e9986416e30b85a45f5732568173f1a5f8b8653e4e43e9de3dbe18457134ed86",
+      "wire_schema_sha256": "25082d4bb25baffcc0880a8c99ad02c5a85d4a2b4beb22e930b1f733773fd2e1",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -20841,7 +20841,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12258,
+      "wire_schema_bytes": 12399,
       "tool_reference_bytes": 4978,
       "tool_reference_sha256": "a59255184701822e566e5691e81b78ac059fd7a5e3b90284837c2f70fed0ef1a",
       "overridden_tool_count": 0,
@@ -20859,7 +20859,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "7d975630d220603ee3b6cbf059fe22fd9783702a41ab1ed034a1728a95a3e658",
-      "wire_schema_sha256": "e99f89fb6b6000ac1fd12877cede72f3105201964c9add14836d790d9bbe128a"
+      "wire_schema_sha256": "2253c5750ed560bd5432ce9193d0311b535a4afd0204a095068dd2df77633d11"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:meeting_series_topics",
@@ -20883,7 +20883,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9179,
+      "wire_schema_bytes": 9320,
       "tool_reference_bytes": 5051,
       "tool_reference_sha256": "41cdd27ed230ed4b8267bb4e12a4374fcbc4760641fb45cbf0b23106dfb028cf",
       "overridden_tool_count": 0,
@@ -20901,7 +20901,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "7e127221944ab98d82c8ea4c6a144d7f65081bd75d2d35700b5e4fc5219e01a6",
-      "wire_schema_sha256": "f0637992f399d4aa9f2e7a7897c476aed290bbe9d3251ec4763f586e679ee40c"
+      "wire_schema_sha256": "90d6c562f04be6f98a5915bc3f594575806d39321edb5e5d4f17e80f0eb33e99"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:member_billing",
@@ -20925,7 +20925,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9764,
+      "wire_schema_bytes": 9905,
       "tool_reference_bytes": 5601,
       "tool_reference_sha256": "a341d5c2e105981cd5b9a59335595d0857f26c560edf48b0224c584bb832e0ff",
       "overridden_tool_count": 0,
@@ -20944,7 +20944,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8699d6181a5d508084790d0cba1a651a4bc2dcd7a4778343c1e1c74d8194805",
-      "wire_schema_sha256": "445ea8435ca1189973da1380ccfaf1f7cf92a320f874c30233584fcd0b5a3751"
+      "wire_schema_sha256": "cabd0cb631cf16d712d77eeb947de1193cb6bf7695a2915ad9e6af229261b644"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:member_company_profile",
@@ -20968,7 +20968,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12646,
+      "wire_schema_bytes": 12787,
       "tool_reference_bytes": 7111,
       "tool_reference_sha256": "35dd65133e09a8f9a9983ac8d38e362612aed792bb65ea66fc08923a1f6a82f6",
       "overridden_tool_count": 0,
@@ -20987,7 +20987,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8f6f85c0206f418794cc44768ecd12209f1b28f37c41bb463800ef829d542c54",
-      "wire_schema_sha256": "ab5c358b264bc08aa27993a3242b5764c599d379a3bea224900bce88ea1df0fd"
+      "wire_schema_sha256": "054ab5c37e70843aba7803a8ae60dc51c77c80d99a68a9282369c441e163b23e"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:member_personal_profile",
@@ -21011,7 +21011,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7415,
+      "wire_schema_bytes": 7556,
       "tool_reference_bytes": 6535,
       "tool_reference_sha256": "0b3ad904d581c85060bf4fcf486b2feaf130f5eb13e53a66c273d0b1628e8ed6",
       "overridden_tool_count": 0,
@@ -21027,7 +21027,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b38dbd9cdb706e4bec9988f5f79ddf06c3add5fbbb3d642d020aa47580a1c188",
-      "wire_schema_sha256": "f291ad37c42ffeeeea7c29772478a34da6482727b580d3e9d5ec17f9c61298d9"
+      "wire_schema_sha256": "26e9ba660534e07fb4c0505b280c3fe5fda36bf20c7cdab9cc1284a565178f2a"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:partner_directory",
@@ -21051,7 +21051,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9846,
+      "wire_schema_bytes": 9987,
       "tool_reference_bytes": 5111,
       "tool_reference_sha256": "a2c31cc736db63698935549fc4cc50145d0d5620aadd13ec001b5a57a6e21a81",
       "overridden_tool_count": 2,
@@ -21070,7 +21070,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bcae4bb08bebd099c9bf9207069921d51e16f79f607ff74883ab20bd515f90f3",
-      "wire_schema_sha256": "c7ec3a0ae906c9bd8ad2c3f0fa2ccf9c85fad786463e86fa52f8047110c23071"
+      "wire_schema_sha256": "a94d80cf2ce8d7ad435c782fb11a6cc9f2a83671ed845c0071d58e1b1c9f0f9b"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:property_identifier_catalog",
@@ -21094,7 +21094,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9122,
+      "wire_schema_bytes": 9263,
       "tool_reference_bytes": 5216,
       "tool_reference_sha256": "f601e979751136d9791f545ecd22c07a13bfe0992d57c8132a4a12236b0acaf2",
       "overridden_tool_count": 0,
@@ -21111,7 +21111,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "aab2803cfb10c48ed22433a12d597a29cfbb108da9594ba642298056510b44f2",
-      "wire_schema_sha256": "3bacda2bff63186913b51b0526b4f63aeb1e2321fb05843800566b3dc6abee4c"
+      "wire_schema_sha256": "6515b61fd8007e5748125c56512bd494fc0ed387fe4b020f2804a08b65629b29"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:property_list_enrichment",
@@ -21135,7 +21135,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7229,
+      "wire_schema_bytes": 7370,
       "tool_reference_bytes": 5065,
       "tool_reference_sha256": "0d5b48fe7e301b593e2c037bbe63663f9b8b8657b79ab8fd08c7fa24307c2a17",
       "overridden_tool_count": 0,
@@ -21151,7 +21151,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "438911e6103584c2b1a56dc85cb88fc27a4058a972f2ada41568f97e40f118b6",
-      "wire_schema_sha256": "1df55b955f0f9894c63614ffe350252a80ee584016135d8c5f338aff86d9d220"
+      "wire_schema_sha256": "07d9f089ad797a270dee73fb19e83a6555caf8d7067249e480ed9bd738bdb97a"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:property_registry_records",
@@ -21175,7 +21175,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8492,
+      "wire_schema_bytes": 8633,
       "tool_reference_bytes": 5294,
       "tool_reference_sha256": "9db46b41e9dcb5583694e069f64c5cfd02727e6134feebe06666e3ea8505f6e8",
       "overridden_tool_count": 0,
@@ -21193,7 +21193,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "f35d857d81802956401ab47bd71f0b06a480bb636ca347f0ae928e5af642da8a",
-      "wire_schema_sha256": "704f0a3527433030c4a3ed82a7eb4878dacb1c0d45262db00e414437e3c75144"
+      "wire_schema_sha256": "49382c593b971754422988be697c341b872061d8aef7bb996dd1860419980869"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:publishing_assets",
@@ -21217,7 +21217,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8606,
+      "wire_schema_bytes": 8747,
       "tool_reference_bytes": 5019,
       "tool_reference_sha256": "76b5d90221f61a3b3510669dbbb83391980b917f6e01d6949205e8a669477bbd",
       "overridden_tool_count": 0,
@@ -21235,7 +21235,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b28f189dc7f1f3e9c0e3b1e8c21c782031a27af29ee92fdc774cad495f9d358d",
-      "wire_schema_sha256": "73ef5c2b385d2445dc245d4d018fc45359090ac4bd0a7df36cb3713cdc58302c"
+      "wire_schema_sha256": "3fc9213c19c46c09e85ab261d2ec3031ff2db832e33634b1323b9c003f07a9c8"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:publishing_promotion",
@@ -21259,7 +21259,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8091,
+      "wire_schema_bytes": 8232,
       "tool_reference_bytes": 4908,
       "tool_reference_sha256": "028b475316bf9318c8daf7e8db4c2bc999f6765438191278143deaf41d83f84c",
       "overridden_tool_count": 0,
@@ -21275,7 +21275,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "12fc6a926164fc6d781582726b792bce04c0d955dcd1881fcba91cfccad46a43",
-      "wire_schema_sha256": "531a42722f29d3fec4e1b6c2db4eb62bae0ea522e050c88e9369f48c8346dad9"
+      "wire_schema_sha256": "71e143fc055ea35d849ae8031d3204717aecc703ec5a09d3eeafcf7ee47e943b"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:publishing_review",
@@ -21299,7 +21299,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7935,
+      "wire_schema_bytes": 8076,
       "tool_reference_bytes": 5089,
       "tool_reference_sha256": "293cccb606c14259488ae08b58dd5864c1cd5cdb261ebdde177cdf71c030930d",
       "overridden_tool_count": 0,
@@ -21317,7 +21317,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "6367bb5059c34b3346ad8ffe1e3b768852a2e7389e6c2c0f4e1d97d2b006b666",
-      "wire_schema_sha256": "2f060dff5af7d527393686dc2d1e06986583280a86a15e95d4cf831c8f4384cd"
+      "wire_schema_sha256": "361f6c77be8270ad9e01ff835a9d8fed47baf1891b879ce3e6e99bb6d838b352"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:publishing_submission",
@@ -21341,7 +21341,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9623,
+      "wire_schema_bytes": 9764,
       "tool_reference_bytes": 5865,
       "tool_reference_sha256": "c43c878587751a7b5f684d5e3b47be6f94c4bbe7ad889cf32b4713ed6ba2a924",
       "overridden_tool_count": 0,
@@ -21358,7 +21358,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "aba155c978eca98aa50d8e3397966f83f4b0b8532484458082433d8f106032f5",
-      "wire_schema_sha256": "6d5281a4edb4988ce0166404aa7043db2cc82af4f52b6b0e9ae6380c38bd9190"
+      "wire_schema_sha256": "1f600b2b4d9e9a1fb722ad9a84b946476ab263ace6dd6b0b7b6baf5e66f58dcd"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:schema_reference",
@@ -21382,7 +21382,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8711,
+      "wire_schema_bytes": 8852,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 4,
@@ -21400,7 +21400,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "8b72f1ae05db4aeef98159092ffd8e443b623eb4e19b30bf0be9443cc739bd90"
+      "wire_schema_sha256": "b680060649c8e0fc0921e98428b53f5b567d84f31c4ecd952047679811816401"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:sponsored_intelligence_discovery",
@@ -21424,7 +21424,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7899,
+      "wire_schema_bytes": 8040,
       "tool_reference_bytes": 5241,
       "tool_reference_sha256": "3c43d712cf42391096e4c83cfb5ce4cf7388385519d5ec966d1edc73e53a964c",
       "overridden_tool_count": 0,
@@ -21441,7 +21441,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "10dc3537f2c3b17d9f0364e80871604779981fcba52329e34b442ceee2c396b6",
-      "wire_schema_sha256": "00e9bf28f9d1e0b60747706f7a756166f8222ce66f08ab5d826b5f7437674f4b"
+      "wire_schema_sha256": "922c919dc877b18418917c7fe2a9515f8fc6661841065875779824cd1d810a80"
     },
     {
       "id": "slack_bolt:private_mention_member:routed:sponsored_intelligence_session",
@@ -21465,7 +21465,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7418,
+      "wire_schema_bytes": 7559,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "b0c20685f8468efe08eda7704772d86eb52c6f23de9d4af2425b8f97ffecc870",
       "overridden_tool_count": 0,
@@ -21482,7 +21482,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a57a8f996c5c03f33848a5dc74ef82c65a5d990f8ee2c9dbf85a08b8f90628b3",
-      "wire_schema_sha256": "b346004519c43ef64023ce979be1c59481536490c537b430d5c06f08e9e24b11"
+      "wire_schema_sha256": "612102c9dec28da25aa58d000a5890ccf2134cccb68a5b5f423140a609287e05"
     },
     {
       "id": "slack_bolt:private_mention_member:safe_fallback",
@@ -21552,7 +21552,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12693,
+      "wire_schema_bytes": 12834,
       "tool_reference_bytes": 6244,
       "tool_reference_sha256": "81ada737ca8dd234194561c6e5bc645cec7a51b099450546ea4af275ef31ce42",
       "overridden_tool_count": 0,
@@ -21569,7 +21569,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "ef5f0d65423720243295a1d43b95ac8187ecc2d52bbc4d22def910b097db7ea1",
-      "wire_schema_sha256": "6770de7af265ec65ff1cb9b80f5881d26c3355d495fa46dddfc753be6020e9ec"
+      "wire_schema_sha256": "031eb120d06273adda5e5bf79ec94466fd36172f3a93f7db75e6cb13f4e0e103"
     },
     {
       "id": "slack_bolt:public_channel_admin:adcp_task_operations",
@@ -21593,7 +21593,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11141,
+      "wire_schema_bytes": 11282,
       "tool_reference_bytes": 6292,
       "tool_reference_sha256": "754c3f7fd5bb236bc471a91ea08aa03d2f37efc145c55f416e1fb4ecfd86f22d",
       "overridden_tool_count": 0,
@@ -21609,7 +21609,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "2884fe21fddd17bd7e9237c361ae09175436ea6bc4053ac7d5ec6052232ab69e",
-      "wire_schema_sha256": "f2e5de7ec874845eec21c8cc24173c4b3a8ed47b4b914d5d680fe223147b0184"
+      "wire_schema_sha256": "62be844dcaf364007af54ce5debba844f002e0ce786d5192b2be6d85c3adcff1"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_billing_account",
@@ -21633,7 +21633,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 5810,
+      "wire_schema_bytes": 5951,
       "tool_reference_bytes": 4679,
       "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
@@ -21646,7 +21646,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
-      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
+      "wire_schema_sha256": "82ca1d7dfa887a93ae42006395543aa86d4d07147bf2b282b074ad57d1309e79"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_billing_discounts",
@@ -21670,7 +21670,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 5810,
+      "wire_schema_bytes": 5951,
       "tool_reference_bytes": 4679,
       "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
@@ -21683,7 +21683,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
-      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
+      "wire_schema_sha256": "82ca1d7dfa887a93ae42006395543aa86d4d07147bf2b282b074ad57d1309e79"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_billing_payments",
@@ -21707,7 +21707,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 5810,
+      "wire_schema_bytes": 5951,
       "tool_reference_bytes": 4679,
       "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
@@ -21720,7 +21720,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
-      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
+      "wire_schema_sha256": "82ca1d7dfa887a93ae42006395543aa86d4d07147bf2b282b074ad57d1309e79"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_brand_logo_review",
@@ -21744,7 +21744,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7555,
+      "wire_schema_bytes": 7696,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "e28b81d8a073fcfa47c086ae7e29e6e41cc1205178b340b1f2419db2ebb20151",
       "overridden_tool_count": 0,
@@ -21760,7 +21760,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "8ae0afe3e0060ff4a745ba983f797a1a04e090af905b88575fe83784a7555d12",
-      "wire_schema_sha256": "bfa31b2c296da92f9f2ed395798877124909bbe12cac3e8cc56bcd102ee22dbd"
+      "wire_schema_sha256": "c9cf256a0ac37570d8a792a6f3715f08c59b83ac6fd3dbe89549dbc3bad30892"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_brand_registry_integrity",
@@ -21784,7 +21784,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8264,
+      "wire_schema_bytes": 8405,
       "tool_reference_bytes": 5120,
       "tool_reference_sha256": "8cf71e9272bae280ae2d2686f120d20ee4771aa02ed6319564c8996fa5d9bfa2",
       "overridden_tool_count": 0,
@@ -21802,7 +21802,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "82b4727a9835c66e90e1b52b9e78f310e1b56b9890361bb93b582f8cf2bc4459",
-      "wire_schema_sha256": "a334cf564da2cbe9e0e5f9679e365fa19fe66455beaff650aa9410fd79ea2a81"
+      "wire_schema_sha256": "36be53f26840515e92eacf23504e8388c67fd54a7b19a4b6e0672e2bd30f2471"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_conversation_review",
@@ -21826,7 +21826,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8255,
+      "wire_schema_bytes": 8396,
       "tool_reference_bytes": 4894,
       "tool_reference_sha256": "d1b06376838f8ca42518b679319b2265f202f4b97429bad485ce2adf4916f4f5",
       "overridden_tool_count": 0,
@@ -21842,7 +21842,7 @@
         "review_flagged_conversation"
       ],
       "ordered_tool_names_sha256": "d0518cb4490415bd70923e15a6ee756893c65b99c4c042a26331dec6aefe80b0",
-      "wire_schema_sha256": "a074a92fdf8f1be21c999cde4b44a0ae1081f9bfa8c59ae32211edfb065701c7"
+      "wire_schema_sha256": "044f669c8f6f64e77e7912e4e8fcddf1aac3e004afd575f38dcf9c1ff9ba066b"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_events",
@@ -21866,7 +21866,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11840,
+      "wire_schema_bytes": 11981,
       "tool_reference_bytes": 4959,
       "tool_reference_sha256": "811c6c0fb4294b05ca52bdab60124a4b9a0b7321fbe01c02f10bfc43270dcedd",
       "overridden_tool_count": 0,
@@ -21884,7 +21884,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "78fceac6fc5a984b5d0b66ae9e9beefa63774103c244635741cb1455ad9418f8",
-      "wire_schema_sha256": "392a39b1953b4c61808ce4ecee693888fe2504611170962bedd7d0af65b8e1a4"
+      "wire_schema_sha256": "b59ad656e49bfb3256767e26d83f29fdbe9ab69486825d8f574ddb928b08933b"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_feed_curation",
@@ -21908,7 +21908,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8002,
+      "wire_schema_bytes": 8143,
       "tool_reference_bytes": 4868,
       "tool_reference_sha256": "b24a016dd74f346d3ccf5e257a6f081cd871b1505f014a98b583b030eccf4398",
       "overridden_tool_count": 0,
@@ -21925,7 +21925,7 @@
         "add_media_contact"
       ],
       "ordered_tool_names_sha256": "274734154d8ca91ffe729feb220e97bafda6a4b2fb0fe70c710f8c53d94e0964",
-      "wire_schema_sha256": "7e9c8b99c5d2674b5d16fd6d8f1137db86f71fe0ee52632c781eb83af9beca25"
+      "wire_schema_sha256": "d60b43e115304aa235e95a91e63d84b70a39e7e0c8fa8938c46857277f05c96e"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_feed_monitoring",
@@ -21949,7 +21949,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6789,
+      "wire_schema_bytes": 6930,
       "tool_reference_bytes": 4847,
       "tool_reference_sha256": "df9f47c5f7ef1ee31dc7b21d5f05d880e7e8cce2a36ebd3f6209eaf5d0f56f1c",
       "overridden_tool_count": 0,
@@ -21965,7 +21965,7 @@
         "list_feed_proposals"
       ],
       "ordered_tool_names_sha256": "e844d612698c24fc0bba84fc87ef64aaf3da94cf680b3522b51a1ee44a7b940d",
-      "wire_schema_sha256": "9c2ad51f5bf1476030957fd5d49fbdcbd79ce46eb71653ef5c24dec44f625a44"
+      "wire_schema_sha256": "1a4741cbbf67a82c54d17ea7cd3c04ee57d0d2014d1fa4b3b59b7eeead613afc"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_followup_tasks",
@@ -21989,7 +21989,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7521,
+      "wire_schema_bytes": 7662,
       "tool_reference_bytes": 4875,
       "tool_reference_sha256": "b109f94ee671c2d3e17c7b90ffe7f1c23722765419788bedf3079d57637bbe11",
       "overridden_tool_count": 0,
@@ -22006,7 +22006,7 @@
         "log_conversation"
       ],
       "ordered_tool_names_sha256": "0b0d0aefc725b42276b1855c221a785069d1bcc9c0d4393dd6fa91964c37e866",
-      "wire_schema_sha256": "13f6a17f25580b1d1b062e133863d9ec5d229471d7fc00cea398129f7fba4d40"
+      "wire_schema_sha256": "294109cf7f6da074f5b42877ad37c646a1dc4074af3ef7d45df967b695e56019"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_leadership",
@@ -22030,7 +22030,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7993,
+      "wire_schema_bytes": 8134,
       "tool_reference_bytes": 4955,
       "tool_reference_sha256": "3b6fc79f5405f85c4ac8fdc11c84447805d178349630465015dee92f2e5b58bd",
       "overridden_tool_count": 0,
@@ -22048,7 +22048,7 @@
         "list_committee_leaders"
       ],
       "ordered_tool_names_sha256": "1a7e4053773341480e40bf3d5719a92149f41f6907cec6255826c72ca8eaee71",
-      "wire_schema_sha256": "1c3d1f15a36a25939dfb0dd7a72798ad54f7945b6bb2d0d0644c8855915c9866"
+      "wire_schema_sha256": "301046e51eb80c89e404fb842b8cc40aee29ca38aa395f93433fdf641eef586a"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_membership",
@@ -22072,7 +22072,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7899,
+      "wire_schema_bytes": 8040,
       "tool_reference_bytes": 4931,
       "tool_reference_sha256": "4321359f37138d0ebc6423ecb922349c8f8e18e39e8b3603f85ec36c8bcfb1e9",
       "overridden_tool_count": 0,
@@ -22089,7 +22089,7 @@
         "remove_working_group_member"
       ],
       "ordered_tool_names_sha256": "26d7f34d6d73328f9c1b0408f02126cf96b685e649f7d79c8f0b19b4b3549933",
-      "wire_schema_sha256": "768655c2e80ea7f3a8da9586098700ed2a1568a8deb4ecfaab5509d060c2363c"
+      "wire_schema_sha256": "3a052a0c6730de5ed3d9ec10ae09ed3b93dff4148ec6e38ca6b65949bd7aa42e"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_group_structure",
@@ -22113,7 +22113,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7962,
+      "wire_schema_bytes": 8103,
       "tool_reference_bytes": 4948,
       "tool_reference_sha256": "335588e02a9a72b5cc803ed01c4c096be23d532b34c33c5d736368dcb856e061",
       "overridden_tool_count": 0,
@@ -22131,7 +22131,7 @@
         "rename_working_group"
       ],
       "ordered_tool_names_sha256": "d8bcae23edd575d85fc9e4111e78ad8f6a7b3de078c16e63811c77615666b8fc",
-      "wire_schema_sha256": "b96fee00d0b51273b91181ada9c4306cd8c81773aa926481d1a99ef969c85828"
+      "wire_schema_sha256": "4f67c45b2af25490a528aef11e3721996ed113ba57101a0600c41995aba426c3"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_organization_integrity",
@@ -22155,7 +22155,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7949,
+      "wire_schema_bytes": 8090,
       "tool_reference_bytes": 5177,
       "tool_reference_sha256": "00bfb4efb8e1117627f5e627ce4266ffd74fe563c6437ccfbbad280c52abe1dc",
       "overridden_tool_count": 0,
@@ -22172,7 +22172,7 @@
         "manage_organization_domains"
       ],
       "ordered_tool_names_sha256": "8817b9f4e95283dab992570d9b8567921665e51276a1c905e500f702ec526eb8",
-      "wire_schema_sha256": "764a093b5d77af5add95b3cd24816d64389a4d5446f5cb2991b4fba7f95a41dc"
+      "wire_schema_sha256": "4eafdccba4feb185d292fb2e113054018d55f83899ace7e7232b5af741d3aceb"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_organization_member_records",
@@ -22196,7 +22196,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10837,
+      "wire_schema_bytes": 10978,
       "tool_reference_bytes": 5193,
       "tool_reference_sha256": "24bcd9738cf8a5e65e84a99e579da0428309fa6641d9fcd2a910744a44b9e935",
       "overridden_tool_count": 0,
@@ -22214,7 +22214,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "9dd17e0a7d3dc426c02db75741f57446bd3abb8d25ace4295292990ae957d618",
-      "wire_schema_sha256": "f1cd2aa9849e9559b9465b63e2a56605b8d1fe36974ba7fa079b0930fbecbdcb"
+      "wire_schema_sha256": "cd277295b225ffb4308673970a9763a3a4903e08fd615b17f5a4d80c37ddab43"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_prospect_pipeline",
@@ -22238,7 +22238,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9754,
+      "wire_schema_bytes": 9895,
       "tool_reference_bytes": 4903,
       "tool_reference_sha256": "7310e2e2a9e1cf86319c13a9702cfffdc8af443c38868b4053920569a2f9d509",
       "overridden_tool_count": 0,
@@ -22255,7 +22255,7 @@
         "claim_prospect"
       ],
       "ordered_tool_names_sha256": "40115ab456ffb5d295da399aeee6a3ebbe6bfda7111df9bc28f5c54dbe41f0cb",
-      "wire_schema_sha256": "254fb1063353d33e773798e1df41fb5a5645ae022a3bcf28c2718e68c26326ec"
+      "wire_schema_sha256": "66f9241006aec6a817738d45d5bd341c5f2269644b0d53a583a0f44870a730ea"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_prospect_research",
@@ -22279,7 +22279,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8141,
+      "wire_schema_bytes": 8282,
       "tool_reference_bytes": 4921,
       "tool_reference_sha256": "64107b0b02853afe931d64cc4d5f1018f445fb2581f94d81b4026a911f0d36a6",
       "overridden_tool_count": 0,
@@ -22296,7 +22296,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "74d0ccb082241445af98c620eaa636b6cbd4f1428eb085e1177dfde5d1debaf7",
-      "wire_schema_sha256": "e26d21ac4427479ec537b11680a24b31b4d24711d9a91de8ae1b4a661b99fb2d"
+      "wire_schema_sha256": "2b8edb5092bbf22290016128fa888e56acf19ef6edb5dc97484299a238ac29ee"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_authentication",
@@ -22320,7 +22320,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8506,
+      "wire_schema_bytes": 8647,
       "tool_reference_bytes": 5982,
       "tool_reference_sha256": "2e3e5d4fd673adda8800ea768de8edb0b644c4fe091ce9344af09087950b2e1b",
       "overridden_tool_count": 0,
@@ -22335,7 +22335,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "51c444ff7e90b9cd4728789bdf47ed84cf7da29bb8e269c67a1fc1246ad0bef8",
-      "wire_schema_sha256": "2a6d5f01c6f46041d2c9ae786567c2ac73beaadd0a6f254e0bdcf567d6d66aa3"
+      "wire_schema_sha256": "760a76c316f458bd62a1a9992b0907d993821174e696045ec9bc07e602d29fd2"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_conformance",
@@ -22359,7 +22359,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7211,
+      "wire_schema_bytes": 7352,
       "tool_reference_bytes": 5706,
       "tool_reference_sha256": "d8f3e2e7bd71653c858614ef8b689d63957f45fe16c7a3e10bb069f0265e85e6",
       "overridden_tool_count": 0,
@@ -22374,7 +22374,7 @@
         "run_conformance_against_my_agent"
       ],
       "ordered_tool_names_sha256": "0fa7c1408af4686efb4e6dbd59e7c48f5491ddd2efd4052b782ee854ae88f1a6",
-      "wire_schema_sha256": "6673bdac28443d4d60382dfbdc53ab839f22a164918e27a5e519c93014f12dda"
+      "wire_schema_sha256": "8ac9981cf3948c72af0f4dc9df0604f0d62f492189d4ab65feb9fb5c0ebc6384"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_end_to_end",
@@ -22398,7 +22398,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17048,
+      "wire_schema_bytes": 17189,
       "tool_reference_bytes": 6550,
       "tool_reference_sha256": "0ab8109a2f0f25348122080fb7f64fe305ccfad798a7b74533903b50fb916084",
       "overridden_tool_count": 1,
@@ -22421,7 +22421,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "0e5db57c4d45f9244087dbefbe8cbdc0427aa9c4367b7f64d7bef050db0f61de",
-      "wire_schema_sha256": "a113b87298a3ae4780b9a34ca869515a0d103c21f3ff44537d860e3c0f235d1a",
+      "wire_schema_sha256": "fcfbe4c39f756891281285e4ca50e35ae701e743668f15889aeb2b6a8d9b75d8",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -22446,7 +22446,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7183,
+      "wire_schema_bytes": 7324,
       "tool_reference_bytes": 5031,
       "tool_reference_sha256": "98b76cc82427cbe9a056b5f7318c70d79ce51c0ff58aa54cd37c361c62058258",
       "overridden_tool_count": 4,
@@ -22463,7 +22463,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c77e6b9340e2cd4e18f9cb2aaef814635b8ec503f02db8356aee3964ee6329de",
-      "wire_schema_sha256": "870d9608c81b1c54aa646e25c0f1ac39d834caf3360ddadd981dea834d1c4c28"
+      "wire_schema_sha256": "606ad6394531d975904e216505420b235a32ecb58917afe83739e64c6addfc45"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_quality",
@@ -22487,7 +22487,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11885,
+      "wire_schema_bytes": 12026,
       "tool_reference_bytes": 6053,
       "tool_reference_sha256": "623c78700d4c24b2b99574e33c8af9cd61c60f6fcf74b1ac59f49ca20eb8a164",
       "overridden_tool_count": 0,
@@ -22503,7 +22503,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "22b683ae113338a0d0437c1172eca780abe22103df94c4c4addf2dca3f6da300",
-      "wire_schema_sha256": "7b3d1c32371037c72062dee8d01a29e64b67b756f5566dd3e4489538f564c179"
+      "wire_schema_sha256": "fd9882a730a2a2cf119d36449f9dd3d6289e82ea818176bbf9a1d630e4280735"
     },
     {
       "id": "slack_bolt:public_channel_admin:agent_registry",
@@ -22527,7 +22527,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8277,
+      "wire_schema_bytes": 8418,
       "tool_reference_bytes": 6615,
       "tool_reference_sha256": "bb434ddb22c7b200d183a085afbd5d3635266af4397665d325f4e45dfaa2b773",
       "overridden_tool_count": 1,
@@ -22545,7 +22545,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "24423c12ddb094003c50c25b85089047bdd9d412921ff7c9e8be1346a1f2b230",
-      "wire_schema_sha256": "ecff72d5e963c33f79ff0ddceaa0d1ac6c5de68466204ecb28aac8fc88eecfed"
+      "wire_schema_sha256": "7bd4686e1ba7b389643c67b847bea3c3cc5dc6820910635e523691dae427b8f9"
     },
     {
       "id": "slack_bolt:public_channel_admin:all_valid_sets_maximum",
@@ -22635,7 +22635,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 157989,
+      "wire_schema_bytes": 158130,
       "tool_reference_bytes": 38011,
       "tool_reference_sha256": "b7d09c9f53d7fe03b437a24aa21e4dd5e40969bef7f9276897a1106795dd7eb2",
       "overridden_tool_count": 11,
@@ -22844,7 +22844,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "a60d9e15a94a1f70f8fe7cab849a938a387c52e4f1253183f5ae640e40ccc4f5",
-      "wire_schema_sha256": "0bce39d571d9b51c216e32793ca4222e77a7fe828c22d3ebfc847273249da0e1",
+      "wire_schema_sha256": "459b17ab59f72d15b93862c2e883ecbbb3e31a7bb3cfc45e7e1e2eae0f587f97",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -22869,7 +22869,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13390,
+      "wire_schema_bytes": 13531,
       "tool_reference_bytes": 5531,
       "tool_reference_sha256": "2b878337fef72078a045054e09447714faafdc9f5876b152a3ce950088805430",
       "overridden_tool_count": 0,
@@ -22887,7 +22887,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "5e92adcffb6c3b4328608d87745cd5004540475dc2ea23263bf9609972d81228",
-      "wire_schema_sha256": "2585de480762a9917696f6e4eda29db9a5d65fb083eb41cf6ae8c6db4eee8000"
+      "wire_schema_sha256": "747a001917facf717606e7d20d9c771dacd32bf1e4693b0de66b4cd36981b184"
     },
     {
       "id": "slack_bolt:public_channel_admin:brand_registry_records",
@@ -22911,7 +22911,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8300,
+      "wire_schema_bytes": 8441,
       "tool_reference_bytes": 5194,
       "tool_reference_sha256": "40f2a9bb90490f176b7e1b0276fbd088226b81a474a0374478e5d3b2c0572275",
       "overridden_tool_count": 0,
@@ -22929,7 +22929,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "d2db41880ecd6eb43b049517f08ef4f693bb1c065153770c1c17b2551229289a",
-      "wire_schema_sha256": "2ba7eadc87c8fde05c6480df10ebbf9a4c6d596b526bc332cf18427a9fcad949"
+      "wire_schema_sha256": "e6f190beef0c1adcf1ce25b8253ad2162cdfc3ccbd80dad815f9f0428c103b2f"
     },
     {
       "id": "slack_bolt:public_channel_admin:certification_assessment",
@@ -22953,7 +22953,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16950,
+      "wire_schema_bytes": 17091,
       "tool_reference_bytes": 6834,
       "tool_reference_sha256": "00100bad072964a6ff52407a77807af70d49e3e3d7ad7a643578276cbed84f63",
       "overridden_tool_count": 0,
@@ -22975,7 +22975,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "8ac4c56c1525cdc7dc33c1dce45e8192c4e2ef35a3534be78ea1e573a45b7a51",
-      "wire_schema_sha256": "1e4390b1fea96985281ca194a8c65486f319c2e4afbcd4da57388f475acea9cc",
+      "wire_schema_sha256": "87ebdf040b68368e09a1db6900fb2f3f9cd8fe0f1020a6e5fa8635fb9ac7eb1d",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -23000,7 +23000,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17853,
+      "wire_schema_bytes": 17994,
       "tool_reference_bytes": 8071,
       "tool_reference_sha256": "09c17f2d7be8670598cee0d28be64d0030eeb7a23653120ad573ee12e0b1f602",
       "overridden_tool_count": 0,
@@ -23023,7 +23023,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c48ea42b9e2155bd3f7e2071d4b9e0a73a62009e45239a0a93d2b1b1ad3fb904",
-      "wire_schema_sha256": "9322e31737e513b306f554a5600dff665dd30a7266779354451076d8eb83911f",
+      "wire_schema_sha256": "ee70bc45858def844b6b0e232eefe9596ede8870de2cc197a326a25e541e7546",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -23048,7 +23048,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7854,
+      "wire_schema_bytes": 7995,
       "tool_reference_bytes": 5628,
       "tool_reference_sha256": "49a0ad11f82bc0e092aaa06ef1a244ca15e5b0e896692835133a6ae0b4b85a88",
       "overridden_tool_count": 0,
@@ -23066,7 +23066,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "76d0045ed7ed72a0d064b425d402583e71d874e94a76722044d0fa92b4ce9b24",
-      "wire_schema_sha256": "635babec938811396f1e376045d5d0e0b73bb2d0acdb8331fd7fe78e5a720a44"
+      "wire_schema_sha256": "0d64480e94f0c14585ef9c8eea21d0b47becd9e8079e9533a5a47014b2ee4b64"
     },
     {
       "id": "slack_bolt:public_channel_admin:collaboration",
@@ -23090,7 +23090,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7064,
+      "wire_schema_bytes": 7205,
       "tool_reference_bytes": 4895,
       "tool_reference_sha256": "10f61a027ef688857f3355342fa14e772d652fd15e70da96df88a418f99833b9",
       "overridden_tool_count": 0,
@@ -23104,7 +23104,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "4511d88caefcdce804d554bd69b578cf536f2f43618a951273e9ccb8d2f3c014",
-      "wire_schema_sha256": "9055537247ae12d2a027f65ee5403db037814ac6b44d7b98b2d4386031bd1cf4"
+      "wire_schema_sha256": "da4dd5a70e1d20d6e680c2b133f49c559cf6bb1f95f5013ff68e5c62291ad3a1"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_co_leaders",
@@ -23128,7 +23128,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8394,
+      "wire_schema_bytes": 8535,
       "tool_reference_bytes": 4895,
       "tool_reference_sha256": "8f7d150a82bbc380d9474e142cb5c2c79fac72fc29b4b0ebcc3db733f103118a",
       "overridden_tool_count": 0,
@@ -23145,7 +23145,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ee91735b103b525c1642fe968d8f2c22275dbe0f1939e14c5167c05da008bc5b",
-      "wire_schema_sha256": "62f39be777ddd39a51a37423fbd2fcf189eaaabd19efabc48eae718003317af6"
+      "wire_schema_sha256": "fcb7ccfb35dd576c3cdd678fee47919b5e8cbfe971c66a9bf522b8801e6cd466"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_event_planning",
@@ -23169,7 +23169,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9980,
+      "wire_schema_bytes": 10121,
       "tool_reference_bytes": 4851,
       "tool_reference_sha256": "6ff4a2945aec64b8355a1af61596b79dd04312c52790328381be907dee780815",
       "overridden_tool_count": 0,
@@ -23185,7 +23185,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "89e0412b4d0ae38011d83c0f2dc83302d88f3350f64f1a7b3e4a8f746098ecb8",
-      "wire_schema_sha256": "90065097b074aa0279418521ddc83cd6b5fb434f592fdb4fffba136c7be25aad"
+      "wire_schema_sha256": "560a2fe451f119e7ca02fe31c391e6cacc6bf4674da6d621ed2aed5b9c2a0a62"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_event_registrations",
@@ -23209,7 +23209,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8704,
+      "wire_schema_bytes": 8845,
       "tool_reference_bytes": 4908,
       "tool_reference_sha256": "8267c976d3e1d7de232f8023297548ef9c86d11734f79e7b336110407d35afc5",
       "overridden_tool_count": 0,
@@ -23226,7 +23226,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "e01cd2c2687b6172b3ed3b80ca04c47ecdd989837fd94676bf28451cc5c58d09",
-      "wire_schema_sha256": "d4fd2ecdc6aaa4d50788177ba8ec8749659ff6ea87e77876e451f0bfc0754d09"
+      "wire_schema_sha256": "25be3aaa0339b1cfe007d1c8d735cda2c2a10726ec18bf8aeeb525d69afb1e17"
     },
     {
       "id": "slack_bolt:public_channel_admin:committee_full_leadership",
@@ -23250,7 +23250,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14424,
+      "wire_schema_bytes": 14565,
       "tool_reference_bytes": 5186,
       "tool_reference_sha256": "e0f6e1854b5b3d4917e6d5d43621e1216417e2aa31ca060f983136a0ff977c95",
       "overridden_tool_count": 0,
@@ -23272,7 +23272,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "63d3d934436b7b22c32804baf79a34407d7c63fd8b26eeae139925b4ef4cce40",
-      "wire_schema_sha256": "acc7dd198a71fc4f9816c15ba44b7a24fae583775deebb956796fe39fc13865c",
+      "wire_schema_sha256": "c0ca917fad14979f688ac44db872ae2c8af644854216fa2c7e7ccd7473ee42d5",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -23297,7 +23297,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8144,
+      "wire_schema_bytes": 8285,
       "tool_reference_bytes": 5000,
       "tool_reference_sha256": "04277ab1c2f8dda0e8e767d34144e12adc19e4d9016f21f3318c83adef65d610",
       "overridden_tool_count": 0,
@@ -23313,7 +23313,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e6e761983c7afb46eed182c1bce8c8f93c59abfa128144f6ad2f95765c1fa4b",
-      "wire_schema_sha256": "4a3b50882cfafa9248ebe44c83417cd3d819a858b509728bbd5ec8098877ae91"
+      "wire_schema_sha256": "d16eadafe8118d91025fddc4438344a0277636dc90a3abe00b739de9eaf50aa8"
     },
     {
       "id": "slack_bolt:public_channel_admin:community_group_contribution",
@@ -23337,7 +23337,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7345,
+      "wire_schema_bytes": 7486,
       "tool_reference_bytes": 5228,
       "tool_reference_sha256": "c46d16d93f7305812970c16ef87645d6c6513564c4f47f8b07ad3cb68c08f605",
       "overridden_tool_count": 0,
@@ -23353,7 +23353,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f4272e41ca3ce9b4b3a34662972d7f6eefb26a2ff5f92c7aa0c79122c9d28927",
-      "wire_schema_sha256": "b73355412a530a3cd1c553fd5c9eaaa8762a02e1237ac00bab95b238b0876288"
+      "wire_schema_sha256": "6e583e852471c7a47e398e1cd77664d1dc08c4a6c6787ac4ddc7bf98f021b540"
     },
     {
       "id": "slack_bolt:public_channel_admin:community_group_discovery",
@@ -23377,7 +23377,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7388,
+      "wire_schema_bytes": 7529,
       "tool_reference_bytes": 5169,
       "tool_reference_sha256": "7979ad04e414e4d0b5820b1bcc018ace6fdb91f99b097931f121fd412e9733a0",
       "overridden_tool_count": 0,
@@ -23394,7 +23394,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "67006919d0b798ffaa5ca4f122f24c3da494739d1a46c338f1a213602eff4613",
-      "wire_schema_sha256": "50afc21a7cfdd94d04753fb85d03ed816604ec1776cb5cf58ead5b623d90fa53"
+      "wire_schema_sha256": "7a84ee9f38964c9897d0647a2c7ec06ed928b859a86c049311aac7e04c75e0ec"
     },
     {
       "id": "slack_bolt:public_channel_admin:community_group_full_participation",
@@ -23418,7 +23418,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10633,
+      "wire_schema_bytes": 10774,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "8d42100ab1d95a9ff7a1084dc8354ff6a9d9d8c69e59a101145549f0f3805b04",
       "overridden_tool_count": 0,
@@ -23442,7 +23442,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "91bf1372e425f64e3d7e018308e3e3e3c2fb10bc4e878920e102732ac79d3568",
-      "wire_schema_sha256": "8caa72c0c231415a0eb457ea33ac659606533b6af03338247dc2300c60796cbf",
+      "wire_schema_sha256": "a8eeb535afa689782a282718b50515c92978a6dfcd3f1fdc37f1e596426aebde",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -23467,7 +23467,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7755,
+      "wire_schema_bytes": 7896,
       "tool_reference_bytes": 5202,
       "tool_reference_sha256": "06a5b1eac15d2f65297dec374b827aba8ec714819f23209aa3197c5bee1e2f47",
       "overridden_tool_count": 0,
@@ -23484,7 +23484,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "091f7471f4f5e96ea8f786003041f2595bd379c6a3bd7af4ee5616a838faf2f8",
-      "wire_schema_sha256": "096c33c7fa411859ab1fccd53fd93b8703cb2ec07627fe96232288af489510da"
+      "wire_schema_sha256": "3467942c43f92342fd39978dce5f5fc06b7c8fa357e4c307819bacd69bb2575a"
     },
     {
       "id": "slack_bolt:public_channel_admin:content",
@@ -23508,7 +23508,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8361,
+      "wire_schema_bytes": 8502,
       "tool_reference_bytes": 4997,
       "tool_reference_sha256": "fae4e05a056314d2988fc31d178f7b1459929831b07856998d6f90d0b06b844a",
       "overridden_tool_count": 0,
@@ -23525,7 +23525,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bc3829064c2772b1c825a305b46be1ef2905e7a67ac5104a19cf76d91c259f7c",
-      "wire_schema_sha256": "1d8f7d65f8a818845c8c8e7a8e47027e3e0e0ec18db8fa4f1d12903365bd4e1a"
+      "wire_schema_sha256": "a641b03b26d881687d732a4709aef97efb7ed10df81a150cafd04edd1219e20e"
     },
     {
       "id": "slack_bolt:public_channel_admin:council_interest",
@@ -23549,7 +23549,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7389,
+      "wire_schema_bytes": 7530,
       "tool_reference_bytes": 5164,
       "tool_reference_sha256": "047897a9a7d9c11418d2f03de2eda90fabba920910e8a68db7ab699ba31dab70",
       "overridden_tool_count": 0,
@@ -23566,7 +23566,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a9a396c3ffd54fcb22d7fd6843c9d5f2f77a4403bd1cc24bab98bcc463ee35c2",
-      "wire_schema_sha256": "57945ecd1e893217d7fef841c59d5276c8d418ae55f3fd3cd316d62062b27b91"
+      "wire_schema_sha256": "9e7ba832295de53d345ac58de1236bf64ae98d618a2055c142d36aa580e2b576"
     },
     {
       "id": "slack_bolt:public_channel_admin:events",
@@ -23590,7 +23590,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8289,
+      "wire_schema_bytes": 8430,
       "tool_reference_bytes": 5004,
       "tool_reference_sha256": "9b575799940a8b63ab4d71e213b265c696166a661fe7ed83b1e63ffa389aa3d5",
       "overridden_tool_count": 0,
@@ -23607,7 +23607,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "921fdc7c56d62f0ad6eeef8ca78fb66df7512b19d01a596b946bd725789eec70",
-      "wire_schema_sha256": "1aa539dc1073e18a2e098498cc2557da3eacf93954e220652ea5a02b5b00b6a1"
+      "wire_schema_sha256": "830f858b5f3868c72a7f694b69d4629f172f5d9bc2acc1272067c54c06169a36"
     },
     {
       "id": "slack_bolt:public_channel_admin:github",
@@ -23631,7 +23631,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9934,
+      "wire_schema_bytes": 10075,
       "tool_reference_bytes": 5987,
       "tool_reference_sha256": "1f39a7f444dae2a1907f5118c3549cf2c083fcfdbe5b0049db2675ecd21065a5",
       "overridden_tool_count": 0,
@@ -23648,7 +23648,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1ab36f15b2f5563e9367dfe4489947d43fc4b5dfd950070be51b704acfe40fb2",
-      "wire_schema_sha256": "8be5c072cc64b4155e97561172ec8ce9f2ef2964c0db47d2cb7066f9ead4667f"
+      "wire_schema_sha256": "dd582997398f7fed1401c8552dd98c6f2e52cbe0f7c7affb496d650415382ff1"
     },
     {
       "id": "slack_bolt:public_channel_admin:illustrations",
@@ -23672,7 +23672,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6743,
+      "wire_schema_bytes": 6884,
       "tool_reference_bytes": 5600,
       "tool_reference_sha256": "a037859ae5edeacc387d5ed3cee34e55ee10b40a6086437979d63964c42a6943",
       "overridden_tool_count": 0,
@@ -23686,7 +23686,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "cd89f28f6579d916c36483c82e551a9c0b7dbc6fd28607ef058608030a87c469",
-      "wire_schema_sha256": "a4da5112c15e5cec6a754fb50481e54bf81d21ccfc6f95a6f64172bb8172fd8b"
+      "wire_schema_sha256": "1e42bbed6155b98e523dba0cf91bddc8e0bec9d30a6f984539098ad7287331b7"
     },
     {
       "id": "slack_bolt:public_channel_admin:industry_research",
@@ -23710,7 +23710,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7985,
+      "wire_schema_bytes": 8126,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "9277bb766c6049f7041333f5c1268ec12ada869b467cfca9ef4d2614e365f6f9",
       "overridden_tool_count": 0,
@@ -23726,7 +23726,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8f0c0ed5de94a54cf7d7b15f49ddd54bcbc38432ef4a997fddaf71ffed4f755",
-      "wire_schema_sha256": "4fa1ec066aaa09b7075f21c08829f75f13fd175bac3b42b68d9cad97cb016eda"
+      "wire_schema_sha256": "286d4e7c125260dfef869088a07fa419948fa0540759203bc08722bd5c70969f"
     },
     {
       "id": "slack_bolt:public_channel_admin:knowledge",
@@ -23750,7 +23750,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9090,
+      "wire_schema_bytes": 9231,
       "tool_reference_bytes": 6186,
       "tool_reference_sha256": "aef54854ee629e7e5fea9dd3b84d5de9acb8cda3847076d6647485fe3ea69ecf",
       "overridden_tool_count": 0,
@@ -23766,7 +23766,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b50ed01628a8175d4cad4a3c7a9dd466c519165354b6a963a9e2522456ee2ca6",
-      "wire_schema_sha256": "1056cc345ad659003130bb386ae21f80d7048b13e261302b7e07b2c41b28a8ae"
+      "wire_schema_sha256": "a70f16cc0c3dcd620fabd7f6745cd20b9cd87dfc5ebe8a412382e65729383223"
     },
     {
       "id": "slack_bolt:public_channel_admin:meeting_attendance",
@@ -23790,7 +23790,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8472,
+      "wire_schema_bytes": 8613,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "0ee2d9b5571c5b0cdce2c4699418905b6aea03d7df6b56ad67937b48c19eb44b",
       "overridden_tool_count": 0,
@@ -23808,7 +23808,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "4ad868d6d114604043f19c16953ca449a5fc8e438366fa3bd1bc04770e05ca13",
-      "wire_schema_sha256": "cfa6e99c0545aaf06f3b725ba0f2a79b1f1dc5bf46c9f1288f1534f89298da59"
+      "wire_schema_sha256": "5ae38386404f22053a0e71762375dab1bc07e06d189d78766e4ebd9b8d1210c3"
     },
     {
       "id": "slack_bolt:public_channel_admin:meeting_full_administration",
@@ -23832,7 +23832,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15927,
+      "wire_schema_bytes": 16068,
       "tool_reference_bytes": 5109,
       "tool_reference_sha256": "cfc119c5528a3d7cbc7962f28dab550e93220a12af4e8ea40f468d787bf69d05",
       "overridden_tool_count": 0,
@@ -23856,7 +23856,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "6a688c893300b6c9e954316fccf089ad30c48b7b26192b13ca3edfd28e90846c",
-      "wire_schema_sha256": "8bb4f6262591577fb3bfcbc96d9fbcc0cf3790393b75ff92f7145db4f5d65bf3",
+      "wire_schema_sha256": "10b93170dcc74ad3e33bb9c3627941dd21a60f79a1094195f3a16f7845e6a125",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -23881,7 +23881,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11785,
+      "wire_schema_bytes": 11926,
       "tool_reference_bytes": 4960,
       "tool_reference_sha256": "44da43736532633f99431c28942cc11ab98896e66f2e766015c14adcfdef1bb5",
       "overridden_tool_count": 0,
@@ -23898,7 +23898,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "6522fe425784c3691c75cf3386e044071d31ebafef4d0abe1600c857ceefdd99",
-      "wire_schema_sha256": "21347382febcdfe977b9b58f4867b535cfc76550ab4c0cd1106e41ef5b431547"
+      "wire_schema_sha256": "6128a7beb1855b0c976e25a145734e31346d6d31a3a443cdcbd76b4bac3bf8bf"
     },
     {
       "id": "slack_bolt:public_channel_admin:meeting_series_topics",
@@ -23922,7 +23922,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8706,
+      "wire_schema_bytes": 8847,
       "tool_reference_bytes": 5033,
       "tool_reference_sha256": "6f1fdbd1c8e96d2417594ae72d079a12694850514f1eee5aa7519d4ee17e41d5",
       "overridden_tool_count": 0,
@@ -23939,7 +23939,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "278373a11db662055d171b04d07dde0e8756563d96084805bc2213dcde2c1e7f",
-      "wire_schema_sha256": "0a708298b2d9199b6d4ef942bfcc8c6b4947a8b30166bb4e0719ee7cd65529ba"
+      "wire_schema_sha256": "4678b028f88fd24c32c61ebade5864506bb67fda9f2f7045848fd97f928e0422"
     },
     {
       "id": "slack_bolt:public_channel_admin:member_billing",
@@ -23963,7 +23963,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 5810,
+      "wire_schema_bytes": 5951,
       "tool_reference_bytes": 4679,
       "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
@@ -23976,7 +23976,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
-      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
+      "wire_schema_sha256": "82ca1d7dfa887a93ae42006395543aa86d4d07147bf2b282b074ad57d1309e79"
     },
     {
       "id": "slack_bolt:public_channel_admin:member_company_profile",
@@ -24000,7 +24000,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12173,
+      "wire_schema_bytes": 12314,
       "tool_reference_bytes": 7093,
       "tool_reference_sha256": "0e02b4dea01ea74f9eae09547b11663196e5210a81b058a4948a3e9d69ce4ff2",
       "overridden_tool_count": 0,
@@ -24018,7 +24018,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "e3c0076f53ba3014c1de4c0880755d181eeff63f62dd02478f1d7b2adcb1c19b",
-      "wire_schema_sha256": "1eeed70bbe3f79619e02b6775a031822a10de2805bb68c7bed86eaa1d32def54"
+      "wire_schema_sha256": "9a907aa87acf94a190f3a7aac9f14615e73beededf17f25a4b04183152aedaaf"
     },
     {
       "id": "slack_bolt:public_channel_admin:member_personal_profile",
@@ -24042,7 +24042,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6942,
+      "wire_schema_bytes": 7083,
       "tool_reference_bytes": 6517,
       "tool_reference_sha256": "c9e584af1f6aeffadc203b42a6599fabec9c5fac7ba6eb3e2271582b1cf66ee5",
       "overridden_tool_count": 0,
@@ -24057,7 +24057,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b98f9f4bd4e0f60081d52bdd1402c33859a85decaab03a5ad06af8d96ee514bf",
-      "wire_schema_sha256": "ac64b0445b2116384b62fc7894f83630fb253193a04cced009d1745caa6e0497"
+      "wire_schema_sha256": "05ce43aa2dfdeeeab473b3cd18624881bcd206c751947db29a6d296d4b65b2cb"
     },
     {
       "id": "slack_bolt:public_channel_admin:outreach_contact_management",
@@ -24081,7 +24081,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7822,
+      "wire_schema_bytes": 7963,
       "tool_reference_bytes": 4871,
       "tool_reference_sha256": "bd3764ffb508a96cf794457d091b6aefc885d3600ae4f52941365fe652d0695d",
       "overridden_tool_count": 0,
@@ -24098,7 +24098,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "dc1021a2f9358c3d623a72961968a23fc652f3b84e5e1dcd82bb638f32286172",
-      "wire_schema_sha256": "46a787074e50afff54df995bf79577563bfad7fa2f680f0602cd61bf7ef201ef"
+      "wire_schema_sha256": "b3f9a84c50f4822fb156ddba061126d31e286ce95beb376c9c05aeeb1919bfd7"
     },
     {
       "id": "slack_bolt:public_channel_admin:outreach_reporting",
@@ -24122,7 +24122,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7393,
+      "wire_schema_bytes": 7534,
       "tool_reference_bytes": 4863,
       "tool_reference_sha256": "451a2ae9ee04485812cd42f13e22643a5bdd56e8f00f88f3d54f0344e55d9552",
       "overridden_tool_count": 0,
@@ -24138,7 +24138,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "a0c5d711da548a48a691744045cbfd3b04d8b7ed1b14d807e32fbc11d1e30d28",
-      "wire_schema_sha256": "bcd6517abf2b7b9f25bcb3711784b4fd6c9733ef133314999457815474d836dd"
+      "wire_schema_sha256": "0fb1ddee741f1a7d0c08eb32c0651ed85e60e4e586d2c66ef68720c51a1bd4e9"
     },
     {
       "id": "slack_bolt:public_channel_admin:partner_directory",
@@ -24162,7 +24162,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9373,
+      "wire_schema_bytes": 9514,
       "tool_reference_bytes": 5093,
       "tool_reference_sha256": "268c9be254b94c9a7eac8cb691a638bd09ca4e4c6eecb2cdd3a9cde94185f720",
       "overridden_tool_count": 2,
@@ -24180,7 +24180,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3473f077feee4796a866460cbaa8481d61d1bb163f7f26327227aa8fbb3a3216",
-      "wire_schema_sha256": "e26bcc1728f13db93694e1211a8c4a034afe504143b096216b64b36908de9b11"
+      "wire_schema_sha256": "f2bb56064bb83afdae30f82ded40b9ca1ccf0e137f0e93d58d18600db94e5fbe"
     },
     {
       "id": "slack_bolt:public_channel_admin:property_identifier_catalog",
@@ -24204,7 +24204,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8649,
+      "wire_schema_bytes": 8790,
       "tool_reference_bytes": 5198,
       "tool_reference_sha256": "f6ef453cc5f692447ff7fe514424938b0cdc38520e3435b6cbd063323d080283",
       "overridden_tool_count": 0,
@@ -24220,7 +24220,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "59c0b1ee765a965cc1cf46dc4adef20a805ebbe3cc9522527f5e169ce7ec8a2c",
-      "wire_schema_sha256": "2cfb6319e0677ea956019c020b59e4b19317421252ff990532c0f9537a196c50"
+      "wire_schema_sha256": "91c6a4c8e28798b4efcc547bd01476f818acdd1dca6a30782c3b9031eab4312f"
     },
     {
       "id": "slack_bolt:public_channel_admin:property_list_enrichment",
@@ -24244,7 +24244,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6756,
+      "wire_schema_bytes": 6897,
       "tool_reference_bytes": 5047,
       "tool_reference_sha256": "cfbadab03d4e790317d8090b50327bc9c5fd70fc3f7cd176e80af75a7bc366a2",
       "overridden_tool_count": 0,
@@ -24259,7 +24259,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "1caed613347ab3bcf21bb469b8b40f07b08cc8f249bad7dca9326ee7b52c7b22",
-      "wire_schema_sha256": "6582f4032bf8c18eccb6a047fbbdec724209261d093229e797b3b3ac2da6faae"
+      "wire_schema_sha256": "b4cc63470f04e6c98f299c63ec99484979ecb2db877fe9e823cb8fe2d5de8bdb"
     },
     {
       "id": "slack_bolt:public_channel_admin:property_registry_records",
@@ -24283,7 +24283,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8019,
+      "wire_schema_bytes": 8160,
       "tool_reference_bytes": 5276,
       "tool_reference_sha256": "28d3dc723dc5e252efd2fa2237e912ddff8cacb15935ba66322d85894143102d",
       "overridden_tool_count": 0,
@@ -24300,7 +24300,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "2f83b56c25291f24fdab99db726897cb6ec21e1241e3efa8eb9df985988b610a",
-      "wire_schema_sha256": "21682a0d842482d81b8d3574705bab7302c7bdbafa30d99a68a5fac91d9523a7"
+      "wire_schema_sha256": "77ebae8e805c83ac3dc01c0c81120523fff4e589fcc5c0b1ff57981be0086d96"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_assets",
@@ -24324,7 +24324,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8133,
+      "wire_schema_bytes": 8274,
       "tool_reference_bytes": 5001,
       "tool_reference_sha256": "9520994a04b396e588cbd0b4cbaebc844649716d0c21421f76b44622620e5e54",
       "overridden_tool_count": 0,
@@ -24341,7 +24341,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "786fa22373e4d6d8edad19fe20691415fa072a6b7575dabed3c0b5042f1d1f49",
-      "wire_schema_sha256": "a1eb43c6ec10ecc34ea4063d3339ef60bdd70b6741855a31323b0c7708c8bf38"
+      "wire_schema_sha256": "4f11d46908a24e521ad9d74fe3a85805b8c8946e8e3630bf3997baac9e0dd746"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_promotion",
@@ -24365,7 +24365,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7618,
+      "wire_schema_bytes": 7759,
       "tool_reference_bytes": 4890,
       "tool_reference_sha256": "63844236d8b4fc32eace11c1a05b363295cdf7e7a21f9dba208494c8a8ca037d",
       "overridden_tool_count": 0,
@@ -24380,7 +24380,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "77444af6faddc476c3d5b7d4c187d13ca3f9f0cc376abb7a5ef29a1c0e9d99eb",
-      "wire_schema_sha256": "a2db2492c6f81398b324a7f598ae4abf3ea1ade88547cf4149650a895d14c44e"
+      "wire_schema_sha256": "0bcb47a3fafa90a94df794ecc0817e270726423589fdac961562fd7fcd24ffba"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_review",
@@ -24404,7 +24404,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7462,
+      "wire_schema_bytes": 7603,
       "tool_reference_bytes": 5071,
       "tool_reference_sha256": "e622e4729cac9277baee6ba3dda72ab0ac460f4c8a9a55bdd36e05886d14895f",
       "overridden_tool_count": 0,
@@ -24421,7 +24421,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "853dc8d9f0ae66e04744148486b180e9fe12294a4cc6331c12d1731888c051e7",
-      "wire_schema_sha256": "39c2d7af0ea491b0692583223e554127e76d2341b7c591ccc46265bb5cfda402"
+      "wire_schema_sha256": "5bbe11ec96f264740fb16932349387b2716311b0ede7bb9ba8521cfa7a4a1d95"
     },
     {
       "id": "slack_bolt:public_channel_admin:publishing_submission",
@@ -24445,7 +24445,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9150,
+      "wire_schema_bytes": 9291,
       "tool_reference_bytes": 5847,
       "tool_reference_sha256": "c589e1d69cf85ca8389caf09cef857e22b67949b23c5dec256ba87e2e8789615",
       "overridden_tool_count": 0,
@@ -24461,7 +24461,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "5a59f770620a09d9eb4ab6649514984010296cb123fbd3563424c64e187ef606",
-      "wire_schema_sha256": "9b7a8c82e6715bdd6722b02c44954ca6c1d17681f3cfbcbfaffb30e94102df2b"
+      "wire_schema_sha256": "9f246332ed3c4c28ca0f3227da2b21d1998a0c0d5f7ea226c9965f52b6921fe7"
     },
     {
       "id": "slack_bolt:public_channel_admin:router_unavailable",
@@ -24485,7 +24485,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16027,
+      "wire_schema_bytes": 16168,
       "tool_reference_bytes": 7341,
       "tool_reference_sha256": "d443dac04c8256c25600eb2c7da3fd9c43fd3d7f172f0c450c80b71c30170a76",
       "overridden_tool_count": 4,
@@ -24511,7 +24511,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
-      "wire_schema_sha256": "10f56cf068ce89b5bc33fbac5933084694747027861800ae0669c7753a0bece5",
+      "wire_schema_sha256": "b72ee206407719a3f2b3b8bd3e1895b5306fc63298e8ab482ef3654ec97310e1",
       "target_exception_category": "legacy_channel_router_continuity"
     },
     {
@@ -24536,7 +24536,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8238,
+      "wire_schema_bytes": 8379,
       "tool_reference_bytes": 5268,
       "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
@@ -24553,7 +24553,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
-      "wire_schema_sha256": "3cdf5b56369f21f44f191c0f4b5a87711235264a774a5f57fb3437c209ff331f"
+      "wire_schema_sha256": "01d8006799be746f30bbc395f0750876309e62773c960e5890da6fbe89dd1c5d"
     },
     {
       "id": "slack_bolt:public_channel_admin:sponsored_intelligence_discovery",
@@ -24577,7 +24577,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7426,
+      "wire_schema_bytes": 7567,
       "tool_reference_bytes": 5223,
       "tool_reference_sha256": "17acfaeead1da3a8d82047fe16c058af19ef29d513d7c3e663552e6b83dff968",
       "overridden_tool_count": 0,
@@ -24593,7 +24593,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8cfd5201ca46d75fe53c9c27fdc4256df285fdfe4fcc0b2dcd0249f63d7241c",
-      "wire_schema_sha256": "a48f4ae3e3991a381f0f6d7ac82ac64462d7553dd6eae2f25a793510bdbf51ee"
+      "wire_schema_sha256": "4e6640483f2fae7009a7ceb16a2b856a7eb2b900a5a3739993552b86bd99e637"
     },
     {
       "id": "slack_bolt:public_channel_admin:sponsored_intelligence_session",
@@ -24617,7 +24617,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6945,
+      "wire_schema_bytes": 7086,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "696df339745a57995853ecc6865918211a16d81f072633a5eb3e4238bac8013f",
       "overridden_tool_count": 0,
@@ -24633,7 +24633,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8fa651f7af60832a1ab923c128d02a9c854ed4c045f121d04e3d801641dd484c",
-      "wire_schema_sha256": "2abc6a51af3fea0e719a49f337dc034b6aa708180a484bbe314bbfe8cfdeb892"
+      "wire_schema_sha256": "c07064676945c1ff72df826e9030654f109ec7b9d67e7977baac216822a65c00"
     },
     {
       "id": "slack_bolt:public_channel_member:adcp_agent_management",
@@ -24657,7 +24657,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12693,
+      "wire_schema_bytes": 12834,
       "tool_reference_bytes": 6244,
       "tool_reference_sha256": "81ada737ca8dd234194561c6e5bc645cec7a51b099450546ea4af275ef31ce42",
       "overridden_tool_count": 0,
@@ -24674,7 +24674,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "ef5f0d65423720243295a1d43b95ac8187ecc2d52bbc4d22def910b097db7ea1",
-      "wire_schema_sha256": "6770de7af265ec65ff1cb9b80f5881d26c3355d495fa46dddfc753be6020e9ec"
+      "wire_schema_sha256": "031eb120d06273adda5e5bf79ec94466fd36172f3a93f7db75e6cb13f4e0e103"
     },
     {
       "id": "slack_bolt:public_channel_member:adcp_task_operations",
@@ -24698,7 +24698,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11141,
+      "wire_schema_bytes": 11282,
       "tool_reference_bytes": 6292,
       "tool_reference_sha256": "754c3f7fd5bb236bc471a91ea08aa03d2f37efc145c55f416e1fb4ecfd86f22d",
       "overridden_tool_count": 0,
@@ -24714,7 +24714,7 @@
         "get_adcp_capabilities"
       ],
       "ordered_tool_names_sha256": "2884fe21fddd17bd7e9237c361ae09175436ea6bc4053ac7d5ec6052232ab69e",
-      "wire_schema_sha256": "f2e5de7ec874845eec21c8cc24173c4b3a8ed47b4b914d5d680fe223147b0184"
+      "wire_schema_sha256": "62be844dcaf364007af54ce5debba844f002e0ce786d5192b2be6d85c3adcff1"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_authentication",
@@ -24738,7 +24738,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8506,
+      "wire_schema_bytes": 8647,
       "tool_reference_bytes": 5982,
       "tool_reference_sha256": "2e3e5d4fd673adda8800ea768de8edb0b644c4fe091ce9344af09087950b2e1b",
       "overridden_tool_count": 0,
@@ -24753,7 +24753,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "51c444ff7e90b9cd4728789bdf47ed84cf7da29bb8e269c67a1fc1246ad0bef8",
-      "wire_schema_sha256": "2a6d5f01c6f46041d2c9ae786567c2ac73beaadd0a6f254e0bdcf567d6d66aa3"
+      "wire_schema_sha256": "760a76c316f458bd62a1a9992b0907d993821174e696045ec9bc07e602d29fd2"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_conformance",
@@ -24777,7 +24777,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7211,
+      "wire_schema_bytes": 7352,
       "tool_reference_bytes": 5706,
       "tool_reference_sha256": "d8f3e2e7bd71653c858614ef8b689d63957f45fe16c7a3e10bb069f0265e85e6",
       "overridden_tool_count": 0,
@@ -24792,7 +24792,7 @@
         "run_conformance_against_my_agent"
       ],
       "ordered_tool_names_sha256": "0fa7c1408af4686efb4e6dbd59e7c48f5491ddd2efd4052b782ee854ae88f1a6",
-      "wire_schema_sha256": "6673bdac28443d4d60382dfbdc53ab839f22a164918e27a5e519c93014f12dda"
+      "wire_schema_sha256": "8ac9981cf3948c72af0f4dc9df0604f0d62f492189d4ab65feb9fb5c0ebc6384"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_end_to_end",
@@ -24816,7 +24816,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17048,
+      "wire_schema_bytes": 17189,
       "tool_reference_bytes": 6550,
       "tool_reference_sha256": "0ab8109a2f0f25348122080fb7f64fe305ccfad798a7b74533903b50fb916084",
       "overridden_tool_count": 1,
@@ -24839,7 +24839,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "0e5db57c4d45f9244087dbefbe8cbdc0427aa9c4367b7f64d7bef050db0f61de",
-      "wire_schema_sha256": "a113b87298a3ae4780b9a34ca869515a0d103c21f3ff44537d860e3c0f235d1a",
+      "wire_schema_sha256": "fcfbe4c39f756891281285e4ca50e35ae701e743668f15889aeb2b6a8d9b75d8",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -24864,7 +24864,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7183,
+      "wire_schema_bytes": 7324,
       "tool_reference_bytes": 5031,
       "tool_reference_sha256": "98b76cc82427cbe9a056b5f7318c70d79ce51c0ff58aa54cd37c361c62058258",
       "overridden_tool_count": 4,
@@ -24881,7 +24881,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c77e6b9340e2cd4e18f9cb2aaef814635b8ec503f02db8356aee3964ee6329de",
-      "wire_schema_sha256": "870d9608c81b1c54aa646e25c0f1ac39d834caf3360ddadd981dea834d1c4c28"
+      "wire_schema_sha256": "606ad6394531d975904e216505420b235a32ecb58917afe83739e64c6addfc45"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_quality",
@@ -24905,7 +24905,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11885,
+      "wire_schema_bytes": 12026,
       "tool_reference_bytes": 6053,
       "tool_reference_sha256": "623c78700d4c24b2b99574e33c8af9cd61c60f6fcf74b1ac59f49ca20eb8a164",
       "overridden_tool_count": 0,
@@ -24921,7 +24921,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "22b683ae113338a0d0437c1172eca780abe22103df94c4c4addf2dca3f6da300",
-      "wire_schema_sha256": "7b3d1c32371037c72062dee8d01a29e64b67b756f5566dd3e4489538f564c179"
+      "wire_schema_sha256": "fd9882a730a2a2cf119d36449f9dd3d6289e82ea818176bbf9a1d630e4280735"
     },
     {
       "id": "slack_bolt:public_channel_member:agent_registry",
@@ -24945,7 +24945,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8277,
+      "wire_schema_bytes": 8418,
       "tool_reference_bytes": 6615,
       "tool_reference_sha256": "bb434ddb22c7b200d183a085afbd5d3635266af4397665d325f4e45dfaa2b773",
       "overridden_tool_count": 1,
@@ -24963,7 +24963,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "24423c12ddb094003c50c25b85089047bdd9d412921ff7c9e8be1346a1f2b230",
-      "wire_schema_sha256": "ecff72d5e963c33f79ff0ddceaa0d1ac6c5de68466204ecb28aac8fc88eecfed"
+      "wire_schema_sha256": "7bd4686e1ba7b389643c67b847bea3c3cc5dc6820910635e523691dae427b8f9"
     },
     {
       "id": "slack_bolt:public_channel_member:all_valid_sets_maximum",
@@ -25034,7 +25034,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 125807,
+      "wire_schema_bytes": 125948,
       "tool_reference_bytes": 33856,
       "tool_reference_sha256": "280e917c7c6c2e988dd18e85716f6cad41416a99ad1bfc4c66a26a5d1c66f228",
       "overridden_tool_count": 11,
@@ -25189,7 +25189,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "b79441af450553b02c114d59697db1c4f78fae557e69dd4e0760f6927298607a",
-      "wire_schema_sha256": "e2b622875b4dbb04870734fcca1d92a9a7d17a9dba59b4871f4b15b1aa90d641",
+      "wire_schema_sha256": "c38ababeefd144d5618827c34c7a622a74cd37d0e3f841150c6836575d459c74",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -25214,7 +25214,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13390,
+      "wire_schema_bytes": 13531,
       "tool_reference_bytes": 5531,
       "tool_reference_sha256": "2b878337fef72078a045054e09447714faafdc9f5876b152a3ce950088805430",
       "overridden_tool_count": 0,
@@ -25232,7 +25232,7 @@
         "notify_pending_verification"
       ],
       "ordered_tool_names_sha256": "5e92adcffb6c3b4328608d87745cd5004540475dc2ea23263bf9609972d81228",
-      "wire_schema_sha256": "2585de480762a9917696f6e4eda29db9a5d65fb083eb41cf6ae8c6db4eee8000"
+      "wire_schema_sha256": "747a001917facf717606e7d20d9c771dacd32bf1e4693b0de66b4cd36981b184"
     },
     {
       "id": "slack_bolt:public_channel_member:brand_registry_records",
@@ -25256,7 +25256,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8300,
+      "wire_schema_bytes": 8441,
       "tool_reference_bytes": 5194,
       "tool_reference_sha256": "40f2a9bb90490f176b7e1b0276fbd088226b81a474a0374478e5d3b2c0572275",
       "overridden_tool_count": 0,
@@ -25274,7 +25274,7 @@
         "list_missing_brands"
       ],
       "ordered_tool_names_sha256": "d2db41880ecd6eb43b049517f08ef4f693bb1c065153770c1c17b2551229289a",
-      "wire_schema_sha256": "2ba7eadc87c8fde05c6480df10ebbf9a4c6d596b526bc332cf18427a9fcad949"
+      "wire_schema_sha256": "e6f190beef0c1adcf1ce25b8253ad2162cdfc3ccbd80dad815f9f0428c103b2f"
     },
     {
       "id": "slack_bolt:public_channel_member:certification_assessment",
@@ -25298,7 +25298,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16950,
+      "wire_schema_bytes": 17091,
       "tool_reference_bytes": 6834,
       "tool_reference_sha256": "00100bad072964a6ff52407a77807af70d49e3e3d7ad7a643578276cbed84f63",
       "overridden_tool_count": 0,
@@ -25320,7 +25320,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "8ac4c56c1525cdc7dc33c1dce45e8192c4e2ef35a3534be78ea1e573a45b7a51",
-      "wire_schema_sha256": "1e4390b1fea96985281ca194a8c65486f319c2e4afbcd4da57388f475acea9cc",
+      "wire_schema_sha256": "87ebdf040b68368e09a1db6900fb2f3f9cd8fe0f1020a6e5fa8635fb9ac7eb1d",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -25345,7 +25345,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17853,
+      "wire_schema_bytes": 17994,
       "tool_reference_bytes": 8071,
       "tool_reference_sha256": "09c17f2d7be8670598cee0d28be64d0030eeb7a23653120ad573ee12e0b1f602",
       "overridden_tool_count": 0,
@@ -25368,7 +25368,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "c48ea42b9e2155bd3f7e2071d4b9e0a73a62009e45239a0a93d2b1b1ad3fb904",
-      "wire_schema_sha256": "9322e31737e513b306f554a5600dff665dd30a7266779354451076d8eb83911f",
+      "wire_schema_sha256": "ee70bc45858def844b6b0e232eefe9596ede8870de2cc197a326a25e541e7546",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -25393,7 +25393,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7854,
+      "wire_schema_bytes": 7995,
       "tool_reference_bytes": 5628,
       "tool_reference_sha256": "49a0ad11f82bc0e092aaa06ef1a244ca15e5b0e896692835133a6ae0b4b85a88",
       "overridden_tool_count": 0,
@@ -25411,7 +25411,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "76d0045ed7ed72a0d064b425d402583e71d874e94a76722044d0fa92b4ce9b24",
-      "wire_schema_sha256": "635babec938811396f1e376045d5d0e0b73bb2d0acdb8331fd7fe78e5a720a44"
+      "wire_schema_sha256": "0d64480e94f0c14585ef9c8eea21d0b47becd9e8079e9533a5a47014b2ee4b64"
     },
     {
       "id": "slack_bolt:public_channel_member:collaboration",
@@ -25435,7 +25435,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7064,
+      "wire_schema_bytes": 7205,
       "tool_reference_bytes": 4895,
       "tool_reference_sha256": "10f61a027ef688857f3355342fa14e772d652fd15e70da96df88a418f99833b9",
       "overridden_tool_count": 0,
@@ -25449,7 +25449,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "4511d88caefcdce804d554bd69b578cf536f2f43618a951273e9ccb8d2f3c014",
-      "wire_schema_sha256": "9055537247ae12d2a027f65ee5403db037814ac6b44d7b98b2d4386031bd1cf4"
+      "wire_schema_sha256": "da4dd5a70e1d20d6e680c2b133f49c559cf6bb1f95f5013ff68e5c62291ad3a1"
     },
     {
       "id": "slack_bolt:public_channel_member:committee_co_leaders",
@@ -25473,7 +25473,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8394,
+      "wire_schema_bytes": 8535,
       "tool_reference_bytes": 4895,
       "tool_reference_sha256": "8f7d150a82bbc380d9474e142cb5c2c79fac72fc29b4b0ebcc3db733f103118a",
       "overridden_tool_count": 0,
@@ -25490,7 +25490,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "ee91735b103b525c1642fe968d8f2c22275dbe0f1939e14c5167c05da008bc5b",
-      "wire_schema_sha256": "62f39be777ddd39a51a37423fbd2fcf189eaaabd19efabc48eae718003317af6"
+      "wire_schema_sha256": "fcb7ccfb35dd576c3cdd678fee47919b5e8cbfe971c66a9bf522b8801e6cd466"
     },
     {
       "id": "slack_bolt:public_channel_member:committee_event_planning",
@@ -25514,7 +25514,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9980,
+      "wire_schema_bytes": 10121,
       "tool_reference_bytes": 4851,
       "tool_reference_sha256": "6ff4a2945aec64b8355a1af61596b79dd04312c52790328381be907dee780815",
       "overridden_tool_count": 0,
@@ -25530,7 +25530,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "89e0412b4d0ae38011d83c0f2dc83302d88f3350f64f1a7b3e4a8f746098ecb8",
-      "wire_schema_sha256": "90065097b074aa0279418521ddc83cd6b5fb434f592fdb4fffba136c7be25aad"
+      "wire_schema_sha256": "560a2fe451f119e7ca02fe31c391e6cacc6bf4674da6d621ed2aed5b9c2a0a62"
     },
     {
       "id": "slack_bolt:public_channel_member:committee_event_registrations",
@@ -25554,7 +25554,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8704,
+      "wire_schema_bytes": 8845,
       "tool_reference_bytes": 4908,
       "tool_reference_sha256": "8267c976d3e1d7de232f8023297548ef9c86d11734f79e7b336110407d35afc5",
       "overridden_tool_count": 0,
@@ -25571,7 +25571,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "e01cd2c2687b6172b3ed3b80ca04c47ecdd989837fd94676bf28451cc5c58d09",
-      "wire_schema_sha256": "d4fd2ecdc6aaa4d50788177ba8ec8749659ff6ea87e77876e451f0bfc0754d09"
+      "wire_schema_sha256": "25be3aaa0339b1cfe007d1c8d735cda2c2a10726ec18bf8aeeb525d69afb1e17"
     },
     {
       "id": "slack_bolt:public_channel_member:committee_full_leadership",
@@ -25595,7 +25595,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14424,
+      "wire_schema_bytes": 14565,
       "tool_reference_bytes": 5186,
       "tool_reference_sha256": "e0f6e1854b5b3d4917e6d5d43621e1216417e2aa31ca060f983136a0ff977c95",
       "overridden_tool_count": 0,
@@ -25617,7 +25617,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "63d3d934436b7b22c32804baf79a34407d7c63fd8b26eeae139925b4ef4cce40",
-      "wire_schema_sha256": "acc7dd198a71fc4f9816c15ba44b7a24fae583775deebb956796fe39fc13865c",
+      "wire_schema_sha256": "c0ca917fad14979f688ac44db872ae2c8af644854216fa2c7e7ccd7473ee42d5",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -25642,7 +25642,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8144,
+      "wire_schema_bytes": 8285,
       "tool_reference_bytes": 5000,
       "tool_reference_sha256": "04277ab1c2f8dda0e8e767d34144e12adc19e4d9016f21f3318c83adef65d610",
       "overridden_tool_count": 0,
@@ -25658,7 +25658,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e6e761983c7afb46eed182c1bce8c8f93c59abfa128144f6ad2f95765c1fa4b",
-      "wire_schema_sha256": "4a3b50882cfafa9248ebe44c83417cd3d819a858b509728bbd5ec8098877ae91"
+      "wire_schema_sha256": "d16eadafe8118d91025fddc4438344a0277636dc90a3abe00b739de9eaf50aa8"
     },
     {
       "id": "slack_bolt:public_channel_member:community_group_contribution",
@@ -25682,7 +25682,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7345,
+      "wire_schema_bytes": 7486,
       "tool_reference_bytes": 5228,
       "tool_reference_sha256": "c46d16d93f7305812970c16ef87645d6c6513564c4f47f8b07ad3cb68c08f605",
       "overridden_tool_count": 0,
@@ -25698,7 +25698,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f4272e41ca3ce9b4b3a34662972d7f6eefb26a2ff5f92c7aa0c79122c9d28927",
-      "wire_schema_sha256": "b73355412a530a3cd1c553fd5c9eaaa8762a02e1237ac00bab95b238b0876288"
+      "wire_schema_sha256": "6e583e852471c7a47e398e1cd77664d1dc08c4a6c6787ac4ddc7bf98f021b540"
     },
     {
       "id": "slack_bolt:public_channel_member:community_group_discovery",
@@ -25722,7 +25722,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7388,
+      "wire_schema_bytes": 7529,
       "tool_reference_bytes": 5169,
       "tool_reference_sha256": "7979ad04e414e4d0b5820b1bcc018ace6fdb91f99b097931f121fd412e9733a0",
       "overridden_tool_count": 0,
@@ -25739,7 +25739,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "67006919d0b798ffaa5ca4f122f24c3da494739d1a46c338f1a213602eff4613",
-      "wire_schema_sha256": "50afc21a7cfdd94d04753fb85d03ed816604ec1776cb5cf58ead5b623d90fa53"
+      "wire_schema_sha256": "7a84ee9f38964c9897d0647a2c7ec06ed928b859a86c049311aac7e04c75e0ec"
     },
     {
       "id": "slack_bolt:public_channel_member:community_group_full_participation",
@@ -25763,7 +25763,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10633,
+      "wire_schema_bytes": 10774,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "8d42100ab1d95a9ff7a1084dc8354ff6a9d9d8c69e59a101145549f0f3805b04",
       "overridden_tool_count": 0,
@@ -25787,7 +25787,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "91bf1372e425f64e3d7e018308e3e3e3c2fb10bc4e878920e102732ac79d3568",
-      "wire_schema_sha256": "8caa72c0c231415a0eb457ea33ac659606533b6af03338247dc2300c60796cbf",
+      "wire_schema_sha256": "a8eeb535afa689782a282718b50515c92978a6dfcd3f1fdc37f1e596426aebde",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -25812,7 +25812,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7755,
+      "wire_schema_bytes": 7896,
       "tool_reference_bytes": 5202,
       "tool_reference_sha256": "06a5b1eac15d2f65297dec374b827aba8ec714819f23209aa3197c5bee1e2f47",
       "overridden_tool_count": 0,
@@ -25829,7 +25829,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "091f7471f4f5e96ea8f786003041f2595bd379c6a3bd7af4ee5616a838faf2f8",
-      "wire_schema_sha256": "096c33c7fa411859ab1fccd53fd93b8703cb2ec07627fe96232288af489510da"
+      "wire_schema_sha256": "3467942c43f92342fd39978dce5f5fc06b7c8fa357e4c307819bacd69bb2575a"
     },
     {
       "id": "slack_bolt:public_channel_member:content",
@@ -25853,7 +25853,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8361,
+      "wire_schema_bytes": 8502,
       "tool_reference_bytes": 4997,
       "tool_reference_sha256": "fae4e05a056314d2988fc31d178f7b1459929831b07856998d6f90d0b06b844a",
       "overridden_tool_count": 0,
@@ -25870,7 +25870,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "bc3829064c2772b1c825a305b46be1ef2905e7a67ac5104a19cf76d91c259f7c",
-      "wire_schema_sha256": "1d8f7d65f8a818845c8c8e7a8e47027e3e0e0ec18db8fa4f1d12903365bd4e1a"
+      "wire_schema_sha256": "a641b03b26d881687d732a4709aef97efb7ed10df81a150cafd04edd1219e20e"
     },
     {
       "id": "slack_bolt:public_channel_member:council_interest",
@@ -25894,7 +25894,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7389,
+      "wire_schema_bytes": 7530,
       "tool_reference_bytes": 5164,
       "tool_reference_sha256": "047897a9a7d9c11418d2f03de2eda90fabba920910e8a68db7ab699ba31dab70",
       "overridden_tool_count": 0,
@@ -25911,7 +25911,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a9a396c3ffd54fcb22d7fd6843c9d5f2f77a4403bd1cc24bab98bcc463ee35c2",
-      "wire_schema_sha256": "57945ecd1e893217d7fef841c59d5276c8d418ae55f3fd3cd316d62062b27b91"
+      "wire_schema_sha256": "9e7ba832295de53d345ac58de1236bf64ae98d618a2055c142d36aa580e2b576"
     },
     {
       "id": "slack_bolt:public_channel_member:events",
@@ -25935,7 +25935,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8289,
+      "wire_schema_bytes": 8430,
       "tool_reference_bytes": 5004,
       "tool_reference_sha256": "9b575799940a8b63ab4d71e213b265c696166a661fe7ed83b1e63ffa389aa3d5",
       "overridden_tool_count": 0,
@@ -25952,7 +25952,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "921fdc7c56d62f0ad6eeef8ca78fb66df7512b19d01a596b946bd725789eec70",
-      "wire_schema_sha256": "1aa539dc1073e18a2e098498cc2557da3eacf93954e220652ea5a02b5b00b6a1"
+      "wire_schema_sha256": "830f858b5f3868c72a7f694b69d4629f172f5d9bc2acc1272067c54c06169a36"
     },
     {
       "id": "slack_bolt:public_channel_member:github",
@@ -25976,7 +25976,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9934,
+      "wire_schema_bytes": 10075,
       "tool_reference_bytes": 5987,
       "tool_reference_sha256": "1f39a7f444dae2a1907f5118c3549cf2c083fcfdbe5b0049db2675ecd21065a5",
       "overridden_tool_count": 0,
@@ -25993,7 +25993,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1ab36f15b2f5563e9367dfe4489947d43fc4b5dfd950070be51b704acfe40fb2",
-      "wire_schema_sha256": "8be5c072cc64b4155e97561172ec8ce9f2ef2964c0db47d2cb7066f9ead4667f"
+      "wire_schema_sha256": "dd582997398f7fed1401c8552dd98c6f2e52cbe0f7c7affb496d650415382ff1"
     },
     {
       "id": "slack_bolt:public_channel_member:illustrations",
@@ -26017,7 +26017,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6743,
+      "wire_schema_bytes": 6884,
       "tool_reference_bytes": 5600,
       "tool_reference_sha256": "a037859ae5edeacc387d5ed3cee34e55ee10b40a6086437979d63964c42a6943",
       "overridden_tool_count": 0,
@@ -26031,7 +26031,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "cd89f28f6579d916c36483c82e551a9c0b7dbc6fd28607ef058608030a87c469",
-      "wire_schema_sha256": "a4da5112c15e5cec6a754fb50481e54bf81d21ccfc6f95a6f64172bb8172fd8b"
+      "wire_schema_sha256": "1e42bbed6155b98e523dba0cf91bddc8e0bec9d30a6f984539098ad7287331b7"
     },
     {
       "id": "slack_bolt:public_channel_member:industry_research",
@@ -26055,7 +26055,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7985,
+      "wire_schema_bytes": 8126,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "9277bb766c6049f7041333f5c1268ec12ada869b467cfca9ef4d2614e365f6f9",
       "overridden_tool_count": 0,
@@ -26071,7 +26071,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8f0c0ed5de94a54cf7d7b15f49ddd54bcbc38432ef4a997fddaf71ffed4f755",
-      "wire_schema_sha256": "4fa1ec066aaa09b7075f21c08829f75f13fd175bac3b42b68d9cad97cb016eda"
+      "wire_schema_sha256": "286d4e7c125260dfef869088a07fa419948fa0540759203bc08722bd5c70969f"
     },
     {
       "id": "slack_bolt:public_channel_member:knowledge",
@@ -26095,7 +26095,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9090,
+      "wire_schema_bytes": 9231,
       "tool_reference_bytes": 6186,
       "tool_reference_sha256": "aef54854ee629e7e5fea9dd3b84d5de9acb8cda3847076d6647485fe3ea69ecf",
       "overridden_tool_count": 0,
@@ -26111,7 +26111,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b50ed01628a8175d4cad4a3c7a9dd466c519165354b6a963a9e2522456ee2ca6",
-      "wire_schema_sha256": "1056cc345ad659003130bb386ae21f80d7048b13e261302b7e07b2c41b28a8ae"
+      "wire_schema_sha256": "a70f16cc0c3dcd620fabd7f6745cd20b9cd87dfc5ebe8a412382e65729383223"
     },
     {
       "id": "slack_bolt:public_channel_member:meeting_attendance",
@@ -26135,7 +26135,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8472,
+      "wire_schema_bytes": 8613,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "0ee2d9b5571c5b0cdce2c4699418905b6aea03d7df6b56ad67937b48c19eb44b",
       "overridden_tool_count": 0,
@@ -26153,7 +26153,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "4ad868d6d114604043f19c16953ca449a5fc8e438366fa3bd1bc04770e05ca13",
-      "wire_schema_sha256": "cfa6e99c0545aaf06f3b725ba0f2a79b1f1dc5bf46c9f1288f1534f89298da59"
+      "wire_schema_sha256": "5ae38386404f22053a0e71762375dab1bc07e06d189d78766e4ebd9b8d1210c3"
     },
     {
       "id": "slack_bolt:public_channel_member:meeting_full_administration",
@@ -26177,7 +26177,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15927,
+      "wire_schema_bytes": 16068,
       "tool_reference_bytes": 5109,
       "tool_reference_sha256": "cfc119c5528a3d7cbc7962f28dab550e93220a12af4e8ea40f468d787bf69d05",
       "overridden_tool_count": 0,
@@ -26201,7 +26201,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "6a688c893300b6c9e954316fccf089ad30c48b7b26192b13ca3edfd28e90846c",
-      "wire_schema_sha256": "8bb4f6262591577fb3bfcbc96d9fbcc0cf3790393b75ff92f7145db4f5d65bf3",
+      "wire_schema_sha256": "10b93170dcc74ad3e33bb9c3627941dd21a60f79a1094195f3a16f7845e6a125",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -26226,7 +26226,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11785,
+      "wire_schema_bytes": 11926,
       "tool_reference_bytes": 4960,
       "tool_reference_sha256": "44da43736532633f99431c28942cc11ab98896e66f2e766015c14adcfdef1bb5",
       "overridden_tool_count": 0,
@@ -26243,7 +26243,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "6522fe425784c3691c75cf3386e044071d31ebafef4d0abe1600c857ceefdd99",
-      "wire_schema_sha256": "21347382febcdfe977b9b58f4867b535cfc76550ab4c0cd1106e41ef5b431547"
+      "wire_schema_sha256": "6128a7beb1855b0c976e25a145734e31346d6d31a3a443cdcbd76b4bac3bf8bf"
     },
     {
       "id": "slack_bolt:public_channel_member:meeting_series_topics",
@@ -26267,7 +26267,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8706,
+      "wire_schema_bytes": 8847,
       "tool_reference_bytes": 5033,
       "tool_reference_sha256": "6f1fdbd1c8e96d2417594ae72d079a12694850514f1eee5aa7519d4ee17e41d5",
       "overridden_tool_count": 0,
@@ -26284,7 +26284,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "278373a11db662055d171b04d07dde0e8756563d96084805bc2213dcde2c1e7f",
-      "wire_schema_sha256": "0a708298b2d9199b6d4ef942bfcc8c6b4947a8b30166bb4e0719ee7cd65529ba"
+      "wire_schema_sha256": "4678b028f88fd24c32c61ebade5864506bb67fda9f2f7045848fd97f928e0422"
     },
     {
       "id": "slack_bolt:public_channel_member:member_billing",
@@ -26308,7 +26308,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 5810,
+      "wire_schema_bytes": 5951,
       "tool_reference_bytes": 4679,
       "tool_reference_sha256": "b0f49463d9985d1f9465047d3184b5dbd86baa6babd421a79c35f7271ab36fb7",
       "overridden_tool_count": 0,
@@ -26321,7 +26321,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fd9e458f0e7bbb1be3344ec8a83dda9390d33de4e1f08ecbb57625c0518a9d2b",
-      "wire_schema_sha256": "7fd580a6c7f2e2c0b172e34fdd84fb587fe256233254a5276a970648b51692f3"
+      "wire_schema_sha256": "82ca1d7dfa887a93ae42006395543aa86d4d07147bf2b282b074ad57d1309e79"
     },
     {
       "id": "slack_bolt:public_channel_member:member_company_profile",
@@ -26345,7 +26345,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12173,
+      "wire_schema_bytes": 12314,
       "tool_reference_bytes": 7093,
       "tool_reference_sha256": "0e02b4dea01ea74f9eae09547b11663196e5210a81b058a4948a3e9d69ce4ff2",
       "overridden_tool_count": 0,
@@ -26363,7 +26363,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "e3c0076f53ba3014c1de4c0880755d181eeff63f62dd02478f1d7b2adcb1c19b",
-      "wire_schema_sha256": "1eeed70bbe3f79619e02b6775a031822a10de2805bb68c7bed86eaa1d32def54"
+      "wire_schema_sha256": "9a907aa87acf94a190f3a7aac9f14615e73beededf17f25a4b04183152aedaaf"
     },
     {
       "id": "slack_bolt:public_channel_member:member_personal_profile",
@@ -26387,7 +26387,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6942,
+      "wire_schema_bytes": 7083,
       "tool_reference_bytes": 6517,
       "tool_reference_sha256": "c9e584af1f6aeffadc203b42a6599fabec9c5fac7ba6eb3e2271582b1cf66ee5",
       "overridden_tool_count": 0,
@@ -26402,7 +26402,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b98f9f4bd4e0f60081d52bdd1402c33859a85decaab03a5ad06af8d96ee514bf",
-      "wire_schema_sha256": "ac64b0445b2116384b62fc7894f83630fb253193a04cced009d1745caa6e0497"
+      "wire_schema_sha256": "05ce43aa2dfdeeeab473b3cd18624881bcd206c751947db29a6d296d4b65b2cb"
     },
     {
       "id": "slack_bolt:public_channel_member:partner_directory",
@@ -26426,7 +26426,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9373,
+      "wire_schema_bytes": 9514,
       "tool_reference_bytes": 5093,
       "tool_reference_sha256": "268c9be254b94c9a7eac8cb691a638bd09ca4e4c6eecb2cdd3a9cde94185f720",
       "overridden_tool_count": 2,
@@ -26444,7 +26444,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3473f077feee4796a866460cbaa8481d61d1bb163f7f26327227aa8fbb3a3216",
-      "wire_schema_sha256": "e26bcc1728f13db93694e1211a8c4a034afe504143b096216b64b36908de9b11"
+      "wire_schema_sha256": "f2bb56064bb83afdae30f82ded40b9ca1ccf0e137f0e93d58d18600db94e5fbe"
     },
     {
       "id": "slack_bolt:public_channel_member:property_identifier_catalog",
@@ -26468,7 +26468,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8649,
+      "wire_schema_bytes": 8790,
       "tool_reference_bytes": 5198,
       "tool_reference_sha256": "f6ef453cc5f692447ff7fe514424938b0cdc38520e3435b6cbd063323d080283",
       "overridden_tool_count": 0,
@@ -26484,7 +26484,7 @@
         "dispute_catalog_entry"
       ],
       "ordered_tool_names_sha256": "59c0b1ee765a965cc1cf46dc4adef20a805ebbe3cc9522527f5e169ce7ec8a2c",
-      "wire_schema_sha256": "2cfb6319e0677ea956019c020b59e4b19317421252ff990532c0f9537a196c50"
+      "wire_schema_sha256": "91c6a4c8e28798b4efcc547bd01476f818acdd1dca6a30782c3b9031eab4312f"
     },
     {
       "id": "slack_bolt:public_channel_member:property_list_enrichment",
@@ -26508,7 +26508,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6756,
+      "wire_schema_bytes": 6897,
       "tool_reference_bytes": 5047,
       "tool_reference_sha256": "cfbadab03d4e790317d8090b50327bc9c5fd70fc3f7cd176e80af75a7bc366a2",
       "overridden_tool_count": 0,
@@ -26523,7 +26523,7 @@
         "enhance_property"
       ],
       "ordered_tool_names_sha256": "1caed613347ab3bcf21bb469b8b40f07b08cc8f249bad7dca9326ee7b52c7b22",
-      "wire_schema_sha256": "6582f4032bf8c18eccb6a047fbbdec724209261d093229e797b3b3ac2da6faae"
+      "wire_schema_sha256": "b4cc63470f04e6c98f299c63ec99484979ecb2db877fe9e823cb8fe2d5de8bdb"
     },
     {
       "id": "slack_bolt:public_channel_member:property_registry_records",
@@ -26547,7 +26547,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8019,
+      "wire_schema_bytes": 8160,
       "tool_reference_bytes": 5276,
       "tool_reference_sha256": "28d3dc723dc5e252efd2fa2237e912ddff8cacb15935ba66322d85894143102d",
       "overridden_tool_count": 0,
@@ -26564,7 +26564,7 @@
         "list_missing_properties"
       ],
       "ordered_tool_names_sha256": "2f83b56c25291f24fdab99db726897cb6ec21e1241e3efa8eb9df985988b610a",
-      "wire_schema_sha256": "21682a0d842482d81b8d3574705bab7302c7bdbafa30d99a68a5fac91d9523a7"
+      "wire_schema_sha256": "77ebae8e805c83ac3dc01c0c81120523fff4e589fcc5c0b1ff57981be0086d96"
     },
     {
       "id": "slack_bolt:public_channel_member:publishing_assets",
@@ -26588,7 +26588,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8133,
+      "wire_schema_bytes": 8274,
       "tool_reference_bytes": 5001,
       "tool_reference_sha256": "9520994a04b396e588cbd0b4cbaebc844649716d0c21421f76b44622620e5e54",
       "overridden_tool_count": 0,
@@ -26605,7 +26605,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "786fa22373e4d6d8edad19fe20691415fa072a6b7575dabed3c0b5042f1d1f49",
-      "wire_schema_sha256": "a1eb43c6ec10ecc34ea4063d3339ef60bdd70b6741855a31323b0c7708c8bf38"
+      "wire_schema_sha256": "4f11d46908a24e521ad9d74fe3a85805b8c8946e8e3630bf3997baac9e0dd746"
     },
     {
       "id": "slack_bolt:public_channel_member:publishing_promotion",
@@ -26629,7 +26629,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7618,
+      "wire_schema_bytes": 7759,
       "tool_reference_bytes": 4890,
       "tool_reference_sha256": "63844236d8b4fc32eace11c1a05b363295cdf7e7a21f9dba208494c8a8ca037d",
       "overridden_tool_count": 0,
@@ -26644,7 +26644,7 @@
         "draft_social_posts"
       ],
       "ordered_tool_names_sha256": "77444af6faddc476c3d5b7d4c187d13ca3f9f0cc376abb7a5ef29a1c0e9d99eb",
-      "wire_schema_sha256": "a2db2492c6f81398b324a7f598ae4abf3ea1ade88547cf4149650a895d14c44e"
+      "wire_schema_sha256": "0bcb47a3fafa90a94df794ecc0817e270726423589fdac961562fd7fcd24ffba"
     },
     {
       "id": "slack_bolt:public_channel_member:publishing_review",
@@ -26668,7 +26668,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7462,
+      "wire_schema_bytes": 7603,
       "tool_reference_bytes": 5071,
       "tool_reference_sha256": "e622e4729cac9277baee6ba3dda72ab0ac460f4c8a9a55bdd36e05886d14895f",
       "overridden_tool_count": 0,
@@ -26685,7 +26685,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "853dc8d9f0ae66e04744148486b180e9fe12294a4cc6331c12d1731888c051e7",
-      "wire_schema_sha256": "39c2d7af0ea491b0692583223e554127e76d2341b7c591ccc46265bb5cfda402"
+      "wire_schema_sha256": "5bbe11ec96f264740fb16932349387b2716311b0ede7bb9ba8521cfa7a4a1d95"
     },
     {
       "id": "slack_bolt:public_channel_member:publishing_submission",
@@ -26709,7 +26709,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9150,
+      "wire_schema_bytes": 9291,
       "tool_reference_bytes": 5847,
       "tool_reference_sha256": "c589e1d69cf85ca8389caf09cef857e22b67949b23c5dec256ba87e2e8789615",
       "overridden_tool_count": 0,
@@ -26725,7 +26725,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "5a59f770620a09d9eb4ab6649514984010296cb123fbd3563424c64e187ef606",
-      "wire_schema_sha256": "9b7a8c82e6715bdd6722b02c44954ca6c1d17681f3cfbcbfaffb30e94102df2b"
+      "wire_schema_sha256": "9f246332ed3c4c28ca0f3227da2b21d1998a0c0d5f7ea226c9965f52b6921fe7"
     },
     {
       "id": "slack_bolt:public_channel_member:router_unavailable",
@@ -26749,7 +26749,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16027,
+      "wire_schema_bytes": 16168,
       "tool_reference_bytes": 7341,
       "tool_reference_sha256": "d443dac04c8256c25600eb2c7da3fd9c43fd3d7f172f0c450c80b71c30170a76",
       "overridden_tool_count": 4,
@@ -26775,7 +26775,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a3e0336f18c95c4cc7d2d6790b7bb6464703b8fef7b0c33220180ce40956e1fc",
-      "wire_schema_sha256": "10f56cf068ce89b5bc33fbac5933084694747027861800ae0669c7753a0bece5",
+      "wire_schema_sha256": "b72ee206407719a3f2b3b8bd3e1895b5306fc63298e8ab482ef3654ec97310e1",
       "target_exception_category": "legacy_channel_router_continuity"
     },
     {
@@ -26800,7 +26800,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8238,
+      "wire_schema_bytes": 8379,
       "tool_reference_bytes": 5268,
       "tool_reference_sha256": "90b6a08492f4d0df6c5d15e5240b25a9a9c90c48a56ed25729148549f2cde643",
       "overridden_tool_count": 4,
@@ -26817,7 +26817,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "042ad1ca12b6e91615c671d5534c5c00029c168a0e491e4ac285582f3f242405",
-      "wire_schema_sha256": "3cdf5b56369f21f44f191c0f4b5a87711235264a774a5f57fb3437c209ff331f"
+      "wire_schema_sha256": "01d8006799be746f30bbc395f0750876309e62773c960e5890da6fbe89dd1c5d"
     },
     {
       "id": "slack_bolt:public_channel_member:sponsored_intelligence_discovery",
@@ -26841,7 +26841,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7426,
+      "wire_schema_bytes": 7567,
       "tool_reference_bytes": 5223,
       "tool_reference_sha256": "17acfaeead1da3a8d82047fe16c058af19ef29d513d7c3e663552e6b83dff968",
       "overridden_tool_count": 0,
@@ -26857,7 +26857,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a8cfd5201ca46d75fe53c9c27fdc4256df285fdfe4fcc0b2dcd0249f63d7241c",
-      "wire_schema_sha256": "a48f4ae3e3991a381f0f6d7ac82ac64462d7553dd6eae2f25a793510bdbf51ee"
+      "wire_schema_sha256": "4e6640483f2fae7009a7ceb16a2b856a7eb2b900a5a3739993552b86bd99e637"
     },
     {
       "id": "slack_bolt:public_channel_member:sponsored_intelligence_session",
@@ -26881,7 +26881,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 6945,
+      "wire_schema_bytes": 7086,
       "tool_reference_bytes": 5040,
       "tool_reference_sha256": "696df339745a57995853ecc6865918211a16d81f072633a5eb3e4238bac8013f",
       "overridden_tool_count": 0,
@@ -26897,7 +26897,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8fa651f7af60832a1ab923c128d02a9c854ed4c045f121d04e3d801641dd484c",
-      "wire_schema_sha256": "2abc6a51af3fea0e719a49f337dc034b6aa708180a484bbe314bbfe8cfdeb892"
+      "wire_schema_sha256": "c07064676945c1ff72df826e9030654f109ec7b9d67e7977baac216822a65c00"
     },
     {
       "id": "slack_bolt:public_mention_admin:maximum",
@@ -31040,7 +31040,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -31266,7 +31266,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31357,7 +31357,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -31583,7 +31583,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31674,7 +31674,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39400,
       "tool_reference_sha256": "6a0f0ff7d5f449c3041704877d5ed811126b3293701645f40a5f380c3ae69482",
       "overridden_tool_count": 11,
@@ -31900,7 +31900,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31990,7 +31990,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -32216,7 +32216,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -32308,7 +32308,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170663,
+      "wire_schema_bytes": 170804,
       "tool_reference_bytes": 39435,
       "tool_reference_sha256": "27c0906adc1ff63ee7d92c37832cddc9d4e994884f2be4d70a50ab8e3240c5c8",
       "overridden_tool_count": 11,
@@ -32534,7 +32534,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "ff7a074ccdeaacb9249966748b44e038aa2479a56865920023216f77563ef916",
+      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -32556,7 +32556,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 23517,
+      "wire_schema_bytes": 23658,
       "tool_reference_bytes": 5796,
       "tool_reference_sha256": "b158ad6a1fe8c1b2319cb055811193d742374f066473cb053e72ae48ca6c7453",
       "overridden_tool_count": 0,
@@ -32594,7 +32594,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "406479222ce57005fb81249d4095ed0217de2f9a43d21462cdb722b385d6b948",
-      "wire_schema_sha256": "b3a27fe7f332554aa9b0be47956f20bc6de5010bdd7749b52110c0c82129917a",
+      "wire_schema_sha256": "1559e5b68dcc35d5919ceaa9773e60a8c8f512b0f8c60467c7b6431dfd467f0b",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32616,7 +32616,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 17407,
+      "wire_schema_bytes": 17548,
       "tool_reference_bytes": 9115,
       "tool_reference_sha256": "8f12004cadcd6c534de0b16708e0f0cdcb5a773bd407204922880f8e1e30cab6",
       "overridden_tool_count": 0,
@@ -32642,7 +32642,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf77e7db8c07c504355a9e3f11c3dcb19fb9e648836f0b11fe3e4be18276b768",
-      "wire_schema_sha256": "e1163ad14f5c7d434ec3318f10c516f061f02ed58a6f58a8862b40995793a932",
+      "wire_schema_sha256": "eb48d47d95797e72c1524c0643db2b178a4692fe2717bece7553b55e9835c765",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32664,7 +32664,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 27308,
+      "wire_schema_bytes": 27449,
       "tool_reference_bytes": 5702,
       "tool_reference_sha256": "8dcd4836d5397df9615fd25b6542cb7e6c5a6b200d80ccf0e1800744dee7ba44",
       "overridden_tool_count": 0,
@@ -32700,7 +32700,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "65b4d81ef37ff23853d42ffd1095a16982d137003ef2fc40c033161edc2b40cc",
-      "wire_schema_sha256": "591663e8606f5277c242418bd7c80386af65aef2a8256bfe5c6de4757b5af31a",
+      "wire_schema_sha256": "e1f11c002aa3ceac9bd92b40f0d861cfdee6d1f98077218b30effe69a74fbec8",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32764,7 +32764,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 21223,
+      "wire_schema_bytes": 21364,
       "tool_reference_bytes": 5728,
       "tool_reference_sha256": "3a4ac7a72653f778e92d4eec7985cd2afbda5a796dcbd507e63ae38cfe3d188d",
       "overridden_tool_count": 0,
@@ -32800,7 +32800,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "4c6e5ff8e0162e9c70d85f6198820b878495c2d33fead84c657fbb96b3cc3906",
-      "wire_schema_sha256": "08ed4c7649728abe9b1e605104ffd22ac70653e1f01f6c8c220d94ab360e7eb4",
+      "wire_schema_sha256": "3de03ab2d78240db5686d209e522de08592c410ba077739a63b1fcdf19507de9",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32822,7 +32822,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 15113,
+      "wire_schema_bytes": 15254,
       "tool_reference_bytes": 9047,
       "tool_reference_sha256": "cb713a3d203755f4c357c49ee64fb4c5b44dac62501826acd2cc191a80e88606",
       "overridden_tool_count": 0,
@@ -32846,7 +32846,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "62671b1d88ed4c35de57283c8ca2e01037dfd647c8d9ff3fdf08864d3cdf7db4",
-      "wire_schema_sha256": "19056caedea5ced001ab23f98dec2220bc52e3dd9f8ce5671b4b19a4a40295e3",
+      "wire_schema_sha256": "fbc1f5e226525da022f17fb824d0bec011019c4b54bac2e7caac0d67e88739e4",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32868,7 +32868,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 23283,
+      "wire_schema_bytes": 23424,
       "tool_reference_bytes": 6692,
       "tool_reference_sha256": "706a805cf5b4d54ef3e8fb30350da8889c9d06873b5f68dd50397846c552c1ea",
       "overridden_tool_count": 0,
@@ -32897,7 +32897,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "222164e32e7a6b1aa2716bd843776345d05afafa44563c3673b982d9d43354ef",
-      "wire_schema_sha256": "e9e349eda996adef0370588f5c709d70fa05238c66eceef449a139ca44f31208",
+      "wire_schema_sha256": "b005cb88a01df542f6aa06d4ad40cef9e5b7845d93cb8727540201831d68cf06",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -32960,7 +32960,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 17469,
+      "wire_schema_bytes": 17610,
       "tool_reference_bytes": 7712,
       "tool_reference_sha256": "327b31c9445865d03ff6b18cdcd8770a85d1475890ab1da754b11374bb5e414c",
       "overridden_tool_count": 0,
@@ -32990,7 +32990,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a9c96a273b3ad8d2497f18e39a7f0fd7888610e9a420fa76634d559a25654117",
-      "wire_schema_sha256": "b8c560cae8cc1aed77c896e89b9fbc7b94d08d9e027c274756cd511d62ab1b42",
+      "wire_schema_sha256": "44dea786664eb8cb5efe8f126b4ebbe13938ddc951a33051e41fd3f1670e44df",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33011,7 +33011,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 15113,
+      "wire_schema_bytes": 15254,
       "tool_reference_bytes": 9047,
       "tool_reference_sha256": "cb713a3d203755f4c357c49ee64fb4c5b44dac62501826acd2cc191a80e88606",
       "overridden_tool_count": 0,
@@ -33035,7 +33035,7 @@
         "validate_adagents"
       ],
       "ordered_tool_names_sha256": "62671b1d88ed4c35de57283c8ca2e01037dfd647c8d9ff3fdf08864d3cdf7db4",
-      "wire_schema_sha256": "19056caedea5ced001ab23f98dec2220bc52e3dd9f8ce5671b4b19a4a40295e3",
+      "wire_schema_sha256": "fbc1f5e226525da022f17fb824d0bec011019c4b54bac2e7caac0d67e88739e4",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33056,7 +33056,7 @@
       "maximum_provider_tool_names": [],
       "maximum_provider_tool_wire_bytes": 2,
       "maximum_provider_tool_wire_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-      "wire_schema_bytes": 19529,
+      "wire_schema_bytes": 19670,
       "tool_reference_bytes": 8676,
       "tool_reference_sha256": "1f3212562bf75d7ce8ebfdc03ce8926736dd73492f1ea3cb47a5b3c9e795a991",
       "overridden_tool_count": 0,
@@ -33079,7 +33079,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "db378d93a19c58579e5f63a382d5ffe24b0d12be939adb55dca8a41568f197ec",
-      "wire_schema_sha256": "d7228e7e9dcaab92ec6949b0b2e029d451849177ad7723288efee8cf71123272",
+      "wire_schema_sha256": "0070341865d0bb9a1860cf53f49474093cb7a71c21bef1975eb47e929e479c22",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33218,7 +33218,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 29699,
+      "wire_schema_bytes": 29840,
       "tool_reference_bytes": 10396,
       "tool_reference_sha256": "db9a08024ac032c8d1cb3b6461ba2c93400186150a367607c6ba25bd88c874a9",
       "overridden_tool_count": 0,
@@ -33255,7 +33255,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bd72ada800be89b75c9934f22d39da2716d408cfd7082d78250a5d8ba518170c",
-      "wire_schema_sha256": "98bd0d494db54cfae97716ee919ad986266a4bb02ef44cd75b5d25b7c75a869a",
+      "wire_schema_sha256": "1bf0ea29a228a641b60693b21cd920b00db7d15a8e61459d3c6e87cdf77cbf5f",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -33280,7 +33280,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30602,
+      "wire_schema_bytes": 30743,
       "tool_reference_bytes": 11633,
       "tool_reference_sha256": "1bd37ffb44301d475e80aa305ffd4e4d3440ca40680e6dadc354df7c954b711c",
       "overridden_tool_count": 0,
@@ -33318,7 +33318,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "35d65076ecee4d988204088ee64422da183fe75da2c59e606217e62e228e1024",
-      "wire_schema_sha256": "b20da638d0c91f535bd07bd22095869530eff24f780f410f62e25f79f28161ad",
+      "wire_schema_sha256": "2fba0bd51a8b7ac4fc849454571fd86bb6440457c71e96b21ed7dc6307eda7a7",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -33344,7 +33344,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 33051,
+      "wire_schema_bytes": 33192,
       "tool_reference_bytes": 13788,
       "tool_reference_sha256": "65b93b7217131d1a8eb7b9d8a848e22c9ad6e717060b059ea5feebe50ed943e3",
       "overridden_tool_count": 0,
@@ -33385,7 +33385,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "6c5ec13ab1e04229284b2416d75b4b9ad7f06ff570821cea95cffa4c972ff8c6",
-      "wire_schema_sha256": "1e9335e86f5d85d9b937feb00d160ab842f6982200734fb6ccfac8bbc381bea3",
+      "wire_schema_sha256": "c1326983220f1ec3b41cf22eb890be28333143fc810091879c27d4580a204665",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -33409,7 +33409,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 32993,
+      "wire_schema_bytes": 33134,
       "tool_reference_bytes": 10389,
       "tool_reference_sha256": "0facc2995e2d13ee0b676e0981dec54c8e11b4b18aa2feb85756275931937a2f",
       "overridden_tool_count": 1,
@@ -33448,7 +33448,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "149c1f71cfc348258d03be4fc30163baeb808ea9370dd73a34c04d8e7a27e49d",
-      "wire_schema_sha256": "ab5ff1c1ec241d9c2f37467999be9b52ddbb70de3eac8ba1c05d165fe2bc9582",
+      "wire_schema_sha256": "4412aadbc0825d6f54d493308a1912ca96272a812e74819f0e61301a1fc10978",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33472,7 +33472,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 24652,
+      "wire_schema_bytes": 24793,
       "tool_reference_bytes": 6157,
       "tool_reference_sha256": "fe1ff193bf1d76fe9ce5e8cd0fae7346feab6181648dd83bca54b619f0bb7c03",
       "overridden_tool_count": 0,
@@ -33513,7 +33513,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "72797edb266c5688d07bd08f242c17bcc62e317351ab2324d94919dd21ce2268",
-      "wire_schema_sha256": "182a994c3a992e01089e82f5abc857061a7aa24a27cef740274507304fb2e9c6",
+      "wire_schema_sha256": "c6beca5286f029ddbb4e30d1c7171098e4ac402e56c0aa963dea86e35f332f7e",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33537,7 +33537,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28118,
+      "wire_schema_bytes": 28259,
       "tool_reference_bytes": 10932,
       "tool_reference_sha256": "111cd7597a76c890bb6ad724e6f2aa1e2fa01a16d8451b54572108ffc0598a80",
       "overridden_tool_count": 0,
@@ -33571,7 +33571,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "158c453937b60e693b2cfbd41179126ca0ef97f4c9507f25ef4cbbb26fb520f3",
-      "wire_schema_sha256": "5c9f0f0e7ae692bf3e181e40e88afa84d90215eb3071025f269e8e7a55a08874",
+      "wire_schema_sha256": "04f6f546ffea06f1492b4b82d824d610aea4ea0f60316238a2b26c21d8647244",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -33592,7 +33592,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 15460,
+      "wire_schema_bytes": 15601,
       "tool_reference_bytes": 6330,
       "tool_reference_sha256": "6aef477bf109d821bdfa8fd07c90523f69b3a7fbe386ae353280665105de3e0f",
       "overridden_tool_count": 0,
@@ -33612,7 +33612,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ad8390526ff9af140bd7e4b0416ad3cfc4c028e44028070b95a06ae152bfa05e",
-      "wire_schema_sha256": "dc7103f30f9e621253fee5592d6b96ef643d57b5903fd0382052fff981b07d2a"
+      "wire_schema_sha256": "ca0da259992847a847763ab958007800ba2f205f075ee4881cb44a5333dc211a"
     },
     {
       "id": "web_chat:authenticated_admin:routed:adcp_task_operations",
@@ -33632,7 +33632,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13908,
+      "wire_schema_bytes": 14049,
       "tool_reference_bytes": 6378,
       "tool_reference_sha256": "6f40fffb21d3be25b7651e53dd9c9555d8b6e844e0ada398314863d004ece8c6",
       "overridden_tool_count": 0,
@@ -33651,7 +33651,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ec7ac19895cfe76a47ceb18f70d93c022d19ad3e2290decbadb56c0047588e75",
-      "wire_schema_sha256": "9543c7a7609cc5c224da90a8ba1e092b1952dda668fa00879ea0154b3d4ac080"
+      "wire_schema_sha256": "95ff2ff5a555cd5e32c2abe640a6f6e19dbdb15bdea6437de7d5ee3a4a60cea1"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_billing_account",
@@ -33671,7 +33671,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11076,
+      "wire_schema_bytes": 11217,
       "tool_reference_bytes": 4918,
       "tool_reference_sha256": "c633c81589d01cce53e416bffb362e31d3fb38c1fa7ae0be2bc1b3a89b8a30c3",
       "overridden_tool_count": 0,
@@ -33691,7 +33691,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bf202ec0b5c16623f805b27e931a3423b95b24caee51e1a76dab242af5e113f2",
-      "wire_schema_sha256": "e9ded10e5ae64f63be983786276642b415b919c5a67b81f273864451863a0fbf"
+      "wire_schema_sha256": "cc2ab61e3ad19b17010c5a5c7de0eafa41a6fae2de4810a38e3808934506a57b"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_billing_discounts",
@@ -33711,7 +33711,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10390,
+      "wire_schema_bytes": 10531,
       "tool_reference_bytes": 4885,
       "tool_reference_sha256": "e6c54c011bf4113a5acfb57919b1eea144a9e2e9b037a7fa90402c91e92c4af4",
       "overridden_tool_count": 0,
@@ -33731,7 +33731,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3d5a0d9845becf4948711c6b98b82b974ad8a580d75ec4b9440d3ba0df936d28",
-      "wire_schema_sha256": "01b4c5607355c8cc879da53dc000c63d208a6c74db48dacbc300d9da16dfeba9"
+      "wire_schema_sha256": "0f0359f0ff406ae27ba491aa5346a3141b5f9c5d7d5a41e6c4c072406ff8be64"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_billing_payments",
@@ -33751,7 +33751,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11959,
+      "wire_schema_bytes": 12100,
       "tool_reference_bytes": 4873,
       "tool_reference_sha256": "beafff27d131ccfccf76c4ebf261d2ea9266a44aed3072c3e5af8b876cab4ef7",
       "overridden_tool_count": 0,
@@ -33770,7 +33770,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4658b9b7dbd4a931f13ea064882fc4fa4fdd16b52cc772c54896e65520480301",
-      "wire_schema_sha256": "c16b5a136d8ab7e05713da928b904228b45c0d43d80ca474cbae14ad0c64182f"
+      "wire_schema_sha256": "2dd912f723bb64fecdfb58f2d684ea5b45d30d38512179b7b8f1356baf188325"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_brand_logo_review",
@@ -33790,7 +33790,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10322,
+      "wire_schema_bytes": 10463,
       "tool_reference_bytes": 5103,
       "tool_reference_sha256": "18a8f680141c30fb3779c55d499734812898390dba839f7e842c5402550132d5",
       "overridden_tool_count": 0,
@@ -33809,7 +33809,7 @@
         "review_brand_logo"
       ],
       "ordered_tool_names_sha256": "6c9af95c4975829a7bf94aec01f35a754b8d9cdb812f5dd150c15eabac456de1",
-      "wire_schema_sha256": "c075708004e5259ded57bf7b460f7a123abf8b3c00f6327dd1f6820be35ab45b"
+      "wire_schema_sha256": "35c211082c30ee248197647c07c439c14d8c53f354fb224abdd862b433c98f55"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_brand_registry_integrity",
@@ -33829,7 +33829,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11031,
+      "wire_schema_bytes": 11172,
       "tool_reference_bytes": 5206,
       "tool_reference_sha256": "076d054efacb1b4921f34c5b4c2fa862adeb91d2c383f34ad016cb46c3ef9cdc",
       "overridden_tool_count": 0,
@@ -33850,7 +33850,7 @@
         "list_orphaned_brands"
       ],
       "ordered_tool_names_sha256": "746626ce504e9042354df763f06c197fd762442961f478b4c8c25592bbcaf932",
-      "wire_schema_sha256": "92303785bf482da9effc3c6d34fb6adc5ab3d894d78a56a3bf48158e2bdb7dfb"
+      "wire_schema_sha256": "05ac6416a409c2e0a15b74a5dac605298cbd25c9ed6f381947d03fc8ebd2dda8"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_conversation_review",
@@ -33870,7 +33870,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11022,
+      "wire_schema_bytes": 11163,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -33889,7 +33889,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "46c7d110ac26bd45dec3fc0870880584f46522717bd470d4e8242b1eeada4c77"
+      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_events",
@@ -33909,7 +33909,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14607,
+      "wire_schema_bytes": 14748,
       "tool_reference_bytes": 5045,
       "tool_reference_sha256": "c30cb271ee192379bdfd17da6cd5bab315e4c560f86a13f66f5192aa38ca6ed7",
       "overridden_tool_count": 0,
@@ -33930,7 +33930,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "0e315f56035f7f695f6e8b981c5b484c9802fc1b0f948e767a6bd57eb3cbafa8",
-      "wire_schema_sha256": "2b1d53f3e95f2dc8b66f3b91c52775cfb3292ed32bbf151edd33c069fdda5b20"
+      "wire_schema_sha256": "2ad96203888e13bb531d0725ed59dc9bdbc70bfebcaca69b6104225882d68f64"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_feed_curation",
@@ -33950,7 +33950,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10769,
+      "wire_schema_bytes": 10910,
       "tool_reference_bytes": 4954,
       "tool_reference_sha256": "51b1859d98819b87b8cf43469c7151cee160b47dab60e0185ebbdb25b7206911",
       "overridden_tool_count": 0,
@@ -33970,7 +33970,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3dcfb69f2292cd2753faf15d02c0077a157e404763b47af52d306370c4975ea2",
-      "wire_schema_sha256": "dfe8b2570e3c6dd0470221132cebbb5c33bc6f4c95ee55c06f29bf5318fe49fa"
+      "wire_schema_sha256": "abf4e1210aaac63fb0b6abe901bb89edac2f3994ebce7572b3fd3ddfec918d56"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_feed_monitoring",
@@ -33990,7 +33990,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9556,
+      "wire_schema_bytes": 9697,
       "tool_reference_bytes": 4933,
       "tool_reference_sha256": "348f8bf0680b6697aa4db7fe642d0d2b592d98bac5ef05017653e3d5f76d1ee0",
       "overridden_tool_count": 0,
@@ -34009,7 +34009,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b1689086b33ea143c9b79edc3954c1fc9320bd7c73bf26c05d79d00a50999e6b",
-      "wire_schema_sha256": "69b08c0e33b7f5e0483b2d9faa24e71d5d8cf7a9af626b6983050b85608002dd"
+      "wire_schema_sha256": "356c5447324224f57135895bdf0755581a2b86d5bdfb0236962e92922898df10"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_followup_tasks",
@@ -34029,7 +34029,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10288,
+      "wire_schema_bytes": 10429,
       "tool_reference_bytes": 4961,
       "tool_reference_sha256": "d3b7df07a7bf17cddab315557f4db71a7e2fea4f4956d3ace06b9d96340d50d6",
       "overridden_tool_count": 0,
@@ -34049,7 +34049,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "e9891ff20b83d67e8cadb649d24df495c51f5d78064af75532944a98a14ef9e4",
-      "wire_schema_sha256": "61929aa8491fc1efa2a84b9017ac2d040d4f2e0df6893bb4939b7f0b48d01735"
+      "wire_schema_sha256": "310fa974b97a6c82109c0aac9e36fe45501e4c2acba52c730cb7dba8abe587b0"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_group_leadership",
@@ -34069,7 +34069,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10760,
+      "wire_schema_bytes": 10901,
       "tool_reference_bytes": 5041,
       "tool_reference_sha256": "90476e3b3516fa008b3063f2d55126f0c4622dfce286824afe3e33917711c10d",
       "overridden_tool_count": 0,
@@ -34090,7 +34090,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ecd5015062feb97397c759e03480c2fc6f9ef58425774b7f88d6793fc51a261a",
-      "wire_schema_sha256": "8870ff455c80a2c3ac9270a2bfaaf2fa62d4eb715f25069469a180d1523d46ac"
+      "wire_schema_sha256": "292b461d56fd3d1d6ec082dfdd8ad4b7be80323422f7d55476a2a7c50de11b62"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_group_membership",
@@ -34110,7 +34110,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10666,
+      "wire_schema_bytes": 10807,
       "tool_reference_bytes": 5017,
       "tool_reference_sha256": "2388dc80f99651611a2695a01e1caaba5a3fe4d36cb4f74ef9c5443dc96b3664",
       "overridden_tool_count": 0,
@@ -34130,7 +34130,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "47db1de6135e646a948a53018f4edc8c974d39573961f5f74cf110c620b28b7d",
-      "wire_schema_sha256": "b0c37e8442437e8bf5da967213533952a688d75f9044159913740a4bb7cbc68d"
+      "wire_schema_sha256": "75cfcf4d3e182f12be3a8409b69086eb4e8395ee1eb57d6897cbe1532ffa3464"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_group_structure",
@@ -34150,7 +34150,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10729,
+      "wire_schema_bytes": 10870,
       "tool_reference_bytes": 5034,
       "tool_reference_sha256": "8f34d5a18362f50aacb64db4cba78ed35949e1ff5e47db886ea4344224766823",
       "overridden_tool_count": 0,
@@ -34171,7 +34171,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f386cc7f41b925aa66274b8f8753f1f807aab57f0b25196035c9b470d7e97e08",
-      "wire_schema_sha256": "a156969da8f3918f83e0cae37c1307567e88d7976052443702e086be3d52fa99"
+      "wire_schema_sha256": "8976f868aa83ffca02729d688267b8682dffe4bc1f3c0f75818e46c3b67208ea"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_organization_integrity",
@@ -34191,7 +34191,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10716,
+      "wire_schema_bytes": 10857,
       "tool_reference_bytes": 5263,
       "tool_reference_sha256": "2babace46b46bd3c1757a93a4fc523910763ecdc00941c9526aa723cc966057c",
       "overridden_tool_count": 0,
@@ -34211,7 +34211,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "282a96131a9d387b5b297a1798d427fb77f27935a25c03cbf2cc22b79160265d",
-      "wire_schema_sha256": "042e6ecaa3f021ea34283325da3d528e17494d89e9be9284ffadb1e84cd44dea"
+      "wire_schema_sha256": "43278aa0ec15d4cc49fd7beb7bb4ea369b7b21123737932188b480921cdd3335"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_organization_member_records",
@@ -34231,7 +34231,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13604,
+      "wire_schema_bytes": 13745,
       "tool_reference_bytes": 5279,
       "tool_reference_sha256": "3b20b9520b711943b33384fc793a5aa81c1356222e27031371fa9568fa5ddaa6",
       "overridden_tool_count": 0,
@@ -34252,7 +34252,7 @@
         "update_member_profile"
       ],
       "ordered_tool_names_sha256": "fbaa28ba1001813d3f1a0cb66477a6c9b0efc4ff32214d6414c9ec478d93f373",
-      "wire_schema_sha256": "199ccde69119f622e85af6e7878095321c7af70fa6df08c2108a7db357d40f96"
+      "wire_schema_sha256": "b1827a4f4ba256571df9eb871d48d0a0822985d974b1ae9181643a2297083e8e"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_prospect_pipeline",
@@ -34272,7 +34272,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12521,
+      "wire_schema_bytes": 12662,
       "tool_reference_bytes": 4989,
       "tool_reference_sha256": "b0cd167136b0167f5271d0c640104f9e84ab19c55065b2c375ea59fd650658c6",
       "overridden_tool_count": 0,
@@ -34292,7 +34292,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "57a38e3fff723ab752525360ac09e49c8383a799c437fd7e8997db01d00d6102",
-      "wire_schema_sha256": "5c49b5d4e0419b5255b6c8f54697e65d1eb6eb15fef63635c8afd65fc5449358"
+      "wire_schema_sha256": "35a27cf6032281aba5d04bf4381436e9ebc3726f4ac1656e219c4be2bdd6ddf5"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_prospect_research",
@@ -34312,7 +34312,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10908,
+      "wire_schema_bytes": 11049,
       "tool_reference_bytes": 5007,
       "tool_reference_sha256": "1854a1b2fe6f4dc131539e2d425764f7819eea370158742211c02c1910f21338",
       "overridden_tool_count": 0,
@@ -34332,7 +34332,7 @@
         "triage_prospect_domain"
       ],
       "ordered_tool_names_sha256": "da07d5b25562ab15e7f17ce74015434853f8be2fac2917339e18cc4fb6139fd7",
-      "wire_schema_sha256": "b4cc5316fe13a05a6ed97843fecd37451808a421f1e941644f9762e268999059"
+      "wire_schema_sha256": "22bc774943369c808b85b557cdd40fc4177145a9508b613f974c1a6b37050178"
     },
     {
       "id": "web_chat:authenticated_admin:routed:agent_authentication",
@@ -34352,7 +34352,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11273,
+      "wire_schema_bytes": 11414,
       "tool_reference_bytes": 6068,
       "tool_reference_sha256": "8c5110b85f73579cbd881419b997fcc9a9d99d3b2ebdf415f4929585bd6298d5",
       "overridden_tool_count": 0,
@@ -34370,7 +34370,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "07eb0de4a4c6332c5429079c33017a24205c5f3507e6399772c561ff4a092d78",
-      "wire_schema_sha256": "598a80e9d63967c72734a2a480fcc2d438cdb06af506672907ac273711905aa2"
+      "wire_schema_sha256": "c817f6a6a00ce8caeb3ceb89d2c9a6cdd34c142d48680ab1968ae85dcdd8bf32"
     },
     {
       "id": "web_chat:authenticated_admin:routed:agent_conformance",
@@ -34432,7 +34432,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19815,
+      "wire_schema_bytes": 19956,
       "tool_reference_bytes": 6636,
       "tool_reference_sha256": "d02b3eff67be7a38f952ebe0196ddb996dc932aa9e501167b0b1d71e454da1e4",
       "overridden_tool_count": 1,
@@ -34458,7 +34458,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "38cc0a34bdeb0b27e32fc731aab76c06cd76603a03930b877377db96c6605530",
-      "wire_schema_sha256": "250d6dbdc9d8664c11712fb804985dd399aa86e058858d610282c78f5d72028e",
+      "wire_schema_sha256": "4484d75b9be2d873d5439f8532cd31a9cf90f828683a5b15155c27d260b234dc",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -34479,7 +34479,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9950,
+      "wire_schema_bytes": 10091,
       "tool_reference_bytes": 5117,
       "tool_reference_sha256": "aa7e1f31ef1c683786e229c8050793d9faad83b5a5cbde309960dc4a3271a991",
       "overridden_tool_count": 4,
@@ -34499,7 +34499,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a512a4cbd9fe2e02bb76d6a1b31cd09a7638761efb4a0230834fdfb2e861159e",
-      "wire_schema_sha256": "7b05ded6a160ec1efae4e67f6132c9301be3989ba40f9ee725e1dea20d011c28"
+      "wire_schema_sha256": "a9712d8f28136b46063ae010c6e790982153087943feb2d6acaf3c7e4a4df93d"
     },
     {
       "id": "web_chat:authenticated_admin:routed:agent_quality",
@@ -34519,7 +34519,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14652,
+      "wire_schema_bytes": 14793,
       "tool_reference_bytes": 6139,
       "tool_reference_sha256": "ecf8f60600a263d6a3120321ab1f65e138a08b082a96153eed01d1968552a91f",
       "overridden_tool_count": 0,
@@ -34538,7 +34538,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f527be89fee5e5536b0b51b8c6c72924fbb8d3d9f3fee080986890437ae83065",
-      "wire_schema_sha256": "0da514e38da9e5be4280e7490b7f597ac0976df6fb9860bfd3c2abdb06f9ce69"
+      "wire_schema_sha256": "2927e76e9a88dce21cf946e0034908a0526605e5cb05f02305ffd1331cc4d91a"
     },
     {
       "id": "web_chat:authenticated_admin:routed:agent_registry",
@@ -34558,7 +34558,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11044,
+      "wire_schema_bytes": 11185,
       "tool_reference_bytes": 6701,
       "tool_reference_sha256": "25cdf10cfcafee88979211e822031ff6983a2f38b20fae8fa7088210136e135d",
       "overridden_tool_count": 1,
@@ -34579,7 +34579,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "daf3e6218a62213fc85ab2ab1851293c3fbd4477d1e99a45b9e3f0d80ab5c0b8",
-      "wire_schema_sha256": "8246ed04689bbdec7e8d5b4f69da7148badf783d18ce332febe2682ac4f65d37"
+      "wire_schema_sha256": "1b9a9db659fadd19af1ec2e1662fc8b51521ae5b85e2175005cfd25013f04256"
     },
     {
       "id": "web_chat:authenticated_admin:routed:brand_registry_identity",
@@ -34641,7 +34641,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11067,
+      "wire_schema_bytes": 11208,
       "tool_reference_bytes": 5280,
       "tool_reference_sha256": "6e5a06f631d52e8db048ca417e593ab9731058f6ad56b3b963a13fba4576803d",
       "overridden_tool_count": 0,
@@ -34662,7 +34662,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "eda3df4f80454edef279b95cefe13cec88f3b96e642a522fbb8d637e62ea6c1a",
-      "wire_schema_sha256": "d5bd8133e1def1b66e1545b070047a2453600f95c6774f0a4932e0c8e224ab9f"
+      "wire_schema_sha256": "322ed22197bca8977e1bd62697272d9b20d43df1c426f029aee9c4786a395887"
     },
     {
       "id": "web_chat:authenticated_admin:routed:certification_assessment",
@@ -34682,7 +34682,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 19717,
+      "wire_schema_bytes": 19858,
       "tool_reference_bytes": 6920,
       "tool_reference_sha256": "8c278765ad621dd11f89ff7b35d60af9f51ae88d569155f91733a06a4a51aab5",
       "overridden_tool_count": 0,
@@ -34707,7 +34707,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "67f49b83d4e4b07b7f7910ff2f50557ab03f385f30eeb8fe41232923a99894f8",
-      "wire_schema_sha256": "b6f423f18f5733ba77f3d0096debf96a0c1443cca36508ad3a3ef1551070d8d3",
+      "wire_schema_sha256": "aa4768cee6ea2625ced36131d76dc110ed6a7f93a462323862f5a9c27d5ccf24",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -34728,7 +34728,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 20620,
+      "wire_schema_bytes": 20761,
       "tool_reference_bytes": 8157,
       "tool_reference_sha256": "488a0f80dc27b82e9d7a04226a70a00d8dddb18c5801dba7d287839e9f70315d",
       "overridden_tool_count": 0,
@@ -34754,7 +34754,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "bd3ab369c155ab0c39e4eb0daa1a025adb8543612053db25490c4704861b54f6",
-      "wire_schema_sha256": "82894322c112e5a176b354bd9ed7ada2f1203f815e73a7485673f0e077568c3e",
+      "wire_schema_sha256": "df84d2d4513a0cb10f10866bf37adad6dba7244dd344a67c738e6cae30ba1762",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -34775,7 +34775,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10621,
+      "wire_schema_bytes": 10762,
       "tool_reference_bytes": 5714,
       "tool_reference_sha256": "ffe228a0d892df8178b8697bb3c470318c7c60e0bb97e578159b3fb4376e1674",
       "overridden_tool_count": 0,
@@ -34796,7 +34796,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "ee3db406e4008c85d2f335b2fe7059e760da0e713c7eb8ac0b1637d5aafee9bf",
-      "wire_schema_sha256": "aaae80b2bfca1a0873e379f7b3f59584e4637b9410bc33a48c2ac271e2debf68"
+      "wire_schema_sha256": "baa7498589a9adc2ce2bfe02eff40213b64558459bfbe4e057ed358e149b1c01"
     },
     {
       "id": "web_chat:authenticated_admin:routed:collaboration",
@@ -34816,7 +34816,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9831,
+      "wire_schema_bytes": 9972,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "e538eef1415fb4f47251a65eff930e1abb048b1440679990cff368a65814cb1b",
       "overridden_tool_count": 0,
@@ -34833,7 +34833,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "11274be30eaff96df7d3a088f1c91d7ce876a5ef74f4f65679f51f93964bb107",
-      "wire_schema_sha256": "b57a5fbf2e3185acfe0f5728d98dc166e7e8fba608ae6f79e19a91a087dfee08"
+      "wire_schema_sha256": "610a632766f98d2858732eb8d8e16fbfd1f0c23b33c6c0007909d7a33516d062"
     },
     {
       "id": "web_chat:authenticated_admin:routed:committee_co_leaders",
@@ -34853,7 +34853,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11161,
+      "wire_schema_bytes": 11302,
       "tool_reference_bytes": 4981,
       "tool_reference_sha256": "a74c5c2bd2d65d9f5639a6aad516e33599b92edba4bf9cc24ff468efc9889c51",
       "overridden_tool_count": 0,
@@ -34873,7 +34873,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "bbe7d7c41eafa947c0f6456ae91b140fe2fb526a765ada057940d8283bad2d3e",
-      "wire_schema_sha256": "88e25ae1df383ca28285df07031c9b2bdd6471f2156802e8ef1c2165c884bf1c"
+      "wire_schema_sha256": "b5d99ae490ded1a4f5d20aa7753412959680237b21afe1e1faa9179927ed46d5"
     },
     {
       "id": "web_chat:authenticated_admin:routed:committee_event_planning",
@@ -34893,7 +34893,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12747,
+      "wire_schema_bytes": 12888,
       "tool_reference_bytes": 4937,
       "tool_reference_sha256": "48c146ce05f85c6d37c76ff566e74f7c5432a42f18243f0dd88c1100ffed6109",
       "overridden_tool_count": 0,
@@ -34912,7 +34912,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "4cbb76ebfc638e5e178b77ce51517e1700f437cbe07eed14ef67bc9c6d6beed1",
-      "wire_schema_sha256": "a689a1a7836d76c8570bc6da9931e3233aca3358fcd24d29b3094674a967c7b8"
+      "wire_schema_sha256": "ec641792556c5b33bada8fd491025299c5ce888240aad9e397e609d90ad96f20"
     },
     {
       "id": "web_chat:authenticated_admin:routed:committee_event_registrations",
@@ -34932,7 +34932,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11471,
+      "wire_schema_bytes": 11612,
       "tool_reference_bytes": 4994,
       "tool_reference_sha256": "e5adaa7cf86f32e770b3d2ac8ba70be81d79ad573a6e6232ec8ab514c9c512ef",
       "overridden_tool_count": 0,
@@ -34952,7 +34952,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "9c759c6159787b0bf813b405babe98af8b80fd8132ad1c292125b2998c70e9fe",
-      "wire_schema_sha256": "83042a8f9c7a4d2365e3fb6dae5f3260154fbd20283b4d0cb6a82e95f2eb866d"
+      "wire_schema_sha256": "7442c8f0343cadeaebc9fbf7b53c126800f0b4e645a77e79d1fd7b5726cf14f6"
     },
     {
       "id": "web_chat:authenticated_admin:routed:committee_full_leadership",
@@ -34972,7 +34972,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17191,
+      "wire_schema_bytes": 17332,
       "tool_reference_bytes": 5272,
       "tool_reference_sha256": "8f6e40ff2049c4b545422207ee004ad7e0d78caba7b71253994e0ebdf73978e5",
       "overridden_tool_count": 0,
@@ -34997,7 +34997,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "04ec5e8b84cc7c87cf26efc8cd7c37398baefb992eb687800a7c461a0f74b752",
-      "wire_schema_sha256": "986037ea14111776d73dad81f6c8abd2bc4ccc0b7d121343f3cb53274d06e478",
+      "wire_schema_sha256": "93e170f15266310c33b743c22b939e1f1d2b418fd332ed530e08c71a794cac1b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -35060,7 +35060,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10112,
+      "wire_schema_bytes": 10253,
       "tool_reference_bytes": 5314,
       "tool_reference_sha256": "ad46a2c27c92e139603118ccdda8ca72104b761f404d0e3619e2aa338331c3d2",
       "overridden_tool_count": 0,
@@ -35079,7 +35079,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "495a4a8817c854d8d9b0be45cd4c4365585ca02748a9560222f7fe7fb4498af9",
-      "wire_schema_sha256": "68a04baeb53dc384c109b00f6d6ee34f44d0c4a864bee4bc470de2f9a81e6c42"
+      "wire_schema_sha256": "48a55496c36ad8118cceda62dfc6e3f2f7512d6d4c2df52559c5b807b88487a9"
     },
     {
       "id": "web_chat:authenticated_admin:routed:community_group_discovery",
@@ -35099,7 +35099,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10155,
+      "wire_schema_bytes": 10296,
       "tool_reference_bytes": 5255,
       "tool_reference_sha256": "fd71bca33c484bb3fb934c9486a18fc1e274917ff3cc95ef90e177e47326bb7c",
       "overridden_tool_count": 0,
@@ -35119,7 +35119,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "64a3330edea439fa8fb9fdacd1f81a66133cc4f256e7f2ac470bb5f2eea00ffb",
-      "wire_schema_sha256": "37e23fe68f4983194b7eda715844651a7b67caef71aff3d641f02997d71f7689"
+      "wire_schema_sha256": "9d05198d8f6fe5f252c0dea042255b1fda4049aa7deab37bb01c0260f9ba895c"
     },
     {
       "id": "web_chat:authenticated_admin:routed:community_group_full_participation",
@@ -35139,7 +35139,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13400,
+      "wire_schema_bytes": 13541,
       "tool_reference_bytes": 5366,
       "tool_reference_sha256": "b749062fe5be6a24e2d97f9299b3264bcbd84aef9c6fbabc470dc4e186a41e3a",
       "overridden_tool_count": 0,
@@ -35166,7 +35166,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "1761c6fb6a24457352ea873f301ed6c24757cb0a4fed773919c1371fb343d70c",
-      "wire_schema_sha256": "a0cc93bef80d9523deb66aad071350b6ad2cc093fed8ff770c5cf2ce7940b269",
+      "wire_schema_sha256": "ae2a4ff316eb3f6cda571b706c3d47c72b904f623fbf477450a33e9a96bd3684",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -35187,7 +35187,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10522,
+      "wire_schema_bytes": 10663,
       "tool_reference_bytes": 5288,
       "tool_reference_sha256": "60f5f1015a0888599dcff1c673ebe02a5e83258c2d048256843f2a9c791188fa",
       "overridden_tool_count": 0,
@@ -35207,7 +35207,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "c6cf0f8155798e253cad3ac0be806ac43f96ca1259a860e19d265dc255d15d91",
-      "wire_schema_sha256": "9cd71c39be1813e2691d5ea448ff001cffd85464e5ba36f812c3d0692794dedb"
+      "wire_schema_sha256": "c49379c6569c8148bfec76439fb59409ede93e45094c4b65fc2dda4c83e2c145"
     },
     {
       "id": "web_chat:authenticated_admin:routed:content",
@@ -35227,7 +35227,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11128,
+      "wire_schema_bytes": 11269,
       "tool_reference_bytes": 5083,
       "tool_reference_sha256": "282313bd3f11de63c991eb1ca9c05498a4164020624527406eb3d21ac16e72a6",
       "overridden_tool_count": 0,
@@ -35247,7 +35247,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "284c752554ad643959685c0b0fbc1b1b5221bc3c0bf42c804731caa9a351cb44",
-      "wire_schema_sha256": "b1a8d18593b12e60f70e4d7b5f04f1f171979934591eba16dc6bf63d3b58a91c"
+      "wire_schema_sha256": "22f888fa99a27d79e9434f9738fd74a67556e1f58f46e4bcdc31b8e8cdd46bfc"
     },
     {
       "id": "web_chat:authenticated_admin:routed:council_interest",
@@ -35267,7 +35267,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10156,
+      "wire_schema_bytes": 10297,
       "tool_reference_bytes": 5250,
       "tool_reference_sha256": "2a9275ce948cff4e13410aedb7932cd1483a286cb9b2f729e4b987bed296009c",
       "overridden_tool_count": 0,
@@ -35287,7 +35287,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "86286a9b99f37c50106ca5b3ab9111c7b0af4d130d68d0640ccb929363610e72",
-      "wire_schema_sha256": "117775a58f2f01975ea5b101b1f11a64957762186c77e21374cea5c666bf2af4"
+      "wire_schema_sha256": "ea7cb652802c1ee0c9b4d03ae244118218032d33579555f29bf7a97f7c665618"
     },
     {
       "id": "web_chat:authenticated_admin:routed:events",
@@ -35307,7 +35307,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11056,
+      "wire_schema_bytes": 11197,
       "tool_reference_bytes": 5090,
       "tool_reference_sha256": "ee0839be778b2e32476815c6931204145048cdaf4433bf88e0986fcf8ac24183",
       "overridden_tool_count": 0,
@@ -35327,7 +35327,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "5751ff1ac10de94ad9b147e63d707924bb971a542515ebb9a89b5cb9446451cc",
-      "wire_schema_sha256": "afedc4bd3e025df66df66083454b5b5c8113509a335eb52289ad7fd4763ab335"
+      "wire_schema_sha256": "1237e2a89f231accdbaa9e3541aedb3ae018762173d929744cf6d065596ac9b6"
     },
     {
       "id": "web_chat:authenticated_admin:routed:github",
@@ -35347,7 +35347,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12701,
+      "wire_schema_bytes": 12842,
       "tool_reference_bytes": 6073,
       "tool_reference_sha256": "17d2b9fdd26009df7efeba7b01d291553c2d578f4c4b8d2f3fa952cadd338030",
       "overridden_tool_count": 0,
@@ -35367,7 +35367,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "188b898cef2ba9447f41cdc60c27bd6433d96dd606d2c429d18247d8c752753b",
-      "wire_schema_sha256": "6457216659e15cbc7f241b6ae36b0b98c4923f7673328fba7ed8c11cfe01d23f"
+      "wire_schema_sha256": "7559b3f050430dab78f8148ddb9e83afa19514cef5de15458c7f99e9fa897512"
     },
     {
       "id": "web_chat:authenticated_admin:routed:illustrations",
@@ -35387,7 +35387,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9510,
+      "wire_schema_bytes": 9651,
       "tool_reference_bytes": 5686,
       "tool_reference_sha256": "a08ac061f8dbe6da9867b23df6239f4f64a3605e97869e827b33ebc0aca341c0",
       "overridden_tool_count": 0,
@@ -35404,7 +35404,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "548aacf53b9f5c1904aedfc60e1dce5eb750d0fde3326269c929e687f62b6755",
-      "wire_schema_sha256": "ed03f64b99568ac200f452948f2ddf355138c70ce8ee509760bece089d497514"
+      "wire_schema_sha256": "b8b24f057ea99e98d3d26af8bb40132538cb6c311cb6bb1ca82d2477eb7e70fe"
     },
     {
       "id": "web_chat:authenticated_admin:routed:industry_research",
@@ -35466,7 +35466,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11857,
+      "wire_schema_bytes": 11998,
       "tool_reference_bytes": 6272,
       "tool_reference_sha256": "41833a3b88217e1f6717c2402369116266203940d43e850a95385115de65b203",
       "overridden_tool_count": 0,
@@ -35485,7 +35485,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4e599b4b9422738f948e58c2b92e4ef8a98b54f3bce93c382101388f9a515518",
-      "wire_schema_sha256": "c19a7e8340bc410cf6849c54d43fe762ea3cde8796b90832521c4cb4cf71c713"
+      "wire_schema_sha256": "f6bf3dde92b2d28eb26b85e932e6f2b1b6bc2d5eff122ad4e571467a58f3bcd3"
     },
     {
       "id": "web_chat:authenticated_admin:routed:meeting_attendance",
@@ -35505,7 +35505,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11239,
+      "wire_schema_bytes": 11380,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "5fdc3f50ba46d26ffa75ff27538a5e7e8bcef3ea837fef8fd48705abd8624725",
       "overridden_tool_count": 0,
@@ -35526,7 +35526,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "28efbd2ca8b10c2368f967e639fd7652cd7f04960ad188392ce93fda2392bdc0",
-      "wire_schema_sha256": "f39c41b8e78c64611672126ff6b8393087a60b3cb4923b7c7d43a4ed27968343"
+      "wire_schema_sha256": "7c9f5de06def5824696babe0d384b9aa60bc3b94db3038fc4a73d7cfa6cad728"
     },
     {
       "id": "web_chat:authenticated_admin:routed:meeting_full_administration",
@@ -35546,7 +35546,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18694,
+      "wire_schema_bytes": 18835,
       "tool_reference_bytes": 5195,
       "tool_reference_sha256": "17af7be874d34d79f1adf04bfa613c4b2faa3ea2bd74ea4ad3a91bb480be9741",
       "overridden_tool_count": 0,
@@ -35573,7 +35573,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "582f87a23ce4af178918f9bb042c999466b46904c3c9f7cbfed3dd27ab8dead2",
-      "wire_schema_sha256": "59170ff943f740317737157d7a781bb80349d107c7f6f69508f9b389329e2521",
+      "wire_schema_sha256": "b70c211ed1c3c6cb49bed93c09baef38c39849ea7df747db1bffa3ffb1e9b59b",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -35594,7 +35594,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14552,
+      "wire_schema_bytes": 14693,
       "tool_reference_bytes": 5046,
       "tool_reference_sha256": "fce02e48f5ad06db1fee5ed46a2a2689371e71fdceb63cc1bd3e165515ba43e6",
       "overridden_tool_count": 0,
@@ -35614,7 +35614,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "63f1c3b48687fc9d68ddd930787a7d59561f1ba9ddb8d3698f0457486829dcba",
-      "wire_schema_sha256": "19cbd7895fd5b360a6871c5b552e565ae8e2ba0439ff80de008ba76f5614e44e"
+      "wire_schema_sha256": "232dd0f7f5208d747a5c794474720434b79d43962d28c56eda22300017e1ef7c"
     },
     {
       "id": "web_chat:authenticated_admin:routed:meeting_series_topics",
@@ -35634,7 +35634,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11473,
+      "wire_schema_bytes": 11614,
       "tool_reference_bytes": 5119,
       "tool_reference_sha256": "fe9228ca48c839aefda1068097db4be03171b5d2f70101b996207477ee011b43",
       "overridden_tool_count": 0,
@@ -35654,7 +35654,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "1b799fe2a16442d418c0628fec9bdc8ae73d6c67a2f1acda08a5b99c73255258",
-      "wire_schema_sha256": "d324fb9e0c1e8b1a8df594959b9ef3a70cc3920fd1949ea7cd4606f57b8dc0ed"
+      "wire_schema_sha256": "a6ef0e4690050c165fd0cda7076be36676b0bfa48f3a72ee9fe9f689946628c6"
     },
     {
       "id": "web_chat:authenticated_admin:routed:member_billing",
@@ -35674,7 +35674,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12058,
+      "wire_schema_bytes": 12199,
       "tool_reference_bytes": 5669,
       "tool_reference_sha256": "61c7298906378b4f2f154f7275a9f56c9102bfb6247ae654a3861f7cc8895b98",
       "overridden_tool_count": 0,
@@ -35695,7 +35695,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "b5c6e2b75d0038129a56a2e17cf39b4d4a2c7a62d22869867b6ea74f960b572d",
-      "wire_schema_sha256": "683767549cf943e6c8bff02f7104622ba2e430e7b6c834bc253d552697838c9f"
+      "wire_schema_sha256": "3c33baec429a4e242fd30fe0eaa54737e77ee5bc99ce2d7355479cb856962cb2"
     },
     {
       "id": "web_chat:authenticated_admin:routed:member_company_profile",
@@ -35715,7 +35715,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14940,
+      "wire_schema_bytes": 15081,
       "tool_reference_bytes": 7179,
       "tool_reference_sha256": "b0aa1c7af0bf4591e4177f3a8127c527154606d4587dc08756e7f18105e83bb6",
       "overridden_tool_count": 0,
@@ -35736,7 +35736,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "0e1b8aa348778ebfd306f8e063d3984473a27d9aa3475eada444f6cfdba0bfea",
-      "wire_schema_sha256": "7537b15dd2395d96fda05841d4378fe5aa4357bef70d9cd7f09b2da02a47fd91"
+      "wire_schema_sha256": "7b5e7201ecfa6b413eb78c9286cf4b047ef55fc178665bc55a0bda1331a4d963"
     },
     {
       "id": "web_chat:authenticated_admin:routed:member_personal_profile",
@@ -35756,7 +35756,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9709,
+      "wire_schema_bytes": 9850,
       "tool_reference_bytes": 6603,
       "tool_reference_sha256": "1be10e69d1c2468a8f3619e586e9b7cd0fb80f57e737ceb7614f552e89795e0d",
       "overridden_tool_count": 0,
@@ -35774,7 +35774,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "278d2a60ad51f3a69b5f03330f7f2b7d3d4a8ff98509f14e558cba79fe3c6e7a",
-      "wire_schema_sha256": "ff1df39b36fdc7627c9c15607a9430d3e0ee3bc271294fbd4adfbf2c6b863edc"
+      "wire_schema_sha256": "40b3a07842f235277a229615209ef66121aef314b998e85c2d866bdc980d9f21"
     },
     {
       "id": "web_chat:authenticated_admin:routed:outreach_contact_management",
@@ -35794,7 +35794,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10589,
+      "wire_schema_bytes": 10730,
       "tool_reference_bytes": 4957,
       "tool_reference_sha256": "978d81ac4be58b4e5f0c59260b589e96a95acd041895d6e47cb238614e05642a",
       "overridden_tool_count": 0,
@@ -35814,7 +35814,7 @@
         "create_contact"
       ],
       "ordered_tool_names_sha256": "53eb64b204251c7934442c3397a72020de3c911f9c3d29dec3d2d239591e1aa5",
-      "wire_schema_sha256": "0fed13e32364c9ec0ca1f839f71f05aa6215c616be36f94d6c5acf78200d1f5e"
+      "wire_schema_sha256": "204ec6558f12dd0ca3621e36c719d8fdf2d9d1697b4006410e380cd706a221ff"
     },
     {
       "id": "web_chat:authenticated_admin:routed:outreach_reporting",
@@ -35834,7 +35834,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10160,
+      "wire_schema_bytes": 10301,
       "tool_reference_bytes": 4949,
       "tool_reference_sha256": "deb6aeea7143042d8abb8afc908abe958eb2c6bb562fd6e31b92162b7c6e4a7a",
       "overridden_tool_count": 0,
@@ -35853,7 +35853,7 @@
         "get_action_items"
       ],
       "ordered_tool_names_sha256": "9fea2f2b6f7bd11b93a4c4b87e0034f358fccbfe72dbed4ca9c9f45d3030d677",
-      "wire_schema_sha256": "02874ad0cff3f58ac2dd0dfb07d6fcfc5fb113471151252ce1818b4002f645a7"
+      "wire_schema_sha256": "f9579b024ed866df5ee027174ee45ef12edab77db4d3adfd2988fb152b022ea4"
     },
     {
       "id": "web_chat:authenticated_admin:routed:partner_directory",
@@ -35873,7 +35873,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12140,
+      "wire_schema_bytes": 12281,
       "tool_reference_bytes": 5179,
       "tool_reference_sha256": "2f1bdba181f4d89bed5f22bf21f070d49964f094ed9aa1638220d2e53bd350bc",
       "overridden_tool_count": 3,
@@ -35894,7 +35894,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "efd1f4e75ed263acdc49d36f7ad1f21b876dde26f1b451b5c5d1337ff8fc157a",
-      "wire_schema_sha256": "01763e02d3b3c219185d38a8e1fae4d666a95b8f3c6acd0db52990674490091f"
+      "wire_schema_sha256": "e44f0d531dd58979cf6987f8bbf164719aee88ce22280526a57d9f34318e8387"
     },
     {
       "id": "web_chat:authenticated_admin:routed:property_identifier_catalog",
@@ -35914,7 +35914,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11416,
+      "wire_schema_bytes": 11557,
       "tool_reference_bytes": 5284,
       "tool_reference_sha256": "13831dbee6b1a3c7cd6921429eec948d1b4ee446eddb9e088ed00d7939de7a8d",
       "overridden_tool_count": 0,
@@ -35933,7 +35933,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "24ccf0f03b6c2a4dcce69a5b4df0aa2db14efa2d1aee9426cd1480a1fc838ee6",
-      "wire_schema_sha256": "60fa94106a010c8f3b149fbc8bc8999f6fa03ffca6c5c53cf481609d8ece5733"
+      "wire_schema_sha256": "711d40e5bc8ddc3f736c08763917b673bdccdbfc94e6ab52d3292a0b82880044"
     },
     {
       "id": "web_chat:authenticated_admin:routed:property_list_enrichment",
@@ -35953,7 +35953,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9523,
+      "wire_schema_bytes": 9664,
       "tool_reference_bytes": 5133,
       "tool_reference_sha256": "90a495e511e631244025479c57aabdaf44869fbda341849f33d6e5d82d1d4f98",
       "overridden_tool_count": 0,
@@ -35971,7 +35971,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "09241c7be4edf72b88dba82001908af6565fcac05f77f0456c52d49f5908ff8d",
-      "wire_schema_sha256": "b9d2d5a23c86eb2e4d81627d096651785d89fac1f80465e9c2ac92c5ba2def0f"
+      "wire_schema_sha256": "653689082cc4e9d026be813b1f1584ea48e96eda5414e20f499cc58d0916a2cc"
     },
     {
       "id": "web_chat:authenticated_admin:routed:property_registry_records",
@@ -35991,7 +35991,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10786,
+      "wire_schema_bytes": 10927,
       "tool_reference_bytes": 5362,
       "tool_reference_sha256": "f8db16b555a1cd7f2ed5547a7decd4a45c47a371d05b447825d9d6bdd7f1477e",
       "overridden_tool_count": 0,
@@ -36011,7 +36011,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "3ccbd09596b6a91a6bbf16e7b34bcc0b23d9c1547b9a2ed61288da078568dce5",
-      "wire_schema_sha256": "d9fd7c072a9949ca7e5ccd0197bba3564d928550c175dfedc6b7f8214570960c"
+      "wire_schema_sha256": "adb2637401f10e641b175893468c22538a9e6c9d6a1d34c0be197689064a1483"
     },
     {
       "id": "web_chat:authenticated_admin:routed:publishing_assets",
@@ -36115,7 +36115,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10229,
+      "wire_schema_bytes": 10370,
       "tool_reference_bytes": 5157,
       "tool_reference_sha256": "bbd74b8e4738835551b2440b98a1ae56d7846f2d971933af09ec972ed5b40682",
       "overridden_tool_count": 0,
@@ -36135,7 +36135,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "a895f645f68398d3e561173892a44e31eaa1cfdfa5dfa74cd3cdd30c833aadda",
-      "wire_schema_sha256": "c5caa7ddc47fa48618ba74b09cc76301ba5554af9e9c2df7d4a555c514b3aa19"
+      "wire_schema_sha256": "4827ac2b31737f015deea00bd512859c97ee3b6fde1b4453b02d30e6b290c16e"
     },
     {
       "id": "web_chat:authenticated_admin:routed:publishing_submission",
@@ -36197,7 +36197,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11005,
+      "wire_schema_bytes": 11146,
       "tool_reference_bytes": 5354,
       "tool_reference_sha256": "f587c5f3a0336231600fb685bbfe264f96dda0ee796091942e1340b8bcd2ee0b",
       "overridden_tool_count": 0,
@@ -36217,7 +36217,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "5551f6b60200dee61066fc65f42695b7a9b6f6c677a97d164812935faf702261",
-      "wire_schema_sha256": "443689ec626f64502248bcf217d42ef60900891d9a4163e30f52dba93a237984"
+      "wire_schema_sha256": "fb719521c0abe29641c041144222f371429552b112530b64a7ada5244f864852"
     },
     {
       "id": "web_chat:authenticated_admin:routed:sponsored_intelligence_discovery",
@@ -36237,7 +36237,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10193,
+      "wire_schema_bytes": 10334,
       "tool_reference_bytes": 5309,
       "tool_reference_sha256": "3a8d840efe998abbd5d636abcc586fe5889c3e1282e0bd5e503674461bcd0dd9",
       "overridden_tool_count": 0,
@@ -36256,7 +36256,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "273d2551a68559859045673bd43c47271fa94a6c2d964d52ea97b3ddcc82a3e1",
-      "wire_schema_sha256": "14fb233d8d227dfabb95f29858a9676478f4da482b6872205d51eae2494fc8e7"
+      "wire_schema_sha256": "50638db9f4084536bad895819c3394c83de09b7038f2177a0df409d83ff1da97"
     },
     {
       "id": "web_chat:authenticated_admin:routed:sponsored_intelligence_session",
@@ -36276,7 +36276,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9712,
+      "wire_schema_bytes": 9853,
       "tool_reference_bytes": 5126,
       "tool_reference_sha256": "a6db91f7f951d33d2386aa95c8902dc13d042413c343658a7764921db30faba2",
       "overridden_tool_count": 0,
@@ -36295,7 +36295,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "4374fdf27f7f4d8646711d9cd15247ada5ff2a909ed24cfbd9b847b40c6fe3e7",
-      "wire_schema_sha256": "cd9443cf3509268c019d4d7528f0a9b650efcff272b88d9653863825f1a2f41a"
+      "wire_schema_sha256": "f2795405837d1a84a8998ef506930127f587d4a073fbf730249dfd9dc989a10d"
     },
     {
       "id": "web_chat:authenticated_admin:safe_fallback",
@@ -36361,7 +36361,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 27405,
+      "wire_schema_bytes": 27546,
       "tool_reference_bytes": 10328,
       "tool_reference_sha256": "cc07c52a8da0fd78de071cdb373fb3735cbf5e8379321279ac2b7e8282db60a3",
       "overridden_tool_count": 0,
@@ -36396,7 +36396,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "d5fede9abe22dc9e9881c02a0273f7c97d12f14b898f6a95124633edf174fb03",
-      "wire_schema_sha256": "857157207243c92d3f4297ae7a27aa0f11aa478f32d05ffa5d8662732db3ea30",
+      "wire_schema_sha256": "03652c4850d0a96b8473008a8c8e7e8fd9b55fa2ce0581f70d6611fdc92f79b0",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -36421,7 +36421,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 28308,
+      "wire_schema_bytes": 28449,
       "tool_reference_bytes": 11565,
       "tool_reference_sha256": "91d965f37e957a399cdc8f029246edafe50162d525bc724a197415692cb1d094",
       "overridden_tool_count": 0,
@@ -36457,7 +36457,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "bab8226b2b5de31430f15b50111a74fb4c48b6c740a6acb7cd827244d1f65c6e",
-      "wire_schema_sha256": "1dfaab2b31988afc03b8fc0e951d25a8e865c7dd3ad4adecf2712f0d6998ed73",
+      "wire_schema_sha256": "20c51206600bc24eaf93ff6995532574808bac988b0a2dddb1c63d422aaa7d86",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -36483,7 +36483,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30757,
+      "wire_schema_bytes": 30898,
       "tool_reference_bytes": 13720,
       "tool_reference_sha256": "70a32380ba0df6d668c2ab945a52ee381ae5d9eedceee3b62fb3dfc56fec902c",
       "overridden_tool_count": 0,
@@ -36522,7 +36522,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "409043ee299e0fb5f20b8a94de341fc6e92f1dc0c6f010a74777841984b8542b",
-      "wire_schema_sha256": "03cbe6addbeb7a4de7a1fb694be6a07d201f141c93d73c444437be5af48257b0",
+      "wire_schema_sha256": "572550032dc1a12cb68b73b5a37cf35b3090a610b21b359b999090d7758626e5",
       "target_exception_category": "trusted_certification_session"
     },
     {
@@ -36546,7 +36546,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 30699,
+      "wire_schema_bytes": 30840,
       "tool_reference_bytes": 10321,
       "tool_reference_sha256": "c345073241bbb0aa78ef7366d2c97b3f776183a69a3acab73fed9bba457eb861",
       "overridden_tool_count": 1,
@@ -36583,7 +36583,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "239aa781dc2bbad4cafae408369b09c33c17594e28af7dccd89b8c7e335f6ad4",
-      "wire_schema_sha256": "3d1b029cd872df8c55d9cc0288f9dd22b87eb86d97371e280050b3778d4d8d56",
+      "wire_schema_sha256": "80fbb1ebe318cc3ff4ea751cad4db8845c2d78a394d51e1be6b49be216f27355",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -36607,7 +36607,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 22358,
+      "wire_schema_bytes": 22499,
       "tool_reference_bytes": 6089,
       "tool_reference_sha256": "2dedd93f34bb8bb96a840a2650e817f7f883931785541ffec854710e6ef68489",
       "overridden_tool_count": 0,
@@ -36646,7 +36646,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "a9e974b90b45f7a06c5f20a790efe7b1b48c32b69e1a546e1d30531a3a617a1a",
-      "wire_schema_sha256": "772e82bf18df11171a0929159b29a564160f9e30c383416a49a2ea4bbae32792",
+      "wire_schema_sha256": "f6440a41f9a66135dac9dfb70cdcd0938071233062b8c54937eeff50774a4187",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -36670,7 +36670,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 25824,
+      "wire_schema_bytes": 25965,
       "tool_reference_bytes": 10864,
       "tool_reference_sha256": "c1c660ec26e128b9aedfa96fe0c1b85588c45a7221f7b9a141e2f0aa9fa0b174",
       "overridden_tool_count": 0,
@@ -36702,7 +36702,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "55dda212adc074b6c5ce79b60bee4cfc91f773942e3195ccd82a12710479a121",
-      "wire_schema_sha256": "ed64942bdc69fd11d793b26c9711079071894012aa804f7733555da33376d672",
+      "wire_schema_sha256": "bd1d18f4b69143b2a11ff2edbcfbb084f1ed0e3d3920a5cd2a094e021c597cae",
       "target_exception_category": "bounded_multi_domain_plan"
     },
     {
@@ -36723,7 +36723,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 13166,
+      "wire_schema_bytes": 13307,
       "tool_reference_bytes": 6262,
       "tool_reference_sha256": "3d2ccbb6aba85bd38419a3d9045f5707e4d0f0ba6be27a89a1d1fe8143715007",
       "overridden_tool_count": 0,
@@ -36741,7 +36741,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c0d2d1533050187c0d555031976948036cb84a1b937814f81af6b77701972ab0",
-      "wire_schema_sha256": "1dfd23f8107e98dd592c8c633949e3314b854147b63e602c40d3f736e0e8d047"
+      "wire_schema_sha256": "bbefddd5ad515565950049ea6a7e1ba108020755a2d9c8e58a7d489dfacfd91d"
     },
     {
       "id": "web_chat:authenticated_member:routed:adcp_task_operations",
@@ -36761,7 +36761,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11614,
+      "wire_schema_bytes": 11755,
       "tool_reference_bytes": 6310,
       "tool_reference_sha256": "04603aeb0ae569596b5ee5fd6be628303bece3bf65625633a68f9e6e2879d538",
       "overridden_tool_count": 0,
@@ -36778,7 +36778,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "fbefd58db9c1a6ac0d4d459d4e9a2d858510f067ecd58d8eedf377145d606e4e",
-      "wire_schema_sha256": "0053e6b3d6a4747c9f4f6e3b50a529e6b0a1ba254ae363693aac7626bdd06a55"
+      "wire_schema_sha256": "0509753330ff45280c152536091b3b4a8746f773c6c0a4e6a7a01082f4c0c45f"
     },
     {
       "id": "web_chat:authenticated_member:routed:agent_authentication",
@@ -36798,7 +36798,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8979,
+      "wire_schema_bytes": 9120,
       "tool_reference_bytes": 6000,
       "tool_reference_sha256": "b937948691c576fbcb7f1b179d3d84d2fd8ee5354cf0e9ec23e02728eaf9d3cc",
       "overridden_tool_count": 0,
@@ -36814,7 +36814,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "aa35268403f3b37ff1f3ae0b78bfd8f2fdbefc392a5d3546fbeeca83ca5c6ed7",
-      "wire_schema_sha256": "e616084893239a3360d038f27f027e253460b07d34eb9fa2cd3902a5c7764906"
+      "wire_schema_sha256": "c32fecfcbf637c9b547a939f7c850f3e46c387cef5a396b4193986ae68a49771"
     },
     {
       "id": "web_chat:authenticated_member:routed:agent_conformance",
@@ -36876,7 +36876,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17521,
+      "wire_schema_bytes": 17662,
       "tool_reference_bytes": 6568,
       "tool_reference_sha256": "724c570df0c1afbfc5474f247fa2d289e56582171e19ca033a263bf4a38a8591",
       "overridden_tool_count": 1,
@@ -36900,7 +36900,7 @@
         "diagnose_agent_auth"
       ],
       "ordered_tool_names_sha256": "fca82ce62ad0b9e6ae281a723c4fde4a64f62054db1fed015fedbd24cccf44c4",
-      "wire_schema_sha256": "4c2dc85ac3818f6d50b6ea0349539ab60f631b73203709438376ba23a0213a89",
+      "wire_schema_sha256": "149d55d3b06e85506f57ecde732301ea374e7506bf30f0b5154db9157eb0f33c",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -36921,7 +36921,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7656,
+      "wire_schema_bytes": 7797,
       "tool_reference_bytes": 5049,
       "tool_reference_sha256": "e864b0a33e55d3e7caf062c73af9a521bbcf2a8494a6f1c34e42fcbe54749910",
       "overridden_tool_count": 4,
@@ -36939,7 +36939,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "f44279c0b16e64b09a8a1fdd183eb3b82606b5477a249986eae941d027b18aca",
-      "wire_schema_sha256": "03b93c5ac8de474e43c6586f7b8fc43fa9147b8e241dde51a8c6ea15735e3c8e"
+      "wire_schema_sha256": "6ab6dbf06b50ba07dd90c9de354c870af777499e851295d577ff9deb91d2b900"
     },
     {
       "id": "web_chat:authenticated_member:routed:agent_quality",
@@ -36959,7 +36959,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12358,
+      "wire_schema_bytes": 12499,
       "tool_reference_bytes": 6071,
       "tool_reference_sha256": "815eb22df22b1d8f37c869018b9c5e49c83178001b26f1e7523ce09aec7b230e",
       "overridden_tool_count": 0,
@@ -36976,7 +36976,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "32ee638aa5b9177bbea802803498f87f715d059b195e4d0492e56312ff6c9cbe",
-      "wire_schema_sha256": "0a2850d80b2523a669874d940a93a714c73e21f8db67a61371a50c644e019815"
+      "wire_schema_sha256": "a1d8c157b5a199141179bc09a30808ecde2c99bd7975c39ef01f6aa21dc55634"
     },
     {
       "id": "web_chat:authenticated_member:routed:agent_registry",
@@ -36996,7 +36996,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8750,
+      "wire_schema_bytes": 8891,
       "tool_reference_bytes": 6633,
       "tool_reference_sha256": "e78fc94ddc9de419855cc10bf05d7a05126c4c50f23abc99d90fc08c530ccdf3",
       "overridden_tool_count": 1,
@@ -37015,7 +37015,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4957a73972e6ccbf78c7aa7a26b9c07ef4521197894f2a1fe95839d7e3583786",
-      "wire_schema_sha256": "bad61118fa016bf0689f0cafbe883079c36220b5e2f2bfc1c3f868e6aa11db7c"
+      "wire_schema_sha256": "1c80bf1ca6c69d999ba583837500e115fceafe7b2b4a633aae3fbd1006a49b40"
     },
     {
       "id": "web_chat:authenticated_member:routed:brand_registry_identity",
@@ -37077,7 +37077,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8773,
+      "wire_schema_bytes": 8914,
       "tool_reference_bytes": 5212,
       "tool_reference_sha256": "7bda40be2f135095e28761f77dda59f399bd5198a9cca4cc4de885041d8207b7",
       "overridden_tool_count": 0,
@@ -37096,7 +37096,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd62a1ce3cba6305a4fabdcbfc2181c09706d57d4c70b9513d9e95bdc0dc3c6e",
-      "wire_schema_sha256": "4d11d8ce47d870d683f91075a8b2441a0bbe8f90d72265d0399e7bf15c4ea258"
+      "wire_schema_sha256": "932d51b5e8f50421653b83d6dad9d18751777e821ccc7e927648efe3876df7c1"
     },
     {
       "id": "web_chat:authenticated_member:routed:certification_assessment",
@@ -37116,7 +37116,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 17423,
+      "wire_schema_bytes": 17564,
       "tool_reference_bytes": 6852,
       "tool_reference_sha256": "414adb08a79ac4142a2967f857c3abb49345cd48daad70100e6a1762b980779a",
       "overridden_tool_count": 0,
@@ -37139,7 +37139,7 @@
         "checkpoint_teaching_progress"
       ],
       "ordered_tool_names_sha256": "2f5d84296b8040bca96f4c1ca4c53d58e97027ea93c417b146adbf080e05f05d",
-      "wire_schema_sha256": "5a4d4b5841fc41c5c9478994f002e0549d38d43f52ce61137d79dfe13b14cecf",
+      "wire_schema_sha256": "6fa1f6ac48b01a93056affec31b8b171e70e71602a26388bfc7c8acbfe0906b7",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -37160,7 +37160,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 18326,
+      "wire_schema_bytes": 18467,
       "tool_reference_bytes": 8089,
       "tool_reference_sha256": "346659796dfa0cb862a77cb3dbe215b925a8c59aa3c0296e22a0af15cf384ba6",
       "overridden_tool_count": 0,
@@ -37184,7 +37184,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "05e6751604e0664016472e3f20c46d2e22ba5dffd0a557e34418a0b88daccb29",
-      "wire_schema_sha256": "dc9feb86d4ee84029366ae1b7e490f22d286384bda28836f9701b4b27fcefa57",
+      "wire_schema_sha256": "32f6fc42055aaec5afca0222ca919a447b33f629533d1268b4f78d2cd4e8d640",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -37205,7 +37205,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8327,
+      "wire_schema_bytes": 8468,
       "tool_reference_bytes": 5646,
       "tool_reference_sha256": "9a53ee96acd89cd57b17a1e2eefd7db0579223584a0a08c489b75fae2dd819e7",
       "overridden_tool_count": 0,
@@ -37224,7 +37224,7 @@
         "check_credentials"
       ],
       "ordered_tool_names_sha256": "cf9fc5e1f9fa1da6e4fab7287829c6367f01894d0fe2e1dad8c4ccc244ce8048",
-      "wire_schema_sha256": "8d674770df02dc173a35c04b26bda66251d51506e3aff4d0002cb5aeeaafe10b"
+      "wire_schema_sha256": "8082725b3570063223db9c483d4e4e092876bfb3e19ea38446fc764ac26d37d3"
     },
     {
       "id": "web_chat:authenticated_member:routed:collaboration",
@@ -37244,7 +37244,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7537,
+      "wire_schema_bytes": 7678,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "068dd1ae345e461198b3955d26166dcd9bf6d94102993b93f7c2c6115a642fef",
       "overridden_tool_count": 0,
@@ -37259,7 +37259,7 @@
         "send_member_dm"
       ],
       "ordered_tool_names_sha256": "91b057a3704a11380e0df622192c815eb5c43e514d3701109890f421f27a6561",
-      "wire_schema_sha256": "7d56e0c735dc09c3b7c8ab8b6c4bc04dc5e489fe7b23070a35896a36fe18ae0b"
+      "wire_schema_sha256": "7bc2452f52378498e733ff13b1a665d9f6ed7fd8336e49fbba7ca91331fba0c6"
     },
     {
       "id": "web_chat:authenticated_member:routed:committee_co_leaders",
@@ -37279,7 +37279,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8867,
+      "wire_schema_bytes": 9008,
       "tool_reference_bytes": 4913,
       "tool_reference_sha256": "6c3e8581decba525396c1e53df2d6afaf7aa6e9b5bf80df401e63e1cda3bc0ea",
       "overridden_tool_count": 0,
@@ -37297,7 +37297,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "063596a30c0f4e99cfdd77779d92a7145e459caff78c9dff3604043a9ae8c59c",
-      "wire_schema_sha256": "ef2df999c1e0e89e3a4d2f29e58c096f2a05db5781b97ab22681cf724593a156"
+      "wire_schema_sha256": "ab974565c5b82fadcde3f73292631edbe36a14535a1c668bb7dc19112b30549d"
     },
     {
       "id": "web_chat:authenticated_member:routed:committee_event_planning",
@@ -37317,7 +37317,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10453,
+      "wire_schema_bytes": 10594,
       "tool_reference_bytes": 4869,
       "tool_reference_sha256": "07ca352ac259a3f7ba7fc6d292b3d7651993267bcef116dd2b83d8e407d50ad0",
       "overridden_tool_count": 0,
@@ -37334,7 +37334,7 @@
         "update_event"
       ],
       "ordered_tool_names_sha256": "61b15f24d4412ef90e46e186ee894b94fd1934ec2c87650d4ffee7284407076a",
-      "wire_schema_sha256": "af63723c8ec93ac60a616fdbf98cf77bb6c6ec6ab539d57585bb1fa943fdb86e"
+      "wire_schema_sha256": "a3b5babe3fae195cd6181062015bebbaa2db05fe94d81f0cc7e3095c79b5a78b"
     },
     {
       "id": "web_chat:authenticated_member:routed:committee_event_registrations",
@@ -37354,7 +37354,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9177,
+      "wire_schema_bytes": 9318,
       "tool_reference_bytes": 4926,
       "tool_reference_sha256": "648cd8b0d8d84b2a2208c82f366b7ac9f4e84dab8bdfc5e72160c898d80f29a2",
       "overridden_tool_count": 0,
@@ -37372,7 +37372,7 @@
         "invite_to_event"
       ],
       "ordered_tool_names_sha256": "369b9218680099ed68bc9d5552efe5f4446c5b4792ab573e9e890c507a44185f",
-      "wire_schema_sha256": "41344247ea67693b5b673df108a1a293f73e872286bcebe60e0390a5465f4480"
+      "wire_schema_sha256": "e3502e6d2b036fcd84070f1ac13a3da42fef4115deecbffa7e7deb40be149a92"
     },
     {
       "id": "web_chat:authenticated_member:routed:committee_full_leadership",
@@ -37392,7 +37392,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 14897,
+      "wire_schema_bytes": 15038,
       "tool_reference_bytes": 5204,
       "tool_reference_sha256": "73a64178cee70c326c45c27854fa4b29f61c9dc4203c20deb8cdbde7d932d29b",
       "overridden_tool_count": 0,
@@ -37415,7 +37415,7 @@
         "list_committee_co_leaders"
       ],
       "ordered_tool_names_sha256": "3ef51ef6c23dc0bb939300d94c013762dcc27966aecdaaa1260aa3786c167cdc",
-      "wire_schema_sha256": "904072f3004a6f52d211601a328088912734622ae51622caaaebcde80b08f731",
+      "wire_schema_sha256": "b30205b328e7ca8969df567373277d78f4729864a0c27005b635a125e754c8dc",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -37478,7 +37478,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7818,
+      "wire_schema_bytes": 7959,
       "tool_reference_bytes": 5246,
       "tool_reference_sha256": "152900bc3d9f41d32d451c4ac8be8c23f69dffadbc08ae9ca8bc2096f1afcbe8",
       "overridden_tool_count": 0,
@@ -37495,7 +37495,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d0d8e5d8794d84fcbc14242245599cfffc6efdaf2f0c95c364b38bb8d6d2d726",
-      "wire_schema_sha256": "6a8c30e0c92df59895e554df7e745d6fef443088a09d3f6cf9956611d1b3270d"
+      "wire_schema_sha256": "794be7c89294c0994e2119f91ac06b4b5e07d3dbb20efc15a4e271923e54751c"
     },
     {
       "id": "web_chat:authenticated_member:routed:community_group_discovery",
@@ -37515,7 +37515,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7861,
+      "wire_schema_bytes": 8002,
       "tool_reference_bytes": 5187,
       "tool_reference_sha256": "d0e9bd5129bd8760c05e98f921ccc95426fe90e70d6aef554bd686fdfcfa5d0e",
       "overridden_tool_count": 0,
@@ -37533,7 +37533,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "3ee5d15eafe1c588bced75166f704e89aab43275266d8b47ba666388fa23ca6d",
-      "wire_schema_sha256": "44415464c14f4750bf57e001721a201670761b6beeb6d3b64e0314e6baa65682"
+      "wire_schema_sha256": "df63d6fd395cf19acf04212a86e6f017d21801bf89a1fd13cdf1488f0e991679"
     },
     {
       "id": "web_chat:authenticated_member:routed:community_group_full_participation",
@@ -37553,7 +37553,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11106,
+      "wire_schema_bytes": 11247,
       "tool_reference_bytes": 5298,
       "tool_reference_sha256": "80fe2d2700902546fe5e83a4dabb0972bd02912c7f3e4a4c30b3d63a7f11c144",
       "overridden_tool_count": 0,
@@ -37578,7 +37578,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "d84555d6b82afdd6959fa75186599e3cb0eb59ba7ef4fc9bdc342620712cf0f9",
-      "wire_schema_sha256": "dec4c8306907826d97cb014172aaabc8a1813780abe21071bda8d0c09f56a48a",
+      "wire_schema_sha256": "23f519cf63cf92e41183131c60e30587cd7809627864cb4f6a6c7e0fc396ea74",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -37599,7 +37599,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8228,
+      "wire_schema_bytes": 8369,
       "tool_reference_bytes": 5220,
       "tool_reference_sha256": "24ab86bf1679054829bd2cd425f87f559118fa501aaaebd060429615a876d5a5",
       "overridden_tool_count": 0,
@@ -37617,7 +37617,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "93da32ba816b1c3678855eacc260dadf902727d23ccb7c524d29e132b1b31551",
-      "wire_schema_sha256": "f6ee5d3de237607b436dab4f7f332f67fb5fafa3b5db5ffa3db30e83fc13d06e"
+      "wire_schema_sha256": "6783b521c6665b4ae2e51a99d16dbc0a09776486e1be4d69f905d8092c700cc9"
     },
     {
       "id": "web_chat:authenticated_member:routed:content",
@@ -37637,7 +37637,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8834,
+      "wire_schema_bytes": 8975,
       "tool_reference_bytes": 5015,
       "tool_reference_sha256": "ff49e5adf006709f1a45aa0a9af51aa9f8a7f85e224c512aea4dad1fc291b2ea",
       "overridden_tool_count": 0,
@@ -37655,7 +37655,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "82ce1e649afc38958ef06db762d13fe999ee4b04095ff5d5044344ac7fce4e7a",
-      "wire_schema_sha256": "950976d1ed4068184b73e7c853f123f95d5b443b039f7872105816915d9c378b"
+      "wire_schema_sha256": "79ec89ff0a645818b29e0203efacbd531835cab5f5191ac3a88571a1d3b20b73"
     },
     {
       "id": "web_chat:authenticated_member:routed:council_interest",
@@ -37675,7 +37675,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7862,
+      "wire_schema_bytes": 8003,
       "tool_reference_bytes": 5182,
       "tool_reference_sha256": "00a0d6dd08ec9626b5f39dd01e60f62a4c0d6b052136b3cb8186188c163e9ce7",
       "overridden_tool_count": 0,
@@ -37693,7 +37693,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b6f0d8f9b4251533f855be149de6d5f265bd92f498ff458283723dcba93d547a",
-      "wire_schema_sha256": "e0224c9085f0e6f6006568a08ecf325ce6b2380cd8211a275cd65f718262085f"
+      "wire_schema_sha256": "7c4b1ed6479478e8230803c538d540f37d87d96a63fcde05e121128c60b3ff07"
     },
     {
       "id": "web_chat:authenticated_member:routed:events",
@@ -37713,7 +37713,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8762,
+      "wire_schema_bytes": 8903,
       "tool_reference_bytes": 5022,
       "tool_reference_sha256": "d0d0a800352042ec9c342399e44ba8df2453093ceb8854bcd9b2210d7d67c138",
       "overridden_tool_count": 0,
@@ -37731,7 +37731,7 @@
         "list_event_attendees"
       ],
       "ordered_tool_names_sha256": "dec8b1e73a67b4044e464a8ada67f64611e9cdbe2683c0e7e5fe8732aad1dd0d",
-      "wire_schema_sha256": "c66df15de10255687d4d0200d52556b0ab8b57c5c69814399ed31a74e4935b05"
+      "wire_schema_sha256": "673bb0e6c25a1321be42f8c7d4cd0ad374bd40430ffef5fdf381a20ec034a800"
     },
     {
       "id": "web_chat:authenticated_member:routed:github",
@@ -37751,7 +37751,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 10407,
+      "wire_schema_bytes": 10548,
       "tool_reference_bytes": 6005,
       "tool_reference_sha256": "153b3f7994700206e694fde53f0dd0a55ff7bd73f6fbe7bbdd3133068c3a57ca",
       "overridden_tool_count": 0,
@@ -37769,7 +37769,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "4e7cde1aedf4ffdc3722e9b8d80a15e06e7a92767847470acbf77aaa7294c402",
-      "wire_schema_sha256": "c2e6b031ee991457569e82e13ffc2893cd2309f0eb8eed7483ee0573acc504ef"
+      "wire_schema_sha256": "665355ed88edfbec2ddf83c2070aa07e59e686d9fe64950611c7a0f80a415044"
     },
     {
       "id": "web_chat:authenticated_member:routed:illustrations",
@@ -37789,7 +37789,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7216,
+      "wire_schema_bytes": 7357,
       "tool_reference_bytes": 5618,
       "tool_reference_sha256": "623ebf79339bd5110e3c5fc552029d1dd963ec75656ee5c33d0a70ae0bb424c8",
       "overridden_tool_count": 0,
@@ -37804,7 +37804,7 @@
         "search_image_library"
       ],
       "ordered_tool_names_sha256": "2262e46c9d68205fbc414bd4692d1f8c6fc2016e9e23c26a41d5f07990ca23f3",
-      "wire_schema_sha256": "01bf7d3937ebe469a34902a012f306e28554f298c7ca92ceb552a45f0a47be10"
+      "wire_schema_sha256": "c7be7227a3ed18b712471906aa926f2812b523208d79c5506c5d5e10624e8040"
     },
     {
       "id": "web_chat:authenticated_member:routed:industry_research",
@@ -37866,7 +37866,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9563,
+      "wire_schema_bytes": 9704,
       "tool_reference_bytes": 6204,
       "tool_reference_sha256": "f58387aa8f92a9c6e726f71976fadb0c55e82720e233832930697d711efd5d52",
       "overridden_tool_count": 0,
@@ -37883,7 +37883,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "1de4bdbd34850fb1688fde04a30734d990dd6b9cebcbd23b31c9e0dd04165280",
-      "wire_schema_sha256": "5438b4aa64ac11bb20f3f810fa76e1a542f6b54087b2329203de2a124311c11a"
+      "wire_schema_sha256": "ec8ac68fd4d8b0eb30babafab56ea4414f429e10dd4e22c738884a51a8c2b42d"
     },
     {
       "id": "web_chat:authenticated_member:routed:meeting_attendance",
@@ -37903,7 +37903,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8945,
+      "wire_schema_bytes": 9086,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "df3af926f99c7f9d48206b0c20048f46be655ec3881722c8be2be2db81a63acf",
       "overridden_tool_count": 0,
@@ -37922,7 +37922,7 @@
         "add_meeting_attendee"
       ],
       "ordered_tool_names_sha256": "9a66a9d3f906bd65c3235d8f9fd264d2dfc900ffc5860af19c7b5d32f99a4d8f",
-      "wire_schema_sha256": "b7ec2bfb8d39f7899e36e8d654f46802b48bd67a8bb966de97ea5b84860cb125"
+      "wire_schema_sha256": "5d0cc9b52e8442f9bbd21e684ec4837f286f6054c93f320e53db8817bfaea287"
     },
     {
       "id": "web_chat:authenticated_member:routed:meeting_full_administration",
@@ -37942,7 +37942,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 16400,
+      "wire_schema_bytes": 16541,
       "tool_reference_bytes": 5127,
       "tool_reference_sha256": "000143f1682565038450ae5a74b8276cca8d354dbec76741dd85d46052760238",
       "overridden_tool_count": 0,
@@ -37967,7 +37967,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "8bcb247100605d8c2354b2fa7a9f1a2b5c349fa2aab59266996b5bcdf634fa51",
-      "wire_schema_sha256": "e9986416e30b85a45f5732568173f1a5f8b8653e4e43e9de3dbe18457134ed86",
+      "wire_schema_sha256": "25082d4bb25baffcc0880a8c99ad02c5a85d4a2b4beb22e930b1f733773fd2e1",
       "target_exception_category": "explicit_multi_step_workflow"
     },
     {
@@ -37988,7 +37988,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12258,
+      "wire_schema_bytes": 12399,
       "tool_reference_bytes": 4978,
       "tool_reference_sha256": "a59255184701822e566e5691e81b78ac059fd7a5e3b90284837c2f70fed0ef1a",
       "overridden_tool_count": 0,
@@ -38006,7 +38006,7 @@
         "update_meeting"
       ],
       "ordered_tool_names_sha256": "7d975630d220603ee3b6cbf059fe22fd9783702a41ab1ed034a1728a95a3e658",
-      "wire_schema_sha256": "e99f89fb6b6000ac1fd12877cede72f3105201964c9add14836d790d9bbe128a"
+      "wire_schema_sha256": "2253c5750ed560bd5432ce9193d0311b535a4afd0204a095068dd2df77633d11"
     },
     {
       "id": "web_chat:authenticated_member:routed:meeting_series_topics",
@@ -38026,7 +38026,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9179,
+      "wire_schema_bytes": 9320,
       "tool_reference_bytes": 5051,
       "tool_reference_sha256": "41cdd27ed230ed4b8267bb4e12a4374fcbc4760641fb45cbf0b23106dfb028cf",
       "overridden_tool_count": 0,
@@ -38044,7 +38044,7 @@
         "manage_committee_topics"
       ],
       "ordered_tool_names_sha256": "7e127221944ab98d82c8ea4c6a144d7f65081bd75d2d35700b5e4fc5219e01a6",
-      "wire_schema_sha256": "f0637992f399d4aa9f2e7a7897c476aed290bbe9d3251ec4763f586e679ee40c"
+      "wire_schema_sha256": "90d6c562f04be6f98a5915bc3f594575806d39321edb5e5d4f17e80f0eb33e99"
     },
     {
       "id": "web_chat:authenticated_member:routed:member_billing",
@@ -38064,7 +38064,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9764,
+      "wire_schema_bytes": 9905,
       "tool_reference_bytes": 5601,
       "tool_reference_sha256": "a341d5c2e105981cd5b9a59335595d0857f26c560edf48b0224c584bb832e0ff",
       "overridden_tool_count": 0,
@@ -38083,7 +38083,7 @@
         "get_billing_portal"
       ],
       "ordered_tool_names_sha256": "15e84b2f191840bb9c885e2df04792fd83e26834050e140b5c5e87105176b63d",
-      "wire_schema_sha256": "f1126f7d5759760bf2df63533e9b5e3a3708f121a0d40b5ea1ad0f1e92b4fa75"
+      "wire_schema_sha256": "f2feb8d3674acb79918ef49bf14d6f4eef11d20b4080768c20700bd3086b958b"
     },
     {
       "id": "web_chat:authenticated_member:routed:member_company_profile",
@@ -38103,7 +38103,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 12646,
+      "wire_schema_bytes": 12787,
       "tool_reference_bytes": 7111,
       "tool_reference_sha256": "35dd65133e09a8f9a9983ac8d38e362612aed792bb65ea66fc08923a1f6a82f6",
       "overridden_tool_count": 0,
@@ -38122,7 +38122,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "8f6f85c0206f418794cc44768ecd12209f1b28f37c41bb463800ef829d542c54",
-      "wire_schema_sha256": "ab5c358b264bc08aa27993a3242b5764c599d379a3bea224900bce88ea1df0fd"
+      "wire_schema_sha256": "054ab5c37e70843aba7803a8ae60dc51c77c80d99a68a9282369c441e163b23e"
     },
     {
       "id": "web_chat:authenticated_member:routed:member_personal_profile",
@@ -38142,7 +38142,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7415,
+      "wire_schema_bytes": 7556,
       "tool_reference_bytes": 6535,
       "tool_reference_sha256": "0b3ad904d581c85060bf4fcf486b2feaf130f5eb13e53a66c273d0b1628e8ed6",
       "overridden_tool_count": 0,
@@ -38158,7 +38158,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "b38dbd9cdb706e4bec9988f5f79ddf06c3add5fbbb3d642d020aa47580a1c188",
-      "wire_schema_sha256": "f291ad37c42ffeeeea7c29772478a34da6482727b580d3e9d5ec17f9c61298d9"
+      "wire_schema_sha256": "26e9ba660534e07fb4c0505b280c3fe5fda36bf20c7cdab9cc1284a565178f2a"
     },
     {
       "id": "web_chat:authenticated_member:routed:partner_directory",
@@ -38178,7 +38178,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9846,
+      "wire_schema_bytes": 9987,
       "tool_reference_bytes": 5111,
       "tool_reference_sha256": "a2c31cc736db63698935549fc4cc50145d0d5620aadd13ec001b5a57a6e21a81",
       "overridden_tool_count": 3,
@@ -38197,7 +38197,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "89eed7ed3cb4d339c04d5c7a0480fd9d9956784a861e0f0eeee840e850dbbe18",
-      "wire_schema_sha256": "9e6ac5ddc8a6ea64ec988fc5dac286b1a35bba4a1e2dbad921dae5572bcc9f9f"
+      "wire_schema_sha256": "434710dc85708cfa0cde9fec418d50150bc51662900e309f14766234a83d6ce8"
     },
     {
       "id": "web_chat:authenticated_member:routed:property_identifier_catalog",
@@ -38217,7 +38217,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 9122,
+      "wire_schema_bytes": 9263,
       "tool_reference_bytes": 5216,
       "tool_reference_sha256": "f601e979751136d9791f545ecd22c07a13bfe0992d57c8132a4a12236b0acaf2",
       "overridden_tool_count": 0,
@@ -38234,7 +38234,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a1e489a9c121c4a79aa94f22be12e79b516b82f86f3dcc3b055b2708a5f975df",
-      "wire_schema_sha256": "11109b516e406546703f7de84828974564205a149e00574073482a82e21ecf5d"
+      "wire_schema_sha256": "cc5515e41fc13aff90c429f4cb49f4140919ff18b5a66a25a7d14dc43e108b71"
     },
     {
       "id": "web_chat:authenticated_member:routed:property_list_enrichment",
@@ -38254,7 +38254,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7229,
+      "wire_schema_bytes": 7370,
       "tool_reference_bytes": 5065,
       "tool_reference_sha256": "0d5b48fe7e301b593e2c037bbe63663f9b8b8657b79ab8fd08c7fa24307c2a17",
       "overridden_tool_count": 0,
@@ -38270,7 +38270,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "c4b1f925a53576a9be25da0eb9eeafd918817380bb2c79fa5a0e8cf22fc959f1",
-      "wire_schema_sha256": "2c7dbc06fffafd37fbc82b70dd45fc9c5996125b7a8d927f585aeee197b609f6"
+      "wire_schema_sha256": "ac6e9a1d053db8467bacfecdd0ceb81d1b70fe683638ca49875c8aec2473e104"
     },
     {
       "id": "web_chat:authenticated_member:routed:property_registry_records",
@@ -38290,7 +38290,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8492,
+      "wire_schema_bytes": 8633,
       "tool_reference_bytes": 5294,
       "tool_reference_sha256": "9db46b41e9dcb5583694e069f64c5cfd02727e6134feebe06666e3ea8505f6e8",
       "overridden_tool_count": 0,
@@ -38308,7 +38308,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "ecc844b1129e49efdaccbd1d49228adff1f77fe0d9fe1f99548691e8c8f9d342",
-      "wire_schema_sha256": "bed04f7c233bf3c08a94767fcf8324947c34dd1c30395e8a51f0b2909773d905"
+      "wire_schema_sha256": "8985a68841831badd61ec5d7c1b75f77485495514c2a068501ae0171015d3f0f"
     },
     {
       "id": "web_chat:authenticated_member:routed:publishing_assets",
@@ -38412,7 +38412,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7935,
+      "wire_schema_bytes": 8076,
       "tool_reference_bytes": 5089,
       "tool_reference_sha256": "293cccb606c14259488ae08b58dd5864c1cd5cdb261ebdde177cdf71c030930d",
       "overridden_tool_count": 0,
@@ -38430,7 +38430,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "6367bb5059c34b3346ad8ffe1e3b768852a2e7389e6c2c0f4e1d97d2b006b666",
-      "wire_schema_sha256": "2f060dff5af7d527393686dc2d1e06986583280a86a15e95d4cf831c8f4384cd"
+      "wire_schema_sha256": "361f6c77be8270ad9e01ff835a9d8fed47baf1891b879ce3e6e99bb6d838b352"
     },
     {
       "id": "web_chat:authenticated_member:routed:publishing_submission",
@@ -38492,7 +38492,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8711,
+      "wire_schema_bytes": 8852,
       "tool_reference_bytes": 5286,
       "tool_reference_sha256": "4dbc259349decbfacdc25ec24170e6cf312c78421e8a4e1aa7d77f62c8abd9e7",
       "overridden_tool_count": 0,
@@ -38510,7 +38510,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "cd5dc42703c26c13651fdb28de1c74a46a143b059ac568c761bbd3b987dea76b",
-      "wire_schema_sha256": "8b72f1ae05db4aeef98159092ffd8e443b623eb4e19b30bf0be9443cc739bd90"
+      "wire_schema_sha256": "b680060649c8e0fc0921e98428b53f5b567d84f31c4ecd952047679811816401"
     },
     {
       "id": "web_chat:authenticated_member:routed:sponsored_intelligence_discovery",
@@ -38530,7 +38530,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7899,
+      "wire_schema_bytes": 8040,
       "tool_reference_bytes": 5241,
       "tool_reference_sha256": "3c43d712cf42391096e4c83cfb5ce4cf7388385519d5ec966d1edc73e53a964c",
       "overridden_tool_count": 0,
@@ -38547,7 +38547,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "10dc3537f2c3b17d9f0364e80871604779981fcba52329e34b442ceee2c396b6",
-      "wire_schema_sha256": "00e9bf28f9d1e0b60747706f7a756166f8222ce66f08ab5d826b5f7437674f4b"
+      "wire_schema_sha256": "922c919dc877b18418917c7fe2a9515f8fc6661841065875779824cd1d810a80"
     },
     {
       "id": "web_chat:authenticated_member:routed:sponsored_intelligence_session",
@@ -38567,7 +38567,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 7418,
+      "wire_schema_bytes": 7559,
       "tool_reference_bytes": 5058,
       "tool_reference_sha256": "b0c20685f8468efe08eda7704772d86eb52c6f23de9d4af2425b8f97ffecc870",
       "overridden_tool_count": 0,
@@ -38584,7 +38584,7 @@
         "capture_learning"
       ],
       "ordered_tool_names_sha256": "a57a8f996c5c03f33848a5dc74ef82c65a5d990f8ee2c9dbf85a08b8f90628b3",
-      "wire_schema_sha256": "b346004519c43ef64023ce979be1c59481536490c537b430d5c06f08e9e24b11"
+      "wire_schema_sha256": "612102c9dec28da25aa58d000a5890ccf2134cccb68a5b5f423140a609287e05"
     },
     {
       "id": "web_chat:authenticated_member:safe_fallback",
@@ -38661,13 +38661,13 @@
       "prompt_catalog_tools_missing_runtime": -2,
       "always_available_tools": -13,
       "tool_reference_bytes": -4358,
-      "system_prompt_bytes": 478,
+      "system_prompt_bytes": 541,
       "maximum_slack_member_tools": -115,
       "maximum_slack_admin_tools": -182,
       "maximum_slack_public_tools": -8,
-      "maximum_slack_member_schema_bytes": -92237,
-      "maximum_slack_admin_schema_bytes": -131901,
-      "maximum_slack_public_schema_bytes": -2128,
+      "maximum_slack_member_schema_bytes": -92096,
+      "maximum_slack_admin_schema_bytes": -131760,
+      "maximum_slack_public_schema_bytes": -1987,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -203
     }
@@ -38852,11 +38852,11 @@
       }
     },
     "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-    "profile_contract_sha256": "43de051e55ebad332933397cf5fa46684a723819a545b0a31c38168b7b3f3fe3",
+    "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-    "profile_contract_sha256": "43de051e55ebad332933397cf5fa46684a723819a545b0a31c38168b7b3f3fe3"
+    "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db"
   }
 }

--- a/server/src/addie/mcp/adcp-tools.ts
+++ b/server/src/addie/mcp/adcp-tools.ts
@@ -30,6 +30,7 @@ import { TRAINING_AGENT_HOSTNAMES } from '../../training-agent/config.js';
 import {
   PROPOSAL_NEGOTIATION_PROFILES,
   TRAINING_AGENT_CURRENT_ADCP_VERSION,
+  type TrainingContext,
   type ProposalNegotiationProfile,
 } from '../../training-agent/types.js';
 import { agentConfigAuthFields, type SdkAuth } from '../../services/sdk-auth-adapter.js';
@@ -326,11 +327,29 @@ export const ADCP_TASK_REGISTRY: Record<string, AdcpTaskMeta> = {
   validate_content_delivery: { area: 'governance', description: 'Validate delivered content against content standards' },
 
   // Sponsored Intelligence (SI)
-  si_initiate_session: { area: 'si', description: 'Start a conversational session with a brand agent' },
+  si_initiate_session: {
+    area: 'si',
+    description: 'Start a conversational session with a brand agent',
+    validate: (params) => {
+      const idempotencyError = validateIdempotencyKey(params);
+      if (idempotencyError) return idempotencyError;
+      if (typeof params.intent !== 'string' || !params.intent.trim()) return 'intent is required.';
+      if (
+        typeof params.identity !== 'object'
+        || params.identity === null
+        || typeof (params.identity as Record<string, unknown>).consent_granted !== 'boolean'
+      ) {
+        return 'identity.consent_granted must be a boolean.';
+      }
+      return null;
+    },
+  },
   si_send_message: {
     area: 'si',
     description: 'Send a message within an active SI session',
     validate: (params) => {
+      const idempotencyError = validateIdempotencyKey(params);
+      if (idempotencyError) return idempotencyError;
       if (!params.message && !params.action_response) return 'Either message or action_response must be provided.';
       return null;
     },
@@ -934,6 +953,24 @@ export function createAdcpToolHandlers(
     return candidate as ProposalNegotiationProfile;
   }
 
+  function trainingTenantFromUrl(url: URL): TrainingContext['tenantId'] {
+    const tenantIds = new Set<NonNullable<TrainingContext['tenantId']>>([
+      'sales',
+      'signals',
+      'governance',
+      'creative',
+      'creative-builder',
+      'brand',
+      'si',
+    ]);
+    return url.pathname
+      .split('/')
+      .filter(Boolean)
+      .find((segment): segment is NonNullable<TrainingContext['tenantId']> => (
+        tenantIds.has(segment as NonNullable<TrainingContext['tenantId']>)
+      ));
+  }
+
   // Helper to validate agent URL
   function validateAgentUrl(agentUrl: string): string | null {
     try {
@@ -999,6 +1036,7 @@ export function createAdcpToolHandlers(
       if (isTrainingAgentUrl(parsedUrl)) {
         const { executeTrainingAgentTool } = await import('../../training-agent/task-handlers.js');
         const proposalNegotiationProfile = proposalNegotiationProfileFromUrl(parsedUrl);
+        const tenantId = trainingTenantFromUrl(parsedUrl);
         const userId = memberContext?.workos_user?.workos_user_id;
         const memberModuleId = memberContext?.certification?.status === 'in_progress'
           ? memberContext.certification.module_id ?? undefined
@@ -1008,6 +1046,7 @@ export function createAdcpToolHandlers(
           userId,
           ...(access.trainingPrincipal && { principal: access.trainingPrincipal }),
           moduleId: trainingModuleContext?.moduleId ?? memberModuleId,
+          ...(tenantId && { tenantId }),
           ...(proposalNegotiationProfile && { proposalNegotiationProfile }),
         };
         const trainingRequestParams = task === 'get_adcp_capabilities'
@@ -1028,6 +1067,15 @@ export function createAdcpToolHandlers(
             `**Recovery:** if the error mentions a field shape (oneOf / required / additionalProperties), ` +
             `read \`adcp_error.issues[].variants[]\` if present and patch the pointers. Reuse the same ` +
             `\`idempotency_key\` on retry — fresh UUIDs cause duplicates.`,
+          ].join('\n');
+        }
+        const protocolErrors = (result.data as { errors?: Array<{ code?: string; message?: string }> } | undefined)?.errors;
+        if (task.startsWith('si_') && Array.isArray(protocolErrors) && protocolErrors.length > 0) {
+          const firstError = protocolErrors[0];
+          return [
+            `**Task failed:** \`${task}\`\n`,
+            `**Error:** ${firstError?.code ?? 'SI_TASK_ERROR'}${firstError?.message ? ` — ${firstError.message}` : ''}\n`,
+            '**Recovery:** correct the request and retry. Reuse the same `idempotency_key` only when retrying the same logical request.',
           ].join('\n');
         }
         let output = `**Task:** \`${task}\`\n**Status:** Success (sandbox)\n\n`;

--- a/server/src/addie/mcp/escalation-tools.ts
+++ b/server/src/addie/mcp/escalation-tools.ts
@@ -44,6 +44,7 @@ DO NOT USE FOR:
 - Questions you can answer with your tools or your rule files (knowledge.md, behaviors.md)
 - Community-fit questions ("would my background be a fit for the working groups?") — answer directly using the working-group mapping in knowledge.md and behaviors.md
 - Routine membership pricing, including upgrade proration for any tier on credit card or invoice — the FAQ in knowledge.md covers this; only escalate refunds, out-of-cycle credits, custom contracts, and currency changes
+- A separate self-paid membership — send signed-in users to /onboarding?mode=personal; it bills their personal workspace, not the company
 - Multi-part questions where each part is independently answerable — decompose first, answer the parts, do NOT escalate the bundle (see "Decompose bundled questions" in constraints.md)
 - "Complex" and "sensitive" are NOT magic words. Bundled or multi-domain questions are not automatically Complex; check whether each part is genuinely outside your knowledge or capability before escalating
 - Things that don't require admin attention

--- a/server/src/addie/rules/behaviors.md
+++ b/server/src/addie/rules/behaviors.md
@@ -85,13 +85,15 @@ Rules:
 ## Individual Practitioner Suitability
 When someone asks whether membership or certification is right for them — especially individual practitioners like programmatic traders, media planners, buyers, or agency strategists — be direct and encouraging:
 
-1. **Certification is designed for practitioners, not just engineers.** The Basics track is free and requires zero coding. The Practitioner track uses vibe coding — you describe what you want in plain language, an AI writes the code. Marketing executives with no programming experience complete it successfully.
+1. **Certification supports non-engineers.** Basics is free and requires no coding. In Practitioner, learners describe what they want and AI writes code.
 
-2. **Individual membership exists for exactly this purpose.** You do not need to represent a company. Individual members get certification access, working group participation, and community connections.
+2. **Individual membership does not require representing a company.** It includes certification, working groups, and community connections.
 
 3. **Programmatic experience is an advantage.** People who understand how ad tech works today (RTB, DSPs, trading desks) are the ones best positioned to shape how it works tomorrow. Their operational knowledge is valuable in working groups where protocol decisions are made.
 
 4. **Start free, then decide.** Suggest they take the free Basics track first — three modules, about 50 minutes. They can also join the Slack community. If it resonates, individual membership unlocks the Practitioner track.
+
+5. **Personal and company memberships can coexist.** For a separate self-paid membership, do not escalate or use company billing tools. Send signed-in users to `https://agenticadvertising.org/onboarding?mode=personal`; it creates or selects their personal workspace and bills only it.
 
 Do NOT frame this as "primarily for businesses and engineers." The community needs diverse perspectives — traders, planners, and buyers bring real-world workflow knowledge that makes the protocol better for everyone.
 

--- a/server/src/training-agent/si-handlers.ts
+++ b/server/src/training-agent/si-handlers.ts
@@ -22,6 +22,121 @@
 import { randomUUID } from 'node:crypto';
 import type { ToolArgs, TrainingContext } from './types.js';
 
+// These definitions keep the legacy monolith and Addie's in-process training
+// shortcut aligned with the SDK-backed /si tenant. The tenant owns canonical
+// schema validation on the public HTTP path; the monolith still needs to
+// advertise the same tool names so certification demos can reach the shared
+// handlers without an HTTP round-trip.
+export const SI_TOOLS = [
+  {
+    name: 'si_get_offering',
+    description: 'Get offering details and availability before starting a Sponsored Intelligence session.',
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    execution: { taskSupport: 'forbidden' as const },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        offering_id: { type: 'string', description: 'Offering identifier from the catalog' },
+        intent: { type: 'string', description: 'Optional anonymous user intent for personalized results' },
+        include_products: { type: 'boolean' },
+        product_limit: { type: 'integer', minimum: 1, maximum: 50 },
+        context: { type: 'object' },
+        ext: { type: 'object' },
+      },
+      required: ['offering_id'] as const,
+    },
+  },
+  {
+    name: 'si_initiate_session',
+    description: 'Start a Sponsored Intelligence conversation with a brand agent.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    execution: { taskSupport: 'forbidden' as const },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        idempotency_key: {
+          type: 'string',
+          minLength: 16,
+          maxLength: 255,
+          pattern: '^[A-Za-z0-9_.:-]{16,255}$',
+        },
+        intent: { type: 'string' },
+        identity: {
+          type: 'object',
+          properties: {
+            consent_granted: { type: 'boolean' },
+            consent_timestamp: { type: 'string', format: 'date-time' },
+            consent_scope: { type: 'array', items: { type: 'string' } },
+            privacy_policy_acknowledged: { type: 'object' },
+            user: { type: 'object' },
+            anonymous_session_id: { type: 'string' },
+          },
+          required: ['consent_granted'],
+        },
+        media_buy_id: { type: 'string' },
+        placement: { type: 'string' },
+        offering_id: { type: 'string' },
+        offering_token: { type: 'string' },
+        supported_capabilities: { type: 'object' },
+        sponsored_context_receipt: { type: 'object' },
+        context: { type: 'object' },
+        ext: { type: 'object' },
+      },
+      required: ['idempotency_key', 'intent', 'identity'] as const,
+    },
+  },
+  {
+    name: 'si_send_message',
+    description: 'Send a user message or action response within an active Sponsored Intelligence session.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    execution: { taskSupport: 'forbidden' as const },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        idempotency_key: {
+          type: 'string',
+          minLength: 16,
+          maxLength: 255,
+          pattern: '^[A-Za-z0-9_.:-]{16,255}$',
+        },
+        session_id: { type: 'string' },
+        message: { type: 'string' },
+        action_response: { type: 'object' },
+        sponsored_context_receipt: { type: 'object' },
+        context: { type: 'object' },
+        ext: { type: 'object' },
+      },
+      required: ['idempotency_key', 'session_id'] as const,
+    },
+  },
+  {
+    name: 'si_terminate_session',
+    description: 'Terminate a Sponsored Intelligence session.',
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+    execution: { taskSupport: 'forbidden' as const },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        session_id: { type: 'string' },
+        reason: {
+          type: 'string',
+          enum: [
+            'handoff_transaction',
+            'handoff_complete',
+            'user_exit',
+            'session_timeout',
+            'host_terminated',
+          ],
+        },
+        termination_context: { type: 'object' },
+        context: { type: 'object' },
+        ext: { type: 'object' },
+      },
+      required: ['session_id', 'reason'] as const,
+    },
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -316,7 +431,7 @@ export async function handleSiInitiateSession(args: ToolArgs, ctx: TrainingConte
     offering_id: resolvedOfferingId,
     turns: 0,
     status: 'active',
-    principal: ctx.principal ?? 'anonymous',
+    principal: ctx.principal ?? ctx.userId ?? 'anonymous',
     last_activity_at: Date.now(),
   });
 
@@ -403,7 +518,7 @@ const TURN_RESPONSES: Array<{ message: string; ui_elements: unknown[] }> = [
   },
 ];
 
-export async function handleSiSendMessage(args: ToolArgs, _ctx: TrainingContext): Promise<unknown> {
+export async function handleSiSendMessage(args: ToolArgs, ctx: TrainingContext): Promise<unknown> {
   const a = args as ToolArgs & Record<string, unknown>;
   const sessionId = a.session_id as string | undefined;
   const message = a.message as string | undefined;
@@ -456,8 +571,9 @@ export async function handleSiSendMessage(args: ToolArgs, _ctx: TrainingContext)
   }
 
   const session = sessions.get(sessionId);
-  if (!session) {
-    return { errors: [{ code: 'NOT_FOUND', message: `Session "${sessionId}" not found. Use si_initiate_session to start a session.`, field: 'session_id', recovery: 'correctable' }] };
+  const principal = ctx.principal ?? ctx.userId ?? 'anonymous';
+  if (!session || session.principal !== principal) {
+    return { errors: [{ code: 'SESSION_NOT_FOUND', message: `Session "${sessionId}" not found. Use si_initiate_session to start a session.`, field: 'session_id', recovery: 'correctable' }] };
   }
   if (session.status === 'terminated') {
     // Canonical si-send-message-response.json requires session_id + session_status
@@ -508,7 +624,7 @@ export async function handleSiSendMessage(args: ToolArgs, _ctx: TrainingContext)
 // si_terminate_session
 // ---------------------------------------------------------------------------
 
-export async function handleSiTerminateSession(args: ToolArgs, _ctx: TrainingContext): Promise<unknown> {
+export async function handleSiTerminateSession(args: ToolArgs, ctx: TrainingContext): Promise<unknown> {
   const a = args as ToolArgs & Record<string, unknown>;
   const sessionId = a.session_id as string | undefined;
   const reason = a.reason as string | undefined;
@@ -521,6 +637,17 @@ export async function handleSiTerminateSession(args: ToolArgs, _ctx: TrainingCon
   }
 
   const session = sessions.get(sessionId);
+  const principal = ctx.principal ?? ctx.userId ?? 'anonymous';
+  if (session && session.principal !== principal) {
+    return {
+      errors: [{
+        code: 'SESSION_NOT_FOUND',
+        message: `Session "${sessionId}" not found. Use si_initiate_session to start a session.`,
+        field: 'session_id',
+        recovery: 'correctable',
+      }],
+    };
+  }
   if (!session) {
     // Termination is idempotent — a not-found session_id is treated as already terminated.
     return {

--- a/server/src/training-agent/si-handlers.ts
+++ b/server/src/training-agent/si-handlers.ts
@@ -638,18 +638,10 @@ export async function handleSiTerminateSession(args: ToolArgs, ctx: TrainingCont
 
   const session = sessions.get(sessionId);
   const principal = ctx.principal ?? ctx.userId ?? 'anonymous';
-  if (session && session.principal !== principal) {
-    return {
-      errors: [{
-        code: 'SESSION_NOT_FOUND',
-        message: `Session "${sessionId}" not found. Use si_initiate_session to start a session.`,
-        field: 'session_id',
-        recovery: 'correctable',
-      }],
-    };
-  }
-  if (!session) {
-    // Termination is idempotent — a not-found session_id is treated as already terminated.
+  if (!session || session.principal !== principal) {
+    // Termination is idempotent. Return the same result for absent and
+    // cross-principal IDs so callers cannot use this endpoint as a session
+    // existence oracle; a foreign principal still cannot mutate the session.
     return {
       session_id: sessionId,
       terminated: true,

--- a/server/src/training-agent/task-handlers.ts
+++ b/server/src/training-agent/task-handlers.ts
@@ -115,6 +115,7 @@ import {
   proposalCapabilitiesForProfile,
   type TrainingProposalPolicyContext,
 } from './proposal-negotiation-profiles.js';
+import { toolsForTenant } from './tenants/tool-catalog.js';
 
 /** Escape HTML special characters to prevent injection in generated HTML responses. */
 function escapeHtmlAttr(s: string): string {
@@ -3007,6 +3008,13 @@ import {
   handleSyncAudiences,
   findAudienceInSession,
 } from './audience-handlers.js';
+import {
+  SI_TOOLS,
+  handleSiGetOffering,
+  handleSiInitiateSession,
+  handleSiSendMessage,
+  handleSiTerminateSession,
+} from './si-handlers.js';
 import {
   COMPLY_TEST_CONTROLLER_TOOL,
   handleComplyTestController,
@@ -9242,6 +9250,7 @@ const TOOLS = [
   ...COLLECTION_LIST_TOOLS,
   ...CONTENT_STANDARDS_TOOLS,
   ...BRAND_TOOLS,
+  ...SI_TOOLS,
   COMPLY_TEST_CONTROLLER_TOOL,
   {
     name: 'report_usage',
@@ -9329,6 +9338,13 @@ function visibleToolsForContext(ctx: TrainingContext): typeof TOOLS {
 
 export function visibleTrainingToolNamesForContext(ctx: TrainingContext): string[] {
   return visibleToolsForContext(ctx).map(tool => tool.name);
+}
+
+function trainingToolAvailableForContext(toolName: string, ctx: TrainingContext): boolean {
+  if (!visibleTrainingToolNamesForContext(ctx).includes(toolName)) return false;
+  if (!ctx.tenantId) return true;
+  if (toolName === 'get_adcp_capabilities' || toolName === 'comply_test_controller') return true;
+  return toolsForTenant(ctx.tenantId, { storyboardCompat: ctx.storyboardCompat }).includes(toolName);
 }
 
 function toolAvailableForServedAdcpVersion(toolName: string, servedAdcpVersion: string): boolean {
@@ -21423,6 +21439,10 @@ const HANDLER_MAP: Record<string, ToolHandler> = {
   get_rights: handleGetRights,
   acquire_rights: handleAcquireRights,
   update_rights: handleUpdateRights,
+  si_get_offering: handleSiGetOffering,
+  si_initiate_session: handleSiInitiateSession,
+  si_send_message: handleSiSendMessage,
+  si_terminate_session: handleSiTerminateSession,
   creative_approval: handleCreativeApproval,
   create_property_list: handleCreatePropertyList,
   list_property_lists: handleListPropertyLists,
@@ -21646,7 +21666,7 @@ async function executeTrainingAgentToolInContext(
     return { success: false, error: versionResolution.message };
   }
   if (
-    !visibleTrainingToolNamesForContext(ctx).includes(toolName)
+    !trainingToolAvailableForContext(toolName, ctx)
     || !toolAvailableForServedAdcpVersion(toolName, versionResolution.servedVersion)
   ) {
     return { success: false, error: `Unknown tool: ${toolName}` };

--- a/server/tests/unit/addie/adcp-tools.test.ts
+++ b/server/tests/unit/addie/adcp-tools.test.ts
@@ -439,6 +439,52 @@ describe('call_adcp_task training module isolation', () => {
     );
   });
 
+  it('preserves the tenant selected by the training-agent URL', async () => {
+    executeTrainingAgentTool.mockReset();
+    executeTrainingAgentTool.mockResolvedValue({ success: true, data: { session_id: 'si_test' } });
+    const callAdcpTask = createAdcpToolHandlers(null).get('call_adcp_task');
+
+    await callAdcpTask?.({
+      agent_url: 'https://test-agent.adcontextprotocol.org/si/mcp',
+      task: 'si_initiate_session',
+      params: {
+        idempotency_key: 'si-tenant-routing-test-key',
+        intent: 'Compare electric vehicles',
+        identity: { consent_granted: false },
+      },
+    });
+
+    expect(executeTrainingAgentTool).toHaveBeenCalledWith(
+      'si_initiate_session',
+      expect.any(Object),
+      expect.objectContaining({ tenantId: 'si' }),
+    );
+  });
+
+  it('does not label an SI protocol error as a successful sandbox demo', async () => {
+    executeTrainingAgentTool.mockReset();
+    executeTrainingAgentTool.mockResolvedValue({
+      success: true,
+      data: { errors: [{ code: 'INVALID_OFFERING_TOKEN', message: 'Call si_get_offering first.' }] },
+    });
+    const callAdcpTask = createAdcpToolHandlers(null).get('call_adcp_task');
+
+    const output = await callAdcpTask?.({
+      agent_url: 'https://test-agent.adcontextprotocol.org/si/mcp',
+      task: 'si_initiate_session',
+      params: {
+        idempotency_key: 'si-error-rendering-test-key',
+        intent: 'Compare electric vehicles',
+        identity: { consent_granted: false },
+        offering_token: 'invalid-token',
+      },
+    });
+
+    expect(output).toContain('Task failed');
+    expect(output).toContain('INVALID_OFFERING_TOKEN');
+    expect(output).not.toContain('Success (sandbox)');
+  });
+
   it('uses the current prerelease when Addie discovers an unpinned proposal profile', async () => {
     executeTrainingAgentTool.mockReset();
     executeTrainingAgentTool.mockResolvedValue({ success: true, data: { media_buy: {} } });

--- a/server/tests/unit/explicit-org-client-compat.test.ts
+++ b/server/tests/unit/explicit-org-client-compat.test.ts
@@ -37,4 +37,28 @@ describe('explicit organization client compatibility', () => {
       'organization_id: createdOrgId || undefined',
     );
   });
+
+  it('keeps a newly created personal workspace as the checkout organization', () => {
+    expect(onboardingSource).toContain(
+      "localStorage.setItem('selectedOrgId', personalOrgId)",
+    );
+    expect(onboardingSource).toContain(
+      "? destination + '?org=' + encodeURIComponent(personalOrgId)",
+    );
+    expect(onboardingSource).toContain(
+      "? '/dashboard/membership'",
+    );
+  });
+
+  it('opens an existing personal workspace directly in its membership context', () => {
+    expect(onboardingSource).toContain(
+      "data.organizations.find(org => org.is_personal)",
+    );
+    expect(onboardingSource).toContain(
+      "localStorage.setItem('selectedOrgId', personalWorkspace.id)",
+    );
+    expect(onboardingSource).toContain(
+      "'/dashboard/membership?org=' + encodeURIComponent(personalWorkspace.id)",
+    );
+  });
 });

--- a/server/tests/unit/rules-loader.test.ts
+++ b/server/tests/unit/rules-loader.test.ts
@@ -239,6 +239,9 @@ describe('Rules Loader', () => {
     expect(roadmapRules).toContain('# Current AdCP Context');
     expect(roadmapRules).toContain('# Expert Panel');
     expect(billingRules).toContain('## Individual Practitioner Suitability');
+    expect(billingRules).toContain('onboarding?mode=personal');
+    expect(billingRules).toContain('Personal and company memberships can coexist');
+    expect(billingRules).toContain('bills only it');
     expect(billingRules).not.toContain('# Knowledge');
     expect(billingRules).not.toContain('# Current AdCP Context');
     expect(billingRules).toContain('# Canonical URL Reference');

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -1376,7 +1376,10 @@ describe('training agent idempotency middleware', () => {
         reason: 'user_exit',
       }, other);
       expect(terminate.data).toEqual(expect.objectContaining({
-        errors: [expect.objectContaining({ code: 'SESSION_NOT_FOUND' })],
+        session_id: sessionId,
+        terminated: true,
+        session_status: 'terminated',
+        note: 'Session already terminated or not found.',
       }));
 
       const ownerSend = await executeTrainingAgentTool('si_send_message', {

--- a/server/tests/unit/training-agent-idempotency.test.ts
+++ b/server/tests/unit/training-agent-idempotency.test.ts
@@ -27,6 +27,7 @@ import {
   getIdempotencyStore,
 } from '../../src/training-agent/idempotency.js';
 import type { TrainingContext } from '../../src/training-agent/types.js';
+import { SI_TOOLS } from '../../src/training-agent/si-handlers.js';
 import {
   getScopedTrainingTaskStore,
   getTrainingTaskStore,
@@ -1298,6 +1299,94 @@ describe('training agent idempotency middleware', () => {
   });
 
   describe('in-process Addie dispatch', () => {
+    it('keeps legacy SI metadata aligned with the canonical mutation contract', () => {
+      const initiate = SI_TOOLS.find(tool => tool.name === 'si_initiate_session');
+      const send = SI_TOOLS.find(tool => tool.name === 'si_send_message');
+      const terminate = SI_TOOLS.find(tool => tool.name === 'si_terminate_session');
+
+      expect(initiate?.execution.taskSupport).toBe('forbidden');
+      expect(send?.execution.taskSupport).toBe('forbidden');
+      expect(initiate?.annotations.destructiveHint).toBe(false);
+      expect(send?.annotations.destructiveHint).toBe(false);
+      expect(initiate?.inputSchema.properties.idempotency_key).toMatchObject({
+        pattern: '^[A-Za-z0-9_.:-]{16,255}$',
+      });
+      expect(terminate?.annotations.destructiveHint).toBe(true);
+      expect(terminate?.inputSchema.properties.reason).toMatchObject({
+        enum: [
+          'handoff_transaction',
+          'handoff_complete',
+          'user_exit',
+          'session_timeout',
+          'host_terminated',
+        ],
+      });
+    });
+
+    it('executes si_initiate_session through the shared training dispatcher', async () => {
+      const result = await executeTrainingAgentTool('si_initiate_session', {
+        idempotency_key: `addie-si-${randomUUID()}`,
+        intent: 'Compare electric vehicles for long-distance travel',
+        identity: {
+          consent_granted: false,
+          anonymous_session_id: 'certification-demo',
+        },
+      }, { mode: 'training', principal: 'addie-si-test', moduleId: 'C3', tenantId: 'si' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(expect.objectContaining({
+        session_status: 'active',
+        sandbox: true,
+        session_id: expect.stringMatching(/^si_sandbox_/),
+      }));
+    });
+
+    it('rejects SI tasks on the creative tenant', async () => {
+      const result = await executeTrainingAgentTool('si_initiate_session', {
+        idempotency_key: `addie-si-${randomUUID()}`,
+        intent: 'Compare electric vehicles',
+        identity: { consent_granted: false },
+      }, { mode: 'training', principal: 'addie-si-test', moduleId: 'C3', tenantId: 'creative' });
+
+      expect(result).toEqual({ success: false, error: 'Unknown tool: si_initiate_session' });
+    });
+
+    it('isolates SI sessions by training principal', async () => {
+      const owner = { mode: 'training' as const, principal: 'si-owner', tenantId: 'si' as const };
+      const other = { mode: 'training' as const, principal: 'si-other', tenantId: 'si' as const };
+      const initiated = await executeTrainingAgentTool('si_initiate_session', {
+        idempotency_key: `addie-si-${randomUUID()}`,
+        intent: 'Compare electric vehicles',
+        identity: { consent_granted: false },
+      }, owner);
+      expect(initiated.success).toBe(true);
+      const sessionId = (initiated.data as { session_id: string }).session_id;
+
+      const send = await executeTrainingAgentTool('si_send_message', {
+        idempotency_key: `addie-si-${randomUUID()}`,
+        session_id: sessionId,
+        message: 'Show me the range.',
+      }, other);
+      expect(send.data).toEqual(expect.objectContaining({
+        errors: [expect.objectContaining({ code: 'SESSION_NOT_FOUND' })],
+      }));
+
+      const terminate = await executeTrainingAgentTool('si_terminate_session', {
+        session_id: sessionId,
+        reason: 'user_exit',
+      }, other);
+      expect(terminate.data).toEqual(expect.objectContaining({
+        errors: [expect.objectContaining({ code: 'SESSION_NOT_FOUND' })],
+      }));
+
+      const ownerSend = await executeTrainingAgentTool('si_send_message', {
+        idempotency_key: `addie-si-${randomUUID()}`,
+        session_id: sessionId,
+        message: 'Show me the charging options.',
+      }, owner);
+      expect(ownerSend.data).toEqual(expect.objectContaining({ session_status: 'active' }));
+    });
+
     it('honors optional get_products idempotency instead of bypassing the middleware', async () => {
       const ctx: TrainingContext = { mode: 'training', principal: 'addie-test' };
       const missing = await executeTrainingAgentTool('get_products', {

--- a/server/tests/unit/training-agent.test.ts
+++ b/server/tests/unit/training-agent.test.ts
@@ -1636,7 +1636,11 @@ describe('createTrainingAgentServer', () => {
     expect(toolNames).toContain('buy_products');
     expect(toolNames).toContain('accept_proposal');
     expect(toolNames).toContain('control_media_buy');
-    expect(toolNames).toHaveLength(60);
+    expect(toolNames).toContain('si_get_offering');
+    expect(toolNames).toContain('si_initiate_session');
+    expect(toolNames).toContain('si_send_message');
+    expect(toolNames).toContain('si_terminate_session');
+    expect(toolNames).toHaveLength(64);
 
     const validateInput = tools.find(t => t.name === 'validate_input');
     expect(validateInput?.inputSchema?.properties?.targets?.maxItems).toBe(50);


### PR DESCRIPTION
## Summary

- make embedded training dispatch tenant-aware and expose the canonical Sponsored Intelligence lifecycle so C3 can switch from creative to SI and complete
- enforce SI validation, idempotency, failure rendering, and principal-scoped session isolation
- keep the new personal workspace selected through self-service membership checkout and teach Addie the separate-personal-membership flow

Resolves escalations #568 and #569.

## Testing

- focused unit coverage: 191 tests passed
- root unit phase: 1,059 tests passed
- TypeScript typecheck
- Addie tool-surface generation and budget checks
- current-version storyboard matrix: all seven tenants green
- released 3.0 compatibility storyboard matrix: all seven tenants green
- docs navigation: 55 tests passed

## Expert review

- education/certification and protocol: approved
- code/security: approved
- membership UX: approved

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9eeced14-6e24-4672-9046-9af17b54613f)
