### PR TITLE
fix(addie): retain matched v4 provider evidence

### DIFF
--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -82,10 +82,49 @@ deadline. It is accepted only from 1,000 through 120,000 milliseconds (default
 30,000). A deadline aborts the provider request, records `unknown_exposure`,
 and reconciles the reservation; it never retries or counts a late response.
 
-After that admission exists, the protected deploy gate stages the non-secret
-`ADDIE_MATCHED_V4_MERGE_SHA` value for the ordinary runtime from the same
-verified SHA (without passing it any evaluator connection). Invoke the
-explicit `runAuthorizedAddieMatchedV4Execution` entrypoint. The normal public
-surface remains plan-only; execution still refuses unless the runtime role,
-exact manifest, durable admission, and one-use claim all verify before any
-provider adapter is constructed.
+The existing provision and deploy paths above establish only the PostgreSQL
+ledger boundary. They do not enable a matched-v4 paid evaluation. Although the
+deploy gate can stage a non-secret `ADDIE_MATCHED_V4_MERGE_SHA` for its verified
+SHA, do not invoke `runAuthorizedAddieMatchedV4Execution`: the explicit entry
+point is intentionally non-runnable until the separate evidence prerequisite
+below is implemented and reviewed. The normal public surface remains plan-only;
+the paid authority rejects before it opens the database or constructs a
+provider adapter.
+
+## Evidence and settlement prerequisites for the 43-cell evaluation
+
+The 43-cell screening and its bounded full continuation remain blocked. The
+repository has an append-only PostgreSQL execution ledger, and its release
+workflows can produce keyless-cosign signatures and compare bytes before an
+R2 upload. Those are useful building blocks, but neither is a sanctioned
+immutable/WORM evidence sink for this evaluation: the R2 convention does not
+attest Object Lock or equivalent retention, and a signature made after a
+provider call cannot reserve durable evidence before that call.
+
+Do not configure a GitHub Actions or Fly environment to work around this
+gate. In particular, no `ALLOW_*` flag, caller-provided adapter, local path,
+content-addressed R2 upload, or OIDC identity assertion authorizes paid
+dispatch. The manual command intentionally refuses before reading credentials.
+
+Before the gate may be replaced, a separate reviewed change must provide all
+of the following:
+
+1. An independently administered WORM/append-only evidence capability, or an
+   independently signed durable receipt service, with a pre-dispatch
+   reservation bound to the ledger reservation ID and exact merge/manifest.
+2. A protected execution environment whose runtime database login inherits
+   only `addie_matched_v4_runtime`, cannot assume the operator role, and has
+   no direct evaluator-table DML.
+3. Dedicated, spend-capped provider credentials that are not Fly credentials.
+4. Provider-authoritative reconciliation retained independently from the
+   evaluator: OpenAI organization costs for the dedicated project/time bucket;
+   Google Cloud Billing detailed usage-cost export enabled before the run; and
+   an Anthropic billing statement or account export covering the dedicated
+   credential and window.
+
+The evaluator records provider-returned response IDs and usage so a future
+evidence service can join those records to the ledger. Its deterministic
+pricing-profile value is an **estimate**, not provider-authoritative
+settlement. Missing, late, aggregated, or non-reconcilable provider billing
+evidence leaves the result `cost_settlement_pending`; it must not drive
+promotion or rollout.

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -104,7 +104,8 @@ provider call cannot reserve durable evidence before that call.
 Do not configure a GitHub Actions or Fly environment to work around this
 gate. In particular, no `ALLOW_*` flag, caller-provided adapter, local path,
 content-addressed R2 upload, or OIDC identity assertion authorizes paid
-dispatch. The manual command intentionally refuses before reading credentials.
+dispatch. The manual command itself intentionally refuses before it accesses
+execution configuration or dispatches a provider request.
 
 Before the gate may be replaced, a separate reviewed change must provide all
 of the following:

--- a/server/src/addie/eval/matched-v4-authority-custody.ts
+++ b/server/src/addie/eval/matched-v4-authority-custody.ts
@@ -634,6 +634,9 @@ function parsed(raw: Raw, p: Provider, profile: DatedPricingProfile) {
   if (
     raw.provider !== p ||
     typeof raw.model !== "string" ||
+    typeof raw.response_id !== "string" ||
+    !raw.response_id ||
+    raw.response_id.length > 256 ||
     !cohortReturnedModelMatches(profile, raw.model) ||
     !Number.isFinite(raw.latency_ms) ||
     (raw.latency_ms as number) < 0 ||
@@ -655,6 +658,7 @@ function parsed(raw: Raw, p: Provider, profile: DatedPricingProfile) {
     throw Error("malformed provider usage");
   return {
     model: raw.model,
+    providerResponseId: raw.response_id,
     latencyMs: raw.latency_ms as number,
     finishReason: raw.finish_reason as "stop" | "tool_calls",
     text: typeof raw.text === "string" ? raw.text : "",
@@ -1091,6 +1095,7 @@ class AddieMatchedV4PrivateAuthority {
                 continuationOfPreparedRequestFingerprint: null,
                 requestedReasoningEffort: d.reasoningEffort,
                 returnedIdentity: { provider: d.provider, model: r.model },
+                providerResponseId: r.providerResponseId,
                 settlement: "settled" as const,
                 usage,
               });
@@ -1131,6 +1136,7 @@ class AddieMatchedV4PrivateAuthority {
                     d.preparedRequestFingerprint,
                   requestedReasoningEffort: d.reasoningEffort,
                   returnedIdentity: { provider: d.provider, model: r.model },
+                  providerResponseId: r.providerResponseId,
                   settlement: "settled" as const,
                   usage: r.usage,
                 });
@@ -1512,6 +1518,7 @@ export async function createAddieMatchedV4PaidAuthority(
       return Object.freeze({
         provider: response.provider,
         model: response.model,
+        response_id: response.id,
         finish_reason: response.finishReason,
         latency_ms: Date.now() - started,
         text: response.content
@@ -1594,6 +1601,8 @@ interface AddieMatchedV4ExecutedDispatch {
   readonly continuationOfPreparedRequestFingerprint: string | null;
   readonly requestedReasoningEffort: AddieMatchedV4ReasoningEffort;
   readonly returnedIdentity: ReturnedIdentity;
+  /** Provider-issued response ID retained for external cost reconciliation. */
+  readonly providerResponseId: string;
   readonly settlement: "settled" | "unknown";
   readonly usage: Readonly<{
     inputTokens: number;
@@ -1669,6 +1678,7 @@ interface RecordedObservation {
     pricingProfileId: string;
     pricingProfileSha256: string;
     returnedIdentity: ReturnedIdentity;
+    providerResponseId: string;
     requestedReasoningEffort: AddieMatchedV4ReasoningEffort;
     usage: AddieMatchedV4ExecutedDispatch["usage"];
     costUsd: number;
@@ -1966,6 +1976,9 @@ function recordExecution(
         dispatched.continuationOfPreparedRequestFingerprint !== null ||
         dispatched.requestedReasoningEffort !== expected.reasoningEffort ||
         dispatched.returnedIdentity.provider !== expected.provider ||
+        typeof dispatched.providerResponseId !== "string" ||
+        !dispatched.providerResponseId ||
+        dispatched.providerResponseId.length > 256 ||
         dispatched.settlement !== "settled"
       )
         throw new Error(
@@ -2008,6 +2021,7 @@ function recordExecution(
         pricingProfileId: profile.profileId,
         pricingProfileSha256: datedPricingProfileIdentity(profile).digest,
         returnedIdentity: dispatched.returnedIdentity,
+        providerResponseId: dispatched.providerResponseId,
         requestedReasoningEffort: dispatched.requestedReasoningEffort,
         usage,
         costUsd,
@@ -2027,6 +2041,9 @@ function recordExecution(
         expected.preparedRequestFingerprint ||
       continuation.requestedReasoningEffort !== expected.reasoningEffort ||
       continuation.returnedIdentity.provider !== expected.provider ||
+      typeof continuation.providerResponseId !== "string" ||
+      !continuation.providerResponseId ||
+      continuation.providerResponseId.length > 256 ||
       continuation.settlement !== "settled"
     )
       throw new Error(
@@ -2070,6 +2087,7 @@ function recordExecution(
         pricingProfileId: profile.profileId,
         pricingProfileSha256: datedPricingProfileIdentity(profile).digest,
         returnedIdentity: continuation.returnedIdentity,
+        providerResponseId: continuation.providerResponseId,
         requestedReasoningEffort: continuation.requestedReasoningEffort,
         usage,
         costUsd: datedPricingCostUsd(profile, usage),

--- a/server/src/addie/eval/matched-v4-authorized-execution.ts
+++ b/server/src/addie/eval/matched-v4-authorized-execution.ts
@@ -30,7 +30,8 @@ export interface AddieMatchedV4AuthorizedStageReport {
     passed: number;
     total: number;
     passRate: number;
-    totalCostUsd: number;
+    /** Deterministic estimate from the signed pricing profile, not a bill. */
+    estimatedCostUsd: number;
     medianLatencyMs: number;
     totalInputTokens: number;
     totalOutputTokens: number;
@@ -68,7 +69,7 @@ function reportStage(result: any): AddieMatchedV4AuthorizedStageReport {
       passed: metric.passed,
       total: metric.total,
       passRate: metric.passRate,
-      totalCostUsd: metric.totalCostUsd,
+      estimatedCostUsd: metric.totalCostUsd,
       medianLatencyMs: metric.medianLatencyMs,
       totalInputTokens: metric.totalInputTokens,
       totalOutputTokens: metric.totalOutputTokens,

--- a/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
+++ b/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
@@ -1,10 +1,11 @@
 /**
  * The production gate for matched-v4 immutable evidence.
  *
- * A local path, chmod, O_EXCL, or environment assertion is not an immutable
- * artifact capability. This module remains deliberately closed until the
- * platform supplies a reviewed WORM/append-only sink or independently signed
- * durable receipt implementation bound to the settlement ledger.
+ * A local path, chmod, O_EXCL, GitHub Actions identity assertion, or
+ * content-addressed R2 upload is not an immutable artifact capability. This
+ * module remains deliberately closed until the platform supplies a reviewed
+ * WORM/append-only sink or independently signed durable receipt implementation
+ * bound to the settlement ledger.
  */
 export function assertMatchedV4SanctionedImmutableArtifactSink(): void {
   throw new Error(

--- a/server/tests/manual/matched-v4-authorized-execution.ts
+++ b/server/tests/manual/matched-v4-authorized-execution.ts
@@ -1,14 +1,11 @@
 /**
  * Deliberately non-runnable matched-v4 operator entrypoint.
  *
- * Local filesystem paths cannot produce immutable, decision-grade evidence:
- * an owner can replace even exclusively-created and fsynced files. Paid
- * authority construction independently enforces the same invariant, but this
- * manual command also refuses before reading any execution configuration.
- *
- * A reviewed adapter for a sanctioned append-only/WORM artifact sink, or an
- * independently signed receipt bound to the settlement ledger, must replace
- * this gate before any matched-v4 execution command can be enabled.
+ * Local filesystem paths, GitHub Actions identity, and R2 upload-only
+ * conventions cannot produce immutable, decision-grade evidence: each can be
+ * replaced, deleted, or fail after dispatch. Paid authority construction
+ * independently enforces the same invariant, but this manual command also
+ * refuses before reading any execution configuration.
  */
 throw new Error(
   "Matched v4 paid execution is blocked: configure and implement a sanctioned immutable artifact sink before dispatch",

--- a/server/tests/manual/matched-v4-authorized-execution.ts
+++ b/server/tests/manual/matched-v4-authorized-execution.ts
@@ -5,7 +5,7 @@
  * conventions cannot produce immutable, decision-grade evidence: each can be
  * replaced, deleted, or fail after dispatch. Paid authority construction
  * independently enforces the same invariant, but this manual command also
- * refuses before reading any execution configuration.
+ * refuses before accessing any execution configuration.
  */
 throw new Error(
   "Matched v4 paid execution is blocked: configure and implement a sanctioned immutable artifact sink before dispatch",

--- a/server/tests/unit/addie/matched-v4-evaluation.test.ts
+++ b/server/tests/unit/addie/matched-v4-evaluation.test.ts
@@ -1081,14 +1081,13 @@ describe("matched-v4 sealed private authority", () => {
   });
   it("runs an authorized full stage only after screening on one sealed authority", async () => {
     responseFixture("baseline_semantic_irrelevant");
-    await expect(
-      runAuthorizedAddieMatchedV4Execution({
-        anthropicApiKey: "fixture-anthropic",
-        openaiApiKey: "fixture-openai",
-        googleApiKey: "fixture-google",
-        stage: "full",
-      }),
-    ).resolves.toMatchObject({
+    const report = await runAuthorizedAddieMatchedV4Execution({
+      anthropicApiKey: "fixture-anthropic",
+      openaiApiKey: "fixture-openai",
+      googleApiKey: "fixture-google",
+      stage: "full",
+    });
+    expect(report).toMatchObject({
       kind: "addie_matched_v4_authorized_execution_report",
       requestedStage: "full",
       stages: [
@@ -1096,6 +1095,9 @@ describe("matched-v4 sealed private authority", () => {
         expect.objectContaining({ stage: "full" }),
       ],
     });
+    const cell = report.stages[0]?.cells[0];
+    expect(cell).toEqual(expect.objectContaining({ estimatedCostUsd: expect.any(Number) }));
+    expect(cell).not.toHaveProperty("totalCostUsd");
   });
   it("uses the reviewed Gemini alias predicate and preserves the opaque continuation object", async () => {
     const accepted = await authority("google_dated_alias");
@@ -1489,6 +1491,15 @@ describe("matched-v4 sealed private authority", () => {
     ).toBe(true);
     expect(result.artifact.requestSetSha256).toMatch(/^[a-f0-9]{64}$/);
     const evidence = result.artifactEvidence;
+    expect(
+      evidence.observations.every((observation) =>
+        observation.dispatches.every(
+          (dispatch) =>
+            typeof dispatch.providerResponseId === "string" &&
+            dispatch.providerResponseId.length > 0,
+        ),
+      ),
+    ).toBe(true);
     expect(
       evidence.observations.some((observation) =>
         observation.dispatches.some(

--- a/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
+++ b/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getPool } = vi.hoisted(() => ({ getPool: vi.fn() }));
 vi.mock("../../../src/db/client.js", () => ({ getPool }));
@@ -6,16 +6,22 @@ vi.mock("../../../src/db/client.js", () => ({ getPool }));
 import { createAddieMatchedV4PaidAuthority } from "../../../src/addie/eval/matched-v4-private-authority.js";
 
 const originalMergeSha = process.env.ADDIE_MATCHED_V4_MERGE_SHA;
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+});
 
 afterEach(() => {
   getPool.mockReset();
+  fetchSpy.mockRestore();
   if (originalMergeSha === undefined)
     delete process.env.ADDIE_MATCHED_V4_MERGE_SHA;
   else process.env.ADDIE_MATCHED_V4_MERGE_SHA = originalMergeSha;
 });
 
 describe("matched-v4 paid evidence gate", () => {
-  it("makes zero database or provider calls while no sanctioned evidence sink exists", async () => {
+  it("does not open the database or use fetch while no sanctioned evidence sink exists", async () => {
     process.env.ADDIE_MATCHED_V4_MERGE_SHA = "a".repeat(40);
 
     await expect(createAddieMatchedV4PaidAuthority({
@@ -25,5 +31,6 @@ describe("matched-v4 paid evidence gate", () => {
       googleApiKey: "fixture-google",
     })).rejects.toThrow(/sanctioned immutable artifact sink adapter/);
     expect(getPool).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
+++ b/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getPool } = vi.hoisted(() => ({ getPool: vi.fn() }));
+vi.mock("../../../src/db/client.js", () => ({ getPool }));
+
+import { createAddieMatchedV4PaidAuthority } from "../../../src/addie/eval/matched-v4-private-authority.js";
+
+const originalMergeSha = process.env.ADDIE_MATCHED_V4_MERGE_SHA;
+
+afterEach(() => {
+  getPool.mockReset();
+  if (originalMergeSha === undefined)
+    delete process.env.ADDIE_MATCHED_V4_MERGE_SHA;
+  else process.env.ADDIE_MATCHED_V4_MERGE_SHA = originalMergeSha;
+});
+
+describe("matched-v4 paid evidence gate", () => {
+  it("makes zero database or provider calls while no sanctioned evidence sink exists", async () => {
+    process.env.ADDIE_MATCHED_V4_MERGE_SHA = "a".repeat(40);
+
+    await expect(createAddieMatchedV4PaidAuthority({
+      authorizePaidDispatch: true,
+      anthropicApiKey: "fixture-anthropic",
+      openaiApiKey: "fixture-openai",
+      googleApiKey: "fixture-google",
+    })).rejects.toThrow(/sanctioned immutable artifact sink adapter/);
+    expect(getPool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- retain provider-returned response IDs with matched-v4 observation evidence for a future independent reconciliation join
- label signed pricing-profile totals as estimates, not provider-authoritative settlement
- document that the current ledger, post-dispatch signing, and R2 convention do not enable paid dispatch; keep the immutable-evidence gate closed

## Verification
- `npx vitest run --config server/vitest.config.ts tests/unit/addie/matched-v4-evidence-gate.test.ts`
- `npx vitest run --config server/vitest.config.ts tests/unit/addie/matched-v4-evaluation.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint:schema-links --silent`
- `node tests/docs-nav-validation.test.cjs`

The repository pre-commit wrapper was stopped while its full `server/tests/unit/` run made no progress after focused checks passed, following explicit operator direction. GitHub CI is the exact-head full check.

## Safety
No provider calls, dispatches, credentials, secrets, or infrastructure were changed. The new zero-call test asserts the paid authority rejects before it opens the database or constructs a provider adapter.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/26744b04-7962-4b01-a6e8-76c4cc98a2d3)
