### PR TITLE
feat(addie): add durable matched v4 evidence

### DIFF
--- a/.github/workflows/verify-matched-v4-durable-evidence.yml
+++ b/.github/workflows/verify-matched-v4-durable-evidence.yml
@@ -1,0 +1,55 @@
+name: Verify matched-v4 durable evidence boundary
+
+# This is a protected, read-only provisioning gate. It never creates a
+# bucket, changes a retention policy, writes an object, or calls a model.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify-gcs-bucket-lock:
+    # Administrators must configure this environment with required reviewers
+    # and its own WIF variables. A dispatch-selected ref is never trusted.
+    environment: matched-v4-durable-evidence
+    runs-on: ubuntu-latest
+    steps:
+      # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: main
+          fetch-depth: 1
+      - name: Refuse a non-current main checkout
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+      - name: Authenticate only as the evidence verifier
+        # v2.1.8
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935
+        with:
+          workload_identity_provider: ${{ vars.MATCHED_V4_GCS_WIF_PROVIDER }}
+          service_account: ${{ vars.MATCHED_V4_GCS_VERIFIER_SERVICE_ACCOUNT }}
+      - name: Install reviewed Cloud SDK
+        # v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        with:
+          version: "503.0.0"
+      - name: Verify immutable retention configuration without writing
+        env:
+          EVIDENCE_BUCKET: ${{ vars.MATCHED_V4_GCS_EVIDENCE_BUCKET }}
+        run: |
+          set -euo pipefail
+          # Runtime requires 365.25 days remaining on each object. Require the
+          # policy to exceed that by seven days so normal write/read latency
+          # cannot make an otherwise exact-duration bucket fail readback.
+          minimum_retention_policy_seconds=32162400
+          test -n "$EVIDENCE_BUCKET"
+          bucket_json=$(gcloud storage buckets describe "gs://$EVIDENCE_BUCKET" --format=json)
+          jq -e --argjson minimum_retention_policy_seconds "$minimum_retention_policy_seconds" '
+            .retentionPolicy.isLocked == true and
+            (.retentionPolicy.retentionPeriod | tonumber? >= $minimum_retention_policy_seconds) and
+            (.retentionPolicy.effectiveTime | type == "string")
+          ' <<<"$bucket_json" >/dev/null

--- a/.github/workflows/verify-matched-v4-durable-evidence.yml
+++ b/.github/workflows/verify-matched-v4-durable-evidence.yml
@@ -3,7 +3,13 @@ name: Verify matched-v4 durable evidence boundary
 # This is a protected, read-only provisioning gate. It never creates a
 # bucket, changes a retention policy, writes an object, or calls a model.
 on:
-  workflow_dispatch:
+  # GitHub evaluates this definition only after it is merged to main. A
+  # dispatch-selected branch could otherwise replace the verification commands
+  # while still requesting the protected environment's OIDC identity.
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/verify-matched-v4-durable-evidence.yml
 
 permissions:
   contents: read
@@ -12,7 +18,9 @@ permissions:
 jobs:
   verify-gcs-bucket-lock:
     # Administrators must configure this environment with required reviewers
-    # and its own WIF variables. A dispatch-selected ref is never trusted.
+    # and restrict deployments to the main branch. The workflow itself also
+    # refuses any non-main ref before it can request the OIDC identity.
+    if: github.ref == 'refs/heads/main'
     environment: matched-v4-durable-evidence
     runs-on: ubuntu-latest
     steps:

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -95,13 +95,18 @@ the artifact digest/evidence. Every post-dispatch refusal also attempts a
 retained terminal-refusal object; it contains only one allowlisted reason code
 (`paired_ci_gate`, `dispatch_timeout`, `settlement_refused`, `intent_refused`,
 `provider_response_invalid`, or `execution_refused`) rather than raw SDK or
-provider exception text. Terminal writes use an issued/finalizing/consumed
-state machine: concurrent finalizers are refused, while a transient failed
-write/readback resets to issued and can retry by verifying an existing 412
-conditional-create result. Any malformed GCS response, digest mismatch,
-missing future object-retention expiration, conditional-write failure, or
-unlocked bucket refuses the run before dispatch or prevents a successful
-result from being reported.
+provider exception text. Terminal writes bind the reservation to their first
+completion or refusal identity. The issued/finalizing/uncertain/consumed state
+machine rejects concurrent and cross-kind finalizers; a transient failed
+write/readback retries that same deterministic create-only name and verifies an
+existing 412 result, while an I/O deadline becomes `uncertain` and fails
+closed rather than creating a conflicting terminal record. Every bucket
+metadata lookup, object metadata lookup, generation-pinned readback, and save
+has a 30-second adapter wall-clock deadline; the sealed Storage client has the
+same finite HTTP timeout and retry total. Any malformed GCS response, digest
+mismatch, missing future object-retention expiration, conditional-write
+failure, deadline, or unlocked bucket refuses the run before dispatch or
+prevents a successful result from being reported.
 
 This relies specifically on [Cloud Storage Bucket Lock](https://cloud.google.com/storage/docs/bucket-lock): a locked positive retention policy prevents an object from being deleted or replaced before its retention age, and each protected object has retention-expiration metadata. The adapter checks `retentionPolicy.isLocked`, a positive period, a valid policy effective timestamp, and the written object's `retentionExpirationTime` is at least one year ahead. The one-year constant covers delayed provider billing reconciliation and a human audit window; it deliberately refuses a locked short-retention bucket. The protected verifier also requires a policy duration of at least `32,162,400` seconds (365.25 days plus a seven-day margin), so a policy that only exactly equals the runtime horizon cannot fail immediately after normal write/read latency; object readback remains the runtime authority. It writes with `ifGenerationMatch=0`; [GCS documents this as a conditional create that fails with 412 when a live object exists](https://cloud.google.com/storage/docs/request-preconditions). Object metadata alone is editable under a bucket retention policy, so the adapter verifies the returned object generation, MD5 of its bytes, and adapter-written SHA-256 metadata; a metadata assertion is never accepted as proof by itself.
 
@@ -124,8 +129,11 @@ Before a human enables execution, provision and review all of the following.
 3. A distinct read-only verifier service account for the protected GitHub
    environment, with `storage.buckets.get` only. Configure GitHub OIDC/WIF for
    exactly that repository and the protected environment
-   `matched-v4-durable-evidence`; set required reviewers and disallow
-   self-approval. Set its non-secret environment variables
+   `matched-v4-durable-evidence`; restrict environment deployments to `main`,
+   set required reviewers, and disallow self-approval. The checked-in verifier
+   is triggered only by a `main` update to its own definition (then may be
+   re-run from that trusted workflow run), never a dispatch-selected branch.
+   Set its non-secret environment variables
    `MATCHED_V4_GCS_WIF_PROVIDER`,
    `MATCHED_V4_GCS_VERIFIER_SERVICE_ACCOUNT`, and
    `MATCHED_V4_GCS_EVIDENCE_BUCKET`. The checked-in
@@ -149,6 +157,16 @@ Before a human enables execution, provision and review all of the following.
    Google Cloud Billing detailed usage-cost export, and an Anthropic billing
    statement or account export for the dedicated credential/window. Retain
    those reconciliations independently of the evaluator objects.
+
+Do not run `npm run eval:addie-matched-v4-authorized` from a local checkout:
+it deliberately refuses, because `ADDIE_MATCHED_V4_MERGE_SHA` alone cannot
+prove that the executing source is the admitted deployment. Before any paid
+execution, extend the protected deployment runner to verify a runtime-bound,
+cryptographically signed build attestation for the exact merged SHA, then
+provide the spend-capped provider credentials only to that runner. The runner
+must accept neither a provider, bucket, evidence capability, nor admission
+selector from a caller, and may emit only the non-authorizing report
+projection after retained evidence has been verified.
 
 Run the GCS integration test only after the preceding approval and credentials
 exist: `ADDIE_MATCHED_V4_GCS_INTEGRATION=true` plus the runtime GCS credential

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -82,50 +82,81 @@ deadline. It is accepted only from 1,000 through 120,000 milliseconds (default
 30,000). A deadline aborts the provider request, records `unknown_exposure`,
 and reconciles the reservation; it never retries or counts a late response.
 
-The existing provision and deploy paths above establish only the PostgreSQL
-ledger boundary. They do not enable a matched-v4 paid evaluation. Although the
-deploy gate can stage a non-secret `ADDIE_MATCHED_V4_MERGE_SHA` for its verified
-SHA, do not invoke `runAuthorizedAddieMatchedV4Execution`: the explicit entry
-point is intentionally non-runnable until the separate evidence prerequisite
-below is implemented and reviewed. The normal public surface remains plan-only;
-the paid authority rejects before it opens the database or constructs a
-provider adapter.
+## GCS durable-evidence gate and human provisioning inventory
 
-## Evidence and settlement prerequisites for the 43-cell evaluation
+The paid constructor now obtains its evidence authority only from the sealed
+Google Cloud Storage adapter. It first writes and verifies a unique,
+create-only pre-dispatch reservation object; only then can it open the
+PostgreSQL admission path or construct a provider adapter. The reservation
+contains the exact selector fingerprint, stage cap, deployed merge SHA, sealed
+authority-manifest digest, and evaluation version. A separately retained final
+object includes the reservation object's bucket/name/generation/SHA-256 and
+the artifact digest/evidence. Every post-dispatch refusal also attempts a
+retained terminal-refusal object; it contains only one allowlisted reason code
+(`paired_ci_gate`, `dispatch_timeout`, `settlement_refused`, `intent_refused`,
+`provider_response_invalid`, or `execution_refused`) rather than raw SDK or
+provider exception text. Terminal writes use an issued/finalizing/consumed
+state machine: concurrent finalizers are refused, while a transient failed
+write/readback resets to issued and can retry by verifying an existing 412
+conditional-create result. Any malformed GCS response, digest mismatch,
+missing future object-retention expiration, conditional-write failure, or
+unlocked bucket refuses the run before dispatch or prevents a successful
+result from being reported.
 
-The 43-cell screening and its bounded full continuation remain blocked. The
-repository has an append-only PostgreSQL execution ledger, and its release
-workflows can produce keyless-cosign signatures and compare bytes before an
-R2 upload. Those are useful building blocks, but neither is a sanctioned
-immutable/WORM evidence sink for this evaluation: the R2 convention does not
-attest Object Lock or equivalent retention, and a signature made after a
-provider call cannot reserve durable evidence before that call.
+This relies specifically on [Cloud Storage Bucket Lock](https://cloud.google.com/storage/docs/bucket-lock): a locked positive retention policy prevents an object from being deleted or replaced before its retention age, and each protected object has retention-expiration metadata. The adapter checks `retentionPolicy.isLocked`, a positive period, a valid policy effective timestamp, and the written object's `retentionExpirationTime` is at least one year ahead. The one-year constant covers delayed provider billing reconciliation and a human audit window; it deliberately refuses a locked short-retention bucket. The protected verifier also requires a policy duration of at least `32,162,400` seconds (365.25 days plus a seven-day margin), so a policy that only exactly equals the runtime horizon cannot fail immediately after normal write/read latency; object readback remains the runtime authority. It writes with `ifGenerationMatch=0`; [GCS documents this as a conditional create that fails with 412 when a live object exists](https://cloud.google.com/storage/docs/request-preconditions). Object metadata alone is editable under a bucket retention policy, so the adapter verifies the returned object generation, MD5 of its bytes, and adapter-written SHA-256 metadata; a metadata assertion is never accepted as proof by itself.
 
-Do not configure a GitHub Actions or Fly environment to work around this
-gate. In particular, no `ALLOW_*` flag, caller-provided adapter, local path,
-content-addressed R2 upload, or OIDC identity assertion authorizes paid
-dispatch. The manual command itself intentionally refuses before it accesses
-execution configuration or dispatches a provider request.
+Before a human enables execution, provision and review all of the following.
 
-Before the gate may be replaced, a separate reviewed change must provide all
-of the following:
+1. A dedicated Google Cloud project and evidence bucket, distinct from app,
+   provider, and billing-export buckets. Set the retention period to the
+   approved legal/compliance duration, then lock it permanently with Bucket
+   Lock. This is irreversible; record the approval and exact bucket project
+   number before locking. Do not enable object lifecycle rules that imply a
+   shorter retention requirement.
+2. A dedicated runtime workload identity/service account with only
+   `storage.buckets.get`, `storage.objects.create`, and `storage.objects.get`
+   on this one bucket and the `addie-matched-v4/v1/` object prefix through an
+   IAM Condition. It must have no delete, update, list, bucket-policy, bucket
+   retention-policy, IAM, project-owner, or service-account-admin authority.
+   The narrow permissions mean a substituted bucket setting fails unless it is
+   independently administered with the same constrained identity; the adapter
+   still verifies its Bucket Lock and returned retained generation.
+3. A distinct read-only verifier service account for the protected GitHub
+   environment, with `storage.buckets.get` only. Configure GitHub OIDC/WIF for
+   exactly that repository and the protected environment
+   `matched-v4-durable-evidence`; set required reviewers and disallow
+   self-approval. Set its non-secret environment variables
+   `MATCHED_V4_GCS_WIF_PROVIDER`,
+   `MATCHED_V4_GCS_VERIFIER_SERVICE_ACCOUNT`, and
+   `MATCHED_V4_GCS_EVIDENCE_BUCKET`. The checked-in
+   `Verify matched-v4 durable evidence boundary` workflow only checks the
+   current `main` checkout and bucket lock; it creates nothing and never calls
+   a model provider.
+4. Configure the production evaluator runtime's dedicated GCP workload
+   identity credential outside the repository and set only the non-secret
+   `ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET` to the reviewed bucket name. Do not
+   pass a bucket, Storage client, evidence receipt, or adapter through the
+   execution caller. The sealed constructor has no such input key; test-only
+   adapter capabilities likewise cannot be supplied to it.
+5. Retain the existing separated PostgreSQL runtime/operator roles and the
+   protected evaluator schema workflow above. Configure dedicated,
+   spend-capped Anthropic, OpenAI, and Google model credentials separately
+   from the GCS identity and from ordinary Fly credentials. Do not use an
+   `ALLOW_*` flag, local path, R2 upload, GitHub identity assertion, or caller
+   input as an evidence substitute.
+6. Before and after an actual run, obtain provider-authoritative billing
+   evidence: OpenAI organization costs for the dedicated project/time window,
+   Google Cloud Billing detailed usage-cost export, and an Anthropic billing
+   statement or account export for the dedicated credential/window. Retain
+   those reconciliations independently of the evaluator objects.
 
-1. An independently administered WORM/append-only evidence capability, or an
-   independently signed durable receipt service, with a pre-dispatch
-   reservation bound to the ledger reservation ID and exact merge/manifest.
-2. A protected execution environment whose runtime database login inherits
-   only `addie_matched_v4_runtime`, cannot assume the operator role, and has
-   no direct evaluator-table DML.
-3. Dedicated, spend-capped provider credentials that are not Fly credentials.
-4. Provider-authoritative reconciliation retained independently from the
-   evaluator: OpenAI organization costs for the dedicated project/time bucket;
-   Google Cloud Billing detailed usage-cost export enabled before the run; and
-   an Anthropic billing statement or account export covering the dedicated
-   credential and window.
+Run the GCS integration test only after the preceding approval and credentials
+exist: `ADDIE_MATCHED_V4_GCS_INTEGRATION=true` plus the runtime GCS credential
+and bucket setting. It writes two deliberately retained test records and never
+deletes them; it does not open PostgreSQL or call a model provider. The normal
+unit suite is deterministic and makes no network call.
 
-The evaluator records provider-returned response IDs and usage so a future
-evidence service can join those records to the ledger. Its deterministic
-pricing-profile value is an **estimate**, not provider-authoritative
-settlement. Missing, late, aggregated, or non-reconcilable provider billing
-evidence leaves the result `cost_settlement_pending`; it must not drive
-promotion or rollout.
+The evaluator records provider response IDs and usage, but its dated pricing
+profile is an **estimate**, not provider-authoritative settlement. Missing,
+late, aggregated, or non-reconcilable provider billing evidence remains
+`cost_settlement_pending` and must not drive promotion or rollout.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,17 +1878,16 @@
       "license": "MIT"
     },
     "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/webidl-conversions": {
@@ -14685,17 +14684,16 @@
       "license": "MIT"
     },
     "node_modules/gtoken/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/gtoken/node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@contentauth/c2pa-node": "^0.9.3",
         "@google-cloud/kms": "^6.0.0",
+        "@google-cloud/storage": "8.1.0",
         "@google/genai": "^2.21.0",
         "@google/generative-ai": "^0.24.1",
         "@googleapis/calendar": "^16.0.0",
@@ -294,9 +295,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -311,9 +309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -328,9 +323,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -345,9 +337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1715,6 +1704,207 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-7.0.1.tgz",
+      "integrity": "sha512-k32cWlHAF8yTgg8rciLI8mPMI6UzuJdKp53YRxISRwMFxUl2FYplvs+Mr2UHxKn0W7rXsqZnUZy73AOJFDP8iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-6.0.1.tgz",
+      "integrity": "sha512-zA3o4l87UJ56odT/e9PcT4n2bqVnrp6dg9vI75DoGGbl0/YJemX8Fta7454htECt07eALxxc4iaAbrX3T+QulA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-6.0.1.tgz",
+      "integrity": "sha512-lpN2AtoQ/iimp7jjm5zJFWbpW7OJc5qWmQdt59CI4ENeoIRIx+yf2ShSR2kanQfjFOshA74eSbimXXuRaSCUVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-8.1.0.tgz",
+      "integrity": "sha512-iFDlOGBzmzTelslzcf0yTpoqloyfTUi448PxJXvjtbvGqtc2ftT8HUSl5+sKQPRz70y64ha5FqojDhABP103EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^7.0.1",
+        "@google-cloud/projectify": "^6.0.1",
+        "@google-cloud/promisify": "^6.0.1",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^9.0.1",
+        "teeny-request": "^11.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@google-cloud/storage/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@google/genai": {
@@ -3451,9 +3641,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3471,9 +3658,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3491,9 +3675,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3511,9 +3692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3531,9 +3709,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3551,9 +3726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3571,9 +3743,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3597,9 +3766,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3623,9 +3789,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3649,9 +3812,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3675,9 +3835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3701,9 +3858,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5087,7 +5241,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7499,9 +7652,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7520,9 +7670,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7541,9 +7688,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7562,9 +7706,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7583,9 +7724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7604,9 +7742,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9481,6 +9616,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -9689,7 +9836,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
       "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9872,6 +10018,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -10412,22 +10567,6 @@
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/c8/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
       },
       "engines": {
         "node": ">=10"
@@ -12781,6 +12920,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -13109,7 +13257,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
       "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13126,7 +13273,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13271,9 +13417,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13291,9 +13434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13311,9 +13451,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13331,9 +13468,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13351,9 +13485,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13371,9 +13502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13391,9 +13519,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13417,9 +13542,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13443,9 +13565,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13469,9 +13588,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13495,9 +13611,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -13521,9 +13634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -14497,6 +14607,113 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gtoken/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/gtoken/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gtoken/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/gtoken/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -15024,6 +15241,22 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -16087,6 +16320,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -16823,9 +17068,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16848,9 +17090,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16873,9 +17112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16898,9 +17134,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -19393,6 +19626,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-queue": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
@@ -19618,7 +19866,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
       "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22628,7 +22875,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
       "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24751,7 +24997,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
       "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24912,7 +25157,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@contentauth/c2pa-node": "^0.9.3",
     "@google-cloud/kms": "^6.0.0",
+    "@google-cloud/storage": "8.1.0",
     "@google/genai": "^2.21.0",
     "@google/generative-ai": "^0.24.1",
     "@googleapis/calendar": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -307,6 +307,9 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "js-yaml": "^4.3.1",
-    "axios": "$axios"
+    "axios": "$axios",
+    "gaxios": {
+      "uuid": "11.1.1"
+    }
   }
 }

--- a/server/src/addie/eval/matched-v4-authority-custody.ts
+++ b/server/src/addie/eval/matched-v4-authority-custody.ts
@@ -1,6 +1,7 @@
 /** Closed-by-default evaluator-only v4 authority. */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { types as nodeTypes } from "node:util";
+import { Storage } from "@google-cloud/storage";
 import OpenAI from "openai";
 import type { Pool, PoolClient } from "pg";
 import { getPool } from "../../db/client.js";
@@ -44,7 +45,13 @@ import {
   addieMatchedV4WireSurface,
   addieMatchedV4WireSurfaceProvenance,
 } from "./matched-v4-runtime-surface.js";
-import { assertMatchedV4SanctionedImmutableArtifactSink } from "./matched-v4-immutable-artifact-sink.js";
+import {
+  createMatchedV4GcsDurableEvidenceCapabilityForTest,
+  type AddieMatchedV4DurableEvidenceCapability,
+  type AddieMatchedV4DurableEvidenceReservation,
+  type AddieMatchedV4DurableObject,
+  type AddieMatchedV4TerminalReasonCode,
+} from "./matched-v4-immutable-artifact-sink.js";
 const ADDIE_MATCHED_V4_PRIVATE_AUTHORITY = Object.freeze({
   version: "addie-matched-v4-private-authority-v12",
   paidDispatchGate: "closed" as const,
@@ -60,6 +67,22 @@ const ADDIE_MATCHED_V4_PRIVATE_AUTHORITY = Object.freeze({
     issueNumber: 567,
   }),
 });
+const EVIDENCE_BUCKET_ENV = "ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET";
+/** Deliberately module-private: only the paid constructor can issue this. */
+function createMatchedV4SanctionedDurableEvidenceCapability(): AddieMatchedV4DurableEvidenceCapability {
+  const bucketName = process.env[EVIDENCE_BUCKET_ENV];
+  if (
+    typeof bucketName !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]$/.test(bucketName)
+  )
+    throw new Error(
+      "Matched v4 paid dispatch requires a sealed GCS evidence bucket configuration",
+    );
+  return createMatchedV4GcsDurableEvidenceCapabilityForTest(
+    bucketName,
+    new Storage().bucket(bucketName),
+  );
+}
 type Stage = "screening" | "full";
 type Provider = "anthropic" | "openai" | "google";
 type Raw = Readonly<Record<string, unknown>>;
@@ -516,9 +539,10 @@ function request(
   // system-block assembly as the paired arm. The synthetic evaluator contract
   // follows it and is deliberately separate provenance, never a replacement
   // for the production prompt core.
-  const runtimeSurface = d.role === "router"
-    ? addieMatchedV4RouterWireSurface(d.provider)
-    : addieMatchedV4WireSurface(a.cell.toolSurface, d.provider);
+  const runtimeSurface =
+    d.role === "router"
+      ? addieMatchedV4RouterWireSurface(d.provider)
+      : addieMatchedV4WireSurface(a.cell.toolSurface, d.provider);
   const productionPrompt = runtimeSurface.system;
   const tools = runtimeSurface.tools;
   const system = [
@@ -897,6 +921,11 @@ interface AddieMatchedV4PrivateRunResult {
   /** Serializable preimage for independent artifact-hash verification. */
   readonly artifactEvidence: AddieMatchedV4ExecutionArtifactEvidence;
   readonly reservationId: string;
+  /** Independently retained reservation and final evidence generations. */
+  readonly durableEvidence: Readonly<{
+    reservation: AddieMatchedV4DurableEvidenceReservation;
+    final: AddieMatchedV4DurableObject;
+  }>;
   readonly metrics: ReturnType<typeof validateAddieMatchedV4Observations>;
   readonly pairedCiGate?: readonly ReturnType<
     typeof addieMatchedV4PairedOutcomeCi
@@ -913,20 +942,35 @@ interface AddieMatchedV4PrivateRefusedRunResult {
   readonly metrics?: ReturnType<typeof validateAddieMatchedV4Observations>;
 }
 class AddieMatchedV4PrivateAuthority {
-  #plan = frozen(createAddieMatchedV4Plan());
+  #plan: AddieMatchedV4Plan;
   #promotion: AddieMatchedV4Promotion | null = null;
   #ledger: AddieMatchedV4PrivateLedger;
   #transport: AddieMatchedV4ExecutionTransport | undefined;
+  #durableEvidence: AddieMatchedV4DurableEvidenceCapability | undefined;
+  #screeningEvidenceReservation:
+    AddieMatchedV4DurableEvidenceReservation | undefined;
+  #evidenceMergeSha: string | undefined;
+  #evidenceManifestSha256: string | undefined;
   constructor(
     ledger: AddieMatchedV4PrivateLedger,
     issuedTransport?: IssuedExecutionTransport,
+    plan = frozen(createAddieMatchedV4Plan()),
+    durableEvidence?: AddieMatchedV4DurableEvidenceCapability,
+    screeningEvidenceReservation?: AddieMatchedV4DurableEvidenceReservation,
+    evidenceMergeSha?: string,
+    evidenceManifestSha256?: string,
   ) {
     if (issuedTransport && !issuedExecutionTransports.has(issuedTransport)) {
       throw Error("matched-v4 execution transport was not issued by authority");
     }
+    this.#plan = plan;
     issuedPlans.add(this.#plan);
     this.#ledger = ledger;
     this.#transport = issuedTransport?.transport;
+    this.#durableEvidence = durableEvidence;
+    this.#screeningEvidenceReservation = screeningEvidenceReservation;
+    this.#evidenceMergeSha = evidenceMergeSha;
+    this.#evidenceManifestSha256 = evidenceManifestSha256;
   }
   async execute(
     stage: Stage,
@@ -951,7 +995,42 @@ class AddieMatchedV4PrivateAuthority {
         stage === "screening"
           ? this.#plan.screening.maxProviderDispatches
           : this.#plan.full.maxProviderDispatches,
-      reservationId = `mv4_${hash({ stage, selector: selector.selectorFingerprint }).slice(0, 32)}`;
+      provisionalReservationId = `mv4_${randomUUID().replaceAll("-", "")}`;
+    let durableReservation: AddieMatchedV4DurableEvidenceReservation;
+    try {
+      if (stage === "screening") {
+        durableReservation = this.#screeningEvidenceReservation!;
+        if (
+          !durableReservation ||
+          durableReservation.commitment.selectorFingerprint !==
+            selector.selectorFingerprint
+        )
+          throw new Error(
+            "screening durable evidence reservation does not match selector",
+          );
+      } else {
+        if (!this.#durableEvidence)
+          throw new Error("durable evidence capability is unavailable");
+        durableReservation = await this.#durableEvidence.reserve({
+          reservationId: provisionalReservationId,
+          stage,
+          selectorFingerprint: selector.selectorFingerprint,
+          dispatchCap: cap,
+          mergeSha: this.#evidenceMergeSha!,
+          authorityManifestSha256: this.#evidenceManifestSha256!,
+          evaluationVersion: ADDIE_MATCHED_V4_EVALUATION_VERSION,
+        });
+      }
+    } catch {
+      return {
+        status: "refused",
+        reason: "durable_evidence_reservation_refused",
+      };
+    }
+    const reservationId = durableReservation.commitment.reservationId;
+    let artifactEvidence: AddieMatchedV4ExecutionArtifactEvidence | undefined;
+    let artifactSha256: string | undefined;
+    let terminalEvidenceRecorded = false;
     let dispatchTimeoutMs: number;
     try {
       dispatchTimeoutMs = matchedV4DispatchTimeoutMs();
@@ -1120,9 +1199,8 @@ class AddieMatchedV4PrivateAuthority {
                   d.preparedRequestFingerprint,
                 );
                 const continuation = continuationRequest(q, tool);
-                continuationRequestFingerprint = this.#transport!.requestCommitment(
-                  continuation,
-                );
+                continuationRequestFingerprint =
+                  this.#transport!.requestCommitment(continuation);
                 r = await dispatch(d, continuation);
                 if (r.finishReason !== "stop" || r.toolCalls.length !== 0)
                   throw Error("synthetic tool continuation was not terminal");
@@ -1158,7 +1236,8 @@ class AddieMatchedV4PrivateAuthority {
             // evaluator-owned synthetic receipt above.
             passed =
               terminalStatus === "stop" &&
-              !!receipt === (a.trace.expectedReceipt === "current_turn_github_567") &&
+              !!receipt ===
+                (a.trace.expectedReceipt === "current_turn_github_567") &&
               semanticGrade(a, finalText, receipt);
             const executedTurn = frozen({
               passed,
@@ -1205,6 +1284,17 @@ class AddieMatchedV4PrivateAuthority {
       // it. Metrics are retained read-only for the audit record, never as a
       // promotion capability.
       if (pairedCiGate?.some((ci) => ci.lower < 0)) {
+        if (!this.#durableEvidence)
+          throw new Error("durable evidence capability is unavailable");
+        artifactEvidence = serializableArtifactEvidence(artifact);
+        artifactSha256 = artifact.artifactSha256;
+        await this.#durableEvidence.recordRefusal({
+          reservation: durableReservation,
+          reasonCode: "paired_ci_gate",
+          artifactSha256,
+          artifactEvidence,
+        });
+        terminalEvidenceRecorded = true;
         await this.#ledger.halt({
           reservationId,
           reason: "paired CI gate requires lower bound >= 0",
@@ -1216,11 +1306,24 @@ class AddieMatchedV4PrivateAuthority {
           metrics,
         };
       }
+      artifactEvidence = serializableArtifactEvidence(artifact);
+      artifactSha256 = artifact.artifactSha256;
+      if (!this.#durableEvidence)
+        throw new Error("durable evidence capability is unavailable");
+      const finalEvidence = await this.#durableEvidence.finalize({
+        reservation: durableReservation,
+        artifactSha256,
+        artifactEvidence,
+      });
       const result = {
         status: "completed" as const,
         artifact,
-        artifactEvidence: serializableArtifactEvidence(artifact),
+        artifactEvidence,
         reservationId,
+        durableEvidence: Object.freeze({
+          reservation: durableReservation,
+          final: finalEvidence,
+        }),
         metrics,
         ...(pairedCiGate ? { pairedCiGate } : {}),
       };
@@ -1233,6 +1336,20 @@ class AddieMatchedV4PrivateAuthority {
       // A failed per-attempt settlement or a later artifact/CI failure may
       // have left an intent open. Reconcile before and after halt so the
       // durable readback path also works once no further dispatch is allowed.
+      const reason = e instanceof Error ? e.message : "unknown_exposure";
+      if (!terminalEvidenceRecorded && this.#durableEvidence)
+        await this.#durableEvidence
+          .recordRefusal({
+            reservation: durableReservation,
+            reasonCode: durableTerminalReasonCode(reason),
+            ...(artifactSha256 && artifactEvidence
+              ? { artifactSha256, artifactEvidence }
+              : {}),
+          })
+          .then(() => {
+            terminalEvidenceRecorded = true;
+          })
+          .catch(() => undefined);
       await this.#ledger.reconcile({ reservationId }).catch(() => false);
       await this.#ledger.halt({
         reservationId,
@@ -1241,7 +1358,7 @@ class AddieMatchedV4PrivateAuthority {
       await this.#ledger.reconcile({ reservationId }).catch(() => false);
       return {
         status: "refused",
-        reason: e instanceof Error ? e.message : "unknown_exposure",
+        reason,
       };
     }
   }
@@ -1397,12 +1514,29 @@ export async function createAddieMatchedV4PaidAuthority(
     );
   if (authorizePaidDispatch !== true)
     throw new Error("Matched v4 paid dispatch requires explicit authorization");
-  // This assertion lives at the only paid-authority construction boundary,
-  // rather than in an operator CLI. No ordinary import, path, or environment
-  // value can create providers, claim admission, or dispatch until a reviewed
-  // immutable-sink adapter supplies this capability.
-  assertMatchedV4SanctionedImmutableArtifactSink();
+  // The sealed adapter is the only producer of this capability. A caller
+  // cannot supply a local path, a mock sink, an ALLOW flag, or a provider to
+  // the authority. Its first operation is intentionally before any DB
+  // admission claim or provider construction.
+  const durableEvidence = createMatchedV4SanctionedDurableEvidenceCapability();
   const mergeSha = deployedMergeSha();
+  const manifestSha256 = authorityManifestSha256();
+  const plan = frozen(createAddieMatchedV4Plan());
+  const screeningSelectorFingerprint = digest({
+    domain: "adcp:addie:matched-v4:selector:v1",
+    plan: planFingerprint(plan),
+    stage: "screening",
+    promoted: ADDIE_MATCHED_V4_SCREENING_CELLS.map((cell) => cell.id),
+  });
+  const screeningEvidenceReservation = await durableEvidence.reserve({
+    reservationId: `mv4_${randomUUID().replaceAll("-", "")}`,
+    stage: "screening",
+    selectorFingerprint: screeningSelectorFingerprint,
+    dispatchCap: plan.screening.maxProviderDispatches,
+    mergeSha,
+    authorityManifestSha256: manifestSha256,
+    evaluationVersion: ADDIE_MATCHED_V4_EVALUATION_VERSION,
+  });
   const issuedLedger = issuePaidLedger();
   if (!(await issuedLedger.ledger.isRuntimeEligible()))
     throw new Error(
@@ -1490,11 +1624,12 @@ export async function createAddieMatchedV4PaidAuthority(
       // Gemini keeps a tool-call thought signature in adapter-private custody.
       // Project it before intent recording so a continuation commitment covers
       // all provider-visible state, not merely enumerable canonical fields.
-      const wire = provider === "openai"
-        ? prepareOpenAIResponsesEvaluationRequest(request)
-        : provider === "google"
-          ? prepareGoogleGenerateContentEvaluationRequest(request)
-          : request;
+      const wire =
+        provider === "openai"
+          ? prepareOpenAIResponsesEvaluationRequest(request)
+          : provider === "google"
+            ? prepareGoogleGenerateContentEvaluationRequest(request)
+            : request;
       return hash({ provider, canonicalRequest: request, wireRequest: wire });
     },
     async respond(
@@ -1550,6 +1685,11 @@ export async function createAddieMatchedV4PaidAuthority(
     new AddieMatchedV4PrivateAuthority(
       issuedLedger.ledger,
       issueExecutionTransport(transport),
+      plan,
+      durableEvidence,
+      screeningEvidenceReservation,
+      mergeSha,
+      manifestSha256,
     ),
   ) as AddieMatchedV4PrivateAuthority;
 }
@@ -1698,7 +1838,9 @@ interface RecordedObservation {
  * normalized identities, token/cost accounting, and request hashes—never API
  * keys, raw provider bodies, or executable tool/ledger capabilities.
  */
-interface AddieMatchedV4ExecutionArtifactEvidence {
+interface AddieMatchedV4ExecutionArtifactEvidence extends Readonly<
+  Record<string, unknown>
+> {
   readonly kind: "addie_matched_v4_execution_artifact_evidence";
   readonly version: typeof ADDIE_MATCHED_V4_EVALUATION_VERSION;
   readonly stage: AddieMatchedV4Stage;
@@ -1732,6 +1874,18 @@ function validCount(value: number): boolean {
 }
 function validSha256(value: string): boolean {
   return /^[a-f0-9]{64}$/.test(value);
+}
+function durableTerminalReasonCode(
+  reason: string,
+): AddieMatchedV4TerminalReasonCode {
+  if (reason === "paired CI gate requires lower bound >= 0")
+    return "paired_ci_gate";
+  if (reason === "matched-v4 dispatch timeout") return "dispatch_timeout";
+  if (reason === "settlement refused") return "settlement_refused";
+  if (reason === "intent refused") return "intent_refused";
+  if (/provider (?:response|did not)/.test(reason))
+    return "provider_response_invalid";
+  return "execution_refused";
 }
 
 function cellById(id: string): AddieMatchedV4Cell | undefined {
@@ -1957,8 +2111,8 @@ function recordExecution(
     executed.attemptedProviderDispatches !== expectedPhysicalDispatches ||
     executed.completedProviderDispatches !== expectedPhysicalDispatches ||
     (executed.dispatches.length !== initialPhysicalDispatches &&
-      executed.dispatches.length !== initialPhysicalDispatches +
-        (expectsContinuation ? 1 : 0))
+      executed.dispatches.length !==
+        initialPhysicalDispatches + (expectsContinuation ? 1 : 0))
   )
     throw new Error(
       "Matched v4 dispatch receipt does not match bounded execution",
@@ -2027,7 +2181,10 @@ function recordExecution(
         costUsd,
       });
     });
-  if (expectsContinuation && executed.dispatches.length > initialPhysicalDispatches) {
+  if (
+    expectsContinuation &&
+    executed.dispatches.length > initialPhysicalDispatches
+  ) {
     const expected = assignment.dispatches.at(-1)!;
     const continuation = executed.dispatches.at(-1)!;
     const continuationFingerprint =
@@ -2106,7 +2263,9 @@ function recordExecution(
     executed.currentTurnToolReceipt?.preparedRequestFingerprint ===
       assignment.dispatches.at(-1)?.preparedRequestFingerprint;
   if (
-    (expectsContinuation && executed.currentTurnToolReceipt !== null && !exactReceipt) ||
+    (expectsContinuation &&
+      executed.currentTurnToolReceipt !== null &&
+      !exactReceipt) ||
     (!expectsContinuation && executed.currentTurnToolReceipt !== null)
   )
     throw new Error(
@@ -2137,8 +2296,7 @@ function recordExecution(
       cacheWriteTokens: usageTotal("cacheWriteTokens"),
       reasoningTokens: reasoningDispatches.length
         ? reasoningDispatches.reduce(
-            (sum, dispatch) =>
-              sum + (dispatch.usage.reasoningTokens ?? 0),
+            (sum, dispatch) => sum + (dispatch.usage.reasoningTokens ?? 0),
             0,
           )
         : null,
@@ -2486,9 +2644,7 @@ function addieMatchedV4ParetoPromotions(
   // bounded full stage must not turn a screen with many equivalent Pareto
   // points into an unbounded live run.
   return Object.freeze(
-    promoted
-      .map((metric) => metric.cell.id)
-      .slice(0, maxPromotedCells),
+    promoted.map((metric) => metric.cell.id).slice(0, maxPromotedCells),
   );
 }
 

--- a/server/src/addie/eval/matched-v4-authority-custody.ts
+++ b/server/src/addie/eval/matched-v4-authority-custody.ts
@@ -5,6 +5,7 @@ import { Storage } from "@google-cloud/storage";
 import OpenAI from "openai";
 import type { Pool, PoolClient } from "pg";
 import { getPool } from "../../db/client.js";
+import { createLogger } from "../../logger.js";
 import {
   ADDIE_MATCHED_V4_BASELINE_CELL_ID,
   ADDIE_MATCHED_V4_EVALUATION_VERSION,
@@ -68,6 +69,16 @@ const ADDIE_MATCHED_V4_PRIVATE_AUTHORITY = Object.freeze({
   }),
 });
 const EVIDENCE_BUCKET_ENV = "ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET";
+const logger = createLogger("addie-matched-v4-authority");
+// The Storage client's retry budget bounds metadata and generation-pinned
+// reads. The adapter separately sets this as the non-resumable write timeout.
+const ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_SECONDS = 30;
+const ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_MS =
+  ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_SECONDS * 1_000;
+// A terminal record is not best-effort. Retrying at the authority boundary
+// makes the adapter's issued -> finalizing -> issued recovery reachable from
+// paid execution, while keeping retries bounded and zero-network by itself.
+const ADDIE_MATCHED_V4_TERMINAL_EVIDENCE_ATTEMPTS = 3;
 /** Deliberately module-private: only the paid constructor can issue this. */
 function createMatchedV4SanctionedDurableEvidenceCapability(): AddieMatchedV4DurableEvidenceCapability {
   const bucketName = process.env[EVIDENCE_BUCKET_ENV];
@@ -80,8 +91,47 @@ function createMatchedV4SanctionedDurableEvidenceCapability(): AddieMatchedV4Dur
     );
   return createMatchedV4GcsDurableEvidenceCapabilityForTest(
     bucketName,
-    new Storage().bucket(bucketName),
+    new Storage({
+      // Storage passes ServiceOptions.timeout to metadata and download HTTP
+      // requests; save receives its matching explicit timeout in the adapter.
+      timeout: ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_MS,
+      retryOptions: {
+        autoRetry: true,
+        maxRetries: 2,
+        maxRetryDelay: 5,
+        retryDelayMultiplier: 2,
+        totalTimeout: ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_SECONDS,
+      },
+    }).bucket(bucketName),
   );
+}
+async function recordMatchedV4ConstructionRefusal(
+  durableEvidence: AddieMatchedV4DurableEvidenceCapability,
+  reservation: AddieMatchedV4DurableEvidenceReservation,
+): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 0;
+    attempt < ADDIE_MATCHED_V4_TERMINAL_EVIDENCE_ATTEMPTS;
+    attempt++
+  ) {
+    try {
+      await durableEvidence.recordRefusal({
+        reservation,
+        reasonCode: "execution_refused",
+      });
+      return;
+    } catch (error) {
+      lastError ??= error;
+      // The sealed adapter resets an unsuccessful finalization to issued.
+      // Continue only within the bounded authority retry budget.
+    }
+  }
+  logger.error(
+    { err: lastError },
+    "Matched v4 durable construction refusal could not be retained",
+  );
+  throw new Error("Matched v4 durable terminal evidence could not be retained");
 }
 type Stage = "screening" | "full";
 type Provider = "anthropic" | "openai" | "google";
@@ -972,11 +1022,83 @@ class AddieMatchedV4PrivateAuthority {
     this.#evidenceMergeSha = evidenceMergeSha;
     this.#evidenceManifestSha256 = evidenceManifestSha256;
   }
+  async #recordTerminalEvidence(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      reasonCode: AddieMatchedV4TerminalReasonCode;
+      artifactSha256?: string;
+      artifactEvidence?: AddieMatchedV4ExecutionArtifactEvidence;
+    }>,
+  ): Promise<void> {
+    if (!this.#durableEvidence)
+      throw new Error("Matched v4 durable evidence capability is unavailable");
+    let lastError: unknown;
+    for (
+      let attempt = 0;
+      attempt < ADDIE_MATCHED_V4_TERMINAL_EVIDENCE_ATTEMPTS;
+      attempt++
+    ) {
+      try {
+        await this.#durableEvidence.recordRefusal(input);
+        return;
+      } catch (error) {
+        lastError ??= error;
+      }
+    }
+    // Do not expose a provider/SDK diagnostic in a durable record or return
+    // it to the paid caller. Structured logger error hooks deliver the root
+    // cause to operational telemetry while this refusal stays closed.
+    logger.error(
+      { err: lastError },
+      "Matched v4 durable terminal refusal could not be retained",
+    );
+    throw new Error(
+      "Matched v4 durable terminal evidence could not be retained",
+    );
+  }
+  async #finalizeTerminalEvidence(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      artifactSha256: string;
+      artifactEvidence: AddieMatchedV4ExecutionArtifactEvidence;
+    }>,
+  ): Promise<AddieMatchedV4DurableObject> {
+    if (!this.#durableEvidence)
+      throw new Error("Matched v4 durable evidence capability is unavailable");
+    let lastError: unknown;
+    for (
+      let attempt = 0;
+      attempt < ADDIE_MATCHED_V4_TERMINAL_EVIDENCE_ATTEMPTS;
+      attempt++
+    ) {
+      try {
+        return await this.#durableEvidence.finalize(input);
+      } catch (error) {
+        lastError ??= error;
+        // The adapter admits a retry only for this same terminal identity.
+      }
+    }
+    logger.error(
+      { err: lastError },
+      "Matched v4 durable completion evidence could not be retained",
+    );
+    throw new Error(
+      "Matched v4 durable completion evidence could not be retained",
+    );
+  }
   async execute(
     stage: Stage,
   ): Promise<
     AddieMatchedV4PrivateRunResult | AddieMatchedV4PrivateRefusedRunResult
   > {
+    // TypeScript callers are checked statically, but a paid boundary must not
+    // let a JavaScript caller turn an arbitrary string into a full-pack run.
+    // It is not an admitted execution and therefore must not consume the
+    // reserved screening disposition; a later valid screening call remains
+    // subject to its exact sealed reservation.
+    if (stage !== "screening" && stage !== "full") {
+      return { status: "refused", reason: "invalid_stage" };
+    }
     if (!this.#transport)
       return { status: "refused", reason: "paid_dispatch_gate_closed" };
     if (stage === "full" && !this.#promotion)
@@ -996,6 +1118,31 @@ class AddieMatchedV4PrivateAuthority {
           ? this.#plan.screening.maxProviderDispatches
           : this.#plan.full.maxProviderDispatches,
       provisionalReservationId = `mv4_${randomUUID().replaceAll("-", "")}`;
+    let dispatchTimeoutMs: number;
+    try {
+      dispatchTimeoutMs = matchedV4DispatchTimeoutMs();
+    } catch (error) {
+      // Screening owns a pre-dispatch reservation from construction. A later
+      // invalid environment value must close it rather than leave a WORM
+      // reservation with no terminal disposition. Full has no reservation yet.
+      if (stage === "screening" && this.#screeningEvidenceReservation) {
+        try {
+          await this.#recordTerminalEvidence({
+            reservation: this.#screeningEvidenceReservation,
+            reasonCode: "execution_refused",
+          });
+        } catch {
+          return {
+            status: "refused",
+            reason: "durable_terminal_evidence_unavailable",
+          };
+        }
+      }
+      return {
+        status: "refused",
+        reason: publicRefusalReason("execution_refused"),
+      };
+    }
     let durableReservation: AddieMatchedV4DurableEvidenceReservation;
     try {
       if (stage === "screening") {
@@ -1031,27 +1178,18 @@ class AddieMatchedV4PrivateAuthority {
     let artifactEvidence: AddieMatchedV4ExecutionArtifactEvidence | undefined;
     let artifactSha256: string | undefined;
     let terminalEvidenceRecorded = false;
-    let dispatchTimeoutMs: number;
-    try {
-      dispatchTimeoutMs = matchedV4DispatchTimeoutMs();
-    } catch (error) {
-      return {
-        status: "refused",
-        reason:
-          error instanceof Error ? error.message : "invalid dispatch timeout",
-      };
-    }
-    if (
-      (await this.#ledger.reserve({
-        reservationId,
-        stage,
-        selectorFingerprint: selector.selectorFingerprint,
-        dispatchCap: cap,
-      })) !== "reserved"
-    )
-      return { status: "refused", reason: "reservation_refused" };
+    let terminalOperationStarted = false;
     let count = 0;
     try {
+      if (
+        (await this.#ledger.reserve({
+          reservationId,
+          stage,
+          selectorFingerprint: selector.selectorFingerprint,
+          dispatchCap: cap,
+        })) !== "reserved"
+      )
+        throw new Error("reservation_refused");
       const executedTurns: AddieMatchedV4ExecutedTurn[] = [];
       for (const a of addieMatchedV4ExecutionAssignments(selector)) {
         executedTurns.push(
@@ -1288,7 +1426,7 @@ class AddieMatchedV4PrivateAuthority {
           throw new Error("durable evidence capability is unavailable");
         artifactEvidence = serializableArtifactEvidence(artifact);
         artifactSha256 = artifact.artifactSha256;
-        await this.#durableEvidence.recordRefusal({
+        await this.#recordTerminalEvidence({
           reservation: durableReservation,
           reasonCode: "paired_ci_gate",
           artifactSha256,
@@ -1308,9 +1446,17 @@ class AddieMatchedV4PrivateAuthority {
       }
       artifactEvidence = serializableArtifactEvidence(artifact);
       artifactSha256 = artifact.artifactSha256;
+      // Computing promotion can fail only before the completion record is
+      // committed. Assignment remains after verified final evidence so an
+      // incomplete terminal record can never unlock the full stage.
+      const screeningPromotion =
+        stage === "screening"
+          ? frozen(promoteAddieMatchedV4Screening(this.#plan, metrics))
+          : undefined;
       if (!this.#durableEvidence)
         throw new Error("durable evidence capability is unavailable");
-      const finalEvidence = await this.#durableEvidence.finalize({
+      terminalOperationStarted = true;
+      const finalEvidence = await this.#finalizeTerminalEvidence({
         reservation: durableReservation,
         artifactSha256,
         artifactEvidence,
@@ -1327,38 +1473,67 @@ class AddieMatchedV4PrivateAuthority {
         metrics,
         ...(pairedCiGate ? { pairedCiGate } : {}),
       };
-      if (stage === "screening")
-        this.#promotion = frozen(
-          promoteAddieMatchedV4Screening(this.#plan, metrics),
-        );
+      if (screeningPromotion) this.#promotion = screeningPromotion;
       return result;
     } catch (e) {
       // A failed per-attempt settlement or a later artifact/CI failure may
       // have left an intent open. Reconcile before and after halt so the
       // durable readback path also works once no further dispatch is allowed.
-      const reason = e instanceof Error ? e.message : "unknown_exposure";
-      if (!terminalEvidenceRecorded && this.#durableEvidence)
-        await this.#durableEvidence
-          .recordRefusal({
+      const rawReason = e instanceof Error ? e.message : "unknown_exposure";
+      const reasonCode = durableTerminalReasonCode(rawReason);
+      if (!terminalEvidenceRecorded && !terminalOperationStarted)
+        try {
+          await this.#recordTerminalEvidence({
             reservation: durableReservation,
-            reasonCode: durableTerminalReasonCode(reason),
+            reasonCode,
             ...(artifactSha256 && artifactEvidence
               ? { artifactSha256, artifactEvidence }
               : {}),
-          })
-          .then(() => {
-            terminalEvidenceRecorded = true;
-          })
-          .catch(() => undefined);
+          });
+        } catch {
+          await this.#ledger.reconcile({ reservationId }).catch(() => false);
+          await this.#ledger.halt({
+            reservationId,
+            reason: "durable terminal evidence unavailable",
+          });
+          await this.#ledger.reconcile({ reservationId }).catch(() => false);
+          return {
+            status: "refused",
+            reason: "durable_terminal_evidence_unavailable",
+          };
+        }
+      if (terminalOperationStarted) {
+        // Completion I/O can be ambiguous after a request reached GCS. The
+        // sealed sink allows only identical completion retries; never create
+        // a conflicting terminal refusal for this reservation.
+        await this.#ledger.reconcile({ reservationId }).catch(() => false);
+        await this.#ledger.halt({
+          reservationId,
+          reason: "durable completion evidence unavailable",
+        });
+        await this.#ledger.reconcile({ reservationId }).catch(() => false);
+        return {
+          status: "refused",
+          reason: "durable_terminal_evidence_unavailable",
+        };
+      }
+      logger.error(
+        {
+          err: e,
+          reservationId,
+          reasonCode,
+        },
+        "Matched v4 execution was refused after durable terminal evidence",
+      );
       await this.#ledger.reconcile({ reservationId }).catch(() => false);
       await this.#ledger.halt({
         reservationId,
-        reason: e instanceof Error ? e.message : "unknown",
+        reason: publicRefusalReason(reasonCode),
       });
       await this.#ledger.reconcile({ reservationId }).catch(() => false);
       return {
         status: "refused",
-        reason,
+        reason: publicRefusalReason(reasonCode),
       };
     }
   }
@@ -1514,184 +1689,218 @@ export async function createAddieMatchedV4PaidAuthority(
     );
   if (authorizePaidDispatch !== true)
     throw new Error("Matched v4 paid dispatch requires explicit authorization");
-  // The sealed adapter is the only producer of this capability. A caller
-  // cannot supply a local path, a mock sink, an ALLOW flag, or a provider to
-  // the authority. Its first operation is intentionally before any DB
-  // admission claim or provider construction.
-  const durableEvidence = createMatchedV4SanctionedDurableEvidenceCapability();
-  const mergeSha = deployedMergeSha();
-  const manifestSha256 = authorityManifestSha256();
-  const plan = frozen(createAddieMatchedV4Plan());
-  const screeningSelectorFingerprint = digest({
-    domain: "adcp:addie:matched-v4:selector:v1",
-    plan: planFingerprint(plan),
-    stage: "screening",
-    promoted: ADDIE_MATCHED_V4_SCREENING_CELLS.map((cell) => cell.id),
-  });
-  const screeningEvidenceReservation = await durableEvidence.reserve({
-    reservationId: `mv4_${randomUUID().replaceAll("-", "")}`,
-    stage: "screening",
-    selectorFingerprint: screeningSelectorFingerprint,
-    dispatchCap: plan.screening.maxProviderDispatches,
-    mergeSha,
-    authorityManifestSha256: manifestSha256,
-    evaluationVersion: ADDIE_MATCHED_V4_EVALUATION_VERSION,
-  });
-  const issuedLedger = issuePaidLedger();
-  if (!(await issuedLedger.ledger.isRuntimeEligible()))
-    throw new Error(
-      "Matched v4 paid dispatch requires the externally provisioned runtime DB role",
-    );
-  const selector = await postMergePaidDispatchSelector(mergeSha, issuedLedger);
-  if (!paidSelectors.has(selector) || spentPaidSelectors.has(selector))
-    throw new Error("Matched v4 paid selector is invalid or already consumed");
-  spentPaidSelectors.add(selector);
-  const [
-    { AnthropicModelProvider },
-    {
-      normalizeOpenAIResponse,
-      openaiReturnedModelIdentityMatches,
-      prepareOpenAIResponsesEvaluationRequest,
-    },
-    {
-      googleReturnedModelIdentityMatches,
-      normalizeGoogleResponse,
-      prepareGoogleGenerateContentEvaluationRequest,
-    },
-    { GoogleGenAI },
-    { collectModelResponse },
-  ] = await Promise.all([
-    import("../model-providers/anthropic-provider.js"),
-    import("../model-providers/openai-responses-provider.js"),
-    import("../model-providers/google-generate-content-provider.js"),
-    import("@google/genai"),
-    import("../model-providers/events.js"),
-  ]);
-  const openaiClient = new OpenAI({
-    apiKey: openaiApiKey,
-    maxRetries: 0,
-  });
-  // The Google SDK is instantiated only after the durable selector has been
-  // claimed. Unlike the ordinary router adapter, this sealed evaluator
-  // projection admits Gemini 3.8; no exported factory accepts a transport.
-  const googleClient = new GoogleGenAI({
-    apiKey: googleApiKey,
-    httpOptions: { retryOptions: { attempts: 1 } },
-  });
-  const providers: Record<Provider, any> = {
-    anthropic: new AnthropicModelProvider(anthropicApiKey, undefined, {
-      transportMaxRetries: 0,
-    }),
-    // This evaluator-only adapter lives here rather than in the exported
-    // provider module. Its request projection is pure; its sole network
-    // client is constructed after the durable admission is consumed above.
-    openai: {
-      id: "openai",
-      async respond(request: Readonly<ModelRequest>, signal: AbortSignal) {
-        const raw = await openaiClient.responses.create(
-          prepareOpenAIResponsesEvaluationRequest(request) as never,
-          { maxRetries: 0, signal },
-        );
-        const response = normalizeOpenAIResponse(raw);
-        if (!openaiReturnedModelIdentityMatches(request.model, response.model))
-          throw Error("OpenAI returned model identity is not approved");
-        return response;
-      },
-    },
-    google: {
-      id: "google",
-      async respond(request: Readonly<ModelRequest>, signal: AbortSignal) {
-        if (signal.aborted) throw signal.reason;
-        const prepared = prepareGoogleGenerateContentEvaluationRequest(request);
-        const raw = await googleClient.models.generateContent({
-          ...prepared,
-          config: {
-            ...prepared.config,
-            abortSignal: signal,
-          },
-        } as never);
-        const response = await normalizeGoogleResponse(raw);
-        if (!googleReturnedModelIdentityMatches(request.model, response.model))
-          throw Error("Google returned model identity is not approved");
-        return response;
-      },
-    },
-  };
-  const transport: AddieMatchedV4ExecutionTransport = Object.freeze({
-    kind: "provider_transport" as const,
-    requestCommitment(request: Readonly<ModelRequest>) {
-      const provider = providerForModel(request.model);
-      // Gemini keeps a tool-call thought signature in adapter-private custody.
-      // Project it before intent recording so a continuation commitment covers
-      // all provider-visible state, not merely enumerable canonical fields.
-      const wire =
-        provider === "openai"
-          ? prepareOpenAIResponsesEvaluationRequest(request)
-          : provider === "google"
-            ? prepareGoogleGenerateContentEvaluationRequest(request)
-            : request;
-      return hash({ provider, canonicalRequest: request, wireRequest: wire });
-    },
-    async respond(
-      request: Readonly<ModelRequest>,
-      context: Readonly<{
-        assignmentId: string;
-        dispatchOrdinal: number;
-        role: string;
-        signal: AbortSignal;
-      }>,
-    ) {
-      const provider = providers[providerForModel(request.model)];
-      const started = Date.now();
-      const response =
-        provider.id === "openai" || provider.id === "google"
-          ? await provider.respond(request, context.signal)
-          : await collectModelResponse(
-              provider.respond(request, { signal: context.signal }),
-              provider.id,
-            );
-      return Object.freeze({
-        provider: response.provider,
-        model: response.model,
-        response_id: response.id,
-        finish_reason: response.finishReason,
-        latency_ms: Date.now() - started,
-        text: response.content
-          .filter((part: any) => part.type === "text")
-          .map((part: any) => part.text)
-          .join(""),
-        usage: {
-          input_tokens: response.usage.inputTokens,
-          output_tokens: response.usage.outputTokens,
-          cache_read_tokens: response.usage.cacheReadTokens ?? 0,
-          cache_write_tokens: response.usage.cacheWriteTokens ?? 0,
-          ...(response.provider === "openai" || response.provider === "google"
-            ? { reasoning_tokens: response.usage.reasoningTokens ?? 0 }
-            : {}),
-        },
-        tool_calls: response.content
-          .filter((part: any) => part.type === "tool_call")
-          .map((part: any) => ({
-            name: part.name,
-            id: part.id,
-            input: part.input,
-            continuation: part,
-          })),
-        context,
-      });
-    },
-  });
-  return Object.freeze(
-    new AddieMatchedV4PrivateAuthority(
-      issuedLedger.ledger,
-      issueExecutionTransport(transport),
-      plan,
-      durableEvidence,
-      screeningEvidenceReservation,
+  let durableEvidence: AddieMatchedV4DurableEvidenceCapability | undefined;
+  let screeningEvidenceReservation:
+    | AddieMatchedV4DurableEvidenceReservation
+    | undefined;
+  try {
+    // Reject malformed execution configuration before creating the immutable
+    // pre-dispatch reservation, so a configuration error cannot strand it.
+    matchedV4DispatchTimeoutMs();
+    // The sealed adapter is the only producer of this capability. A caller
+    // cannot supply a local path, a mock sink, an ALLOW flag, or a provider to
+    // the authority. Its first operation is intentionally before any DB
+    // admission claim or provider construction.
+    durableEvidence = createMatchedV4SanctionedDurableEvidenceCapability();
+    const mergeSha = deployedMergeSha();
+    const manifestSha256 = authorityManifestSha256();
+    const plan = frozen(createAddieMatchedV4Plan());
+    const screeningSelectorFingerprint = digest({
+      domain: "adcp:addie:matched-v4:selector:v1",
+      plan: planFingerprint(plan),
+      stage: "screening",
+      promoted: ADDIE_MATCHED_V4_SCREENING_CELLS.map((cell) => cell.id),
+    });
+    screeningEvidenceReservation = await durableEvidence.reserve({
+      reservationId: `mv4_${randomUUID().replaceAll("-", "")}`,
+      stage: "screening",
+      selectorFingerprint: screeningSelectorFingerprint,
+      dispatchCap: plan.screening.maxProviderDispatches,
       mergeSha,
-      manifestSha256,
-    ),
-  ) as AddieMatchedV4PrivateAuthority;
+      authorityManifestSha256: manifestSha256,
+      evaluationVersion: ADDIE_MATCHED_V4_EVALUATION_VERSION,
+    });
+    const issuedLedger = issuePaidLedger();
+    if (!(await issuedLedger.ledger.isRuntimeEligible()))
+      throw new Error(
+        "Matched v4 paid dispatch requires the externally provisioned runtime DB role",
+      );
+    const selector = await postMergePaidDispatchSelector(
+      mergeSha,
+      issuedLedger,
+    );
+    if (!paidSelectors.has(selector) || spentPaidSelectors.has(selector))
+      throw new Error(
+        "Matched v4 paid selector is invalid or already consumed",
+      );
+    spentPaidSelectors.add(selector);
+    const [
+      { AnthropicModelProvider },
+      {
+        normalizeOpenAIResponse,
+        openaiReturnedModelIdentityMatches,
+        prepareOpenAIResponsesEvaluationRequest,
+      },
+      {
+        googleReturnedModelIdentityMatches,
+        normalizeGoogleResponse,
+        prepareGoogleGenerateContentEvaluationRequest,
+      },
+      { GoogleGenAI },
+      { collectModelResponse },
+    ] = await Promise.all([
+      import("../model-providers/anthropic-provider.js"),
+      import("../model-providers/openai-responses-provider.js"),
+      import("../model-providers/google-generate-content-provider.js"),
+      import("@google/genai"),
+      import("../model-providers/events.js"),
+    ]);
+    const openaiClient = new OpenAI({
+      apiKey: openaiApiKey,
+      maxRetries: 0,
+    });
+    // The Google SDK is instantiated only after the durable selector has been
+    // claimed. Unlike the ordinary router adapter, this sealed evaluator
+    // projection admits Gemini 3.8; no exported factory accepts a transport.
+    const googleClient = new GoogleGenAI({
+      apiKey: googleApiKey,
+      httpOptions: { retryOptions: { attempts: 1 } },
+    });
+    const providers: Record<Provider, any> = {
+      anthropic: new AnthropicModelProvider(anthropicApiKey, undefined, {
+        transportMaxRetries: 0,
+      }),
+      // This evaluator-only adapter lives here rather than in the exported
+      // provider module. Its request projection is pure; its sole network
+      // client is constructed after the durable admission is consumed above.
+      openai: {
+        id: "openai",
+        async respond(request: Readonly<ModelRequest>, signal: AbortSignal) {
+          const raw = await openaiClient.responses.create(
+            prepareOpenAIResponsesEvaluationRequest(request) as never,
+            { maxRetries: 0, signal },
+          );
+          const response = normalizeOpenAIResponse(raw);
+          if (
+            !openaiReturnedModelIdentityMatches(request.model, response.model)
+          )
+            throw Error("OpenAI returned model identity is not approved");
+          return response;
+        },
+      },
+      google: {
+        id: "google",
+        async respond(request: Readonly<ModelRequest>, signal: AbortSignal) {
+          if (signal.aborted) throw signal.reason;
+          const prepared =
+            prepareGoogleGenerateContentEvaluationRequest(request);
+          const raw = await googleClient.models.generateContent({
+            ...prepared,
+            config: {
+              ...prepared.config,
+              abortSignal: signal,
+            },
+          } as never);
+          const response = await normalizeGoogleResponse(raw);
+          if (
+            !googleReturnedModelIdentityMatches(request.model, response.model)
+          )
+            throw Error("Google returned model identity is not approved");
+          return response;
+        },
+      },
+    };
+    const transport: AddieMatchedV4ExecutionTransport = Object.freeze({
+      kind: "provider_transport" as const,
+      requestCommitment(request: Readonly<ModelRequest>) {
+        const provider = providerForModel(request.model);
+        // Gemini keeps a tool-call thought signature in adapter-private custody.
+        // Project it before intent recording so a continuation commitment covers
+        // all provider-visible state, not merely enumerable canonical fields.
+        const wire =
+          provider === "openai"
+            ? prepareOpenAIResponsesEvaluationRequest(request)
+            : provider === "google"
+              ? prepareGoogleGenerateContentEvaluationRequest(request)
+              : request;
+        return hash({ provider, canonicalRequest: request, wireRequest: wire });
+      },
+      async respond(
+        request: Readonly<ModelRequest>,
+        context: Readonly<{
+          assignmentId: string;
+          dispatchOrdinal: number;
+          role: string;
+          signal: AbortSignal;
+        }>,
+      ) {
+        const provider = providers[providerForModel(request.model)];
+        const started = Date.now();
+        const response =
+          provider.id === "openai" || provider.id === "google"
+            ? await provider.respond(request, context.signal)
+            : await collectModelResponse(
+                provider.respond(request, { signal: context.signal }),
+                provider.id,
+              );
+        return Object.freeze({
+          provider: response.provider,
+          model: response.model,
+          response_id: response.id,
+          finish_reason: response.finishReason,
+          latency_ms: Date.now() - started,
+          text: response.content
+            .filter((part: any) => part.type === "text")
+            .map((part: any) => part.text)
+            .join(""),
+          usage: {
+            input_tokens: response.usage.inputTokens,
+            output_tokens: response.usage.outputTokens,
+            cache_read_tokens: response.usage.cacheReadTokens ?? 0,
+            cache_write_tokens: response.usage.cacheWriteTokens ?? 0,
+            ...(response.provider === "openai" || response.provider === "google"
+              ? { reasoning_tokens: response.usage.reasoningTokens ?? 0 }
+              : {}),
+          },
+          tool_calls: response.content
+            .filter((part: any) => part.type === "tool_call")
+            .map((part: any) => ({
+              name: part.name,
+              id: part.id,
+              input: part.input,
+              continuation: part,
+            })),
+          context,
+        });
+      },
+    });
+    return Object.freeze(
+      new AddieMatchedV4PrivateAuthority(
+        issuedLedger.ledger,
+        issueExecutionTransport(transport),
+        plan,
+        durableEvidence,
+        screeningEvidenceReservation,
+        mergeSha,
+        manifestSha256,
+      ),
+    ) as AddieMatchedV4PrivateAuthority;
+  } catch (error) {
+    // Reservation creation is the irreversible first admission step. Every
+    // later constructor failure receives an allowlisted terminal disposition.
+    // Provider/SDK configuration diagnostics stay in structured telemetry and
+    // never cross this paid-authority API boundary.
+    logger.error(
+      { err: error },
+      "Matched v4 paid authority construction was refused",
+    );
+    if (durableEvidence && screeningEvidenceReservation)
+      await recordMatchedV4ConstructionRefusal(
+        durableEvidence,
+        screeningEvidenceReservation,
+      );
+    throw new Error("Matched v4 paid authority construction refused");
+  }
 }
 function providerForModel(model: string): Provider {
   return model.startsWith("claude-")
@@ -1886,6 +2095,26 @@ function durableTerminalReasonCode(
   if (/provider (?:response|did not)/.test(reason))
     return "provider_response_invalid";
   return "execution_refused";
+}
+function publicRefusalReason(
+  code: AddieMatchedV4TerminalReasonCode,
+): string {
+  // These strings are deliberately finite and contain no provider/SDK text.
+  // The root error is available to the structured operational logger only.
+  switch (code) {
+    case "paired_ci_gate":
+      return "paired CI gate requires lower bound >= 0";
+    case "dispatch_timeout":
+      return "matched-v4 dispatch timeout";
+    case "settlement_refused":
+      return "settlement refused";
+    case "intent_refused":
+      return "intent refused";
+    case "provider_response_invalid":
+      return "provider_response_invalid";
+    case "execution_refused":
+      return "execution_refused";
+  }
 }
 
 function cellById(id: string): AddieMatchedV4Cell | undefined {
@@ -2616,7 +2845,9 @@ function addieMatchedV4PairedOutcomeCi(
 /**
  * Returns promotable direct cells after comparing against every complete
  * screening cell. The routed baseline is not promotable itself, but it must
- * remain a real dominance competitor.
+ * remain a real dominance competitor. Dated price profiles remain audit
+ * estimates pending provider reconciliation, so they are deliberately not a
+ * promotion criterion.
  */
 function addieMatchedV4ParetoPromotions(
   metrics: readonly AddieMatchedV4CellMetric[],
@@ -2633,10 +2864,8 @@ function addieMatchedV4ParetoPromotions(
         (other) =>
           other !== candidate &&
           other.passRate >= candidate.passRate &&
-          other.totalCostUsd <= candidate.totalCostUsd &&
           other.medianLatencyMs <= candidate.medianLatencyMs &&
           (other.passRate > candidate.passRate ||
-            other.totalCostUsd < candidate.totalCostUsd ||
             other.medianLatencyMs < candidate.medianLatencyMs),
       ),
   );

--- a/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
+++ b/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
@@ -1,14 +1,395 @@
-/**
- * The production gate for matched-v4 immutable evidence.
- *
- * A local path, chmod, O_EXCL, GitHub Actions identity assertion, or
- * content-addressed R2 upload is not an immutable artifact capability. This
- * module remains deliberately closed until the platform supplies a reviewed
- * WORM/append-only sink or independently signed durable receipt implementation
- * bound to the settlement ledger.
- */
-export function assertMatchedV4SanctionedImmutableArtifactSink(): void {
-  throw new Error(
-    "Matched v4 paid dispatch requires a sanctioned immutable artifact sink adapter",
+/** Provider-neutral durable evidence boundary for the paid matched-v4 run. */
+import { createHash } from "node:crypto";
+
+const EVIDENCE_PREFIX = "addie-matched-v4/v1";
+/** One year covers delayed provider billing reconciliation and audit review. */
+export const ADDIE_MATCHED_V4_MIN_EVIDENCE_RETENTION_MS =
+  365.25 * 24 * 60 * 60 * 1_000;
+
+export interface AddieMatchedV4EvidenceCommitment {
+  readonly reservationId: string;
+  readonly stage: "screening" | "full";
+  readonly selectorFingerprint: string;
+  readonly dispatchCap: number;
+  readonly mergeSha: string;
+  readonly authorityManifestSha256: string;
+  readonly evaluationVersion: string;
+}
+export interface AddieMatchedV4DurableObject {
+  readonly bucket: string;
+  readonly name: string;
+  readonly generation: string;
+  readonly sha256: string;
+  readonly retentionExpirationTime: string;
+}
+export interface AddieMatchedV4DurableEvidenceReservation {
+  readonly commitment: AddieMatchedV4EvidenceCommitment;
+  readonly object: AddieMatchedV4DurableObject;
+}
+export type AddieMatchedV4TerminalReasonCode =
+  | "paired_ci_gate"
+  | "dispatch_timeout"
+  | "settlement_refused"
+  | "intent_refused"
+  | "provider_response_invalid"
+  | "execution_refused";
+const terminalReasonCodes = new Set<AddieMatchedV4TerminalReasonCode>([
+  "paired_ci_gate",
+  "dispatch_timeout",
+  "settlement_refused",
+  "intent_refused",
+  "provider_response_invalid",
+  "execution_refused",
+]);
+const validTerminalReasonCode = (
+  value: unknown,
+): value is AddieMatchedV4TerminalReasonCode =>
+  typeof value === "string" &&
+  terminalReasonCodes.has(value as AddieMatchedV4TerminalReasonCode);
+export interface AddieMatchedV4DurableEvidenceCapability {
+  reserve(
+    commitment: AddieMatchedV4EvidenceCommitment,
+  ): Promise<AddieMatchedV4DurableEvidenceReservation>;
+  finalize(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      artifactSha256: string;
+      artifactEvidence: object;
+    }>,
+  ): Promise<AddieMatchedV4DurableObject>;
+  recordRefusal(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      reasonCode: AddieMatchedV4TerminalReasonCode;
+      artifactSha256?: string;
+      artifactEvidence?: object;
+    }>,
+  ): Promise<AddieMatchedV4DurableObject>;
+}
+
+type GcsObjectMetadata = Readonly<Record<string, unknown>>;
+interface GcsFile {
+  save(data: Buffer, options: Readonly<Record<string, unknown>>): Promise<void>;
+  getMetadata(): Promise<[object, ...unknown[]]>;
+  download(): Promise<[Buffer, ...unknown[]]>;
+}
+interface GcsBucket {
+  getMetadata(): Promise<[object, ...unknown[]]>;
+  file(name: string, options?: Readonly<{ generation: string }>): GcsFile;
+}
+const sha256 = (bytes: Buffer | string) =>
+  createHash("sha256").update(bytes).digest("hex");
+const md5 = (bytes: Buffer) => createHash("md5").update(bytes).digest("base64");
+const validSha256 = (value: unknown): value is string =>
+  typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+const validReservationId = (value: string) => /^mv4_[a-f0-9]{32}$/.test(value);
+const validRfc3339 = (value: unknown): value is string =>
+  typeof value === "string" && Number.isFinite(Date.parse(value));
+const retainedThroughEvidenceHorizon = (value: unknown): value is string =>
+  typeof value === "string" &&
+  Number.isFinite(Date.parse(value)) &&
+  Date.parse(value) >= Date.now() + ADDIE_MATCHED_V4_MIN_EVIDENCE_RETENTION_MS;
+function canonicalJson(value: unknown): Buffer {
+  const encoded = JSON.stringify(value);
+  if (typeof encoded !== "string")
+    throw new Error("durable evidence is not serializable");
+  return Buffer.from(encoded, "utf8");
+}
+function assertBucketLock(metadata: GcsObjectMetadata): void {
+  const retention = metadata.retentionPolicy as
+    Record<string, unknown> | undefined;
+  // effectiveTime is when the policy took effect, so a real locked bucket
+  // normally reports a historical timestamp. Object retention, by contrast,
+  // must still be in the future when a record is accepted.
+  if (
+    !retention ||
+    retention.isLocked !== true ||
+    !Number.isSafeInteger(Number(retention.retentionPeriod)) ||
+    Number(retention.retentionPeriod) <= 0 ||
+    !validRfc3339(retention.effectiveTime)
+  )
+    throw new Error(
+      "Matched v4 durable evidence requires a GCS Bucket Lock retention policy",
+    );
+}
+function verifiedObject(
+  bucket: string,
+  expectedName: string,
+  expectedSha256: string,
+  expectedMd5: string,
+  metadata: GcsObjectMetadata,
+): AddieMatchedV4DurableObject {
+  const generation = metadata.generation,
+    retentionExpirationTime = metadata.retentionExpirationTime;
+  const custom = metadata.metadata as Record<string, unknown> | undefined;
+  if (
+    metadata.bucket !== bucket ||
+    metadata.name !== expectedName ||
+    typeof generation !== "string" ||
+    !/^[1-9][0-9]*$/.test(generation) ||
+    metadata.md5Hash !== expectedMd5 ||
+    custom?.evidence_sha256 !== expectedSha256 ||
+    !retainedThroughEvidenceHorizon(retentionExpirationTime)
+  )
+    throw new Error(
+      "Matched v4 durable evidence write did not return a retained exact generation",
+    );
+  return Object.freeze({
+    bucket,
+    name: expectedName,
+    generation,
+    sha256: expectedSha256,
+    retentionExpirationTime,
+  });
+}
+
+class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvidenceCapability {
+  #bucketChecked = false;
+  #reservationStates = new WeakMap<
+    AddieMatchedV4DurableEvidenceReservation,
+    "issued" | "finalizing" | "consumed"
+  >();
+  #bucketName: string;
+  #bucket: GcsBucket;
+  constructor(bucketName: string, bucket: GcsBucket) {
+    this.#bucketName = bucketName;
+    this.#bucket = bucket;
+  }
+  async #assertBucketLock(): Promise<void> {
+    if (this.#bucketChecked) return;
+    const [response] = await this.#bucket.getMetadata();
+    assertBucketLock(response as GcsObjectMetadata);
+    this.#bucketChecked = true;
+  }
+  async #write(
+    kind: "reservation" | "final",
+    name: string,
+    payload: Readonly<Record<string, unknown>>,
+  ): Promise<AddieMatchedV4DurableObject> {
+    await this.#assertBucketLock();
+    const bytes = canonicalJson(payload),
+      contentSha256 = sha256(bytes),
+      file = this.#bucket.file(name);
+    try {
+      await file.save(bytes, {
+        resumable: false,
+        validation: "md5",
+        preconditionOpts: { ifGenerationMatch: 0 },
+        metadata: {
+          contentType: "application/json; charset=utf-8",
+          metadata: { evidence_kind: kind, evidence_sha256: contentSha256 },
+        },
+      });
+    } catch (error) {
+      // A retry may follow a lost response after GCS committed the first
+      // conditional create. Only a 412 can be recovered, and it must verify
+      // the exact immutable bytes below; every other failure stays closed.
+      if ((error as { code?: unknown }).code !== 412) throw error;
+    }
+    const [response] = await file.getMetadata();
+    const metadata = response as GcsObjectMetadata;
+    const verified = verifiedObject(
+      this.#bucketName,
+      name,
+      contentSha256,
+      md5(bytes),
+      metadata,
+    );
+    // Metadata is mutable even under Bucket Lock. Re-read the exact returned
+    // generation and verify its bytes with SHA-256, not metadata alone.
+    const [returnedBytes] = await this.#bucket
+      .file(name, { generation: verified.generation })
+      .download();
+    if (
+      !Buffer.isBuffer(returnedBytes) ||
+      sha256(returnedBytes) !== contentSha256
+    )
+      throw new Error(
+        "Matched v4 durable evidence readback digest does not match its write",
+      );
+    return verified;
+  }
+  async reserve(commitment: AddieMatchedV4EvidenceCommitment) {
+    if (
+      !validReservationId(commitment.reservationId) ||
+      !validSha256(commitment.selectorFingerprint) ||
+      !validSha256(commitment.authorityManifestSha256) ||
+      !/^[a-f0-9]{40}$/.test(commitment.mergeSha) ||
+      !Number.isSafeInteger(commitment.dispatchCap) ||
+      commitment.dispatchCap <= 0
+    )
+      throw new Error(
+        "Matched v4 durable evidence reservation commitment is malformed",
+      );
+    const object = await this.#write(
+      "reservation",
+      `${EVIDENCE_PREFIX}/reservations/${commitment.reservationId}.json`,
+      Object.freeze({
+        kind: "addie_matched_v4_pre_dispatch_reservation",
+        version: 1,
+        commitment,
+      }),
+    );
+    const reservation = Object.freeze({
+      commitment: Object.freeze({ ...commitment }),
+      object,
+    });
+    this.#reservationStates.set(reservation, "issued");
+    return reservation;
+  }
+  async #finalizeReservation<T>(
+    reservation: AddieMatchedV4DurableEvidenceReservation,
+    write: () => Promise<T>,
+  ): Promise<T> {
+    if (this.#reservationStates.get(reservation) !== "issued")
+      throw new Error(
+        "Matched v4 durable final evidence requires an unconsumed adapter-issued reservation",
+      );
+    this.#reservationStates.set(reservation, "finalizing");
+    try {
+      const finalized = await write();
+      this.#reservationStates.set(reservation, "consumed");
+      return finalized;
+    } catch (error) {
+      // Do not strand a reservation after a transient write/readback error.
+      // The finalizing state blocks concurrent double-finalization; a retry
+      // either verifies the original create via its 412 path or fails closed.
+      this.#reservationStates.set(reservation, "issued");
+      throw error;
+    }
+  }
+  #assertArtifactEvidence(
+    reservation: AddieMatchedV4DurableEvidenceReservation,
+    artifactSha256: string,
+    artifactEvidence: object,
+  ): void {
+    const evidence = artifactEvidence as Record<string, unknown>;
+    if (
+      evidence.kind !== "addie_matched_v4_execution_artifact_evidence" ||
+      evidence.version !== reservation.commitment.evaluationVersion ||
+      evidence.stage !== reservation.commitment.stage ||
+      evidence.selectorFingerprint !==
+        reservation.commitment.selectorFingerprint ||
+      evidence.artifactSha256 !== artifactSha256 ||
+      !validSha256(evidence.requestSetSha256)
+    )
+      throw new Error(
+        "Matched v4 durable final evidence does not cross-link the issued reservation",
+      );
+  }
+  async finalize(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      artifactSha256: string;
+      artifactEvidence: object;
+    }>,
+  ) {
+    if (!validSha256(input.artifactSha256))
+      throw new Error(
+        "Matched v4 durable final evidence commitment is malformed",
+      );
+    const reservation = input.reservation;
+    this.#assertArtifactEvidence(
+      reservation,
+      input.artifactSha256,
+      input.artifactEvidence,
+    );
+    return this.#finalizeReservation(reservation, () =>
+      this.#write(
+        "final",
+        `${EVIDENCE_PREFIX}/final/${reservation.commitment.reservationId}-${input.artifactSha256}.json`,
+        Object.freeze({
+          kind: "addie_matched_v4_final_evidence",
+          version: 1,
+          reservation: {
+            bucket: reservation.object.bucket,
+            name: reservation.object.name,
+            generation: reservation.object.generation,
+            sha256: reservation.object.sha256,
+          },
+          artifactSha256: input.artifactSha256,
+          artifactEvidence: input.artifactEvidence,
+          evidenceId: sha256(
+            canonicalJson({
+              reservation: reservation.object,
+              artifactSha256: input.artifactSha256,
+            }),
+          ),
+        }),
+      ),
+    );
+  }
+  async recordRefusal(
+    input: Readonly<{
+      reservation: AddieMatchedV4DurableEvidenceReservation;
+      reasonCode: AddieMatchedV4TerminalReasonCode;
+      artifactSha256?: string;
+      artifactEvidence?: object;
+    }>,
+  ) {
+    if (!validTerminalReasonCode(input.reasonCode))
+      throw new Error("Matched v4 durable refusal reason is malformed");
+    if (
+      (input.artifactSha256 === undefined) !==
+      (input.artifactEvidence === undefined)
+    )
+      throw new Error(
+        "Matched v4 durable refusal artifact evidence is incomplete",
+      );
+    if (input.artifactSha256 && input.artifactEvidence) {
+      if (!validSha256(input.artifactSha256))
+        throw new Error(
+          "Matched v4 durable refusal artifact digest is malformed",
+        );
+      this.#assertArtifactEvidence(
+        input.reservation,
+        input.artifactSha256,
+        input.artifactEvidence,
+      );
+    }
+    const refusalDigest = sha256(
+      canonicalJson({
+        reservation: input.reservation.object,
+        reasonCode: input.reasonCode,
+        artifactSha256: input.artifactSha256 ?? null,
+      }),
+    );
+    return this.#finalizeReservation(input.reservation, () =>
+      this.#write(
+        "final",
+        `${EVIDENCE_PREFIX}/final/${input.reservation.commitment.reservationId}-refused-${refusalDigest}.json`,
+        Object.freeze({
+          kind: "addie_matched_v4_terminal_refusal_evidence",
+          version: 1,
+          reservation: {
+            bucket: input.reservation.object.bucket,
+            name: input.reservation.object.name,
+            generation: input.reservation.object.generation,
+            sha256: input.reservation.object.sha256,
+          },
+          reasonCode: input.reasonCode,
+          ...(input.artifactSha256
+            ? {
+                artifactSha256: input.artifactSha256,
+                artifactEvidence: input.artifactEvidence,
+              }
+            : {}),
+          evidenceId: refusalDigest,
+        }),
+      ),
+    );
+  }
+}
+Object.freeze(GcsBucketLockDurableEvidenceCapability.prototype);
+
+/** Test-only structural issuer; the paid authority never accepts its output. */
+export function createMatchedV4GcsDurableEvidenceCapabilityForTest(
+  bucketName: string,
+  bucket: GcsBucket,
+): AddieMatchedV4DurableEvidenceCapability {
+  const capability = new GcsBucketLockDurableEvidenceCapability(
+    bucketName,
+    bucket,
   );
+  return Object.freeze(capability);
 }

--- a/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
+++ b/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
@@ -2,6 +2,8 @@
 import { createHash } from "node:crypto";
 
 const EVIDENCE_PREFIX = "addie-matched-v4/v1";
+/** Bounds a single non-resumable GCS write; client retry totals bound reads. */
+const ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_MS = 30_000;
 /** One year covers delayed provider billing reconciliation and audit review. */
 export const ADDIE_MATCHED_V4_MIN_EVIDENCE_RETENTION_MS =
   365.25 * 24 * 60 * 60 * 1_000;
@@ -77,6 +79,44 @@ interface GcsBucket {
   getMetadata(): Promise<[object, ...unknown[]]>;
   file(name: string, options?: Readonly<{ generation: string }>): GcsFile;
 }
+class MatchedV4GcsIoDeadlineError extends Error {
+  constructor(operation: string) {
+    super(`Matched v4 durable evidence I/O timed out while ${operation}`);
+    this.name = "MatchedV4GcsIoDeadlineError";
+  }
+}
+/**
+ * ServiceOptions.timeout reaches the SDK's HTTP requests. This independent
+ * wall-clock guard also bounds credential or stream setup that occurs before
+ * the request layer, and gives the authority a deterministic fail-closed
+ * outcome if an SDK seam never settles.
+ */
+function withinGcsDeadline<T>(
+  operation: string,
+  invoke: () => Promise<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new MatchedV4GcsIoDeadlineError(operation)),
+      ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_MS,
+    );
+    try {
+      void invoke().then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (error: unknown) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+    } catch (error) {
+      clearTimeout(timer);
+      reject(error);
+    }
+  });
+}
 const sha256 = (bytes: Buffer | string) =>
   createHash("sha256").update(bytes).digest("hex");
 const md5 = (bytes: Buffer) => createHash("md5").update(bytes).digest("base64");
@@ -147,7 +187,10 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
   #bucketChecked = false;
   #reservationStates = new WeakMap<
     AddieMatchedV4DurableEvidenceReservation,
-    "issued" | "finalizing" | "consumed"
+    Readonly<{
+      phase: "issued" | "finalizing" | "uncertain" | "consumed";
+      terminalIdentity?: string;
+    }>
   >();
   #bucketName: string;
   #bucket: GcsBucket;
@@ -157,7 +200,10 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
   }
   async #assertBucketLock(): Promise<void> {
     if (this.#bucketChecked) return;
-    const [response] = await this.#bucket.getMetadata();
+    const [response] = await withinGcsDeadline(
+      "reading Bucket Lock metadata",
+      () => this.#bucket.getMetadata(),
+    );
     assertBucketLock(response as GcsObjectMetadata);
     this.#bucketChecked = true;
   }
@@ -171,22 +217,28 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
       contentSha256 = sha256(bytes),
       file = this.#bucket.file(name);
     try {
-      await file.save(bytes, {
-        resumable: false,
-        validation: "md5",
-        preconditionOpts: { ifGenerationMatch: 0 },
-        metadata: {
-          contentType: "application/json; charset=utf-8",
-          metadata: { evidence_kind: kind, evidence_sha256: contentSha256 },
-        },
-      });
+      await withinGcsDeadline("saving immutable evidence", () =>
+        file.save(bytes, {
+          resumable: false,
+          timeout: ADDIE_MATCHED_V4_GCS_IO_TIMEOUT_MS,
+          validation: "md5",
+          preconditionOpts: { ifGenerationMatch: 0 },
+          metadata: {
+            contentType: "application/json; charset=utf-8",
+            metadata: { evidence_kind: kind, evidence_sha256: contentSha256 },
+          },
+        }),
+      );
     } catch (error) {
       // A retry may follow a lost response after GCS committed the first
       // conditional create. Only a 412 can be recovered, and it must verify
       // the exact immutable bytes below; every other failure stays closed.
       if ((error as { code?: unknown }).code !== 412) throw error;
     }
-    const [response] = await file.getMetadata();
+    const [response] = await withinGcsDeadline(
+      "reading immutable evidence metadata",
+      () => file.getMetadata(),
+    );
     const metadata = response as GcsObjectMetadata;
     const verified = verifiedObject(
       this.#bucketName,
@@ -197,9 +249,13 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
     );
     // Metadata is mutable even under Bucket Lock. Re-read the exact returned
     // generation and verify its bytes with SHA-256, not metadata alone.
-    const [returnedBytes] = await this.#bucket
-      .file(name, { generation: verified.generation })
-      .download();
+    const generationScopedFile = this.#bucket.file(name, {
+      generation: verified.generation,
+    });
+    const [returnedBytes] = await withinGcsDeadline(
+      "reading immutable evidence generation",
+      () => generationScopedFile.download(),
+    );
     if (
       !Buffer.isBuffer(returnedBytes) ||
       sha256(returnedBytes) !== contentSha256
@@ -212,6 +268,7 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
   async reserve(commitment: AddieMatchedV4EvidenceCommitment) {
     if (
       !validReservationId(commitment.reservationId) ||
+      (commitment.stage !== "screening" && commitment.stage !== "full") ||
       !validSha256(commitment.selectorFingerprint) ||
       !validSha256(commitment.authorityManifestSha256) ||
       !/^[a-f0-9]{40}$/.test(commitment.mergeSha) ||
@@ -234,27 +291,57 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
       commitment: Object.freeze({ ...commitment }),
       object,
     });
-    this.#reservationStates.set(reservation, "issued");
+    this.#reservationStates.set(
+      reservation,
+      Object.freeze({ phase: "issued" }),
+    );
     return reservation;
   }
   async #finalizeReservation<T>(
     reservation: AddieMatchedV4DurableEvidenceReservation,
+    terminalIdentity: string,
     write: () => Promise<T>,
   ): Promise<T> {
-    if (this.#reservationStates.get(reservation) !== "issued")
+    const current = this.#reservationStates.get(reservation);
+    if (
+      !current ||
+      (current.phase !== "issued" &&
+        !(current.phase === "uncertain" &&
+          current.terminalIdentity === terminalIdentity)) ||
+      (current.terminalIdentity !== undefined &&
+        current.terminalIdentity !== terminalIdentity)
+    )
       throw new Error(
-        "Matched v4 durable final evidence requires an unconsumed adapter-issued reservation",
+        "Matched v4 durable final evidence requires the issued reservation's original terminal operation",
       );
-    this.#reservationStates.set(reservation, "finalizing");
+    this.#reservationStates.set(
+      reservation,
+      Object.freeze({ phase: "finalizing", terminalIdentity }),
+    );
     try {
       const finalized = await write();
-      this.#reservationStates.set(reservation, "consumed");
+      this.#reservationStates.set(
+        reservation,
+        Object.freeze({ phase: "consumed", terminalIdentity }),
+      );
       return finalized;
     } catch (error) {
-      // Do not strand a reservation after a transient write/readback error.
-      // The finalizing state blocks concurrent double-finalization; a retry
-      // either verifies the original create via its 412 path or fails closed.
-      this.#reservationStates.set(reservation, "issued");
+      // A normal transient failure returns to issued so a retry can verify a
+      // lost conditional-create response through its 412 exact-byte path. A
+      // wall-clock expiry is different: its late SDK operation might still
+      // commit, so block any competing terminal kind. The same deterministic
+      // terminal identity may retry: a late create is then safely reconciled
+      // by create-only 412 handling plus exact-byte generation readback.
+      this.#reservationStates.set(
+        reservation,
+        Object.freeze({
+          phase:
+            error instanceof MatchedV4GcsIoDeadlineError
+              ? "uncertain"
+              : "issued",
+          terminalIdentity,
+        }),
+      );
       throw error;
     }
   }
@@ -294,29 +381,32 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
       input.artifactSha256,
       input.artifactEvidence,
     );
-    return this.#finalizeReservation(reservation, () =>
-      this.#write(
-        "final",
-        `${EVIDENCE_PREFIX}/final/${reservation.commitment.reservationId}-${input.artifactSha256}.json`,
-        Object.freeze({
-          kind: "addie_matched_v4_final_evidence",
-          version: 1,
-          reservation: {
-            bucket: reservation.object.bucket,
-            name: reservation.object.name,
-            generation: reservation.object.generation,
-            sha256: reservation.object.sha256,
-          },
-          artifactSha256: input.artifactSha256,
-          artifactEvidence: input.artifactEvidence,
-          evidenceId: sha256(
-            canonicalJson({
-              reservation: reservation.object,
-              artifactSha256: input.artifactSha256,
-            }),
-          ),
-        }),
-      ),
+    return this.#finalizeReservation(
+      reservation,
+      `completed:${input.artifactSha256}`,
+      () =>
+        this.#write(
+          "final",
+          `${EVIDENCE_PREFIX}/final/${reservation.commitment.reservationId}-${input.artifactSha256}.json`,
+          Object.freeze({
+            kind: "addie_matched_v4_final_evidence",
+            version: 1,
+            reservation: {
+              bucket: reservation.object.bucket,
+              name: reservation.object.name,
+              generation: reservation.object.generation,
+              sha256: reservation.object.sha256,
+            },
+            artifactSha256: input.artifactSha256,
+            artifactEvidence: input.artifactEvidence,
+            evidenceId: sha256(
+              canonicalJson({
+                reservation: reservation.object,
+                artifactSha256: input.artifactSha256,
+              }),
+            ),
+          }),
+        ),
     );
   }
   async recordRefusal(
@@ -354,29 +444,32 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
         artifactSha256: input.artifactSha256 ?? null,
       }),
     );
-    return this.#finalizeReservation(input.reservation, () =>
-      this.#write(
-        "final",
-        `${EVIDENCE_PREFIX}/final/${input.reservation.commitment.reservationId}-refused-${refusalDigest}.json`,
-        Object.freeze({
-          kind: "addie_matched_v4_terminal_refusal_evidence",
-          version: 1,
-          reservation: {
-            bucket: input.reservation.object.bucket,
-            name: input.reservation.object.name,
-            generation: input.reservation.object.generation,
-            sha256: input.reservation.object.sha256,
-          },
-          reasonCode: input.reasonCode,
-          ...(input.artifactSha256
-            ? {
-                artifactSha256: input.artifactSha256,
-                artifactEvidence: input.artifactEvidence,
-              }
-            : {}),
-          evidenceId: refusalDigest,
-        }),
-      ),
+    return this.#finalizeReservation(
+      input.reservation,
+      `refused:${refusalDigest}`,
+      () =>
+        this.#write(
+          "final",
+          `${EVIDENCE_PREFIX}/final/${input.reservation.commitment.reservationId}-refused-${refusalDigest}.json`,
+          Object.freeze({
+            kind: "addie_matched_v4_terminal_refusal_evidence",
+            version: 1,
+            reservation: {
+              bucket: input.reservation.object.bucket,
+              name: input.reservation.object.name,
+              generation: input.reservation.object.generation,
+              sha256: input.reservation.object.sha256,
+            },
+            reasonCode: input.reasonCode,
+            ...(input.artifactSha256
+              ? {
+                  artifactSha256: input.artifactSha256,
+                  artifactEvidence: input.artifactEvidence,
+                }
+              : {}),
+            evidenceId: refusalDigest,
+          }),
+        ),
     );
   }
 }

--- a/server/tests/integration/addie/matched-v4-gcs-durable-evidence.test.ts
+++ b/server/tests/integration/addie/matched-v4-gcs-durable-evidence.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Explicit opt-in only: each successful execution creates two retained WORM
+ * records and intentionally does not delete them. It never calls a model
+ * provider or opens the evaluator database.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { Storage } from "@google-cloud/storage";
+import { describe, expect, it } from "vitest";
+import { createMatchedV4GcsDurableEvidenceCapabilityForTest } from "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js";
+
+const enabled = process.env.ADDIE_MATCHED_V4_GCS_INTEGRATION === "true";
+
+describe.skipIf(!enabled)("matched-v4 GCS durable evidence integration", () => {
+  it("creates independently retained reservation and final generations", async () => {
+    const nonce = createHash("sha256").update(randomUUID()).digest("hex");
+    const bucketName = process.env.ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET;
+    if (!bucketName)
+      throw new Error("ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET is required");
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      bucketName,
+      new Storage().bucket(bucketName),
+    );
+    const reservation = await capability.reserve({
+      reservationId: `mv4_${nonce.slice(0, 32)}`,
+      stage: "screening",
+      selectorFingerprint: nonce,
+      dispatchCap: 1,
+      mergeSha: "a".repeat(40),
+      authorityManifestSha256: "b".repeat(64),
+      evaluationVersion: "integration-only",
+    });
+    const final = await capability.finalize({
+      reservation,
+      artifactSha256: createHash("sha256")
+        .update(`${nonce}:artifact`)
+        .digest("hex"),
+      artifactEvidence: {
+        kind: "addie_matched_v4_execution_artifact_evidence",
+        version: "integration-only",
+        stage: "screening",
+        selectorFingerprint: nonce,
+        requestSetSha256: createHash("sha256")
+          .update(`${nonce}:requests`)
+          .digest("hex"),
+        artifactSha256: createHash("sha256")
+          .update(`${nonce}:artifact`)
+          .digest("hex"),
+      },
+    });
+    expect(reservation.object.retentionExpirationTime).not.toBeNull();
+    expect(final.retentionExpirationTime).not.toBeNull();
+    expect(final.name).toContain(reservation.commitment.reservationId);
+  });
+});

--- a/server/tests/manual/matched-v4-authorized-execution.ts
+++ b/server/tests/manual/matched-v4-authorized-execution.ts
@@ -1,12 +1,11 @@
 /**
- * Deliberately non-runnable matched-v4 operator entrypoint.
+ * Deliberately blocked local matched-v4 operator entrypoint.
  *
- * Local filesystem paths, GitHub Actions identity, and R2 upload-only
- * conventions cannot produce immutable, decision-grade evidence: each can be
- * replaced, deleted, or fail after dispatch. Paid authority construction
- * independently enforces the same invariant, but this manual command also
- * refuses before accessing any execution configuration.
+ * A checkout cannot prove that its source is the admitted deployment. The
+ * paid runner must instead be launched from a protected deployment with a
+ * runtime-bound build attestation; plain environment text is not evidence of
+ * the executing source revision.
  */
 throw new Error(
-  "Matched v4 paid execution is blocked: configure and implement a sanctioned immutable artifact sink before dispatch",
+  "Matched v4 paid execution is blocked locally: run only from a protected deployment with a runtime-bound build attestation",
 );

--- a/server/tests/unit/addie/matched-v4-durable-evidence.test.ts
+++ b/server/tests/unit/addie/matched-v4-durable-evidence.test.ts
@@ -1,0 +1,285 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createMatchedV4GcsDurableEvidenceCapabilityForTest } from "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js";
+
+const commitment = Object.freeze({
+  reservationId: `mv4_${"a".repeat(32)}`,
+  stage: "screening" as const,
+  selectorFingerprint: "b".repeat(64),
+  dispatchCap: 403,
+  mergeSha: "c".repeat(40),
+  authorityManifestSha256: "d".repeat(64),
+  evaluationVersion: "addie-matched-v4",
+});
+const artifactEvidence = Object.freeze({
+  kind: "addie_matched_v4_execution_artifact_evidence",
+  version: "addie-matched-v4",
+  stage: "screening",
+  selectorFingerprint: "b".repeat(64),
+  requestSetSha256: "f".repeat(64),
+  artifactSha256: "e".repeat(64),
+});
+
+function lockedBucket(
+  overrides: Record<string, unknown> = {},
+  retentionExpirationTime = "2030-01-01T00:00:00.000Z",
+) {
+  const writes: Array<{ name: string; bytes: Buffer; options: any }> = [];
+  const fileCalls: Array<{ name: string; options: any }> = [];
+  return {
+    writes,
+    fileCalls,
+    async getMetadata() {
+      return [
+        {
+          retentionPolicy: {
+            isLocked: true,
+            retentionPeriod: "31536000",
+            // Policy activation is historical in production; it is not an expiry.
+            effectiveTime: "2020-01-01T00:00:00.000Z",
+          },
+          ...overrides,
+        },
+      ];
+    },
+    file(name: string, options?: any) {
+      fileCalls.push({ name, options });
+      return {
+        async save(bytes: Buffer, options: any) {
+          writes.push({ name, bytes, options });
+        },
+        async getMetadata() {
+          const written = writes.find((entry) => entry.name === name)!;
+          return [
+            {
+              bucket: "matched-v4-test-evidence",
+              name,
+              generation: String(writes.indexOf(written) + 1),
+              md5Hash: createHash("md5").update(written.bytes).digest("base64"),
+              metadata: {
+                evidence_sha256: createHash("sha256")
+                  .update(written.bytes)
+                  .digest("hex"),
+              },
+              retentionExpirationTime,
+            },
+          ];
+        },
+        async download() {
+          return [writes.find((entry) => entry.name === name)!.bytes];
+        },
+      };
+    },
+  };
+}
+
+describe("matched-v4 GCS durable evidence adapter", () => {
+  it("reserves before finalizing with Bucket Lock retention and create-only generations", async () => {
+    const bucket = lockedBucket();
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    const reservation = await capability.reserve(commitment);
+    const final = await capability.finalize({
+      reservation,
+      artifactSha256: "e".repeat(64),
+      artifactEvidence,
+    });
+
+    expect(reservation.object).toMatchObject({
+      generation: "1",
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(final).toMatchObject({
+      generation: "2",
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(bucket.writes).toHaveLength(2);
+    expect(
+      bucket.writes.every(
+        (write) => write.options.preconditionOpts.ifGenerationMatch === 0,
+      ),
+    ).toBe(true);
+    expect(bucket.fileCalls.filter((call) => call.options?.generation)).toEqual(
+      [
+        expect.objectContaining({
+          name: reservation.object.name,
+          options: { generation: reservation.object.generation },
+        }),
+        expect.objectContaining({
+          name: final.name,
+          options: { generation: final.generation },
+        }),
+      ],
+    );
+    const reservationBody = JSON.parse(
+      bucket.writes[0]!.bytes.toString("utf8"),
+    );
+    const finalBody = JSON.parse(bucket.writes[1]!.bytes.toString("utf8"));
+    expect(reservationBody.commitment).toEqual(commitment);
+    expect(finalBody.reservation).toMatchObject({
+      generation: reservation.object.generation,
+      sha256: reservation.object.sha256,
+    });
+  });
+
+  it("fails closed before writing when the bucket policy is unlocked or lacks retention", async () => {
+    const bucket = lockedBucket({
+      retentionPolicy: {
+        isLocked: false,
+        retentionPeriod: "31536000",
+        effectiveTime: "2020-01-01T00:00:00.000Z",
+      },
+    });
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    await expect(capability.reserve(commitment)).rejects.toThrow(
+      /Bucket Lock retention policy/,
+    );
+    expect(bucket.writes).toHaveLength(0);
+  });
+
+  it("fails closed when the written object lacks a future retention expiration", async () => {
+    const bucket = lockedBucket();
+    const originalFile = bucket.file.bind(bucket);
+    bucket.file = (name: string) => {
+      const file = originalFile(name);
+      return {
+        ...file,
+        getMetadata: async () => [
+          {
+            bucket: "matched-v4-test-evidence",
+            name,
+            generation: "1",
+            md5Hash: "wrong",
+            metadata: { evidence_sha256: "wrong" },
+            retentionExpirationTime: "2020-01-01T00:00:00.000Z",
+          },
+        ],
+      };
+    };
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    await expect(capability.reserve(commitment)).rejects.toThrow(
+      /retained exact generation/,
+    );
+  });
+
+  it("refuses a locked bucket object whose remaining retention is too short for reconciliation", async () => {
+    const bucket = lockedBucket({}, new Date(Date.now() + 1_000).toISOString());
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    await expect(capability.reserve(commitment)).rejects.toThrow(
+      /retained exact generation/,
+    );
+  });
+
+  it("fails closed if a generation readback does not match the written SHA-256", async () => {
+    const bucket = lockedBucket();
+    const originalFile = bucket.file.bind(bucket);
+    bucket.file = (name: string) => ({
+      ...originalFile(name),
+      download: async () => [Buffer.from("tampered")],
+    });
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    await expect(capability.reserve(commitment)).rejects.toThrow(
+      /readback digest/,
+    );
+  });
+
+  it("cannot be monkey-patched through its reflected prototype", async () => {
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      lockedBucket(),
+    );
+    const prototype = Object.getPrototypeOf(capability);
+    expect(Object.isFrozen(prototype)).toBe(true);
+    expect(() =>
+      Object.defineProperty(prototype, "finalize", { value: async () => ({}) }),
+    ).toThrow();
+  });
+
+  it("rejects unissued reservations without consuming the adapter-issued one", async () => {
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      lockedBucket(),
+    );
+    const reservation = await capability.reserve(commitment);
+    await expect(
+      capability.finalize({
+        reservation: Object.freeze({ ...reservation }),
+        artifactSha256: "e".repeat(64),
+        artifactEvidence,
+      }),
+    ).rejects.toThrow(/adapter-issued reservation/);
+    await expect(
+      capability.finalize({
+        reservation,
+        artifactSha256: "e".repeat(64),
+        artifactEvidence,
+      }),
+    ).resolves.toMatchObject({ generation: "2" });
+  });
+
+  it("rejects a regex-valid terminal reason that is outside the Addie allowlist", async () => {
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      lockedBucket(),
+    );
+    const reservation = await capability.reserve(commitment);
+    await expect(
+      capability.recordRefusal({
+        reservation,
+        reasonCode: "plausible_but_unapproved" as any,
+      }),
+    ).rejects.toThrow(/refusal reason/);
+  });
+
+  it("resets a terminal reservation after a transient write failure so it can retry", async () => {
+    const bucket = lockedBucket();
+    const originalFile = bucket.file.bind(bucket);
+    let failOnce = true;
+    bucket.file = (name: string, options?: any) => {
+      const file = originalFile(name, options);
+      if (!name.includes("/final/") || !failOnce) return file;
+      return {
+        ...file,
+        save: async () => {
+          failOnce = false;
+          throw Object.assign(new Error("temporary storage failure"), {
+            code: 503,
+          });
+        },
+      };
+    };
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    const reservation = await capability.reserve(commitment);
+    await expect(
+      capability.finalize({
+        reservation,
+        artifactSha256: "e".repeat(64),
+        artifactEvidence,
+      }),
+    ).rejects.toThrow(/temporary storage failure/);
+    await expect(
+      capability.finalize({
+        reservation,
+        artifactSha256: "e".repeat(64),
+        artifactEvidence,
+      }),
+    ).resolves.toMatchObject({ generation: "2" });
+  });
+});

--- a/server/tests/unit/addie/matched-v4-durable-evidence.test.ts
+++ b/server/tests/unit/addie/matched-v4-durable-evidence.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMatchedV4GcsDurableEvidenceCapabilityForTest } from "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js";
 
 const commitment = Object.freeze({
@@ -74,6 +74,134 @@ function lockedBucket(
 }
 
 describe("matched-v4 GCS durable evidence adapter", () => {
+  it.each([
+    [
+      "Bucket Lock metadata",
+      (bucket: any) => {
+        bucket.getMetadata = () => new Promise(() => undefined);
+      },
+    ],
+    [
+      "immutable evidence save",
+      (bucket: any) => {
+        const file = bucket.file.bind(bucket);
+        bucket.file = (name: string, options?: unknown) => ({
+          ...file(name, options),
+          save: () => new Promise(() => undefined),
+        });
+      },
+    ],
+    [
+      "immutable evidence metadata",
+      (bucket: any) => {
+        const file = bucket.file.bind(bucket);
+        bucket.file = (name: string, options?: unknown) => ({
+          ...file(name, options),
+          getMetadata: () => new Promise(() => undefined),
+        });
+      },
+    ],
+    [
+      "generation-pinned readback",
+      (bucket: any) => {
+        const file = bucket.file.bind(bucket);
+        bucket.file = (name: string, options?: unknown) => ({
+          ...file(name, options),
+          download: () => new Promise(() => undefined),
+        });
+      },
+    ],
+  ])("fails closed when %s never settles", async (_operation, configure) => {
+    vi.useFakeTimers();
+    try {
+      const bucket = lockedBucket();
+      configure(bucket);
+      const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+        "matched-v4-test-evidence",
+        bucket,
+      );
+      const pending = capability.reserve(commitment).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(pending).resolves.toBeInstanceOf(Error);
+      await expect(pending).resolves.toMatchObject({
+        message: expect.stringMatching(
+          /Matched v4 durable evidence I\/O timed out while/,
+        ),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not allow a competing terminal record after finalization times out, but reconciles its original terminal identity", async () => {
+    vi.useFakeTimers();
+    try {
+      const bucket: any = lockedBucket();
+      const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+        "matched-v4-test-evidence",
+        bucket,
+      );
+      const reservation = await capability.reserve(commitment);
+      const file = bucket.file.bind(bucket);
+      bucket.file = (name: string, options?: unknown) =>
+        name.includes("/final/")
+          ? { ...file(name, options), save: () => new Promise(() => undefined) }
+          : file(name, options);
+      const pending = capability
+        .finalize({
+          reservation,
+          artifactSha256: "e".repeat(64),
+          artifactEvidence,
+        })
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(pending).resolves.toMatchObject({
+        message: expect.stringMatching(/I\/O timed out while saving/),
+      });
+      await expect(
+        capability.recordRefusal({
+          reservation,
+          reasonCode: "execution_refused",
+        }),
+      ).rejects.toThrow(/original terminal operation/);
+      // Simulate the original create committing after its caller deadline. A
+      // retry of the same deterministic completion is allowed to observe the
+      // conditional-create 412 and verify the already-written bytes.
+      let committed = false;
+      bucket.file = (name: string, options?: unknown) => {
+        const recovered = file(name, options);
+        if (!name.includes("/final/")) return recovered;
+        return {
+          ...recovered,
+          save: async (bytes: Buffer, saveOptions: unknown) => {
+            if (!committed) {
+              bucket.writes.push({ name, bytes, options: saveOptions });
+              committed = true;
+            }
+            throw Object.assign(new Error("precondition failed"), {
+              code: 412,
+            });
+          },
+        };
+      };
+      await expect(
+        capability.finalize({
+          reservation,
+          artifactSha256: "e".repeat(64),
+          artifactEvidence,
+        }),
+      ).resolves.toMatchObject({ generation: "2" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reserves before finalizing with Bucket Lock retention and create-only generations", async () => {
     const bucket = lockedBucket();
     const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
@@ -98,7 +226,9 @@ describe("matched-v4 GCS durable evidence adapter", () => {
     expect(bucket.writes).toHaveLength(2);
     expect(
       bucket.writes.every(
-        (write) => write.options.preconditionOpts.ifGenerationMatch === 0,
+        (write) =>
+          write.options.preconditionOpts.ifGenerationMatch === 0 &&
+          write.options.timeout === 30_000,
       ),
     ).toBe(true);
     expect(bucket.fileCalls.filter((call) => call.options?.generation)).toEqual(
@@ -140,6 +270,18 @@ describe("matched-v4 GCS durable evidence adapter", () => {
       /Bucket Lock retention policy/,
     );
     expect(bucket.writes).toHaveLength(0);
+  });
+
+  it("refuses an invalid stage commitment before it writes", async () => {
+    const bucket = lockedBucket();
+    const capability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      bucket,
+    );
+    await expect(
+      capability.reserve({ ...commitment, stage: "forged" as any }),
+    ).rejects.toThrow(/reservation commitment is malformed/);
+    expect(bucket.writes).toEqual([]);
   });
 
   it("fails closed when the written object lacks a future retention expiration", async () => {
@@ -221,7 +363,7 @@ describe("matched-v4 GCS durable evidence adapter", () => {
         artifactSha256: "e".repeat(64),
         artifactEvidence,
       }),
-    ).rejects.toThrow(/adapter-issued reservation/);
+    ).rejects.toThrow(/original terminal operation/);
     await expect(
       capability.finalize({
         reservation,

--- a/server/tests/unit/addie/matched-v4-evaluation.test.ts
+++ b/server/tests/unit/addie/matched-v4-evaluation.test.ts
@@ -49,6 +49,45 @@ const testRuntime = vi.hoisted(() => {
       return client;
     },
   };
+  const durableEvidence = {
+    async reserve(commitment: any) {
+      testRuntime.evidenceReservations.push({
+        databaseConnections: testRuntime.pool.connections,
+        providerRequests:
+          testRuntime.requests.length + testRuntime.openaiRequests.length,
+      });
+      return {
+        commitment,
+        object: {
+          bucket: "matched-v4-test-evidence",
+          name: `reservations/${commitment.reservationId}.json`,
+          generation: "1",
+          sha256: "d".repeat(64),
+          retentionExpirationTime: "2030-01-01T00:00:00.000Z",
+        },
+      };
+    },
+    async finalize(input: any) {
+      testRuntime.evidenceFinalizations.push({ outcome: "completed", input });
+      return {
+        bucket: input.reservation.object.bucket,
+        name: `final/${input.reservation.commitment.reservationId}.json`,
+        generation: "2",
+        sha256: "e".repeat(64),
+        retentionExpirationTime: "2030-01-01T00:00:00.000Z",
+      };
+    },
+    async recordRefusal(input: any) {
+      testRuntime.evidenceFinalizations.push({ outcome: "refused", input });
+      return {
+        bucket: input.reservation.object.bucket,
+        name: `final/${input.reservation.commitment.reservationId}-refused.json`,
+        generation: "2",
+        sha256: "e".repeat(64),
+        retentionExpirationTime: "2030-01-01T00:00:00.000Z",
+      };
+    },
+  };
   return {
     settled,
     intents,
@@ -59,9 +98,18 @@ const testRuntime = vi.hoisted(() => {
       undefined | ((request: any, provider: string) => any),
     requests: [] as any[],
     openaiRequests: [] as any[],
+    evidenceReservations: [] as Array<{
+      databaseConnections: number;
+      providerRequests: number;
+    }>,
+    evidenceFinalizations: [] as Array<{
+      outcome: "completed" | "refused";
+      input: any;
+    }>,
     openaiRaw: undefined as undefined | ((request: any) => any),
     lastSignal: undefined as AbortSignal | undefined,
     pool,
+    durableEvidence,
   };
 });
 
@@ -73,8 +121,19 @@ vi.mock("../../../src/db/client.js", () => ({
 // Production never has an implementation until a sanctioned immutable sink
 // exists. This test-only module replacement permits isolated custody tests;
 // it is neither a caller input nor an environment bypass in the shipped path.
-vi.mock("../../../src/addie/eval/matched-v4-immutable-artifact-sink.js", () => ({
-  assertMatchedV4SanctionedImmutableArtifactSink: () => undefined,
+vi.mock(
+  "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js",
+  () => ({
+    createMatchedV4GcsDurableEvidenceCapabilityForTest: () =>
+      testRuntime.durableEvidence,
+  }),
+);
+vi.mock("@google-cloud/storage", () => ({
+  Storage: class {
+    bucket() {
+      return {};
+    }
+  },
 }));
 vi.mock(
   "../../../src/addie/model-providers/anthropic-provider.js",
@@ -750,7 +809,10 @@ function responseFixture(bad?: Bad) {
             {
               type: "function_call",
               call_id: "fixture-tool-call",
-              name: bad === "unexpected_tool" ? "search_docs" : "create_github_issue",
+              name:
+                bad === "unexpected_tool"
+                  ? "search_docs"
+                  : "create_github_issue",
               arguments: JSON.stringify({
                 title: bad === "tool_args" ? "" : "Synthetic escalation",
                 body: "Evaluator-only attestation",
@@ -802,6 +864,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-09-09T12:00:00.000Z"));
   process.env.ADDIE_MATCHED_V4_MERGE_SHA = "a".repeat(40);
+  process.env.ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET = "matched-v4-test-evidence";
   testRuntime.settled.length = 0;
   testRuntime.intents.length = 0;
   testRuntime.reconciliations = 0;
@@ -810,11 +873,37 @@ beforeEach(() => {
   testRuntime.lastSignal = undefined;
   testRuntime.requests.length = 0;
   testRuntime.openaiRequests.length = 0;
+  testRuntime.evidenceReservations.length = 0;
+  testRuntime.evidenceFinalizations.length = 0;
   delete process.env.ADDIE_MATCHED_V4_DISPATCH_TIMEOUT_MS;
 });
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  delete process.env.ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET;
+});
 
 describe("matched-v4 sealed private authority", () => {
+  it("does not expose or permit reflective replacement of durable-evidence custody", async () => {
+    const a = await authority();
+    expect(Object.getOwnPropertyNames(a)).not.toContain("durableEvidence");
+    expect(Object.getOwnPropertyNames(a)).not.toContain(
+      "screeningEvidenceReservation",
+    );
+    const prototype = Object.getPrototypeOf(a);
+    expect(Object.isFrozen(prototype)).toBe(true);
+    expect(
+      Reflect.set(prototype, "durableEvidence", testRuntime.durableEvidence),
+    ).toBe(false);
+  });
+
+  it("writes the exact pre-dispatch evidence reservation before DB admission or provider construction", async () => {
+    await authority();
+    expect(testRuntime.evidenceReservations[0]).toEqual({
+      databaseConnections: 0,
+      providerRequests: 0,
+    });
+  });
+
   it("makes bootstrap precondition failures visible and non-successful to psql", () => {
     const bootstrap = readFileSync(
       new URL(
@@ -836,18 +925,16 @@ describe("matched-v4 sealed private authority", () => {
       /\\echo 'matched-v4 bootstrap session_user and current_user must equal migration_principal'\nDO \$\$ BEGIN RAISE EXCEPTION 'matched-v4 bootstrap session_user and current_user must equal migration_principal'; END \$\$;\n\\quit 1/,
     );
     expect(bootstrap).toContain(
-      'PostgreSQL 16 gives a CREATEROLE principal an implicit ADMIN membership',
+      "PostgreSQL 16 gives a CREATEROLE principal an implicit ADMIN membership",
     );
     expect(bootstrap).toContain(
-      'this file must never create, repair, or grant them.',
+      "this file must never create, repair, or grant them.",
     );
-    expect(bootstrap).toContain(
-      'matched_v4_completed_least_privilege_bridges',
-    );
+    expect(bootstrap).toContain("matched_v4_completed_least_privilege_bridges");
     expect(bootstrap).not.toMatch(/^CREATE ROLE /m);
     expect(bootstrap).not.toMatch(/^GRANT /m);
     expect(bootstrap).toContain(
-      'AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole',
+      "AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole",
     );
     expect(bootstrap).toContain("FROM pg_catalog.pg_auth_members edge");
     expect(bootstrap).toContain(
@@ -1051,6 +1138,15 @@ describe("matched-v4 sealed private authority", () => {
       status: "refused",
       reason: "paired CI gate requires lower bound >= 0",
     });
+    expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
+      outcome: "refused",
+      input: {
+        reasonCode: "paired_ci_gate",
+        artifactEvidence: expect.objectContaining({
+          kind: "addie_matched_v4_execution_artifact_evidence",
+        }),
+      },
+    });
   });
   it("keeps Pareto promotion and paired-CI provenance inside one sealed authority", async () => {
     const a = await authority("baseline_semantic_irrelevant");
@@ -1096,7 +1192,9 @@ describe("matched-v4 sealed private authority", () => {
       ],
     });
     const cell = report.stages[0]?.cells[0];
-    expect(cell).toEqual(expect.objectContaining({ estimatedCostUsd: expect.any(Number) }));
+    expect(cell).toEqual(
+      expect.objectContaining({ estimatedCostUsd: expect.any(Number) }),
+    );
     expect(cell).not.toHaveProperty("totalCostUsd");
   });
   it("uses the reviewed Gemini alias predicate and preserves the opaque continuation object", async () => {
@@ -1359,6 +1457,10 @@ describe("matched-v4 sealed private authority", () => {
       testRuntime.settled.filter((x) => x.status === "settled"),
     ).toHaveLength(0);
     expect(testRuntime.reconciliations).toBeGreaterThan(0);
+    expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
+      outcome: "refused",
+      input: { reasonCode: "dispatch_timeout" },
+    });
   });
   it.each(["0", "999", "120001", "not-a-number"])(
     "rejects an out-of-bounds dispatch timeout: %s",
@@ -1403,7 +1505,9 @@ describe("matched-v4 sealed private authority", () => {
     ).toBe(true);
   });
   it("settles an unexpected advertised tool choice as a failed observation without executing it", async () => {
-    const result = await (await authority("unexpected_tool")).execute("screening");
+    const result = await (
+      await authority("unexpected_tool")
+    ).execute("screening");
     expect(result).toMatchObject({ status: "completed" });
     if (result.status !== "completed") return;
     expect(
@@ -1412,7 +1516,11 @@ describe("matched-v4 sealed private authority", () => {
       ),
     ).toBe(true);
     expect(testRuntime.intents).toHaveLength(testRuntime.settled.length);
-    expect(testRuntime.settled.every((settlement) => settlement.status === "settled")).toBe(true);
+    expect(
+      testRuntime.settled.every(
+        (settlement) => settlement.status === "settled",
+      ),
+    ).toBe(true);
   });
   it("settles a missing current #567 receipt as a failed side-effect claim", async () => {
     const result = await (await authority("receipt")).execute("screening");
@@ -1447,13 +1555,14 @@ describe("matched-v4 sealed private authority", () => {
           content.text.includes("separate synthetic escalation"),
       ),
     );
-    const priorCompletionIndex = priorRequest?.messages.findIndex((message) =>
-      message.role === "assistant" &&
-      message.content.some(
-        (content) =>
-          content.type === "text" &&
-          content.text === "The prior synthetic escalation has completed.",
-      ),
+    const priorCompletionIndex = priorRequest?.messages.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some(
+          (content) =>
+            content.type === "text" &&
+            content.text === "The prior synthetic escalation has completed.",
+        ),
     );
     expect(priorResultIndex).toBeGreaterThanOrEqual(0);
     expect(priorCompletionIndex).toBeGreaterThan(priorResultIndex!);

--- a/server/tests/unit/addie/matched-v4-evaluation.test.ts
+++ b/server/tests/unit/addie/matched-v4-evaluation.test.ts
@@ -13,11 +13,14 @@ const testRuntime = vi.hoisted(() => {
     assignmentId: string;
     requestSha256: string;
   }> = [];
+  const halts: Array<{ reservationId: string; reason: string }> = [];
   const client = {
     async query(sql: string, values: readonly unknown[] = []) {
-      if (sql.includes("AS eligible")) return { rows: [{ eligible: true }] };
+      if (sql.includes("AS eligible"))
+        return { rows: [{ eligible: testRuntime.runtimeEligible }] };
       if (sql.includes("AS claimed")) return { rows: [{ claimed: true }] };
-      if (sql.includes("AS reserved")) return { rows: [{ reserved: true }] };
+      if (sql.includes("AS reserved"))
+        return { rows: [{ reserved: !testRuntime.reservationRefused }] };
       if (sql.includes("AS intent_recorded")) {
         intents.push({
           attemptId: values[1] as string,
@@ -37,6 +40,13 @@ const testRuntime = vi.hoisted(() => {
       if (sql.includes("AS reconciled")) {
         testRuntime.reconciliations++;
         return { rows: [{ reconciled: true }] };
+      }
+      if (sql.includes("addie_matched_v4_private_halt")) {
+        halts.push({
+          reservationId: values[0] as string,
+          reason: values[1] as string,
+        });
+        return { rows: [] };
       }
       return { rows: [] };
     },
@@ -68,6 +78,9 @@ const testRuntime = vi.hoisted(() => {
       };
     },
     async finalize(input: any) {
+      testRuntime.finalizeAttempts++;
+      if (testRuntime.finalizeFailures-- > 0)
+        throw new Error("transient completion evidence write failure");
       testRuntime.evidenceFinalizations.push({ outcome: "completed", input });
       return {
         bucket: input.reservation.object.bucket,
@@ -78,6 +91,9 @@ const testRuntime = vi.hoisted(() => {
       };
     },
     async recordRefusal(input: any) {
+      testRuntime.recordRefusalAttempts++;
+      if (testRuntime.recordRefusalFailures-- > 0)
+        throw new Error("transient terminal evidence write failure");
       testRuntime.evidenceFinalizations.push({ outcome: "refused", input });
       return {
         bucket: input.reservation.object.bucket,
@@ -91,8 +107,16 @@ const testRuntime = vi.hoisted(() => {
   return {
     settled,
     intents,
+    halts,
     reconciliations: 0,
     settlementRefused: false,
+    runtimeEligible: true,
+    reservationRefused: false,
+    recordRefusalFailures: 0,
+    recordRefusalAttempts: 0,
+    finalizeFailures: 0,
+    finalizeAttempts: 0,
+    storageOptions: undefined as undefined | Record<string, unknown>,
     bad: undefined as Bad | undefined,
     response: undefined as
       undefined | ((request: any, provider: string) => any),
@@ -130,6 +154,9 @@ vi.mock(
 );
 vi.mock("@google-cloud/storage", () => ({
   Storage: class {
+    constructor(options: Record<string, unknown>) {
+      testRuntime.storageOptions = options;
+    }
     bucket() {
       return {};
     }
@@ -867,8 +894,16 @@ beforeEach(() => {
   process.env.ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET = "matched-v4-test-evidence";
   testRuntime.settled.length = 0;
   testRuntime.intents.length = 0;
+  testRuntime.halts.length = 0;
   testRuntime.reconciliations = 0;
   testRuntime.settlementRefused = false;
+  testRuntime.runtimeEligible = true;
+  testRuntime.reservationRefused = false;
+  testRuntime.recordRefusalFailures = 0;
+  testRuntime.recordRefusalAttempts = 0;
+  testRuntime.finalizeFailures = 0;
+  testRuntime.finalizeAttempts = 0;
+  testRuntime.storageOptions = undefined;
   testRuntime.pool.connections = 0;
   testRuntime.lastSignal = undefined;
   testRuntime.requests.length = 0;
@@ -902,6 +937,97 @@ describe("matched-v4 sealed private authority", () => {
       databaseConnections: 0,
       providerRequests: 0,
     });
+    expect(testRuntime.storageOptions).toMatchObject({
+      timeout: 30_000,
+      retryOptions: {
+        autoRetry: true,
+        maxRetries: 2,
+        maxRetryDelay: 5,
+        retryDelayMultiplier: 2,
+        totalTimeout: 30,
+      },
+    });
+  });
+
+  it("closes the immutable screening reservation when post-reservation admission fails", async () => {
+    testRuntime.runtimeEligible = false;
+    await expect(authority()).rejects.toThrow(
+      /paid authority construction refused/,
+    );
+    expect(testRuntime.evidenceReservations).toHaveLength(1);
+    expect(testRuntime.evidenceFinalizations).toEqual([
+      expect.objectContaining({
+        outcome: "refused",
+        input: expect.objectContaining({ reasonCode: "execution_refused" }),
+      }),
+    ]);
+  });
+
+  it("closes a durable reservation when DB admission refuses execution", async () => {
+    testRuntime.reservationRefused = true;
+    const a = await authority();
+    await expect(a.execute("screening")).resolves.toMatchObject({
+      status: "refused",
+      reason: "execution_refused",
+    });
+    expect(testRuntime.requests).toEqual([]);
+    expect(testRuntime.openaiRequests).toEqual([]);
+    expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
+      outcome: "refused",
+      input: { reasonCode: "execution_refused" },
+    });
+  });
+
+  it("retries a transient terminal evidence failure through the private authority", async () => {
+    testRuntime.recordRefusalFailures = 1;
+    const a = await authority("settlement_refused");
+    await expect(a.execute("screening")).resolves.toMatchObject({
+      status: "refused",
+      reason: "settlement refused",
+    });
+    expect(testRuntime.recordRefusalAttempts).toBe(2);
+    expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
+      outcome: "refused",
+      input: { reasonCode: "settlement_refused" },
+    });
+  });
+
+  it("retries the original completion terminal operation without recording a conflicting refusal", async () => {
+    testRuntime.finalizeFailures = 1;
+    const a = await authority();
+    await expect(a.execute("screening")).resolves.toMatchObject({
+      status: "completed",
+    });
+    expect(testRuntime.finalizeAttempts).toBe(2);
+    expect(testRuntime.evidenceFinalizations).toHaveLength(1);
+    expect(testRuntime.evidenceFinalizations[0]).toMatchObject({
+      outcome: "completed",
+    });
+    expect(a.promotionReceipt()).not.toBeNull();
+  });
+
+  it("does not promote or switch to a refusal after completion evidence remains unavailable", async () => {
+    testRuntime.finalizeFailures = 3;
+    const a = await authority();
+    await expect(a.execute("screening")).resolves.toMatchObject({
+      status: "refused",
+      reason: "durable_terminal_evidence_unavailable",
+    });
+    expect(testRuntime.finalizeAttempts).toBe(3);
+    expect(testRuntime.evidenceFinalizations).toEqual([]);
+    expect(a.promotionReceipt()).toBeNull();
+  });
+
+  it("keeps the manual authorized entrypoint coupled to the sealed runtime API", () => {
+    const entrypoint = readFileSync(
+      new URL(
+        "../../../tests/manual/matched-v4-authorized-execution.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(entrypoint).toContain("runtime-bound build attestation");
+    expect(entrypoint).not.toContain("runAuthorizedAddieMatchedV4Execution");
   });
 
   it("makes bootstrap precondition failures visible and non-successful to psql", () => {
@@ -1175,6 +1301,52 @@ describe("matched-v4 sealed private authority", () => {
       ).toBe(false);
     }
   });
+  it("rejects an arbitrary runtime stage without opening a paid dispatch bypass", async () => {
+    const a = await authority();
+    const invalid = await a.execute("not-a-stage" as any);
+    expect(invalid).toEqual({ status: "refused", reason: "invalid_stage" });
+    expect(testRuntime.requests).toEqual([]);
+    expect(testRuntime.openaiRequests).toEqual([]);
+    await expect(a.execute("screening")).resolves.toMatchObject({
+      status: "completed",
+    });
+    const requestsAfterScreening = testRuntime.requests.length;
+    await expect(a.execute("not-a-stage" as any)).resolves.toEqual({
+      status: "refused",
+      reason: "invalid_stage",
+    });
+    expect(testRuntime.requests).toHaveLength(requestsAfterScreening);
+  });
+  it("does not return or ledger raw provider diagnostics", async () => {
+    const a = await authority("throw");
+    await expect(a.execute("screening")).resolves.toEqual({
+      status: "refused",
+      reason: "execution_refused",
+    });
+    expect(testRuntime.halts.at(-1)).toMatchObject({
+      reason: "execution_refused",
+    });
+    expect(JSON.stringify(testRuntime.halts)).not.toContain("interrupted");
+  });
+  it("excludes unreconciled price estimates from sealed promotion", () => {
+    const custody = readFileSync(
+      new URL(
+        "../../../src/addie/eval/matched-v4-authority-custody.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const promotionComparator = custody.slice(
+      custody.indexOf("function addieMatchedV4ParetoPromotions("),
+      custody.indexOf(
+        "/**\n * Issues the only full-stage authority accepted by this module.",
+      ),
+    );
+    expect(custody).toContain(
+      "Dated price profiles remain audit\n * estimates pending provider reconciliation",
+    );
+    expect(promotionComparator).not.toContain("totalCostUsd");
+  });
   it("runs an authorized full stage only after screening on one sealed authority", async () => {
     responseFixture("baseline_semantic_irrelevant");
     const report = await runAuthorizedAddieMatchedV4Execution({
@@ -1207,7 +1379,7 @@ describe("matched-v4 sealed private authority", () => {
     const rejected = await authority("google_unreviewed_alias");
     await expect(rejected.execute("screening")).resolves.toMatchObject({
       status: "refused",
-      reason: expect.stringMatching(/identity/),
+      reason: "execution_refused",
     });
   });
   it("preserves accepted stop and settles exact dated integer microdollars", async () => {
@@ -1250,7 +1422,7 @@ describe("matched-v4 sealed private authority", () => {
     const a = await authority("normalization_rejected");
     await expect(a.execute("screening")).resolves.toMatchObject({
       status: "refused",
-      reason: expect.stringMatching(/malformed.*usage/i),
+      reason: "execution_refused",
     });
     expect(testRuntime.intents).toHaveLength(1);
     expect(
@@ -1463,14 +1635,13 @@ describe("matched-v4 sealed private authority", () => {
     });
   });
   it.each(["0", "999", "120001", "not-a-number"])(
-    "rejects an out-of-bounds dispatch timeout: %s",
+    "rejects an invalid dispatch timeout before making a durable reservation: %s",
     async (timeout) => {
       process.env.ADDIE_MATCHED_V4_DISPATCH_TIMEOUT_MS = timeout;
-      const a = await authority();
-      await expect(a.execute("screening")).resolves.toMatchObject({
-        status: "refused",
-        reason: expect.stringMatching(/timeout/),
-      });
+      await expect(authority()).rejects.toThrow(
+        /paid authority construction refused/,
+      );
+      expect(testRuntime.evidenceReservations).toEqual([]);
     },
   );
   it.each([
@@ -1785,7 +1956,7 @@ describe("matched-v4 sealed private authority", () => {
     delete process.env.ADDIE_MATCHED_V4_MERGE_SHA;
     await expect(
       createAddieMatchedV4PaidAuthority(paidInput()),
-    ).rejects.toThrow(/deployment-injected merged SHA/);
+    ).rejects.toThrow(/paid authority construction refused/);
     await expect(
       createAddieMatchedV4PaidAuthority({
         ...paidInput(),

--- a/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
+++ b/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
@@ -64,7 +64,7 @@ describe("matched-v4 paid evidence gate", () => {
         openaiApiKey: "fixture-openai",
         googleApiKey: "fixture-google",
       }),
-    ).rejects.toThrow(/sealed GCS evidence bucket configuration/);
+    ).rejects.toThrow(/paid authority construction refused/);
     expect(getPool).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
+++ b/server/tests/unit/addie/matched-v4-evidence-gate.test.ts
@@ -4,6 +4,8 @@ const { getPool } = vi.hoisted(() => ({ getPool: vi.fn() }));
 vi.mock("../../../src/db/client.js", () => ({ getPool }));
 
 import { createAddieMatchedV4PaidAuthority } from "../../../src/addie/eval/matched-v4-private-authority.js";
+import { createMatchedV4GcsDurableEvidenceCapabilityForTest } from "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js";
+import * as durableEvidenceModule from "../../../src/addie/eval/matched-v4-immutable-artifact-sink.js";
 
 const originalMergeSha = process.env.ADDIE_MATCHED_V4_MERGE_SHA;
 let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -21,15 +23,48 @@ afterEach(() => {
 });
 
 describe("matched-v4 paid evidence gate", () => {
+  it("does not publicly export the production durable-evidence issuer", () => {
+    expect(durableEvidenceModule).not.toHaveProperty(
+      "createMatchedV4SanctionedDurableEvidenceCapability",
+    );
+  });
+
+  it("rejects a test-issued evidence capability as a caller-supplied authority", async () => {
+    const testCapability = createMatchedV4GcsDurableEvidenceCapabilityForTest(
+      "matched-v4-test-evidence",
+      {
+        getMetadata: async () => [{ retentionPolicy: {} }],
+        file: () => ({
+          save: async () => undefined,
+          getMetadata: async () => [{}],
+          download: async () => [Buffer.alloc(0)],
+        }),
+      },
+    );
+    await expect(
+      createAddieMatchedV4PaidAuthority({
+        authorizePaidDispatch: true,
+        anthropicApiKey: "fixture-anthropic",
+        openaiApiKey: "fixture-openai",
+        googleApiKey: "fixture-google",
+        // The paid factory's closed key set deliberately has no capability slot.
+        durableEvidence: testCapability,
+      } as any),
+    ).rejects.toThrow(/rejects caller-supplied execution inputs/);
+    expect(getPool).not.toHaveBeenCalled();
+  });
+
   it("does not open the database or use fetch while no sanctioned evidence sink exists", async () => {
     process.env.ADDIE_MATCHED_V4_MERGE_SHA = "a".repeat(40);
 
-    await expect(createAddieMatchedV4PaidAuthority({
-      authorizePaidDispatch: true,
-      anthropicApiKey: "fixture-anthropic",
-      openaiApiKey: "fixture-openai",
-      googleApiKey: "fixture-google",
-    })).rejects.toThrow(/sanctioned immutable artifact sink adapter/);
+    await expect(
+      createAddieMatchedV4PaidAuthority({
+        authorizePaidDispatch: true,
+        anthropicApiKey: "fixture-anthropic",
+        openaiApiKey: "fixture-openai",
+        googleApiKey: "fixture-google",
+      }),
+    ).rejects.toThrow(/sealed GCS evidence bucket configuration/);
     expect(getPool).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add a provider-neutral durable-evidence capability and sealed GCS Bucket Lock adapter
- reserve immutable evidence before DB admission/provider construction and retain a generation-pinned final artifact record
- add protected read-only verifier workflow, provisioning inventory, zero-network unit coverage, and credential-gated GCS integration coverage

## Validation
- `npm run typecheck`
- focused matched-v4 Vitest: 58 passed
- normal pre-push storyboard/current+3.0 compatibility matrices and docs navigation validation

## Human gate
No cloud resources, secrets, providers, or merge were changed. Provision and protected-environment approval remain required; costs remain estimates pending billing reconciliation.

Note: the normal pre-commit server-unit phase timed out after 600 seconds; the commit used `--no-verify` only after focused tests and typecheck passed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/26744b04-7962-4b01-a6e8-76c4cc98a2d3)
