### PR TITLE
feat(addie): attest matched v4 runtime and reconcile billing

### DIFF
--- a/.github/workflows/verify-matched-v4-runtime-attestation.yml
+++ b/.github/workflows/verify-matched-v4-runtime-attestation.yml
@@ -1,0 +1,228 @@
+name: Verify matched-v4 runtime build attestation
+
+# This is a protected, provider-credential-free prerequisite for paid
+# screening. It attests and verifies the exact runnable evaluator bundle, but
+# never loads a provider credential or invokes a provider/billing API.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-origin-main:
+    # Keep a dispatch-selected branch away from the protected environment. A
+    # skipped protected job can look successful, so an untrusted ref fails
+    # this ordinary preflight rather than being silently skipped.
+    runs-on: ubuntu-latest
+    outputs:
+      approved_main_sha: ${{ steps.verify.outputs.approved_main_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - name: Refuse a stale or dispatch-selected checkout
+        id: verify
+        env:
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/main"
+          git fetch origin main --depth=1
+          current_main_sha=$(git rev-parse origin/main)
+          test "$DISPATCH_SHA" = "$current_main_sha"
+          test "$(git rev-parse HEAD)" = "$current_main_sha"
+          echo "approved_main_sha=$current_main_sha" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          cache: npm
+      - name: Build an untrusted runnable evaluator bundle
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          printf '%s\n' "${{ steps.verify.outputs.approved_main_sha }}" > /tmp/matched-v4-runtime-commit
+          # This job deliberately has no id-token permission. The protected
+          # job treats these bytes as untrusted until their digest is checked
+          # and its manifest is signed there.
+          tar --sort=name --mtime='UTC 2026-01-01' --owner=0 --group=0 --numeric-owner \
+            -czf /tmp/matched-v4-runtime.tgz \
+            -C /tmp matched-v4-runtime-commit \
+            -C "$GITHUB_WORKSPACE" dist node_modules package.json package-lock.json
+          bundle_sha256=$(sha256sum /tmp/matched-v4-runtime.tgz | awk '{print $1}')
+          printf '{"kind":"addie_matched_v4_runtime_build_attestation","version":1,"commit_sha":"%s","bundle_sha256":"%s"}\n' \
+            "${{ steps.verify.outputs.approved_main_sha }}" "$bundle_sha256" \
+            > /tmp/matched-v4-runtime-attestation.json
+      - name: Transfer build output to the protected attestation job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: matched-v4-runtime-build-${{ steps.verify.outputs.approved_main_sha }}
+          path: |
+            /tmp/matched-v4-runtime.tgz
+            /tmp/matched-v4-runtime-attestation.json
+          # GitHub caps public-repository artifacts at 90 days. A delayed
+          # approval must dispatch a fresh current-main build after that.
+          retention-days: 90
+
+  attest-runtime-bundle:
+    needs: verify-origin-main
+    # Administrators must restrict this environment to main and require
+    # independent approval. OIDC exists only in this clean job; no repository
+    # build, dependency, or package script runs after it is granted.
+    permissions:
+      contents: read
+      id-token: write
+    environment: matched-v4-runtime-attestation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the untrusted build output without executing it
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: matched-v4-runtime-build-${{ needs.verify-origin-main.outputs.approved_main_sha }}
+          path: /tmp/matched-v4-runtime
+      - name: Assert the signing token is bound to the protected environment
+        env:
+          EXPECTED_OIDC_SUBJECT: repo:${{ github.repository }}:environment:matched-v4-runtime-attestation
+        run: |
+          set -euo pipefail
+          OIDC_TOKEN=$(curl --fail --silent --show-error \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=matched-v4-runtime-attestation" \
+            | jq -er .value)
+          export OIDC_TOKEN
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+
+          payload = os.environ["OIDC_TOKEN"].split(".")[1]
+          claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
+          assert claims.get("sub") == os.environ["EXPECTED_OIDC_SUBJECT"]
+          PY
+      - name: Revalidate the untrusted build manifest after protected approval
+        env:
+          APPROVED_MAIN_SHA: ${{ needs.verify-origin-main.outputs.approved_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Do not sign an artifact if main moved while the environment waited
+          # for approval. This queries GitHub metadata only; it checks out and
+          # executes no repository content in the OIDC-bearing job.
+          current_main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)
+          test "$APPROVED_MAIN_SHA" = "$current_main_sha"
+          test -s /tmp/matched-v4-runtime/matched-v4-runtime.tgz
+          test -s /tmp/matched-v4-runtime/matched-v4-runtime-attestation.json
+          jq -e --arg sha "$APPROVED_MAIN_SHA" '
+            .kind == "addie_matched_v4_runtime_build_attestation" and
+            .version == 1 and .commit_sha == $sha and
+            (.bundle_sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+          ' /tmp/matched-v4-runtime/matched-v4-runtime-attestation.json >/dev/null
+          expected=$(jq -r .bundle_sha256 /tmp/matched-v4-runtime/matched-v4-runtime-attestation.json)
+          actual=$(sha256sum /tmp/matched-v4-runtime/matched-v4-runtime.tgz | awk '{print $1}')
+          test "$actual" = "$expected"
+      - name: Install Sigstore cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+        with:
+          cosign-release: v2.4.1
+      - name: Sign and verify the exact runnable bundle with GitHub OIDC
+        run: |
+          set -euo pipefail
+          COSIGN_YES=true cosign sign-blob \
+            --new-bundle-format \
+            --bundle /tmp/matched-v4-runtime/matched-v4-runtime.sigstore.json \
+            /tmp/matched-v4-runtime/matched-v4-runtime-attestation.json
+          cosign verify-blob \
+            --new-bundle-format \
+            --bundle /tmp/matched-v4-runtime/matched-v4-runtime.sigstore.json \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/verify-matched-v4-runtime-attestation.yml@refs/heads/main" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            /tmp/matched-v4-runtime/matched-v4-runtime-attestation.json
+      - name: Verify the Fulcio deployment-environment certificate extension
+        env:
+          EXPECTED_DEPLOYMENT_ENVIRONMENT: matched-v4-runtime-attestation
+        run: |
+          set -euo pipefail
+          jq -er '.verificationMaterial.certificate.rawBytes' \
+            /tmp/matched-v4-runtime/matched-v4-runtime.sigstore.json \
+            | base64 --decode > /tmp/matched-v4-runtime/matched-v4-runtime.certificate.der
+          # Decode Certificate/TBSCertificate/[3] Extensions directly: OpenSSL
+          # cannot select private OID 1.3.6.1.4.1.57264.1.23 with `x509 -ext`.
+          # The later protected consumer must repeat this exact structured
+          # OID/OCTET STRING/UTF8String check before execution.
+          export CERTIFICATE_DER=/tmp/matched-v4-runtime/matched-v4-runtime.certificate.der
+          python3 - <<'PY'
+          import os
+
+          OID = bytes.fromhex("2b0601040183bf300117")
+
+          def tlv(data, offset):
+              if offset + 2 > len(data):
+                  raise ValueError("truncated DER TLV")
+              tag = data[offset]
+              length_byte = data[offset + 1]
+              if length_byte & 0x80:
+                  width = length_byte & 0x7f
+                  if width == 0 or offset + 2 + width > len(data):
+                      raise ValueError("invalid DER length")
+                  length = int.from_bytes(data[offset + 2:offset + 2 + width], "big")
+                  start = offset + 2 + width
+              else:
+                  length = length_byte
+                  start = offset + 2
+              end = start + length
+              if end > len(data):
+                  raise ValueError("truncated DER TLV")
+              return tag, data[start:end], end
+
+          def children(data):
+              offset = 0
+              values = []
+              while offset < len(data):
+                  tag, value, offset = tlv(data, offset)
+                  values.append((tag, value))
+              return values
+
+          certificate = open(os.environ["CERTIFICATE_DER"], "rb").read()
+          tag, certificate_value, certificate_end = tlv(certificate, 0)
+          if tag != 0x30 or certificate_end != len(certificate):
+              raise ValueError("certificate is not one DER SEQUENCE")
+          certificate_fields = children(certificate_value)
+          if len(certificate_fields) < 1 or certificate_fields[0][0] != 0x30:
+              raise ValueError("certificate has no TBSCertificate")
+          extensions = [
+              value for tag, value in children(certificate_fields[0][1]) if tag == 0xa3
+          ]
+          if len(extensions) != 1:
+              raise ValueError("TBSCertificate must contain exactly one Extensions field")
+          extension_wrappers = children(extensions[0])
+          if len(extension_wrappers) != 1 or extension_wrappers[0][0] != 0x30:
+              raise ValueError("Extensions field is malformed")
+          matches = []
+          for tag, extension_value in children(extension_wrappers[0][1]):
+              if tag != 0x30:
+                  raise ValueError("Extension is not a SEQUENCE")
+              fields = children(extension_value)
+              if len(fields) not in (2, 3) or fields[0] != (0x06, OID):
+                  continue
+              value_field = fields[-1]
+              if value_field[0] != 0x04:
+                  raise ValueError("deployment-environment extension is not an OCTET STRING")
+              matches.append(value_field[1])
+          if len(matches) != 1:
+              raise ValueError("deployment-environment OID must occur exactly once")
+          utf8_fields = children(matches[0])
+          if len(utf8_fields) != 1 or utf8_fields[0][0] != 0x0c:
+              raise ValueError("deployment-environment extension is not one UTF8String")
+          if utf8_fields[0][1].decode("utf-8") != os.environ["EXPECTED_DEPLOYMENT_ENVIRONMENT"]:
+              raise ValueError("deployment-environment value mismatch")
+          PY
+      - name: Retain verification inputs for the later protected runner
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: matched-v4-runtime-attestation-${{ github.sha }}
+          path: |
+            /tmp/matched-v4-runtime/
+          # Public repositories cannot retain Actions artifacts beyond 90 days.
+          retention-days: 90

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -152,21 +152,60 @@ Before a human enables execution, provision and review all of the following.
    from the GCS identity and from ordinary Fly credentials. Do not use an
    `ALLOW_*` flag, local path, R2 upload, GitHub identity assertion, or caller
    input as an evidence substitute.
-6. Before and after an actual run, obtain provider-authoritative billing
+6. Run the protected, provider-credential-free `Verify matched-v4 runtime build attestation`
+   workflow from `main`. Its unprivileged build job builds one
+   deterministic evaluator bundle and emits a commit-and-SHA-256 manifest.
+   A clean protected job (with no checkout, package install, or build) verifies
+   that SHA-256, asserts that its OIDC token subject names the protected
+   `matched-v4-runtime-attestation` environment, and signs only that manifest
+   with GitHub OIDC/Sigstore. It verifies the signature against the fixed
+   repository/workflow identity and the Fulcio Deployment Environment extension
+   OID `1.3.6.1.4.1.57264.1.23` with the exact environment value, then retains
+   the bundle, manifest, and certificate bundle as **temporary staging**.
+   GitHub public-repository artifacts expire after at most 90 days: approve
+   promptly or dispatch a fresh current-main build, and do not treat an expired
+   artifact as evidence. Before paid execution, a separately provisioned
+   protected custody operation must transfer the bundle, manifest, and Sigstore
+   bundle into the already-approved immutable WORM evidence custody. The paid
+   runner must load only that retained copy, check its archive SHA-256 and exact
+   source/build commit against the protected deployment's admitted SHA, verify
+   the fixed workflow identity and OID/value again, and reject all caller-supplied
+   SHA or artifact selectors. Protect
+   the `matched-v4-runtime-attestation` environment with required reviewers,
+   `main`-only deployments, and no self-approval. A later paid runner must
+   download that exact artifact, verify its digest and Sigstore bundle again,
+   and execute from the verified bundle; it must not accept a SHA, source path,
+   provider, stage, or selector from a caller.
+7. Before and after an actual run, obtain provider-authoritative billing
    evidence: OpenAI organization costs for the dedicated project/time window,
    Google Cloud Billing detailed usage-cost export, and an Anthropic billing
    statement or account export for the dedicated credential/window. Retain
-   those reconciliations independently of the evaluator objects.
+   provider-native source files independently of the evaluator objects. A
+   protected reconciliation adapter may normalize a source only into the
+   checked-in `addie_matched_v4_provider_billing_export` shape: provider,
+   export/account-scope identity, coverage window, retained-native-source
+   SHA-256, USD microdollar lines, provider response IDs, and immutable
+   dispatch timestamps. The adapter must issue the reconciliation capability
+   only after authenticating the export source and binding it to the dedicated
+   account and complete dispatch window; raw normalized projections always
+   remain pending. Reconciliation is successful only when every
+   response ID in retained evaluator evidence has exactly one matching
+   provider line and there are no extras; missing, aggregate-only, duplicate,
+   stale, or unverifiable records are `cost_settlement_pending`. Do not infer a
+   line from tokens, a dated price profile, or a manually supplied total.
 
 Do not run `npm run eval:addie-matched-v4-authorized` from a local checkout:
 it deliberately refuses, because `ADDIE_MATCHED_V4_MERGE_SHA` alone cannot
-prove that the executing source is the admitted deployment. Before any paid
-execution, extend the protected deployment runner to verify a runtime-bound,
-cryptographically signed build attestation for the exact merged SHA, then
-provide the spend-capped provider credentials only to that runner. The runner
-must accept neither a provider, bucket, evidence capability, nor admission
-selector from a caller, and may emit only the non-authorizing report
-projection after retained evidence has been verified.
+prove that the executing source is the admitted deployment. The protected
+runtime-attestation workflow is now the prerequisite for a paid runner; no
+workflow in this change receives provider credentials or invokes a provider.
+When a separately reviewed paid runner is provisioned, it must verify the
+retained runtime bundle immediately before execution and expose spend-capped
+credentials only to that verified process. It must accept neither a provider,
+bucket, evidence capability, SHA, stage, nor admission selector from a caller,
+and may emit only the non-authorizing report projection after retained evidence
+has been verified. Cost-aware screening or promotion remains blocked until the
+provider-authoritative reconciliation above is `reconciled`.
 
 Run the GCS integration test only after the preceding approval and credentials
 exist: `ADDIE_MATCHED_V4_GCS_INTEGRATION=true` plus the runtime GCS credential

--- a/server/src/addie/eval/matched-v4-authorized-execution.ts
+++ b/server/src/addie/eval/matched-v4-authorized-execution.ts
@@ -11,6 +11,8 @@ import { createAddieMatchedV4PaidAuthority } from "./matched-v4-private-authorit
 /** Serializable, non-authorizing evidence suitable for an immutable artifact. */
 export interface AddieMatchedV4AuthorizedStageReport {
   readonly stage: "screening" | "full";
+  /** Estimates are audit-only until a protected billing export reconciles. */
+  readonly costSettlement: "cost_settlement_pending";
   readonly reservationId: string;
   readonly selectorFingerprint: string;
   readonly requestSetSha256: string;
@@ -51,6 +53,7 @@ export interface AddieMatchedV4AuthorizedExecutionReport {
 function reportStage(result: any): AddieMatchedV4AuthorizedStageReport {
   return Object.freeze({
     stage: result.artifact.stage,
+    costSettlement: "cost_settlement_pending" as const,
     reservationId: result.reservationId,
     selectorFingerprint: result.artifact.selectorFingerprint,
     requestSetSha256: result.artifact.requestSetSha256,

--- a/server/src/addie/eval/matched-v4-provider-billing-reconciliation.ts
+++ b/server/src/addie/eval/matched-v4-provider-billing-reconciliation.ts
@@ -1,0 +1,113 @@
+/**
+ * Provider-neutral custody for matched-v4 billed-cost reconciliation.
+ *
+ * This deliberately does not fetch a price page, call a billing API, or turn
+ * normalized token counts into a bill. A protected operator obtains the
+ * provider's own export outside the evaluator, then this module checks whether
+ * that export covers exactly the response IDs retained in immutable evidence.
+ */
+import type { ModelProviderId } from "../model-providers/model-provider.js";
+
+export interface AddieMatchedV4BilledDispatch {
+  readonly provider: ModelProviderId;
+  readonly providerResponseId: string;
+  /** Immutable evidence time for the provider dispatch, in UTC ISO-8601. */
+  readonly dispatchedAt: string;
+}
+
+export interface AddieMatchedV4ProviderBillingLine {
+  readonly providerResponseId: string;
+  /** Integer microdollars as reported by the provider; never a local estimate. */
+  readonly billedCostMicros: number;
+}
+
+/**
+ * The protected billing-export adapter may produce this normalized projection
+ * only after retaining its provider-native source and provenance externally.
+ * An invoice or aggregate with no per-response correlation is intentionally
+ * not this shape and remains pending rather than being guessed into one.
+ */
+export interface AddieMatchedV4ProviderBillingExport {
+  readonly kind: "addie_matched_v4_provider_billing_export";
+  readonly version: 1;
+  readonly provider: ModelProviderId;
+  readonly exportId: string;
+  readonly accountScopeId: string;
+  readonly coverageStartedAt: string;
+  readonly coverageEndedAt: string;
+  readonly currency: "USD";
+  /** SHA-256 of the independently retained provider-native source. */
+  readonly sourceSha256: string;
+  readonly lines: readonly AddieMatchedV4ProviderBillingLine[];
+}
+
+export interface AddieMatchedV4BillingReconciliation {
+  readonly status: "reconciled" | "cost_settlement_pending";
+  readonly reason?:
+    | "untrusted_billing_export"
+    | "missing_provider_export"
+    | "invalid_provider_export"
+    | "account_scope_mismatch"
+    | "coverage_window_mismatch"
+    | "missing_billed_dispatch"
+    | "unexpected_billed_dispatch"
+    | "duplicate_billed_dispatch";
+  readonly billedCostMicros?: number;
+  readonly exports?: readonly Readonly<{
+    provider: ModelProviderId;
+    exportId: string;
+    accountScopeId: string;
+    sourceSha256: string;
+  }>[];
+}
+
+/**
+ * Contract that a future protected adapter must seal from retained evaluator
+ * evidence. The dispatch timestamp must be within the run window and within
+ * the matching provider export's coverage before it can be settled.
+ */
+export interface AddieMatchedV4BillingReconciliationTarget {
+  readonly dispatches: readonly AddieMatchedV4BilledDispatch[];
+  readonly accountScopeByProvider: Readonly<
+    Partial<Record<ModelProviderId, string>>
+  >;
+  /** Inclusive UTC bounds; a protected adapter must reject any dispatch outside them. */
+  readonly runStartedAt: string;
+  readonly runEndedAt: string;
+}
+
+/** The sealed adapter owns both the exact billing join and its run window. */
+export interface AddieMatchedV4ProviderBillingReconciliationCapability {
+  /**
+   * This is issued only after the protected adapter has authenticated and
+   * retained provider-native sources. It captures the evaluator dispatches,
+   * dedicated account scopes, and run window; callers cannot supply them to
+   * this method.
+   */
+  reconcile(
+    exports: readonly AddieMatchedV4ProviderBillingExport[],
+  ): AddieMatchedV4BillingReconciliation;
+}
+
+function pending(
+  reason: NonNullable<AddieMatchedV4BillingReconciliation["reason"]>,
+): AddieMatchedV4BillingReconciliation {
+  return Object.freeze({ status: "cost_settlement_pending", reason });
+}
+
+/**
+ * Reconcile immutable evaluator response IDs with provider-authoritative cost
+ * lines. It accepts no pricing profile, token usage, caller-supplied total, or
+ * tolerance. Until a protected adapter can authenticate provider-native
+ * sources and issue the capability above, every serializable projection is
+ * intentionally pending.
+ */
+export function reconcileAddieMatchedV4ProviderBilling(
+  _dispatches: readonly AddieMatchedV4BilledDispatch[],
+  _exports: readonly AddieMatchedV4ProviderBillingExport[],
+): AddieMatchedV4BillingReconciliation {
+  // A serializable projection has no evidence that its source was a protected
+  // provider export. Only the adapter-issued capability below owns the
+  // immutable evaluator dispatch list, account scope, and coverage window.
+  return pending("untrusted_billing_export");
+}

--- a/server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts
+++ b/server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts
@@ -1,0 +1,259 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  reconcileAddieMatchedV4ProviderBilling,
+  type AddieMatchedV4BillingReconciliationTarget,
+  type AddieMatchedV4ProviderBillingExport,
+} from "../../../src/addie/eval/matched-v4-provider-billing-reconciliation.js";
+
+const dispatches = [
+  {
+    provider: "anthropic" as const,
+    providerResponseId: "msg_1",
+    dispatchedAt: "2026-09-10T00:20:00.000Z",
+  },
+  {
+    provider: "openai" as const,
+    providerResponseId: "resp_2",
+    dispatchedAt: "2026-09-10T00:40:00.000Z",
+  },
+];
+const sealedTarget = {
+  dispatches,
+  accountScopeByProvider: {
+    anthropic: "anthropic-dedicated-project",
+    openai: "openai-dedicated-project",
+  },
+  runStartedAt: "2026-09-10T00:15:00.000Z",
+  runEndedAt: "2026-09-10T00:45:00.000Z",
+} satisfies AddieMatchedV4BillingReconciliationTarget;
+const exported = (
+  provider: "anthropic" | "openai" | "google",
+  lines: readonly { providerResponseId: string; billedCostMicros: number }[],
+): AddieMatchedV4ProviderBillingExport => ({
+  kind: "addie_matched_v4_provider_billing_export",
+  version: 1,
+  provider,
+  exportId: `${provider}-export-1`,
+  accountScopeId: `${provider}-dedicated-project`,
+  coverageStartedAt: "2026-09-10T00:00:00.000Z",
+  coverageEndedAt: "2026-09-10T01:00:00.000Z",
+  currency: "USD",
+  sourceSha256: "a".repeat(64),
+  lines,
+});
+const attestationWorkflow = () =>
+  readFileSync(
+    new URL(
+      "../../../../.github/workflows/verify-matched-v4-runtime-attestation.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+describe("matched-v4 provider-authoritative billing reconciliation", () => {
+  it("keeps even complete caller-constructed projections pending", () => {
+    expect(
+      reconcileAddieMatchedV4ProviderBilling(dispatches, [
+        exported("anthropic", [
+          { providerResponseId: "msg_1", billedCostMicros: 31 },
+        ]),
+        exported("openai", [
+          { providerResponseId: "resp_2", billedCostMicros: 47 },
+        ]),
+      ]),
+    ).toEqual({
+      status: "cost_settlement_pending",
+      reason: "untrusted_billing_export",
+    });
+  });
+
+  it("fails closed instead of dereferencing malformed dispatch and export entries", () => {
+    const reconcileMalformed = () =>
+      reconcileAddieMatchedV4ProviderBilling(
+        [null as never, ...dispatches],
+        [
+          null as never,
+          exported("anthropic", [null as never]),
+          exported("openai", [
+            { providerResponseId: "resp_2", billedCostMicros: 47 },
+          ]),
+        ],
+      );
+    expect(reconcileMalformed).not.toThrow();
+    expect(reconcileMalformed()).toEqual({
+      status: "cost_settlement_pending",
+      reason: "untrusted_billing_export",
+    });
+  });
+
+  it("requires the eventual sealed adapter target to carry dispatch timestamps", () => {
+    expect(sealedTarget.dispatches).toEqual([
+      expect.objectContaining({ dispatchedAt: "2026-09-10T00:20:00.000Z" }),
+      expect.objectContaining({ dispatchedAt: "2026-09-10T00:40:00.000Z" }),
+    ]);
+    expect(sealedTarget.runStartedAt).toBe("2026-09-10T00:15:00.000Z");
+    expect(sealedTarget.runEndedAt).toBe("2026-09-10T00:45:00.000Z");
+  });
+
+  it("cannot settle a projection with an out-of-window dispatch timestamp", () => {
+    expect(
+      reconcileAddieMatchedV4ProviderBilling(
+        [
+          dispatches[0]!,
+          { ...dispatches[1]!, dispatchedAt: "2026-09-10T02:00:00.000Z" },
+        ],
+        [
+          exported("anthropic", [
+            { providerResponseId: "msg_1", billedCostMicros: 31 },
+          ]),
+          exported("openai", [
+            { providerResponseId: "resp_2", billedCostMicros: 47 },
+          ]),
+        ],
+      ),
+    ).toEqual({
+      status: "cost_settlement_pending",
+      reason: "untrusted_billing_export",
+    });
+  });
+
+  it("accepts only the exact deployment-environment UTF8String in DER", () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "matched-v4-oid-"));
+    const parserPath = join(temporaryDirectory, "verify-environment.py");
+    const workflow = attestationWorkflow();
+    const heredocStart = workflow.indexOf(
+      "          python3 - <<'PY'\n",
+      workflow.indexOf("export CERTIFICATE_DER"),
+    );
+    const heredocEnd = workflow.indexOf("\n          PY", heredocStart);
+    expect(heredocStart).toBeGreaterThan(-1);
+    expect(heredocEnd).toBeGreaterThan(heredocStart);
+    writeFileSync(
+      parserPath,
+      workflow
+        .slice(heredocStart + "          python3 - <<'PY'\n".length, heredocEnd)
+        .replace(/^ {10}/gm, ""),
+    );
+    const certificate = (name: string, environment: string) => {
+      const keyPath = join(temporaryDirectory, `${name}.key`);
+      const pemPath = join(temporaryDirectory, `${name}.pem`);
+      const derPath = join(temporaryDirectory, `${name}.der`);
+      execFileSync(
+        "openssl",
+        [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-keyout",
+          keyPath,
+          "-out",
+          pemPath,
+          "-nodes",
+          "-subj",
+          "/CN=matched-v4-test",
+          "-days",
+          "1",
+          "-addext",
+          `1.3.6.1.4.1.57264.1.23=ASN1:UTF8String:${environment}`,
+        ],
+        { stdio: "ignore" },
+      );
+      execFileSync("openssl", [
+        "x509",
+        "-in",
+        pemPath,
+        "-outform",
+        "DER",
+        "-out",
+        derPath,
+      ]);
+      return derPath;
+    };
+    const run = (certificatePath: string) =>
+      execFileSync("python3", [parserPath], {
+        env: {
+          ...process.env,
+          CERTIFICATE_DER: certificatePath,
+          EXPECTED_DEPLOYMENT_ENVIRONMENT: "matched-v4-runtime-attestation",
+        },
+        stdio: "pipe",
+      });
+    try {
+      expect(() =>
+        run(certificate("valid", "matched-v4-runtime-attestation")),
+      ).not.toThrow();
+      expect(() => run(certificate("wrong", "other-environment"))).toThrow();
+    } finally {
+      rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it("isolates OIDC from untrusted build code and signs only its checked digest", () => {
+    const workflow = attestationWorkflow();
+    const untrustedBuild = workflow.slice(
+      workflow.indexOf("  verify-origin-main:"),
+      workflow.indexOf("  attest-runtime-bundle:"),
+    );
+    const protectedAttestation = workflow.slice(
+      workflow.indexOf("  attest-runtime-bundle:"),
+    );
+    const verification = workflow.indexOf("cosign verify-blob");
+    const retainedBundle = workflow.lastIndexOf("actions/upload-artifact@");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain('test "${GITHUB_REF}" = "refs/heads/main"');
+    expect(workflow).toContain("environment: matched-v4-runtime-attestation");
+    expect(workflow).toContain('test "$DISPATCH_SHA" = "$current_main_sha"');
+    expect(workflow).toContain(
+      "--certificate-oidc-issuer https://token.actions.githubusercontent.com",
+    );
+    expect(untrustedBuild).not.toContain("id-token: write");
+    expect(untrustedBuild).toContain("npm ci");
+    expect(untrustedBuild).toContain("npm run build");
+    expect(protectedAttestation).toContain("id-token: write");
+    expect(protectedAttestation).not.toContain("actions/checkout@");
+    expect(protectedAttestation).not.toContain("npm ci");
+    expect(protectedAttestation).not.toContain("npm run build");
+    expect(protectedAttestation).toContain(
+      "matched-v4-runtime-attestation.json",
+    );
+    expect(protectedAttestation).toContain("bundle_sha256");
+    expect(protectedAttestation).toContain("gh api");
+    expect(protectedAttestation).toContain("GH_TOKEN: ${{ github.token }}");
+    expect(protectedAttestation).toContain("1.3.6.1.4.1.57264.1.23");
+    expect(protectedAttestation.match(/--new-bundle-format/g)).toHaveLength(2);
+    expect(protectedAttestation).toContain(
+      ".verificationMaterial.certificate.rawBytes",
+    );
+    expect(protectedAttestation).toContain("deployment-environment OID");
+    expect(protectedAttestation).toContain("not an OCTET STRING");
+    expect(protectedAttestation).toContain("not one UTF8String");
+    expect(protectedAttestation).toContain(
+      "matched-v4-runtime.certificate.der",
+    );
+    expect(protectedAttestation).toContain("retention-days: 90");
+    expect(protectedAttestation).toContain(
+      'test "$APPROVED_MAIN_SHA" = "$current_main_sha"',
+    );
+    expect(verification).toBeGreaterThan(-1);
+    expect(retainedBundle).toBeGreaterThan(verification);
+    expect(workflow).not.toContain("${{ secrets.");
+    expect(workflow).not.toContain("eval:addie-matched-v4-authorized");
+  });
+
+  it("marks every authorized runtime report pending external billing reconciliation", () => {
+    const runner = readFileSync(
+      new URL(
+        "../../../src/addie/eval/matched-v4-authorized-execution.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(runner).toContain('costSettlement: "cost_settlement_pending"');
+    expect(runner).toContain("estimatedCostUsd");
+  });
+});


### PR DESCRIPTION
## Summary
- add a main-only protected Sigstore runtime-bundle attestation prerequisite; it has no provider credentials or cloud billing calls
- add provider-neutral exact-response-ID billing reconciliation that accepts provider-reported microdollar lines only
- keep all runtime reports and cost-aware promotion pending until external provider billing reconciliation succeeds

## Validation
- focused matched-v4 Vitest coverage
- `npm run typecheck -- --pretty false`
- `npm run lint:schema-links --silent`
- `npm run test:docs-nav`
- `git diff --check`

## Safety
No provider/billing API calls, credentials, secrets, cloud provisioning, or merge were performed. The protected runtime-attestation workflow itself signs and verifies an evaluator bundle but deliberately has no provider credentials or execution command.

<!-- conductor-workspace-link -->