### PR TITLE
fix(addie): retain aggregate provider billing custody

### DIFF
--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -176,23 +176,54 @@ Before a human enables execution, provision and review all of the following.
    download that exact artifact, verify its digest and Sigstore bundle again,
    and execute from the verified bundle; it must not accept a SHA, source path,
    provider, stage, or selector from a caller.
-7. Before and after an actual run, obtain provider-authoritative billing
-   evidence: OpenAI organization costs for the dedicated project/time window,
-   Google Cloud Billing detailed usage-cost export, and an Anthropic billing
-   statement or account export for the dedicated credential/window. Retain
-   provider-native source files independently of the evaluator objects. A
-   protected reconciliation adapter may normalize a source only into the
-   checked-in `addie_matched_v4_provider_billing_export` shape: provider,
-   export/account-scope identity, coverage window, retained-native-source
-   SHA-256, USD microdollar lines, provider response IDs, and immutable
-   dispatch timestamps. The adapter must issue the reconciliation capability
-   only after authenticating the export source and binding it to the dedicated
-   account and complete dispatch window; raw normalized projections always
-   remain pending. Reconciliation is successful only when every
-   response ID in retained evaluator evidence has exactly one matching
-   provider line and there are no extras; missing, aggregate-only, duplicate,
-   stale, or unverifiable records are `cost_settlement_pending`. Do not infer a
-   line from tokens, a dated price profile, or a manually supplied total.
+7. Before and after an actual run, obtain and retain the provider-authoritative
+   native billing source independently of evaluator objects. These sources are
+   aggregate reports, not response-level bills:
+
+   - OpenAI organization costs are daily buckets grouped by `project_id` and
+     `line_item`.
+   - Anthropic usage/cost reports group by time, API key, workspace, and model.
+   - Google Cloud Billing exports group by billing account, project, service,
+     SKU, time, and resource metadata.
+
+   Provision one dedicated project/workspace/API key per provider for this
+   evaluation only. Before dispatch, record its reviewed identity and custody
+   owner; do not share it with app, development, test, or another evaluation
+   traffic source. After the run, a human must confirm from the scope's access,
+   credential, and activity records that it had no extra or shared traffic for
+   the entire UTC settlement window. If that isolation gate cannot be proved,
+   aggregate provider cost cannot be compared truthfully and remains
+   `cost_settlement_pending`.
+
+   A future protected reconciliation adapter may normalize an authenticated,
+   retained native source only into the checked-in
+   `addie_matched_v4_provider_billing_settlement_receipt` contract. It captures
+   the provider, provider-native granularity, native export identity and
+   SHA-256 digest, dedicated scope identity, inclusive UTC coverage window,
+   protected-custody settled-through determination, currency, and provider-reported
+   **aggregate** microdollars. It may include a complete model breakdown for
+   Anthropic or line-item breakdown for OpenAI only when that exact native
+   export supplies it. Google breakdowns must be omitted until a separately
+   reviewed SKU/resource-native breakdown contract exists. It must never
+   synthesize, apportion, or label a per-response billed cost.
+
+   Immutable evaluator response IDs and dispatch timestamps are
+   execution-completeness evidence only: they show the planned execution
+   completed inside the isolated scope/window, not a join to an aggregate bill.
+   The protected adapter must bind that evidence to the dedicated scope, require
+   coverage of the full run, and determine settlement finality at or after the
+   covered window under a provider-specific source-lag/stability policy. That
+   finality determination is protected-custody evidence, not a provider field
+   fabricated from a bucket end or export observation time. It must require
+   exactly one complete retained native export receipt per execution provider;
+   it must reject a duplicate provider receipt or native export and
+   non-USD/unsafe totals, and retain the authenticated source under independent
+   custody. There is
+   deliberately no production receipt-capability issuer yet; every
+   raw/caller-constructible receipt and every current execution report remains
+   `cost_settlement_pending`.
+   Do not infer cost from tokens, a dated price profile, or a manually supplied
+   total.
 
 Do not run `npm run eval:addie-matched-v4-authorized` from a local checkout:
 it deliberately refuses, because `ADDIE_MATCHED_V4_MERGE_SHA` alone cannot
@@ -204,8 +235,9 @@ retained runtime bundle immediately before execution and expose spend-capped
 credentials only to that verified process. It must accept neither a provider,
 bucket, evidence capability, SHA, stage, nor admission selector from a caller,
 and may emit only the non-authorizing report projection after retained evidence
-has been verified. Cost-aware screening or promotion remains blocked until the
-provider-authoritative reconciliation above is `reconciled`.
+has been verified. Cost-aware screening or promotion remains blocked unless a
+future, separately reviewed protected reconciliation system establishes its
+own authority; this checked-in contract cannot do so.
 
 Run the GCS integration test only after the preceding approval and credentials
 exist: `ADDIE_MATCHED_V4_GCS_INTEGRATION=true` plus the runtime GCS credential
@@ -214,6 +246,9 @@ deletes them; it does not open PostgreSQL or call a model provider. The normal
 unit suite is deterministic and makes no network call.
 
 The evaluator records provider response IDs and usage, but its dated pricing
-profile is an **estimate**, not provider-authoritative settlement. Missing,
-late, aggregated, or non-reconcilable provider billing evidence remains
-`cost_settlement_pending` and must not drive promotion or rollout.
+profile is an **estimate**, not provider-authoritative settlement. Aggregation
+does not make billing unusable; it requires the isolated dedicated scope and a
+complete settled UTC window described above. Missing, late, shared-scope,
+duplicate, non-USD, unsafe, or unverifiable billing evidence remains
+`cost_settlement_pending`. No estimate or receipt projection may unlock
+cost-aware screening, promotion, rollout, or an exact per-response cost claim.

--- a/server/src/addie/eval/matched-v4-provider-billing-reconciliation.ts
+++ b/server/src/addie/eval/matched-v4-provider-billing-reconciliation.ts
@@ -1,113 +1,402 @@
 /**
- * Provider-neutral custody for matched-v4 billed-cost reconciliation.
+ * Provider-neutral custody contract for matched-v4 aggregate cost settlement.
  *
- * This deliberately does not fetch a price page, call a billing API, or turn
- * normalized token counts into a bill. A protected operator obtains the
- * provider's own export outside the evaluator, then this module checks whether
- * that export covers exactly the response IDs retained in immutable evidence.
+ * Provider billing exports are aggregates, not response-level bills. This
+ * module therefore keeps response IDs solely as execution-completeness
+ * evidence. It neither fetches a billing source nor assigns provider cost to
+ * an individual response.
  */
 import type { ModelProviderId } from "../model-providers/model-provider.js";
 
 export interface AddieMatchedV4BilledDispatch {
   readonly provider: ModelProviderId;
+  /** Immutable evaluator evidence only; never a provider-billing join key. */
   readonly providerResponseId: string;
   /** Immutable evidence time for the provider dispatch, in UTC ISO-8601. */
   readonly dispatchedAt: string;
 }
 
-export interface AddieMatchedV4ProviderBillingLine {
-  readonly providerResponseId: string;
-  /** Integer microdollars as reported by the provider; never a local estimate. */
-  readonly billedCostMicros: number;
+/** The native grouping available from each provider's authoritative source. */
+export type AddieMatchedV4NativeBillingGranularity =
+  | "openai_daily_project_line_item"
+  | "anthropic_time_api_key_workspace_model"
+  | "google_cloud_billing_account_project_service_sku_time_resource";
+
+/**
+ * An optional aggregate subdivision copied from a native export. A protected
+ * adapter may include this only where its authenticated native source actually
+ * supplies the corresponding dimension: `model` for Anthropic or `line_item`
+ * for OpenAI. Google breakdowns are omitted until SKU/resource granularity has
+ * its own native contract. It is never a per-response amount.
+ */
+export interface AddieMatchedV4ProviderBillingBreakdown {
+  readonly dimension: "model" | "line_item";
+  readonly id: string;
+  readonly providerReportedCostMicros: number;
 }
 
 /**
- * The protected billing-export adapter may produce this normalized projection
- * only after retaining its provider-native source and provenance externally.
- * An invoice or aggregate with no per-response correlation is intentionally
- * not this shape and remains pending rather than being guessed into one.
+ * A future protected adapter's normalized receipt for one provider and one
+ * dedicated evaluation scope. There must be exactly one complete retained
+ * native export receipt per provider in an evaluation. `nativeExportIdentity`
+ * identifies the provider report/query/export itself;
+ * `authenticatedNativeSourceSha256` commits its retained native bytes. Neither
+ * field makes a caller-supplied object trusted.
  */
-export interface AddieMatchedV4ProviderBillingExport {
-  readonly kind: "addie_matched_v4_provider_billing_export";
-  readonly version: 1;
+export interface AddieMatchedV4ProviderBillingSettlementReceipt {
+  readonly kind: "addie_matched_v4_provider_billing_settlement_receipt";
+  readonly version: 2;
   readonly provider: ModelProviderId;
-  readonly exportId: string;
-  readonly accountScopeId: string;
+  readonly nativeGranularity: AddieMatchedV4NativeBillingGranularity;
+  readonly nativeExportIdentity: string;
+  readonly authenticatedNativeSourceSha256: string;
+  readonly dedicatedScopeId: string;
+  /** Inclusive UTC coverage bounds reported by the provider-native export. */
   readonly coverageStartedAt: string;
   readonly coverageEndedAt: string;
+  /**
+   * UTC finality determined by protected custody under its provider-specific
+   * lag/stability policy. It is not asserted to be provider-reported.
+   */
+  readonly settledThroughAt: string;
+  /** Only USD can be represented safely by this microdollar contract. */
   readonly currency: "USD";
-  /** SHA-256 of the independently retained provider-native source. */
-  readonly sourceSha256: string;
-  readonly lines: readonly AddieMatchedV4ProviderBillingLine[];
-}
-
-export interface AddieMatchedV4BillingReconciliation {
-  readonly status: "reconciled" | "cost_settlement_pending";
-  readonly reason?:
-    | "untrusted_billing_export"
-    | "missing_provider_export"
-    | "invalid_provider_export"
-    | "account_scope_mismatch"
-    | "coverage_window_mismatch"
-    | "missing_billed_dispatch"
-    | "unexpected_billed_dispatch"
-    | "duplicate_billed_dispatch";
-  readonly billedCostMicros?: number;
-  readonly exports?: readonly Readonly<{
-    provider: ModelProviderId;
-    exportId: string;
-    accountScopeId: string;
-    sourceSha256: string;
-  }>[];
+  /** Integer provider-reported aggregate USD microdollars for this scope/window. */
+  readonly providerReportedAggregateCostMicros: number;
+  /** Present only when native data supplies a complete model or line-item split. */
+  readonly breakdown?: readonly AddieMatchedV4ProviderBillingBreakdown[];
+  /**
+   * The protected custody process's isolation finding, not a billing join.
+   * It may be set only after the dedicated key/project/workspace has been
+   * checked for extra traffic across the covered window.
+   */
+  readonly scopeIsolation:
+    "exclusive_dedicated_scope" | "extra_or_shared_traffic";
 }
 
 /**
- * Contract that a future protected adapter must seal from retained evaluator
- * evidence. The dispatch timestamp must be within the run window and within
- * the matching provider export's coverage before it can be settled.
+ * Contract captured inside a future protected capability. Dispatch IDs prove
+ * complete execution, while settlement is attached to the isolated scope and
+ * complete settled UTC window.
  */
 export interface AddieMatchedV4BillingReconciliationTarget {
   readonly dispatches: readonly AddieMatchedV4BilledDispatch[];
-  readonly accountScopeByProvider: Readonly<
+  readonly dedicatedScopeByProvider: Readonly<
     Partial<Record<ModelProviderId, string>>
   >;
-  /** Inclusive UTC bounds; a protected adapter must reject any dispatch outside them. */
+  /** Inclusive UTC bounds of the evaluator run. */
   readonly runStartedAt: string;
   readonly runEndedAt: string;
 }
 
-/** The sealed adapter owns both the exact billing join and its run window. */
-export interface AddieMatchedV4ProviderBillingReconciliationCapability {
-  /**
-   * This is issued only after the protected adapter has authenticated and
-   * retained provider-native sources. It captures the evaluator dispatches,
-   * dedicated account scopes, and run window; callers cannot supply them to
-   * this method.
-   */
-  reconcile(
-    exports: readonly AddieMatchedV4ProviderBillingExport[],
-  ): AddieMatchedV4BillingReconciliation;
-}
+export type AddieMatchedV4BillingProjectionIssue =
+  | "invalid_contract_input"
+  | "execution_completeness_failed"
+  | "missing_provider_receipt"
+  | "unexpected_provider_receipt"
+  | "duplicate_provider_receipt"
+  | "malformed_receipt"
+  | "wrong_dedicated_scope"
+  | "coverage_not_complete"
+  | "settlement_not_final"
+  | "scope_isolation_failed"
+  | "duplicate_native_export"
+  | "unsupported_currency"
+  | "unsafe_aggregate_total";
 
-function pending(
-  reason: NonNullable<AddieMatchedV4BillingReconciliation["reason"]>,
-): AddieMatchedV4BillingReconciliation {
-  return Object.freeze({ status: "cost_settlement_pending", reason });
+/**
+ * Diagnostic structural validation only. A valid result does not authenticate
+ * the source, issue a capability, settle cost, or permit promotion.
+ */
+export interface AddieMatchedV4BillingProjectionValidation {
+  readonly valid: boolean;
+  readonly issues: readonly AddieMatchedV4BillingProjectionIssue[];
 }
 
 /**
- * Reconcile immutable evaluator response IDs with provider-authoritative cost
- * lines. It accepts no pricing profile, token usage, caller-supplied total, or
- * tolerance. Until a protected adapter can authenticate provider-native
- * sources and issue the capability above, every serializable projection is
- * intentionally pending.
+ * Current executable paths cannot settle cost. A later reviewed protected
+ * adapter may introduce an internally issued capability, but must not expose a
+ * caller-constructible route to a promotable result.
+ */
+export interface AddieMatchedV4ProviderBillingReconciliationCapability {
+  reconcile(
+    receipts: readonly AddieMatchedV4ProviderBillingSettlementReceipt[],
+  ): AddieMatchedV4BillingReconciliation;
+}
+
+export interface AddieMatchedV4BillingReconciliation {
+  readonly status: "cost_settlement_pending";
+  readonly reason: "untrusted_billing_receipt";
+}
+
+const PROVIDERS: readonly ModelProviderId[] = ["anthropic", "openai", "google"];
+
+const GRANULARITY_BY_PROVIDER: Readonly<
+  Record<ModelProviderId, AddieMatchedV4NativeBillingGranularity>
+> = Object.freeze({
+  openai: "openai_daily_project_line_item",
+  anthropic: "anthropic_time_api_key_workspace_model",
+  google: "google_cloud_billing_account_project_service_sku_time_resource",
+});
+
+/** Google requires its own SKU/resource-native breakdown contract. */
+const BREAKDOWN_DIMENSION_BY_PROVIDER: Readonly<
+  Partial<
+    Record<ModelProviderId, AddieMatchedV4ProviderBillingBreakdown["dimension"]>
+  >
+> = Object.freeze({
+  openai: "line_item",
+  anthropic: "model",
+});
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function utcMilliseconds(value: unknown): number | undefined {
+  if (typeof value !== "string" || !value.endsWith("Z")) return undefined;
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return undefined;
+  return new Date(milliseconds).toISOString() === value
+    ? milliseconds
+    : undefined;
+}
+
+function isProvider(value: unknown): value is ModelProviderId {
+  return (
+    typeof value === "string" && PROVIDERS.includes(value as ModelProviderId)
+  );
+}
+
+function isSha256(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length === 64 &&
+    /^[a-f0-9]{64}$/i.test(value)
+  );
+}
+
+function isSafeMicrodollarTotal(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function addIssue(
+  issues: Set<AddieMatchedV4BillingProjectionIssue>,
+  issue: AddieMatchedV4BillingProjectionIssue,
+): void {
+  issues.add(issue);
+}
+
+/**
+ * Checks the shape and declared relationships of a proposed aggregate receipt
+ * set. It deliberately accepts `unknown` so malformed untrusted input cannot
+ * throw. Its result is not authority and is intentionally unused by promotion.
+ */
+export function validateAddieMatchedV4ProviderBillingSettlementProjection(
+  target: unknown,
+  receipts: unknown,
+): AddieMatchedV4BillingProjectionValidation {
+  const issues = new Set<AddieMatchedV4BillingProjectionIssue>();
+  try {
+    if (!isRecord(target) || !Array.isArray(target.dispatches)) {
+      addIssue(issues, "invalid_contract_input");
+      return Object.freeze({
+        valid: false,
+        issues: Object.freeze([...issues]),
+      });
+    }
+    const runStartedAt = utcMilliseconds(target.runStartedAt);
+    const runEndedAt = utcMilliseconds(target.runEndedAt);
+    if (
+      runStartedAt === undefined ||
+      runEndedAt === undefined ||
+      runStartedAt > runEndedAt ||
+      !isRecord(target.dedicatedScopeByProvider)
+    ) {
+      addIssue(issues, "invalid_contract_input");
+    }
+
+    const expectedProviders = new Set<ModelProviderId>();
+    const dispatchKeys = new Set<string>();
+    for (const dispatch of target.dispatches) {
+      if (
+        !isRecord(dispatch) ||
+        !isProvider(dispatch.provider) ||
+        !nonEmptyString(dispatch.providerResponseId)
+      ) {
+        addIssue(issues, "execution_completeness_failed");
+        continue;
+      }
+      const dispatchedAt = utcMilliseconds(dispatch.dispatchedAt);
+      if (
+        dispatchedAt === undefined ||
+        runStartedAt === undefined ||
+        runEndedAt === undefined ||
+        dispatchedAt < runStartedAt ||
+        dispatchedAt > runEndedAt
+      ) {
+        addIssue(issues, "execution_completeness_failed");
+      }
+      const dispatchKey = `${dispatch.provider}:${dispatch.providerResponseId}`;
+      if (dispatchKeys.has(dispatchKey))
+        addIssue(issues, "execution_completeness_failed");
+      dispatchKeys.add(dispatchKey);
+      expectedProviders.add(dispatch.provider);
+    }
+    if (expectedProviders.size === 0) {
+      addIssue(issues, "execution_completeness_failed");
+    }
+
+    if (!Array.isArray(receipts)) {
+      addIssue(issues, "invalid_contract_input");
+      return Object.freeze({
+        valid: false,
+        issues: Object.freeze([...issues]),
+      });
+    }
+
+    const receiptProviders = new Set<ModelProviderId>();
+    const receiptCountByProvider = new Map<ModelProviderId, number>();
+    const nativeExports = new Set<string>();
+    const nativeSources = new Set<string>();
+    for (const receipt of receipts) {
+      if (
+        !isRecord(receipt) ||
+        receipt.kind !==
+          "addie_matched_v4_provider_billing_settlement_receipt" ||
+        receipt.version !== 2 ||
+        !isProvider(receipt.provider) ||
+        !nonEmptyString(receipt.nativeExportIdentity) ||
+        !isSha256(receipt.authenticatedNativeSourceSha256) ||
+        !nonEmptyString(receipt.dedicatedScopeId)
+      ) {
+        addIssue(issues, "malformed_receipt");
+        continue;
+      }
+      const provider = receipt.provider;
+      receiptProviders.add(provider);
+      const receiptCount = (receiptCountByProvider.get(provider) ?? 0) + 1;
+      receiptCountByProvider.set(provider, receiptCount);
+      if (receiptCount > 1) {
+        addIssue(issues, "duplicate_provider_receipt");
+      }
+      const nativeExportKey = `${provider}:${receipt.nativeExportIdentity}`;
+      const nativeSourceSha256 =
+        receipt.authenticatedNativeSourceSha256.toLowerCase();
+      if (
+        nativeExports.has(nativeExportKey) ||
+        nativeSources.has(nativeSourceSha256)
+      ) {
+        addIssue(issues, "duplicate_native_export");
+      }
+      nativeExports.add(nativeExportKey);
+      nativeSources.add(nativeSourceSha256);
+      if (receipt.nativeGranularity !== GRANULARITY_BY_PROVIDER[provider]) {
+        addIssue(issues, "malformed_receipt");
+      }
+      const scope = isRecord(target.dedicatedScopeByProvider)
+        ? target.dedicatedScopeByProvider[provider]
+        : undefined;
+      if (!nonEmptyString(scope) || scope !== receipt.dedicatedScopeId) {
+        addIssue(issues, "wrong_dedicated_scope");
+      }
+      const coverageStartedAt = utcMilliseconds(receipt.coverageStartedAt);
+      const coverageEndedAt = utcMilliseconds(receipt.coverageEndedAt);
+      const settledThroughAt = utcMilliseconds(receipt.settledThroughAt);
+      if (
+        coverageStartedAt === undefined ||
+        coverageEndedAt === undefined ||
+        coverageStartedAt > coverageEndedAt ||
+        runStartedAt === undefined ||
+        runEndedAt === undefined ||
+        coverageStartedAt > runStartedAt ||
+        coverageEndedAt < runEndedAt
+      ) {
+        addIssue(issues, "coverage_not_complete");
+      }
+      if (
+        settledThroughAt === undefined ||
+        coverageEndedAt === undefined ||
+        settledThroughAt < coverageEndedAt
+      ) {
+        addIssue(issues, "settlement_not_final");
+      }
+      if (receipt.scopeIsolation !== "exclusive_dedicated_scope") {
+        addIssue(issues, "scope_isolation_failed");
+      }
+      if (receipt.currency !== "USD") addIssue(issues, "unsupported_currency");
+      if (
+        !isSafeMicrodollarTotal(receipt.providerReportedAggregateCostMicros)
+      ) {
+        addIssue(issues, "unsafe_aggregate_total");
+      }
+      if (receipt.breakdown !== undefined) {
+        const supportedDimension = BREAKDOWN_DIMENSION_BY_PROVIDER[provider];
+        if (
+          supportedDimension === undefined ||
+          !Array.isArray(receipt.breakdown) ||
+          receipt.breakdown.length === 0
+        ) {
+          addIssue(issues, "malformed_receipt");
+        } else {
+          const breakdownKeys = new Set<string>();
+          let breakdownTotal = 0;
+          for (const entry of receipt.breakdown) {
+            if (
+              !isRecord(entry) ||
+              entry.dimension !== supportedDimension ||
+              !nonEmptyString(entry.id) ||
+              !isSafeMicrodollarTotal(entry.providerReportedCostMicros)
+            ) {
+              addIssue(issues, "malformed_receipt");
+              continue;
+            }
+            const key = `${entry.dimension}:${entry.id}`;
+            if (breakdownKeys.has(key)) addIssue(issues, "malformed_receipt");
+            breakdownKeys.add(key);
+            breakdownTotal += entry.providerReportedCostMicros;
+          }
+          if (
+            !Number.isSafeInteger(breakdownTotal) ||
+            breakdownTotal !== receipt.providerReportedAggregateCostMicros
+          ) {
+            addIssue(issues, "unsafe_aggregate_total");
+          }
+        }
+      }
+    }
+    for (const provider of expectedProviders) {
+      if (!receiptProviders.has(provider))
+        addIssue(issues, "missing_provider_receipt");
+    }
+    for (const provider of receiptProviders) {
+      if (!expectedProviders.has(provider))
+        addIssue(issues, "unexpected_provider_receipt");
+    }
+  } catch {
+    addIssue(issues, "invalid_contract_input");
+  }
+  return Object.freeze({
+    valid: issues.size === 0,
+    issues: Object.freeze([...issues]),
+  });
+}
+
+/**
+ * All caller-constructible/raw inputs fail closed. This intentionally does not
+ * invoke the diagnostic validator: even a structurally perfect projection
+ * cannot authenticate a native source or unlock cost-aware promotion.
  */
 export function reconcileAddieMatchedV4ProviderBilling(
-  _dispatches: readonly AddieMatchedV4BilledDispatch[],
-  _exports: readonly AddieMatchedV4ProviderBillingExport[],
+  _target: unknown,
+  _receipts: unknown,
 ): AddieMatchedV4BillingReconciliation {
-  // A serializable projection has no evidence that its source was a protected
-  // provider export. Only the adapter-issued capability below owns the
-  // immutable evaluator dispatch list, account scope, and coverage window.
-  return pending("untrusted_billing_export");
+  return Object.freeze({
+    status: "cost_settlement_pending",
+    reason: "untrusted_billing_receipt",
+  });
 }

--- a/server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts
+++ b/server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts
@@ -5,8 +5,9 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   reconcileAddieMatchedV4ProviderBilling,
+  validateAddieMatchedV4ProviderBillingSettlementProjection,
   type AddieMatchedV4BillingReconciliationTarget,
-  type AddieMatchedV4ProviderBillingExport,
+  type AddieMatchedV4ProviderBillingSettlementReceipt,
 } from "../../../src/addie/eval/matched-v4-provider-billing-reconciliation.js";
 
 const dispatches = [
@@ -23,28 +24,41 @@ const dispatches = [
 ];
 const sealedTarget = {
   dispatches,
-  accountScopeByProvider: {
-    anthropic: "anthropic-dedicated-project",
+  dedicatedScopeByProvider: {
+    anthropic: "anthropic-dedicated-workspace-key",
     openai: "openai-dedicated-project",
   },
   runStartedAt: "2026-09-10T00:15:00.000Z",
   runEndedAt: "2026-09-10T00:45:00.000Z",
 } satisfies AddieMatchedV4BillingReconciliationTarget;
-const exported = (
+
+const receipt = (
   provider: "anthropic" | "openai" | "google",
-  lines: readonly { providerResponseId: string; billedCostMicros: number }[],
-): AddieMatchedV4ProviderBillingExport => ({
-  kind: "addie_matched_v4_provider_billing_export",
-  version: 1,
+): AddieMatchedV4ProviderBillingSettlementReceipt => ({
+  kind: "addie_matched_v4_provider_billing_settlement_receipt",
+  version: 2,
   provider,
-  exportId: `${provider}-export-1`,
-  accountScopeId: `${provider}-dedicated-project`,
+  nativeGranularity:
+    provider === "openai"
+      ? "openai_daily_project_line_item"
+      : provider === "anthropic"
+        ? "anthropic_time_api_key_workspace_model"
+        : "google_cloud_billing_account_project_service_sku_time_resource",
+  nativeExportIdentity: `${provider}-native-export-1`,
+  authenticatedNativeSourceSha256:
+    provider === "anthropic" ? "a".repeat(64) : "b".repeat(64),
+  dedicatedScopeId:
+    provider === "anthropic"
+      ? "anthropic-dedicated-workspace-key"
+      : `${provider}-dedicated-project`,
   coverageStartedAt: "2026-09-10T00:00:00.000Z",
   coverageEndedAt: "2026-09-10T01:00:00.000Z",
+  settledThroughAt: "2026-09-10T01:00:00.000Z",
   currency: "USD",
-  sourceSha256: "a".repeat(64),
-  lines,
+  providerReportedAggregateCostMicros: 78,
+  scopeIsolation: "exclusive_dedicated_scope",
 });
+const receipts = () => [receipt("anthropic"), receipt("openai")];
 const attestationWorkflow = () =>
   readFileSync(
     new URL(
@@ -54,71 +68,255 @@ const attestationWorkflow = () =>
     "utf8",
   );
 
-describe("matched-v4 provider-authoritative billing reconciliation", () => {
-  it("keeps even complete caller-constructed projections pending", () => {
+describe("matched-v4 provider-authoritative aggregate billing", () => {
+  it("uses immutable response IDs only as execution-completeness evidence", () => {
     expect(
-      reconcileAddieMatchedV4ProviderBilling(dispatches, [
-        exported("anthropic", [
-          { providerResponseId: "msg_1", billedCostMicros: 31 },
-        ]),
-        exported("openai", [
-          { providerResponseId: "resp_2", billedCostMicros: 47 },
-        ]),
-      ]),
+      validateAddieMatchedV4ProviderBillingSettlementProjection(
+        sealedTarget,
+        receipts(),
+      ),
+    ).toEqual({ valid: true, issues: [] });
+    expect(
+      reconcileAddieMatchedV4ProviderBilling(sealedTarget, receipts()),
     ).toEqual({
       status: "cost_settlement_pending",
-      reason: "untrusted_billing_export",
+      reason: "untrusted_billing_receipt",
     });
   });
 
-  it("fails closed instead of dereferencing malformed dispatch and export entries", () => {
-    const reconcileMalformed = () =>
-      reconcileAddieMatchedV4ProviderBilling(
-        [null as never, ...dispatches],
-        [
-          null as never,
-          exported("anthropic", [null as never]),
-          exported("openai", [
-            { providerResponseId: "resp_2", billedCostMicros: 47 },
-          ]),
-        ],
-      );
-    expect(reconcileMalformed).not.toThrow();
-    expect(reconcileMalformed()).toEqual({
-      status: "cost_settlement_pending",
-      reason: "untrusted_billing_export",
-    });
-  });
-
-  it("requires the eventual sealed adapter target to carry dispatch timestamps", () => {
-    expect(sealedTarget.dispatches).toEqual([
-      expect.objectContaining({ dispatchedAt: "2026-09-10T00:20:00.000Z" }),
-      expect.objectContaining({ dispatchedAt: "2026-09-10T00:40:00.000Z" }),
-    ]);
-    expect(sealedTarget.runStartedAt).toBe("2026-09-10T00:15:00.000Z");
-    expect(sealedTarget.runEndedAt).toBe("2026-09-10T00:45:00.000Z");
-  });
-
-  it("cannot settle a projection with an out-of-window dispatch timestamp", () => {
+  it("rejects an empty execution and receipt set", () => {
     expect(
-      reconcileAddieMatchedV4ProviderBilling(
-        [
-          dispatches[0]!,
-          { ...dispatches[1]!, dispatchedAt: "2026-09-10T02:00:00.000Z" },
-        ],
-        [
-          exported("anthropic", [
-            { providerResponseId: "msg_1", billedCostMicros: 31 },
-          ]),
-          exported("openai", [
-            { providerResponseId: "resp_2", billedCostMicros: 47 },
-          ]),
-        ],
+      validateAddieMatchedV4ProviderBillingSettlementProjection(
+        {
+          dispatches: [],
+          dedicatedScopeByProvider: {},
+          runStartedAt: "2026-09-10T00:15:00.000Z",
+          runEndedAt: "2026-09-10T00:45:00.000Z",
+        },
+        [],
       ),
     ).toEqual({
-      status: "cost_settlement_pending",
-      reason: "untrusted_billing_export",
+      valid: false,
+      issues: ["execution_completeness_failed"],
     });
+  });
+
+  it("requires exactly one complete retained native export receipt per provider", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        receipt("openai"),
+        {
+          ...receipt("openai"),
+          nativeExportIdentity: "openai-native-export-2",
+          authenticatedNativeSourceSha256: "c".repeat(64),
+        },
+      ]).issues,
+    ).toContain("duplicate_provider_receipt");
+  });
+
+  it("requires the receipt-provider set to equal the execution-provider set", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        receipt("openai"),
+        receipt("google"),
+      ]).issues,
+    ).toContain("unexpected_provider_receipt");
+  });
+
+  it("rejects a receipt for the wrong dedicated scope", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        { ...receipt("openai"), dedicatedScopeId: "ordinary-project" },
+      ]).issues,
+    ).toContain("wrong_dedicated_scope");
+  });
+
+  it("rejects incomplete coverage and a stale settlement watermark", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        {
+          ...receipt("openai"),
+          coverageEndedAt: "2026-09-10T00:30:00.000Z",
+          settledThroughAt: "2026-09-10T00:20:00.000Z",
+        },
+      ]).issues,
+    ).toEqual(
+      expect.arrayContaining(["coverage_not_complete", "settlement_not_final"]),
+    );
+  });
+
+  it("rejects extra traffic or a shared dedicated scope", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        { ...receipt("openai"), scopeIsolation: "extra_or_shared_traffic" },
+      ]).issues,
+    ).toContain("scope_isolation_failed");
+  });
+
+  it("rejects duplicate native exports", () => {
+    const duplicate = receipt("openai");
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        duplicate,
+        { ...duplicate },
+      ]).issues,
+    ).toContain("duplicate_native_export");
+  });
+
+  it("rejects duplicate native source digests despite hex case variation", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        {
+          ...receipt("openai"),
+          authenticatedNativeSourceSha256: "A".repeat(64),
+        },
+      ]).issues,
+    ).toContain("duplicate_native_export");
+  });
+
+  it("rejects non-USD, unsafe totals, and a partial claimed breakdown", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        {
+          ...receipt("openai"),
+          currency: "EUR",
+          providerReportedAggregateCostMicros: Number.MAX_SAFE_INTEGER + 1,
+          breakdown: [
+            {
+              dimension: "model",
+              id: "model-only-if-native-export-supplies-it",
+              providerReportedCostMicros: 1,
+            },
+          ],
+        },
+      ]).issues,
+    ).toEqual(
+      expect.arrayContaining([
+        "unsupported_currency",
+        "unsafe_aggregate_total",
+      ]),
+    );
+  });
+
+  it("requires an optional native breakdown to total its aggregate", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        {
+          ...receipt("openai"),
+          breakdown: [
+            {
+              dimension: "line_item",
+              id: "provider-native-line-item",
+              providerReportedCostMicros: 1,
+            },
+          ],
+        },
+      ]).issues,
+    ).toContain("unsafe_aggregate_total");
+  });
+
+  it("accepts only a uniform provider-native breakdown dimension", () => {
+    const breakdown = (
+      dimension: "model" | "line_item",
+      id: string,
+      providerReportedCostMicros = 78,
+    ) => ({ dimension, id, providerReportedCostMicros });
+
+    const invalidIssues = (provider: "anthropic" | "openai") =>
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        provider === "anthropic" ? receipt("openai") : receipt("anthropic"),
+        {
+          ...receipt(provider),
+          breakdown: [
+            breakdown(
+              provider === "anthropic" ? "line_item" : "model",
+              "wrong",
+            ),
+          ],
+        },
+      ]).issues;
+
+    expect(invalidIssues("openai")).toContain("malformed_receipt");
+    expect(invalidIssues("anthropic")).toContain("malformed_receipt");
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(sealedTarget, [
+        receipt("anthropic"),
+        {
+          ...receipt("openai"),
+          breakdown: [
+            breakdown("line_item", "native-line-item-a", 39),
+            breakdown("model", "not-a-native-line-item", 39),
+          ],
+        },
+      ]).issues,
+    ).toContain("malformed_receipt");
+
+    const googleTarget = {
+      ...sealedTarget,
+      dispatches: [
+        ...dispatches,
+        {
+          provider: "google" as const,
+          providerResponseId: "google-response-3",
+          dispatchedAt: "2026-09-10T00:30:00.000Z",
+        },
+      ],
+      dedicatedScopeByProvider: {
+        ...sealedTarget.dedicatedScopeByProvider,
+        google: "google-dedicated-project",
+      },
+    } satisfies AddieMatchedV4BillingReconciliationTarget;
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(googleTarget, [
+        receipt("anthropic"),
+        receipt("openai"),
+        {
+          ...receipt("google"),
+          breakdown: [breakdown("line_item", "sku", 78)],
+        },
+      ]).issues,
+    ).toContain("malformed_receipt");
+  });
+
+  it("fails closed without throwing on malformed raw input", () => {
+    expect(() =>
+      validateAddieMatchedV4ProviderBillingSettlementProjection(
+        { dispatches: [null] },
+        [
+          null,
+          {
+            get provider() {
+              throw new Error("hostile");
+            },
+          },
+        ],
+      ),
+    ).not.toThrow();
+    expect(reconcileAddieMatchedV4ProviderBilling(null, null)).toEqual({
+      status: "cost_settlement_pending",
+      reason: "untrusted_billing_receipt",
+    });
+  });
+
+  it("requires complete and unique immutable execution evidence", () => {
+    expect(
+      validateAddieMatchedV4ProviderBillingSettlementProjection(
+        {
+          ...sealedTarget,
+          dispatches: [dispatches[0], { ...dispatches[0] }],
+        },
+        receipts(),
+      ).issues,
+    ).toContain("execution_completeness_failed");
   });
 
   it("accepts only the exact deployment-environment UTF8String in DER", () => {
@@ -245,7 +443,14 @@ describe("matched-v4 provider-authoritative billing reconciliation", () => {
     expect(workflow).not.toContain("eval:addie-matched-v4-authorized");
   });
 
-  it("marks every authorized runtime report pending external billing reconciliation", () => {
+  it("has no production receipt capability issuer and leaves runtime reports pending", () => {
+    const billingContract = readFileSync(
+      new URL(
+        "../../../src/addie/eval/matched-v4-provider-billing-reconciliation.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
     const runner = readFileSync(
       new URL(
         "../../../src/addie/eval/matched-v4-authorized-execution.ts",
@@ -253,6 +458,10 @@ describe("matched-v4 provider-authoritative billing reconciliation", () => {
       ),
       "utf8",
     );
+    expect(billingContract).not.toContain(
+      "createAddieMatchedV4ProviderBilling",
+    );
+    expect(billingContract).not.toContain('status: "reconciled"');
     expect(runner).toContain('costSettlement: "cost_settlement_pending"');
     expect(runner).toContain("estimatedCostUsd");
   });


### PR DESCRIPTION
## Summary
- replace fictional per-response provider billing lines with aggregate, provider-native settlement receipts
- validate only diagnostic scope/window/isolation/aggregate relationships; caller-supplied projections remain pending
- document dedicated-scope custody and the absence of a production settlement capability issuer

## Validation
- `npx vitest run server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts`
- existing focused typecheck, docs/schema checks, and formatting passed before this resumed session
- broad registry run remains affected by the three known unrelated `addie-router.test.ts` failures

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6df4055d-86a4-44eb-a44a-306bc9ee62eb)
