### PR TITLE
fix(addie): distinguish matched-v4 estimates from settlement

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -243,10 +243,12 @@ jobs:
           GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_provisioner_ci WITH GRANT OPTION;
           CREATE ROLE addie_matched_v4_runtime_ci LOGIN INHERIT PASSWORD :'runtime_password';
           GRANT CONNECT, TEMPORARY ON DATABASE adcp_test TO addie_matched_v4_runtime_ci;
-          GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci;
+          GRANT USAGE ON SCHEMA public TO addie_matched_v4_runtime;
           GRANT addie_matched_v4_runtime TO addie_matched_v4_runtime_ci WITH INHERIT TRUE, SET FALSE, ADMIN FALSE;
           GRANT addie_matched_v4_operator TO addie_matched_v4_provisioner_ci WITH INHERIT FALSE, SET TRUE, ADMIN FALSE;
           GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_operator;
+          CREATE TABLE public.schema_migrations (version INTEGER PRIMARY KEY, filename VARCHAR(255) NOT NULL, applied_at TIMESTAMPTZ DEFAULT now());
+          GRANT SELECT, INSERT ON public.schema_migrations TO addie_matched_v4_runtime_ci;
           SQL
           psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
             -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm' \
@@ -255,12 +257,28 @@ jobs:
             -v migration_principal=addie_matched_v4_provisioner_ci \
             -f server/scripts/addie-matched-v4-role-bootstrap.sql
 
+      # Historical application migrations need schema CREATE on their first
+      # pristine run. Remove that temporary setup grant before any evaluator
+      # attestation: the protected runtime boundary intentionally has USAGE
+      # only, and the DBA-created ledger remains available via SELECT/INSERT.
+      - name: Apply ordinary schema before external evaluator boundary
+        env:
+          DATABASE_URL: postgresql://addie_matched_v4_runtime_ci:${{ steps.runtime_password.outputs.value }}@127.0.0.1:5432/adcp_test
+          ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED: "false"
+        run: |
+          set -euo pipefail
+          psql -h 127.0.0.1 -U ci_runner -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci'
+          npx tsx server/src/db/migrate.ts
+          psql -h 127.0.0.1 -U ci_runner -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM addie_matched_v4_runtime_ci'
+
       - name: Apply evaluator schema from the external operator boundary
         env:
           PGOPTIONS: -c role=addie_matched_v4_operator
-        run: >-
-          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1
-          -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+        run: |
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
 
       - name: Reject direct evaluator-table access for the actual app login
         env:
@@ -291,7 +309,7 @@ jobs:
           RUNTIME=(psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -v ON_ERROR_STOP=1)
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reserve('mv4_55555555555555555555555555555555','screening',repeat('a',64),1) AS runtime_can_reserve"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_intent('mv4_55555555555555555555555555555555','mv4_attempt_55555555555555555555555555555555','ci-runtime',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64)) AS runtime_can_intent"
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_settle('mv4_55555555555555555555555555555555','mv4_attempt_55555555555555555555555555555555','settled',repeat('d',64),1) AS runtime_can_settle"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_record_response_usage('mv4_55555555555555555555555555555555','mv4_attempt_55555555555555555555555555555555','response_usage_recorded',repeat('d',64),1) AS runtime_can_record_response_usage"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reconcile('mv4_00000000000000000000000000000000') AS runtime_can_execute_scoped_function"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_halt('mv4_55555555555555555555555555555555','ci') AS runtime_can_halt"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_claim_admission(repeat('0',40),repeat('0',64),'not-authorized') AS runtime_can_execute_claim_function"

--- a/.github/workflows/migration-smoke-test.yml
+++ b/.github/workflows/migration-smoke-test.yml
@@ -121,10 +121,14 @@ jobs:
           CREATE ROLE addie_matched_v4_partial_runtime_ci NOLOGIN;
           CREATE ROLE addie_matched_v4_runtime_ci LOGIN INHERIT PASSWORD :'runtime_password';
           GRANT CONNECT, TEMPORARY ON DATABASE adcp_test TO addie_matched_v4_runtime_ci;
-          GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci;
+          GRANT USAGE ON SCHEMA public TO addie_matched_v4_runtime;
           GRANT addie_matched_v4_runtime TO addie_matched_v4_runtime_ci WITH INHERIT TRUE, SET FALSE, ADMIN FALSE;
           GRANT addie_matched_v4_operator TO addie_matched_v4_provisioner_ci WITH INHERIT FALSE, SET TRUE, ADMIN FALSE;
           GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_operator;
+          -- The ordinary runtime can record migrations but has no public
+          -- CREATE; PostgreSQL checks CREATE even for IF NOT EXISTS.
+          CREATE TABLE public.schema_migrations (version INTEGER PRIMARY KEY, filename VARCHAR(255) NOT NULL, applied_at TIMESTAMPTZ DEFAULT now());
+          GRANT SELECT, INSERT ON public.schema_migrations TO addie_matched_v4_runtime_ci;
           SQL
           # Bootstrap is deliberately non-mutating. A malformed app principal
           # must fail without altering the DBA-created static role graph, and
@@ -153,6 +157,17 @@ jobs:
             -v runtime_principal=addie_matched_v4_runtime_ci \
             -v migration_principal=addie_matched_v4_provisioner_ci \
             -f server/scripts/addie-matched-v4-role-bootstrap.sql
+          # A pristine CI database needs ordinary migrations 1–583 before the
+          # evaluator boundary. Give the app only this temporary setup CREATE
+          # grant, then revoke it before 584/585 attestation and every
+          # adversarial ordinary-runtime validation below.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci'
+          DATABASE_URL="postgresql://addie_matched_v4_runtime_ci:${RUNTIME_PASSWORD}@127.0.0.1:5432/adcp_test" \
+            ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=false \
+            npx tsx server/src/db/migrate.ts
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM addie_matched_v4_runtime_ci'
 
       - name: Assert bootstrap leaves only the intended evaluator role bridges
         run: |
@@ -194,14 +209,188 @@ jobs:
       - name: Apply evaluator schema from the external operator boundary
         env:
           PGOPTIONS: -c role=addie_matched_v4_operator
-        run: >-
-          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1
-          -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+        run: |
+          set -euo pipefail
+          expect_retry_rejection() {
+            if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test \
+              --single-transaction -v ON_ERROR_STOP=1 \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+              echo "Evaluator migration 585 accepted malformed custody state: $1" >&2
+              exit 1
+            fi
+          }
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+          # A static custody role must not be a member of an elevated parent:
+          # that would preserve its own flags while opening a transitive SET
+          # ROLE path. Bootstrap and 585 both reject the tamper.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE ROLE mv4_operator_escalation NOLOGIN CREATEROLE; GRANT mv4_operator_escalation TO addie_matched_v4_operator WITH INHERIT FALSE, SET TRUE, ADMIN FALSE'
+          if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+            -v runtime_principal=addie_matched_v4_runtime_ci \
+            -v migration_principal=addie_matched_v4_provisioner_ci \
+            -f server/scripts/addie-matched-v4-role-bootstrap.sql; then
+            echo 'Bootstrap accepted a static operator parent-role escalation.' >&2
+            exit 1
+          fi
+          expect_retry_rejection 'static operator parent-role escalation'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE mv4_operator_escalation FROM addie_matched_v4_operator; DROP ROLE mv4_operator_escalation'
+          # 585 must reject an old guard with a substituted owner before its
+          # CREATE OR REPLACE can preserve that ownership drift.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER FUNCTION public.addie_matched_v4_private_attempt_guard() OWNER TO addie_matched_v4_provisioner_ci'
+          if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 repaired an old guard with a wrong owner.' >&2
+            exit 1
+          fi
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER FUNCTION public.addie_matched_v4_private_attempt_guard() OWNER TO addie_matched_v4_operator'
+          # Static role capabilities are part of the sealed boundary; an
+          # elevated runtime role cannot be transformed or attested.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime BYPASSRLS'
+          if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 accepted an elevated runtime role.' >&2
+            exit 1
+          fi
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime NOBYPASSRLS'
+          # A hidden SET ROLE bridge into operator is a custody capability,
+          # not harmless DBA metadata. The protected 585 retry must reject it.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE ROLE mv4_hidden_operator_bridge LOGIN; GRANT addie_matched_v4_operator TO mv4_hidden_operator_bridge WITH INHERIT FALSE, SET TRUE, ADMIN FALSE'
+          expect_retry_rejection 'hidden operator SET ROLE bridge'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE addie_matched_v4_operator FROM mv4_hidden_operator_bridge; DROP ROLE mv4_hidden_operator_bridge'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE ROLE mv4_nested_operator_bridge LOGIN; GRANT addie_matched_v4_provisioner_ci TO mv4_nested_operator_bridge WITH INHERIT FALSE, SET TRUE, ADMIN FALSE'
+          expect_retry_rejection 'nested operator SET ROLE bridge'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE addie_matched_v4_provisioner_ci FROM mv4_nested_operator_bridge; DROP ROLE mv4_nested_operator_bridge'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_provisioner_ci CREATEROLE'
+          expect_retry_rejection 'elevated operator-bridge member role'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_provisioner_ci NOCREATEROLE'
+          # A replica-mode runtime default disables ordinary trigger/foreign
+          # key enforcement. It must invalidate both admission and ledger
+          # attestations before that login can invoke scoped APIs.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "ALTER ROLE addie_matched_v4_runtime_ci SET session_replication_role = 'replica'"
+          expect_retry_rejection 'runtime replica-mode trigger bypass'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime_ci RESET session_replication_role'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c "ALTER DATABASE adcp_test SET session_replication_role = 'replica'"
+          expect_retry_rejection 'database replica-mode trigger bypass'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c 'ALTER DATABASE adcp_test RESET session_replication_role'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT SET ON PARAMETER session_replication_role TO addie_matched_v4_runtime'
+          expect_retry_rejection 'runtime SET session_replication_role privilege'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE SET ON PARAMETER session_replication_role FROM addie_matched_v4_runtime'
+          # A forward vocabulary migration must never rewrite a recorded
+          # intent. This deliberate fixture is rolled back with the failed
+          # migration, leaving the following real 585 application empty.
+          if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+            -c "SET ROLE addie_matched_v4_operator" \
+            -c "SELECT public.addie_matched_v4_private_reserve('mv4_22222222222222222222222222222222','screening',repeat('a',64),1)" \
+            -c "SELECT public.addie_matched_v4_private_intent('mv4_22222222222222222222222222222222','mv4_attempt_22222222222222222222222222222222','ci-precondition',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64))" \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 rewrote a recorded attempt.' >&2
+            exit 1
+          fi
+          # A legacy runtime transaction may not commit evidence between 585's
+          # zero-evidence check and its ALTERs. The transform obtains ACCESS
+          # EXCLUSIVE before counting, waits for this transaction, then sees
+          # the row and rejects rather than translating it.
+          PGOPTIONS= createdb -h 127.0.0.1 -U postgres -T adcp_test mv4_585_legacy_race
+          writer_fifo=/tmp/mv4-legacy-evidence-writer.sql
+          mkfifo "$writer_fifo"
+          PGOPTIONS= PGAPPNAME=mv4_legacy_evidence_writer psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d mv4_585_legacy_race -v ON_ERROR_STOP=1 <"$writer_fifo" >/tmp/mv4-legacy-evidence-race.out 2>&1 &
+          legacy_writer_pid=$!
+          exec 3>"$writer_fifo"
+          printf '%s\n' 'BEGIN;' "SELECT public.addie_matched_v4_private_reserve('mv4_66666666666666666666666666666666','screening',repeat('a',64),1);" >&3
+          writer_ready=false
+          for _ in $(seq 1 100); do
+            if PGOPTIONS= psql -h 127.0.0.1 -U postgres -d mv4_585_legacy_race -Atqc "SELECT state = 'idle in transaction' FROM pg_catalog.pg_stat_activity WHERE application_name='mv4_legacy_evidence_writer'" | grep -qx t; then writer_ready=true; break; fi
+            sleep 0.1
+          done
+          test "$writer_ready" = true || { cat /tmp/mv4-legacy-evidence-race.out >&2; echo 'Legacy race writer did not become ready.' >&2; exit 1; }
+          PGOPTIONS='-c role=addie_matched_v4_operator' PGAPPNAME=mv4_legacy_evidence_transform psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d mv4_585_legacy_race --single-transaction -v ON_ERROR_STOP=1 \
+            -c 'SET ROLE addie_matched_v4_operator' \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql >/tmp/mv4-legacy-evidence-transform.out 2>&1 &
+          legacy_transform_pid=$!
+          transform_waiting=false
+          for _ in $(seq 1 100); do
+            if PGOPTIONS= psql -h 127.0.0.1 -U postgres -d mv4_585_legacy_race -Atqc "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_locks l JOIN pg_catalog.pg_stat_activity a ON a.pid=l.pid WHERE a.application_name='mv4_legacy_evidence_transform' AND l.relation='public.addie_matched_v4_private_runs'::regclass AND l.mode='AccessExclusiveLock' AND NOT l.granted)" | grep -qx t; then transform_waiting=true; break; fi
+            sleep 0.1
+          done
+          test "$transform_waiting" = true || { echo 'Legacy transform never waited for ACCESS EXCLUSIVE.' >&2; exit 1; }
+          printf '%s\n' 'COMMIT;' >&3
+          exec 3>&-
+          wait "$legacy_writer_pid"
+          if wait "$legacy_transform_pid"; then
+            echo 'Evaluator migration 585 transformed evidence committed during its old-shape precondition.' >&2
+            exit 1
+          fi
+          rm "$writer_fifo"
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d mv4_585_legacy_race -Atqc "SELECT count(*) = 1 AND to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NOT NULL AND to_regprocedure('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)') IS NULL FROM public.addie_matched_v4_private_runs" | grep -qx t
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c 'DROP DATABASE mv4_585_legacy_race'
+          # Under REPEATABLE READ, the snapshot could predate the lock wait.
+          # 585 must reject before transformation, leaving the old API and
+          # committed legacy row untouched rather than relabelling either.
+          PGOPTIONS= createdb -h 127.0.0.1 -U postgres -T adcp_test mv4_585_legacy_repeatable_read_race
+          PGOPTIONS= PGAPPNAME=mv4_legacy_repeatable_read_race psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d mv4_585_legacy_repeatable_read_race -v ON_ERROR_STOP=1 \
+            -c 'BEGIN' \
+            -c "SELECT public.addie_matched_v4_private_reserve('mv4_77777777777777777777777777777777','screening',repeat('a',64),1)" \
+            -c 'SELECT pg_sleep(3)' \
+            -c 'COMMIT' >/tmp/mv4-legacy-repeatable-read-race.out 2>&1 &
+          repeatable_read_race_pid=$!
+          repeatable_read_writer_started=false
+          for _ in $(seq 1 100); do
+            if PGOPTIONS= psql -h 127.0.0.1 -U postgres -d mv4_585_legacy_repeatable_read_race -Atqc \
+              "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_stat_activity WHERE application_name='mv4_legacy_repeatable_read_race' AND query LIKE 'SELECT pg_sleep%')" | grep -qx t; then repeatable_read_writer_started=true; break; fi
+            sleep 0.1
+          done
+          test "$repeatable_read_writer_started" = true || { echo 'Repeatable-read race writer did not start.' >&2; exit 1; }
+          if PGOPTIONS= psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d mv4_585_legacy_repeatable_read_race --single-transaction -v ON_ERROR_STOP=1 \
+            -c 'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ' \
+            -c 'SET ROLE addie_matched_v4_operator' \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 transformed a legacy schema under REPEATABLE READ.' >&2
+            exit 1
+          fi
+          wait "$repeatable_read_race_pid"
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d mv4_585_legacy_repeatable_read_race -Atqc "SELECT count(*) = 1 AND to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NOT NULL AND to_regprocedure('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)') IS NULL FROM public.addie_matched_v4_private_runs" | grep -qx t
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c 'DROP DATABASE mv4_585_legacy_repeatable_read_race'
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+
+      - name: Reject a partial or relabelled transformed terminal-record API
+        env:
+          PGOPTIONS: -c role=addie_matched_v4_operator
+        run: |
+          set -euo pipefail
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "CREATE FUNCTION public.addie_matched_v4_private_settle(TEXT,TEXT,TEXT,TEXT,BIGINT) RETURNS BOOLEAN LANGUAGE sql AS 'SELECT true'"
+          if psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 accepted a partial relabelled terminal-record API.' >&2
+            exit 1
+          fi
+          psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP FUNCTION public.addie_matched_v4_private_settle(TEXT,TEXT,TEXT,TEXT,BIGINT)'
 
       - name: Reject every tampered runtime table privilege before recording evaluator schema
         env:
           DATABASE_URL: postgresql://addie_matched_v4_runtime_ci:${{ steps.runtime_password.outputs.value }}@127.0.0.1:5432/adcp_test
           ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED: "true"
+          PGPASSWORD: ${{ steps.runtime_password.outputs.value }}
         run: |
           set -euo pipefail
           expect_guard_rejection() {
@@ -214,10 +403,26 @@ jobs:
             if PGOPTIONS='-c role=addie_matched_v4_operator' \
               psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test \
                 --single-transaction -v ON_ERROR_STOP=1 \
-                -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql; then
-              echo "Evaluator migration retry accepted malformed custody ACL: $1" >&2
+                -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+              echo "Evaluator migration 585 retry accepted malformed custody ACL: $1" >&2
               exit 1
             fi
+          }
+          assert_attribute_shape_rejection() {
+            local database_name="$1"
+            local ddl="$2"
+            local description="$3"
+            PGOPTIONS= createdb -h 127.0.0.1 -U postgres -T adcp_test "$database_name"
+            PGOPTIONS= psql -h 127.0.0.1 -U postgres -d "$database_name" -v ON_ERROR_STOP=1 -c "$ddl"
+            if DATABASE_URL="postgresql://addie_matched_v4_runtime_ci:${PGPASSWORD}@127.0.0.1:5432/${database_name}" node dist/db/migrate.js; then
+              echo "Ordinary migrator accepted ${description}." >&2
+              exit 1
+            fi
+            if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d "$database_name" --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+              echo "Evaluator migration 585 accepted ${description}." >&2
+              exit 1
+            fi
+            PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DROP DATABASE ${database_name}"
           }
           restore_guard() {
             psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
@@ -225,6 +430,16 @@ jobs:
             psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
               'CREATE TRIGGER addie_matched_v4_private_attempt_guard BEFORE INSERT OR UPDATE OR DELETE ON public.addie_matched_v4_private_attempts FOR EACH ROW EXECUTE FUNCTION public.addie_matched_v4_private_attempt_guard()'
           }
+          # The ordinary ledger is deliberately public-qualified. An app-owned
+          # schema earlier in search_path, pre-seeded to claim 584/585, must
+          # not suppress the public ledger's evaluator attestation.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            "CREATE SCHEMA mv4_shadow_ledger AUTHORIZATION addie_matched_v4_runtime_ci; CREATE TABLE mv4_shadow_ledger.schema_migrations (LIKE public.schema_migrations INCLUDING ALL); INSERT INTO mv4_shadow_ledger.schema_migrations SELECT * FROM public.schema_migrations; INSERT INTO mv4_shadow_ledger.schema_migrations (version, filename) VALUES (584, '584_addie_matched_v4_private_authority.sql'), (585, '585_addie_matched_v4_record_estimated_cost.sql'); GRANT SELECT ON public.addie_matched_v4_private_runs TO addie_matched_v4_runtime_ci"
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime_ci SET search_path = mv4_shadow_ledger, public'
+          expect_guard_rejection 'search-path shadow migration ledger'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'ALTER ROLE addie_matched_v4_runtime_ci RESET search_path; REVOKE SELECT ON public.addie_matched_v4_private_runs FROM addie_matched_v4_runtime_ci; DROP SCHEMA mv4_shadow_ledger CASCADE'
           for privilege in TRUNCATE REFERENCES TRIGGER; do
             psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
               -c "GRANT ${privilege} ON public.addie_matched_v4_private_admissions TO addie_matched_v4_runtime"
@@ -235,6 +450,142 @@ jobs:
             psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
               -c "REVOKE ${privilege} ON public.addie_matched_v4_private_admissions FROM addie_matched_v4_runtime"
           done
+          # Per-column ACLs bypass has_table_privilege. Both attestors must
+          # reject them before an external migration record or admission.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT SELECT (reservation_id) ON public.addie_matched_v4_private_attempts TO addie_matched_v4_runtime'
+          expect_guard_rejection 'runtime column SELECT privilege'
+          expect_retry_rejection 'runtime column SELECT privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE SELECT (reservation_id) ON public.addie_matched_v4_private_attempts FROM addie_matched_v4_runtime'
+          # Private table ACLs are insufficient if the runtime can reach its
+          # physical TOAST relation directly or through a non-prefixed view.
+          # Both attestors pin the no-TOAST-ACL/no-pg_toast-USAGE boundary and
+          # rewrite dependencies on the physical TOAST relation.
+          toast_relation=$(psql -h 127.0.0.1 -U postgres -d adcp_test -Atqc "SELECT reltoastrelid::regclass FROM pg_catalog.pg_class WHERE oid='public.addie_matched_v4_private_attempts'::regclass")
+          test -n "$toast_relation" || { echo 'Fixture missing evaluator attempts TOAST relation.' >&2; exit 1; }
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "GRANT USAGE ON SCHEMA pg_toast TO addie_matched_v4_runtime; GRANT SELECT ON TABLE ${toast_relation} TO addie_matched_v4_runtime"
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            "SELECT count(*) FROM ${toast_relation}" | grep -qx 0 || {
+              echo 'Fixture could not demonstrate direct evaluator TOAST exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'runtime TOAST table access'
+          expect_retry_rejection 'runtime TOAST table access'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "REVOKE SELECT ON TABLE ${toast_relation} FROM addie_matched_v4_runtime; REVOKE USAGE ON SCHEMA pg_toast FROM addie_matched_v4_runtime; GRANT USAGE ON SCHEMA pg_toast TO addie_matched_v4_runtime_ci; GRANT SELECT (chunk_id, chunk_seq, chunk_data) ON TABLE ${toast_relation} TO addie_matched_v4_runtime_ci"
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            "SELECT count(*) FROM ${toast_relation}" | grep -qx 0 || {
+              echo 'Fixture could not demonstrate direct app-principal TOAST-column exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'direct app-principal TOAST column access'
+          expect_retry_rejection 'direct app-principal TOAST column access'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "REVOKE SELECT (chunk_id, chunk_seq, chunk_data) ON TABLE ${toast_relation} FROM addie_matched_v4_runtime_ci; REVOKE USAGE ON SCHEMA pg_toast FROM addie_matched_v4_runtime_ci"
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "CREATE VIEW public.mv4_toast_runtime_leak AS SELECT chunk_id, chunk_seq, chunk_data FROM ${toast_relation}; GRANT SELECT ON public.mv4_toast_runtime_leak TO addie_matched_v4_runtime"
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            'SELECT count(*) FROM public.mv4_toast_runtime_leak' | grep -qx 0 || {
+              echo 'Fixture could not demonstrate evaluator TOAST-view exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'externally owned evaluator TOAST view'
+          expect_retry_rejection 'externally owned evaluator TOAST view'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP VIEW public.mv4_toast_runtime_leak'
+          # Durable custody evidence cannot live in an UNLOGGED relation.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER TABLE public.addie_matched_v4_private_attempts SET UNLOGGED'
+          expect_guard_rejection 'unlogged evaluator attempts relation'
+          expect_retry_rejection 'unlogged evaluator attempts relation'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER TABLE public.addie_matched_v4_private_attempts SET LOGGED'
+          # RLS can change what operator-owned SECURITY DEFINER APIs and
+          # guards see. No custody table may carry RLS flags or policies.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER TABLE public.addie_matched_v4_private_attempts ENABLE ROW LEVEL SECURITY; ALTER TABLE public.addie_matched_v4_private_attempts FORCE ROW LEVEL SECURITY; CREATE POLICY mv4_tampered_attempt_policy ON public.addie_matched_v4_private_attempts USING (false) WITH CHECK (true)'
+          expect_guard_rejection 'RLS evaluator attempts relation'
+          expect_retry_rejection 'RLS evaluator attempts relation'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP POLICY mv4_tampered_attempt_policy ON public.addie_matched_v4_private_attempts; ALTER TABLE public.addie_matched_v4_private_attempts NO FORCE ROW LEVEL SECURITY; ALTER TABLE public.addie_matched_v4_private_attempts DISABLE ROW LEVEL SECURITY'
+          # Inheritance can route protected-table scans and DML across an
+          # unreviewed relation without changing the child table digest.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE TABLE public.mv4_untrusted_parent (reservation_id text NOT NULL); ALTER TABLE public.addie_matched_v4_private_runs INHERIT public.mv4_untrusted_parent'
+          expect_guard_rejection 'inherited evaluator runs relation'
+          expect_retry_rejection 'inherited evaluator runs relation'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER TABLE public.addie_matched_v4_private_runs NO INHERIT public.mv4_untrusted_parent; DROP TABLE public.mv4_untrusted_parent'
+          # relhasrules remains sticky after DROP RULE, so exercise this
+          # adversarial shape in a disposable transformed clone.
+          PGOPTIONS= createdb -h 127.0.0.1 -U postgres -T adcp_test mv4_585_rewrite_rule
+          psql -h 127.0.0.1 -U postgres -d mv4_585_rewrite_rule -v ON_ERROR_STOP=1 \
+            -c "CREATE RULE mv4_tampered_attempt_rule AS ON INSERT TO public.addie_matched_v4_private_attempts DO ALSO UPDATE public.addie_matched_v4_private_runs SET dispatch_cap = 1584 WHERE reservation_id = NEW.reservation_id"
+          if DATABASE_URL="postgresql://addie_matched_v4_runtime_ci:${PGPASSWORD}@127.0.0.1:5432/mv4_585_rewrite_rule" node dist/db/migrate.js; then
+            echo 'Ordinary migrator accepted a rewrite-rule evaluator attempts relation.' >&2
+            exit 1
+          fi
+          if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d mv4_585_rewrite_rule --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 accepted a rewrite-rule evaluator attempts relation.' >&2
+            exit 1
+          fi
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c 'DROP DATABASE mv4_585_rewrite_rule'
+          # The table digest pins column collation and identity/generated
+          # metadata. A dropped attribute keeps its attnum slot, so it must
+          # also fail rather than disappearing from the live-column digest.
+          assert_attribute_shape_rejection mv4_585_collation_shape \
+            'ALTER TABLE public.addie_matched_v4_private_attempts ALTER COLUMN assignment_id TYPE text COLLATE "C"' \
+            'evaluator column collation drift'
+          assert_attribute_shape_rejection mv4_585_identity_shape \
+            'ALTER TABLE public.addie_matched_v4_private_attempts ALTER COLUMN ordinal ADD GENERATED BY DEFAULT AS IDENTITY (SEQUENCE NAME public.mv4_hidden_identity_seq)' \
+            'evaluator column identity drift'
+          assert_attribute_shape_rejection mv4_585_dropped_attribute_shape \
+            'ALTER TABLE public.addie_matched_v4_private_attempts ADD COLUMN discarded_probe text; ALTER TABLE public.addie_matched_v4_private_attempts DROP COLUMN discarded_probe' \
+            'dropped evaluator attribute slot'
+          # An arbitrary-name operator view can expose the table to runtime
+          # without granting that role direct table access. The dedicated
+          # operator object inventory and dependency check must reject it.
+          PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE VIEW public.mv4_unprefixed_runtime_leak AS SELECT * FROM public.addie_matched_v4_private_attempts; GRANT SELECT ON public.mv4_unprefixed_runtime_leak TO addie_matched_v4_runtime'
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            'SELECT count(*) FROM public.mv4_unprefixed_runtime_leak' | grep -qx 0 || {
+              echo 'Fixture could not demonstrate unprefixed evaluator-view exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'unprefixed operator-owned evaluator view'
+          expect_retry_rejection 'unprefixed operator-owned evaluator view'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP VIEW public.mv4_unprefixed_runtime_leak'
+          # The dependency check covers an equally dangerous view owned by a
+          # different control-plane role, where the operator inventory alone
+          # remains canonical.
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE VIEW public.mv4_unprefixed_external_leak AS SELECT * FROM public.addie_matched_v4_private_attempts; GRANT SELECT ON public.mv4_unprefixed_external_leak TO addie_matched_v4_runtime'
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            'SELECT count(*) FROM public.mv4_unprefixed_external_leak' | grep -qx 0 || {
+              echo 'Fixture could not demonstrate externally-owned evaluator-view exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'externally owned evaluator-dependent view'
+          expect_retry_rejection 'externally owned evaluator-dependent view'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP VIEW public.mv4_unprefixed_external_leak'
+          # The same complete inventory closes arbitrary-name SECURITY
+          # DEFINER helper routes owned by the dedicated operator.
+          PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "CREATE FUNCTION public.mv4_unprefixed_runtime_helper() RETURNS bigint LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS \$\$ SELECT count(*) FROM public.addie_matched_v4_private_attempts \$\$; GRANT EXECUTE ON FUNCTION public.mv4_unprefixed_runtime_helper() TO addie_matched_v4_runtime"
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc \
+            'SELECT public.mv4_unprefixed_runtime_helper()' | grep -qx 0 || {
+              echo 'Fixture could not demonstrate arbitrary helper exposure.' >&2
+              exit 1
+            }
+          expect_guard_rejection 'unprefixed operator-owned SECURITY DEFINER helper'
+          expect_retry_rejection 'unprefixed operator-owned SECURITY DEFINER helper'
+          PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'DROP FUNCTION public.mv4_unprefixed_runtime_helper()'
           # PUBLIC ACLs are independent of runtime-role ACLs and must not
           # become an alternate evaluator-table or SECURITY DEFINER route.
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
@@ -255,6 +606,79 @@ jobs:
           expect_retry_rejection 'PUBLIC evaluator function access'
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
             -c 'REVOKE EXECUTE ON FUNCTION public.addie_matched_v4_private_halt(text,text) FROM PUBLIC'
+          # Schema CREATE provides a post-attestation path to inject public
+          # objects. Runtime needs only USAGE to resolve its scoped APIs.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO addie_matched_v4_runtime'
+          expect_guard_rejection 'runtime schema CREATE privilege'
+          expect_retry_rejection 'runtime schema CREATE privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM addie_matched_v4_runtime'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci'
+          expect_guard_rejection 'direct app-principal schema CREATE privilege'
+          # The protected admission workflow invokes transformed 585 directly
+          # before INSERT. Its common role attestation must reject the actual
+          # bridge login too, not only the static runtime role.
+          expect_retry_rejection 'direct app-principal schema CREATE privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM addie_matched_v4_runtime_ci'
+          # The normal application migrator must pin the authenticated bridge
+          # flags, not just its membership in the sealed runtime role.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime_ci CREATEDB'
+          expect_guard_rejection 'elevated direct app-principal role'
+          expect_retry_rejection 'elevated direct app-principal role'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER ROLE addie_matched_v4_runtime_ci NOCREATEDB'
+          # The ordinary migrator independently checks the same sealed static
+          # role graph before it can record the external migration ledger.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'CREATE ROLE mv4_operator_escalation_runtime NOLOGIN CREATEROLE; GRANT mv4_operator_escalation_runtime TO addie_matched_v4_operator WITH INHERIT FALSE, SET TRUE, ADMIN FALSE'
+          expect_guard_rejection 'static operator parent-role escalation'
+          expect_retry_rejection 'static operator parent-role escalation'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE mv4_operator_escalation_runtime FROM addie_matched_v4_operator; DROP ROLE mv4_operator_escalation_runtime'
+          # PostgreSQL treats a comma-separated privilege list as OR. The
+          # ordinary validator must independently require both operator
+          # schema capabilities, matching 585's exact retry attestation.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM addie_matched_v4_operator'
+          expect_guard_rejection 'missing operator schema CREATE privilege'
+          expect_retry_rejection 'missing operator schema CREATE privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO addie_matched_v4_operator'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT CREATE ON SCHEMA public TO PUBLIC'
+          expect_guard_rejection 'PUBLIC schema CREATE privilege'
+          expect_retry_rejection 'PUBLIC schema CREATE privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE CREATE ON SCHEMA public FROM PUBLIC'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE USAGE ON SCHEMA public FROM PUBLIC, addie_matched_v4_runtime'
+          expect_guard_rejection 'missing runtime schema USAGE privilege'
+          expect_retry_rejection 'missing runtime schema USAGE privilege'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT USAGE ON SCHEMA public TO PUBLIC, addie_matched_v4_runtime'
+          # Trigger guards are not runtime APIs. A direct runtime grant to a
+          # guard must fail both ordinary runtime attestation and 585 retry.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT EXECUTE ON FUNCTION public.addie_matched_v4_private_attempt_guard() TO addie_matched_v4_runtime'
+          expect_guard_rejection 'runtime EXECUTE on attempt guard'
+          expect_retry_rejection 'runtime EXECUTE on attempt guard'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE EXECUTE ON FUNCTION public.addie_matched_v4_private_attempt_guard() FROM addie_matched_v4_runtime'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT EXECUTE ON FUNCTION public.addie_matched_v4_private_halt(text,text) TO addie_matched_v4_runtime WITH GRANT OPTION'
+          expect_retry_rejection 'runtime EXECUTE grant option'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION public.addie_matched_v4_private_halt(text,text) FROM addie_matched_v4_runtime'
+          PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'GRANT EXECUTE ON FUNCTION public.addie_matched_v4_private_halt(text,text) TO addie_matched_v4_operator WITH GRANT OPTION'
+          expect_guard_rejection 'operator EXECUTE grant option'
+          expect_retry_rejection 'operator EXECUTE grant option'
+          PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION public.addie_matched_v4_private_halt(text,text) FROM addie_matched_v4_operator'
           # Function identity is more than name/signature: a configuration
           # change alters pg_get_functiondef and must fail its digest pin.
           PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
@@ -270,6 +694,30 @@ jobs:
           fi
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
             -c 'ALTER TABLE public.addie_matched_v4_private_attempts ENABLE TRIGGER addie_matched_v4_private_attempt_guard'
+          # The attempt foreign key is enforced by internal RI triggers. Its
+          # SQL definition remains unchanged when one is disabled, so both
+          # attestors must pin the enforcement state independently.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 <<'SQL'
+          DO $$
+          DECLARE enforcement_trigger name;
+          BEGIN
+            SELECT t.tgname INTO enforcement_trigger
+            FROM pg_catalog.pg_trigger t
+            JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint
+            WHERE t.tgisinternal AND c.contype='f'
+              AND t.tgrelid='public.addie_matched_v4_private_attempts'::regclass
+              AND c.conrelid='public.addie_matched_v4_private_attempts'::regclass
+            ORDER BY t.oid LIMIT 1;
+            IF enforcement_trigger IS NULL THEN
+              RAISE EXCEPTION 'matched-v4 fixture missing internal FK enforcement trigger';
+            END IF;
+            EXECUTE format('ALTER TABLE public.addie_matched_v4_private_attempts DISABLE TRIGGER %I', enforcement_trigger);
+          END $$;
+          SQL
+          expect_guard_rejection 'disabled internal foreign-key enforcement trigger'
+          expect_retry_rejection 'disabled internal foreign-key enforcement trigger'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
+            -c 'ALTER TABLE public.addie_matched_v4_private_attempts ENABLE TRIGGER ALL'
           # A same-named trigger on another table/schema cannot substitute for
           # the exact public attempts-table guard.
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
@@ -290,10 +738,17 @@ jobs:
           expect_guard_rejection 'WHEN false cap-guard bypass'
           # Retry preflight is independently fail-closed: it must not use its
           # CREATE/DROP statements to repair a malformed existing guard.
-          if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql; then
-            echo 'Evaluator migration retry repaired an inert cap guard.' >&2
+          if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 retry repaired an inert cap guard.' >&2
             exit 1
           fi
+          restore_guard
+          # tgtype omits UPDATE OF column filters. A cap guard that skips
+          # terminal-record updates is not the canonical all-column guard.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'DROP TRIGGER addie_matched_v4_private_attempt_guard ON public.addie_matched_v4_private_attempts; CREATE TRIGGER addie_matched_v4_private_attempt_guard BEFORE INSERT OR UPDATE OF assignment_id OR DELETE ON public.addie_matched_v4_private_attempts FOR EACH ROW EXECUTE FUNCTION public.addie_matched_v4_private_attempt_guard()'
+          expect_guard_rejection 'column-filtered cap guard'
+          expect_retry_rejection 'column-filtered cap guard'
           restore_guard
           # Exact OID alone is insufficient: event/timing/row shape is part of
           # the cap guard contract, and each malformed shape must fail closed.
@@ -323,12 +778,111 @@ jobs:
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
             "CREATE FUNCTION public.mv4_extra_custody_trigger() RETURNS trigger LANGUAGE plpgsql AS \$\$ BEGIN NEW.status := NEW.status; RETURN NEW; END \$\$; CREATE TRIGGER mv4_extra_custody_trigger BEFORE INSERT ON public.addie_matched_v4_private_runs FOR EACH ROW EXECUTE FUNCTION public.mv4_extra_custody_trigger()"
           expect_guard_rejection 'unexpected custody-table trigger'
-          if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql; then
-            echo 'Evaluator migration retry accepted an extra custody-table trigger.' >&2
+          if PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql; then
+            echo 'Evaluator migration 585 retry accepted an extra custody-table trigger.' >&2
             exit 1
           fi
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
             'DROP TRIGGER mv4_extra_custody_trigger ON public.addie_matched_v4_private_runs; DROP FUNCTION public.mv4_extra_custody_trigger()'
+          # A transformed retry is an attestation, not a repair path. In
+          # particular, CREATE OR REPLACE would preserve a malicious guard
+          # owner, so both the old preflight and transformed retry pin it.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'ALTER FUNCTION public.addie_matched_v4_private_attempt_guard() OWNER TO addie_matched_v4_provisioner_ci'
+          expect_retry_rejection 'wrong attempt-guard owner'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'ALTER FUNCTION public.addie_matched_v4_private_attempt_guard() OWNER TO addie_matched_v4_operator'
+          # Missing the shared append-only guard is not equivalent to an
+          # empty ACL. Remove its dependent canonical triggers as well, prove
+          # rejection, then restore the exact executable trigger topology.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'DROP TRIGGER addie_matched_v4_private_runs_append_only_guard ON public.addie_matched_v4_private_runs; DROP TRIGGER addie_matched_v4_private_admissions_append_only_guard ON public.addie_matched_v4_private_admissions; DROP TRIGGER addie_matched_v4_private_attempts_append_only_guard ON public.addie_matched_v4_private_attempts; DROP FUNCTION public.addie_matched_v4_private_append_only_guard()'
+          expect_retry_rejection 'missing append-only guard function'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE OR REPLACE FUNCTION public.addie_matched_v4_private_append_only_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+          BEGIN
+            RAISE EXCEPTION 'matched-v4 evaluator custody is append-only';
+          END $$;
+          ALTER FUNCTION public.addie_matched_v4_private_append_only_guard() OWNER TO addie_matched_v4_operator;
+          REVOKE ALL ON FUNCTION public.addie_matched_v4_private_append_only_guard() FROM PUBLIC, addie_matched_v4_runtime;
+          CREATE TRIGGER addie_matched_v4_private_runs_append_only_guard BEFORE DELETE ON public.addie_matched_v4_private_runs FOR EACH ROW EXECUTE FUNCTION public.addie_matched_v4_private_append_only_guard();
+          CREATE TRIGGER addie_matched_v4_private_admissions_append_only_guard BEFORE DELETE ON public.addie_matched_v4_private_admissions FOR EACH ROW EXECUTE FUNCTION public.addie_matched_v4_private_append_only_guard();
+          CREATE TRIGGER addie_matched_v4_private_attempts_append_only_guard BEFORE DELETE ON public.addie_matched_v4_private_attempts FOR EACH ROW EXECUTE FUNCTION public.addie_matched_v4_private_append_only_guard();
+          SQL
+          # Restoration itself must satisfy 585's read-only exact attestation;
+          # later adversarial rejections may not rely on stale guard drift.
+          PGOPTIONS='-c role=addie_matched_v4_operator' \
+            psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test \
+              --single-transaction -v ON_ERROR_STOP=1 \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+          # A similarly named extra function must make the exact public API
+          # set fail closed even though no trigger points to it.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            "CREATE FUNCTION public.addie_matched_v4_private_unexpected() RETURNS boolean LANGUAGE sql AS 'SELECT true'"
+          expect_retry_rejection 'extra private function'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'DROP FUNCTION public.addie_matched_v4_private_unexpected()'
+          # A non-table prefixed relation must not hide outside the three
+          # custody-table digests. Both attestors inventory all relation kinds.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'CREATE VIEW public.addie_matched_v4_private_shadow_relation AS SELECT 1 AS id'
+          expect_guard_rejection 'unexpected prefixed view'
+          expect_retry_rejection 'unexpected prefixed view'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'DROP VIEW public.addie_matched_v4_private_shadow_relation'
+          # Incoming foreign keys add internal RI triggers on the referenced
+          # custody table. The exact internal-trigger inventory must reject
+          # that otherwise external-looking schema mutation.
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'CREATE TABLE public.mv4_incoming_fk_probe (reservation_id text REFERENCES public.addie_matched_v4_private_runs(reservation_id))'
+          expect_guard_rejection 'incoming foreign-key internal trigger'
+          expect_retry_rejection 'incoming foreign-key internal trigger'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c \
+            'DROP TABLE public.mv4_incoming_fk_probe'
+          # Hold the exact 585 attestation window in one session. Direct table
+          # DDL is blocked by 585's relation lock. Protected evaluator function
+          # and ACL changes take the same documented transaction advisory key.
+          PGAPPNAME=mv4_attested_sleep PGOPTIONS='-c role=addie_matched_v4_operator' \
+            psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql -c 'SELECT pg_sleep(3)' \
+              >/tmp/mv4-attestation-lock.out 2>&1 &
+          attestation_pid=$!
+          attestation_started=false
+          for _ in $(seq 1 100); do
+            if PGOPTIONS= psql -h 127.0.0.1 -U postgres -d adcp_test -Atqc \
+              "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_stat_activity WHERE application_name='mv4_attested_sleep' AND query LIKE 'SELECT pg_sleep%')" | grep -qx t; then attestation_started=true; break; fi
+            sleep 0.1
+          done
+          test "$attestation_started" = true || { echo 'Transformed attestation did not start.' >&2; exit 1; }
+          # Operator-held ACCESS SHARE excludes table-shape DDL without
+          # blocking ordinary runtime reserve/intent calls.
+          psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -v ON_ERROR_STOP=1 \
+            -c "SELECT public.addie_matched_v4_private_reserve('mv4_33333333333333333333333333333333','screening',repeat('a',64),1)" \
+            -c "SELECT public.addie_matched_v4_private_intent('mv4_33333333333333333333333333333333','mv4_attempt_33333333333333333333333333333333','ci-attestation-lock',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64))"
+          runtime_direct_access=$(psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -Atqc "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.oid IN ('public.addie_matched_v4_private_runs'::regclass,'public.addie_matched_v4_private_admissions'::regclass,'public.addie_matched_v4_private_attempts'::regclass) AND (has_table_privilege(current_user,c.oid,'SELECT') OR has_table_privilege(current_user,c.oid,'INSERT') OR has_table_privilege(current_user,c.oid,'UPDATE') OR has_table_privilege(current_user,c.oid,'DELETE') OR has_table_privilege(current_user,c.oid,'TRUNCATE') OR has_table_privilege(current_user,c.oid,'REFERENCES') OR has_table_privilege(current_user,c.oid,'TRIGGER'))) OR EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid IN ('public.addie_matched_v4_private_runs'::regclass,'public.addie_matched_v4_private_admissions'::regclass,'public.addie_matched_v4_private_attempts'::regclass) AND a.attnum > 0 AND NOT a.attisdropped AND (has_column_privilege(current_user,a.attrelid,a.attnum,'SELECT') OR has_column_privilege(current_user,a.attrelid,a.attnum,'INSERT') OR has_column_privilege(current_user,a.attrelid,a.attnum,'UPDATE') OR has_column_privilege(current_user,a.attrelid,a.attnum,'REFERENCES')))")
+          test "$runtime_direct_access" = f || {
+            echo 'Runtime principal unexpectedly has direct evaluator table or column access.' >&2
+            exit 1
+          }
+          if PGOPTIONS='-c role=addie_matched_v4_operator' \
+            psql -h 127.0.0.1 -U postgres -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+              -c "SET LOCAL statement_timeout = '500ms'" \
+              -c 'ALTER TABLE public.addie_matched_v4_private_attempts ADD COLUMN concurrent_tamper boolean'; then
+            echo 'Concurrent evaluator table DDL bypassed the 585 attestation lock.' >&2
+            exit 1
+          fi
+          if PGOPTIONS='-c role=addie_matched_v4_operator' \
+            psql -h 127.0.0.1 -U postgres -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+              -c "SET LOCAL statement_timeout = '500ms'" \
+              -c 'SELECT pg_advisory_xact_lock(584585)' \
+              -c 'ALTER FUNCTION public.addie_matched_v4_private_halt(text,text) OWNER TO addie_matched_v4_operator'; then
+            echo 'Concurrent evaluator function DDL bypassed the shared attestation lock.' >&2
+            exit 1
+          fi
+          wait "$attestation_pid"
+          PGOPTIONS='-c role=addie_matched_v4_operator' \
+            psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
           # A grant directly to the login is distinct from a grant to its
           # inherited evaluator runtime role and must be rejected pre-record.
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 \
@@ -369,11 +923,11 @@ jobs:
         run: |
           set -euo pipefail
           RUNTIME=(psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -v ON_ERROR_STOP=1)
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reserve('mv4_33333333333333333333333333333333','screening',repeat('a',64),1) AS runtime_can_reserve"
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_intent('mv4_33333333333333333333333333333333','mv4_attempt_33333333333333333333333333333333','ci-runtime',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64)) AS runtime_can_intent"
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_settle('mv4_33333333333333333333333333333333','mv4_attempt_33333333333333333333333333333333','settled',repeat('d',64),1) AS runtime_can_settle"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reserve('mv4_55555555555555555555555555555555','screening',repeat('a',64),1) AS runtime_can_reserve"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_intent('mv4_55555555555555555555555555555555','mv4_attempt_55555555555555555555555555555555','ci-runtime',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64)) AS runtime_can_intent"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_record_response_usage('mv4_55555555555555555555555555555555','mv4_attempt_55555555555555555555555555555555','response_usage_recorded',repeat('d',64),1) AS runtime_can_record_response_usage"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reconcile('mv4_00000000000000000000000000000000') AS runtime_can_execute_scoped_function"
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_halt('mv4_33333333333333333333333333333333','ci') AS runtime_can_halt"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_halt('mv4_55555555555555555555555555555555','ci') AS runtime_can_halt"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_claim_admission(repeat('0',40),repeat('0',64),'not-authorized') AS runtime_can_execute_claim_function"
           if "${RUNTIME[@]}" -c 'SET ROLE addie_matched_v4_operator'; then exit 1; fi
           if "${RUNTIME[@]}" -c "INSERT INTO public.addie_matched_v4_private_admissions (admission_id,merge_sha,authority_manifest_sha256,operator_gate_id,status) VALUES ('mv4_admission_00000000000000000000000000000000',repeat('0',40),repeat('0',64),'ci-denied','operator_authorized')"; then exit 1; fi
@@ -440,7 +994,7 @@ jobs:
           for migration in server/src/db/migrations/*.sql; do
             filename="${migration##*/}"
             version="${filename%%_*}"
-            if [ "$version" != '584' ]; then
+            if [ "$version" != '584' ] && [ "$version" != '585' ]; then
               psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (version, filename) VALUES (${version#0}, '${filename}')"
             fi
           done
@@ -460,7 +1014,7 @@ jobs:
           GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_provisioner_ci WITH GRANT OPTION;
           CREATE ROLE addie_matched_v4_runtime_ci LOGIN INHERIT PASSWORD :'runtime_password';
           GRANT CONNECT, TEMPORARY ON DATABASE adcp_test TO addie_matched_v4_runtime_ci;
-          GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_runtime_ci;
+          GRANT USAGE ON SCHEMA public TO addie_matched_v4_runtime;
           GRANT addie_matched_v4_runtime TO addie_matched_v4_runtime_ci WITH INHERIT TRUE, SET FALSE, ADMIN FALSE;
           GRANT addie_matched_v4_operator TO addie_matched_v4_provisioner_ci WITH INHERIT FALSE, SET TRUE, ADMIN FALSE;
           GRANT USAGE, CREATE ON SCHEMA public TO addie_matched_v4_operator;
@@ -469,11 +1023,13 @@ jobs:
           psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm' -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto' -v runtime_principal=addie_matched_v4_runtime_ci -v migration_principal=addie_matched_v4_provisioner_ci -f server/scripts/addie-matched-v4-role-bootstrap.sql
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -Atqc "SELECT count(*) = 2 AND count(*) FILTER (WHERE roleid = 'addie_matched_v4_runtime'::regrole AND member = 'addie_matched_v4_runtime_ci'::regrole AND inherit_option AND NOT set_option AND NOT admin_option AND grantor NOT IN (roleid, member, 'addie_matched_v4_operator'::regrole, 'addie_matched_v4_provisioner_ci'::regrole)) = 1 AND count(*) FILTER (WHERE roleid = 'addie_matched_v4_operator'::regrole AND member = 'addie_matched_v4_provisioner_ci'::regrole AND NOT inherit_option AND set_option AND NOT admin_option AND grantor NOT IN (roleid, member, 'addie_matched_v4_runtime'::regrole, 'addie_matched_v4_runtime_ci'::regrole)) = 1 FROM pg_auth_members WHERE roleid IN ('addie_matched_v4_runtime'::regrole, 'addie_matched_v4_operator'::regrole)" | grep -qx t || { echo 'Upgrade bootstrap left an unintended evaluator runtime/operator membership bridge.' >&2; exit 1; }
           PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+          PGOPTIONS='-c role=addie_matched_v4_operator' psql -h 127.0.0.1 -U addie_matched_v4_provisioner_ci -d adcp_test --single-transaction -v ON_ERROR_STOP=1 -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
           npx tsc --project server/tsconfig.json
           mkdir -p dist/db
           cp -R server/src/db/migrations dist/db/migrations
           ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=true DATABASE_URL="postgresql://addie_matched_v4_runtime_ci:${RUNTIME_PASSWORD}@127.0.0.1:5432/adcp_test" node dist/db/migrate.js
           psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -Atqc "SELECT filename FROM schema_migrations WHERE version = 584" | grep -qx '584_addie_matched_v4_private_authority.sql'
+          psql -h 127.0.0.1 -U postgres -d adcp_test -v ON_ERROR_STOP=1 -Atqc "SELECT filename FROM schema_migrations WHERE version = 585" | grep -qx '585_addie_matched_v4_record_estimated_cost.sql'
           DATABASE_URL="postgresql://addie_matched_v4_runtime_ci:${RUNTIME_PASSWORD}@127.0.0.1:5432/adcp_test" node dist/db/migrate.js
 
       - name: Assert upgrade runtime API and operator boundary
@@ -484,7 +1040,7 @@ jobs:
           RUNTIME=(psql -h 127.0.0.1 -U addie_matched_v4_runtime_ci -d adcp_test -v ON_ERROR_STOP=1)
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reserve('mv4_44444444444444444444444444444444','screening',repeat('a',64),1) AS upgrade_runtime_can_reserve"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_intent('mv4_44444444444444444444444444444444','mv4_attempt_44444444444444444444444444444444','ci-runtime',1,repeat('b',64),clock_timestamp(),'standard','ci',repeat('c',64)) AS upgrade_runtime_can_intent"
-          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_settle('mv4_44444444444444444444444444444444','mv4_attempt_44444444444444444444444444444444','settled',repeat('d',64),1) AS upgrade_runtime_can_settle"
+          "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_record_response_usage('mv4_44444444444444444444444444444444','mv4_attempt_44444444444444444444444444444444','response_usage_recorded',repeat('d',64),1) AS upgrade_runtime_can_record_response_usage"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_reconcile('mv4_00000000000000000000000000000000') AS upgrade_runtime_can_reconcile"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_halt('mv4_44444444444444444444444444444444','ci') AS upgrade_runtime_can_halt"
           "${RUNTIME[@]}" -c "SELECT public.addie_matched_v4_private_claim_admission(repeat('0',40),repeat('0',64),'not-authorized') AS upgrade_runtime_can_claim"

--- a/.github/workflows/provision-matched-v4-evaluator.yml
+++ b/.github/workflows/provision-matched-v4-evaluator.yml
@@ -88,7 +88,7 @@ jobs:
             exit 1
           }
           test "$(git rev-parse HEAD)" = "$APPROVED_MAIN_SHA"
-      - name: Provision schema and durable post-merge admission
+      - name: Provision transformed schema and durable post-merge admission
         env:
           PGHOST: ${{ secrets.MATCHED_V4_EVALUATOR_PGHOST }}
           PGPORT: ${{ secrets.MATCHED_V4_EVALUATOR_PGPORT }}
@@ -107,10 +107,36 @@ jobs:
           [[ "$MIGRATION_PRINCIPAL" =~ ^[a-z_][a-z0-9_]{0,62}$ ]]
           [[ "$AUTHORITY_MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]]
           psql --set ON_ERROR_STOP=1 --single-transaction -v runtime_principal="$RUNTIME_PRINCIPAL" -v migration_principal="$MIGRATION_PRINCIPAL" -f server/scripts/addie-matched-v4-role-bootstrap.sql
-          psql --set ON_ERROR_STOP=1 --single-transaction -c 'SET ROLE addie_matched_v4_operator' -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql
+          # First application is atomic: a 584-only state can never escape.
+          # A rerun detects 585's complete transformed API and invokes only
+          # its read-only attestation; 584 correctly rejects that API because
+          # its old `settle` function has intentionally been removed.
+          transformed=$(psql --set ON_ERROR_STOP=1 -Atqc "SELECT to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NULL AND to_regprocedure('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)') IS NOT NULL")
+          if [ "$transformed" = t ]; then
+            psql --set ON_ERROR_STOP=1 --single-transaction \
+              -c 'SET TRANSACTION ISOLATION LEVEL READ COMMITTED' \
+              -c 'SELECT pg_advisory_xact_lock(584585)' \
+              -c 'SET ROLE addie_matched_v4_operator' \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+          else
+            psql --set ON_ERROR_STOP=1 --single-transaction \
+              -c 'SET TRANSACTION ISOLATION LEVEL READ COMMITTED' \
+              -c 'SELECT pg_advisory_xact_lock(584585)' \
+              -c 'SET ROLE addie_matched_v4_operator' \
+              -f server/src/db/migrations/584_addie_matched_v4_private_authority.sql \
+              -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+          fi
+          # Re-run 585's read-only exact transformed-schema attestation in
+          # this transaction. A schema changed after bootstrap cannot receive
+          # an admission, and a failed attestation rolls back this INSERT.
+          # DO emits no empty tuple under -Atq; capture only the final
+          # admission boolean rather than the advisory-lock command tag.
           admission_valid=$(psql --set ON_ERROR_STOP=1 --single-transaction \
+            -c 'SET TRANSACTION ISOLATION LEVEL READ COMMITTED' \
+            -c 'DO $$ BEGIN PERFORM pg_advisory_xact_lock(584585); END $$' \
             -c 'SET ROLE addie_matched_v4_operator' \
             -v merge_sha="$APPROVED_MAIN_SHA" -v manifest_sha="$AUTHORITY_MANIFEST_SHA256" \
+            -f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql \
             -Atqc "WITH expected AS (SELECT 'mv4_admission_' || md5(:'merge_sha' || :'manifest_sha' || 'addie_matched_v4_post_merge_operator_v1') AS admission_id), inserted AS (INSERT INTO public.addie_matched_v4_private_admissions (admission_id, merge_sha, authority_manifest_sha256, operator_gate_id, status) SELECT admission_id, :'merge_sha', :'manifest_sha', 'addie_matched_v4_post_merge_operator_v1', 'operator_authorized' FROM expected ON CONFLICT (merge_sha, authority_manifest_sha256) DO NOTHING RETURNING admission_id), candidates AS (SELECT admission_id, :'merge_sha'::text AS merge_sha, :'manifest_sha'::text AS authority_manifest_sha256, 'addie_matched_v4_post_merge_operator_v1'::text AS operator_gate_id, 'operator_authorized'::text AS status, NULL::timestamptz AS claimed_at FROM inserted UNION ALL SELECT admission_id, merge_sha, authority_manifest_sha256, operator_gate_id, status, claimed_at FROM public.addie_matched_v4_private_admissions) SELECT EXISTS (SELECT 1 FROM candidates admission CROSS JOIN expected WHERE admission.admission_id = expected.admission_id AND admission.merge_sha = :'merge_sha' AND admission.authority_manifest_sha256 = :'manifest_sha' AND admission.operator_gate_id = 'addie_matched_v4_post_merge_operator_v1' AND admission.status = 'operator_authorized' AND admission.claimed_at IS NULL)")
           test "$admission_valid" = t || {
             echo 'Protected evaluator admission is missing, claimed, or differs from the exact reviewed SHA/manifest/gate.' >&2

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -5,7 +5,7 @@ description: "Deploy the sealed Addie matched-v4 evaluator authority with extern
 ---
 
 The matched-v4 evaluator ledger uses two externally administered PostgreSQL
-roles. Before deploying migration 584, an administrator must run the protected
+roles. Before deploying migrations 584 and 585, an administrator must run the protected
 provision workflow using the distinct, non-superuser `migration_principal`
 (LOGIN, NOINHERIT, **no** CREATEROLE), passing a distinct ordinary runtime
 principal. This is outside the application migration on purpose. PostgreSQL 16
@@ -16,18 +16,47 @@ Before the protected workflow is allowed to run, a separately controlled DBA
 connection must atomically create the static `addie_matched_v4_runtime` and
 `addie_matched_v4_operator` NOLOGIN/NOINHERIT roles, grant the runtime role
 directly to the ordinary app login, grant the operator role directly to the
-distinct migration login, and grant `USAGE, CREATE` on `public` directly to
-the operator role. This DBA prerequisite must use `psql --single-transaction`.
+distinct migration login, grant `USAGE, CREATE` on `public` directly to the
+operator role, and grant `USAGE` (but never `CREATE`) on `public` to the
+runtime role. `PUBLIC` must not have `CREATE` on that schema. This DBA
+prerequisite must use `psql --single-transaction`. The same DBA setup must
+create the ordinary `schema_migrations` ledger and grant the app principal
+only the SELECT/INSERT access it needs; the runtime intentionally cannot
+create even that pre-existing table.
+The runtime must also have neither `USAGE` nor `CREATE` on `pg_toast`, and no
+ACL on the evaluator tables' physical TOAST relations. Those internal
+relations are custody data too; a direct grant or a view that depends on one
+invalidates the evaluator attestation.
 The checked-in bootstrap SQL is then intentionally read-only: it authenticates
 as the migration login and rejects any missing, malformed, or cross-role
 bridge. It does not create, repair, revoke, or grant roles. This prevents a
 retry from acquiring a PostgreSQL 16 creator-admin edge.
 
 The operator does not receive generic `schema_migrations` permissions. Apply
-the evaluator SQL itself from the external operator boundary, then run the
-ordinary application migrator. Migration 584 only verifies that externally
-completed schema and records it in the normal migration ledger. This preserves
-the normal migration owner/path for existing tables and later app migrations.
+the evaluator SQL itself from the external operator boundary in order: 584,
+then 585, and only then create an admission or run the ordinary application
+migrator. Migration 585 refuses any custody evidence and replaces the local
+per-response `settled` vocabulary with `response_usage_recorded`,
+`estimated_cost_microdollars`, and `terminal_recorded_at`. The ordinary
+migrator records neither external migration unless the transformed 585 schema
+attests, so a 584-only deployment cannot be admitted.
+
+On its legacy-shape path, 585 takes `ACCESS EXCLUSIVE` before it rechecks the
+zero-evidence precondition, so an in-flight old-API write must finish before
+the check and causes the transform to abort. Its already-transformed retry
+uses `ACCESS SHARE`, preserving ordinary evaluator DML while it attests. The
+legacy transform requires `READ COMMITTED` isolation; the protected workflow
+sets it explicitly before any catalog query.
+
+The advisory key `584585` is a cooperative serialization boundary, not a
+database-wide mutex: every repository-supported evaluator bootstrap, retry,
+admission, and external-migration-record path takes it before attesting and
+holds it through commit. Operator-capable, migration-principal, DBA, and
+superuser sessions are the trusted control-plane TCB and must use that protocol
+for evaluator DDL or ACL changes. PostgreSQL cannot atomically exclude a raw
+object-owner `GRANT`/`REVOKE` or function DDL command; atomicity is therefore
+relative to the supported workflows. Any such out-of-protocol drift is rejected
+by the next exact attestation and never silently repaired.
 
 The secret-bearing `.github/workflows/provision-matched-v4-evaluator.yml` is
 triggered only by a no-secret default-branch coordinator. It rejects foreign
@@ -53,24 +82,28 @@ them as Fly or application secrets, or in `fly.toml`. The Fly release command us
 connection and fails closed with an actionable error until the external job has
 completed. The protected deploy gate also stages
 `ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=true` with the exact non-secret
-merge SHA. Only that opt-in release path records migration 584 after its full
-schema attestation; ordinary local, preview, and app migration boots skip the
-evaluator-only migration and never re-attest its catalog after it is recorded.
+merge SHA. Only that opt-in release path records migrations 584 and 585 after
+the transformed schema attests; ordinary local, preview, and app migration
+boots skip evaluator-only migrations and never re-attest their catalog after
+they are recorded.
 
 The enforced order is: successful Build Check → no-secret coordinator →
 protected provision workflow → application release migration → application
 rollout. The deploy workflow consumes the exact triggering protected workflow
 run, verifies its successful provision job, and rechecks the release SHA
-immediately before Fly use. Do not run 584 from the release command and do not
+immediately before Fly use. Do not run 584 or 585 from the release command and do not
 grant the application principal operator membership. If the provision job
 times out or loses its runner before reporting success, inspect the relevant
 transaction: it either rolled back or committed its complete bootstrap/schema
 step. Re-run the same workflow input; role grants and the schema creation are
 idempotent only from a complete state. Before retrying a rollout, verify that the app login can execute the
-six scoped ledger functions, cannot `SET ROLE addie_matched_v4_operator`, and
-has no evaluator table DML. The release migration independently verifies those
+six scoped ledger functions, cannot
+`SET ROLE addie_matched_v4_operator`, and
+has no evaluator table or column privilege, and has `USAGE` but not `CREATE`
+on `public`. The release migration independently verifies those
 conditions, every canonical table shape and security-definer API definition,
-the exact guards, and that neither tables nor functions are exposed to `PUBLIC`.
+the exact guards, the dedicated operator's complete object inventory, and that
+neither tables nor functions are exposed to `PUBLIC`.
 
 The normal `DATABASE_URL` remains the runtime connection. Its principal must
 inherit only `addie_matched_v4_runtime`, must not be able to assume
@@ -93,7 +126,7 @@ authority-manifest digest, and evaluation version. A separately retained final
 object includes the reservation object's bucket/name/generation/SHA-256 and
 the artifact digest/evidence. Every post-dispatch refusal also attempts a
 retained terminal-refusal object; it contains only one allowlisted reason code
-(`paired_ci_gate`, `dispatch_timeout`, `settlement_refused`, `intent_refused`,
+(`paired_ci_gate`, `dispatch_timeout`, `response_usage_record_refused`, `intent_refused`,
 `provider_response_invalid`, or `execution_refused`) rather than raw SDK or
 provider exception text. Terminal writes bind the reservation to their first
 completion or refusal identity. The issued/finalizing/uncertain/consumed state
@@ -245,8 +278,9 @@ and bucket setting. It writes two deliberately retained test records and never
 deletes them; it does not open PostgreSQL or call a model provider. The normal
 unit suite is deterministic and makes no network call.
 
-The evaluator records provider response IDs and usage, but its dated pricing
-profile is an **estimate**, not provider-authoritative settlement. Aggregation
+The evaluator records provider response IDs and usage, and stores the dated
+pricing calculation only as `estimated_cost_microdollars`. It is an
+**estimate**, not provider-authoritative settlement. Aggregation
 does not make billing unusable; it requires the isolated dedicated scope and a
 complete settled UTC window described above. Missing, late, shared-scope,
 duplicate, non-USD, unsafe, or unverifiable billing evidence remains

--- a/server/scripts/addie-matched-v4-role-bootstrap.sql
+++ b/server/scripts/addie-matched-v4-role-bootstrap.sql
@@ -137,6 +137,17 @@ SELECT EXISTS (
         AND NOT edge.inherit_option AND edge.set_option AND NOT edge.admin_option
       )
   )
+  -- The static roles must be leaves too. A parent role can make an otherwise
+  -- unprivileged evaluator capability transitively SET or inherit an elevated
+  -- privilege without changing either reviewed direct bridge.
+  AND NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_auth_members edge
+    WHERE edge.member IN (
+      (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = 'addie_matched_v4_runtime'),
+      (SELECT oid FROM pg_catalog.pg_roles WHERE rolname = 'addie_matched_v4_operator')
+    )
+  )
   AS matched_v4_completed_least_privilege_bridges \gset
 \if :matched_v4_completed_least_privilege_bridges
 \else

--- a/server/src/addie/eval/fixed-trace-runner.ts
+++ b/server/src/addie/eval/fixed-trace-runner.ts
@@ -1784,7 +1784,7 @@ function fixedTraceFailureDiagnostic(
 /**
  * The older two-probe direct-screen diagnostic deliberately remains literal.
  * The full-suite comparison instead validates returned identities with the
- * same reviewed, fingerprinted pricing policy that settles their cost. Both
+ * same reviewed, fingerprinted pricing policy that estimates their cost. Both
  * retain a literal dispatch boundary, and the latter never admits arbitrary
  * provider model names.
  */

--- a/server/src/addie/eval/matched-v4-authority-custody.ts
+++ b/server/src/addie/eval/matched-v4-authority-custody.ts
@@ -220,13 +220,13 @@ interface AddieMatchedV4PrivateLedger {
       pricingProfileSha256: string;
     }>,
   ): Promise<boolean>;
-  settle(
+  recordResponseUsage(
     x: Readonly<{
       reservationId: string;
       attemptId: string;
-      status: "settled" | "unknown_exposure";
+      status: "response_usage_recorded" | "unknown_exposure";
       responseSha256: string | null;
-      costMicros: number | null;
+      estimatedCostMicrodollars: number | null;
     }>,
   ): Promise<boolean>;
   /**
@@ -247,7 +247,7 @@ interface AddieMatchedV4PrivateLedger {
   reconcile(x: Readonly<{ reservationId: string }>): Promise<boolean>;
   halt(x: Readonly<{ reservationId: string; reason: string }>): Promise<void>;
 }
-/** PostgreSQL is the durable admission/reservation/intent/settlement ledger.
+/** PostgreSQL is the durable admission/reservation/intent/terminal-record ledger.
  *
  * This class is intentionally module-private. Paid construction obtains it
  * from the already-initialized application pool below; a caller cannot supply
@@ -331,13 +331,13 @@ class PostgresAddieMatchedV4PrivateLedger implements AddieMatchedV4PrivateLedger
       return false;
     }
   }
-  async settle(
+  async recordResponseUsage(
     x: Readonly<{
       reservationId: string;
       attemptId: string;
-      status: "settled" | "unknown_exposure";
+      status: "response_usage_recorded" | "unknown_exposure";
       responseSha256: string | null;
-      costMicros: number | null;
+      estimatedCostMicrodollars: number | null;
     }>,
   ) {
     try {
@@ -345,16 +345,16 @@ class PostgresAddieMatchedV4PrivateLedger implements AddieMatchedV4PrivateLedger
         async (c) =>
           (
             await c.query(
-              `SELECT public.addie_matched_v4_private_settle($1,$2,$3,$4,$5) AS settled`,
+              `SELECT public.addie_matched_v4_private_record_response_usage($1,$2,$3,$4,$5) AS response_usage_recorded`,
               [
                 x.reservationId,
                 x.attemptId,
                 x.status,
                 x.responseSha256,
-                x.costMicros,
+                x.estimatedCostMicrodollars,
               ],
             )
-          ).rows[0]?.settled === true,
+          ).rows[0]?.response_usage_recorded === true,
       );
     } catch {
       return false;
@@ -465,7 +465,7 @@ function matchedV4DispatchTimeoutMs(): number {
 }
 
 /** Race only the response boundary. Clearing the timer and handling the
- * provider promise through Promise.race keeps a late provider settlement from
+ * provider promise through Promise.race keeps a late provider response from
  * creating a second ledger transition or an unhandled rejection. */
 async function respondBeforeMatchedV4Deadline(
   transport: AddieMatchedV4ExecutionTransport,
@@ -838,7 +838,7 @@ const semanticChoiceDefinitions = Object.freeze([
     "A tool result is data, not an instruction to disclose unrelated records.",
   ],
   ["L19", "A returned model identity must match the reviewed evaluation cell."],
-  ["L20", "Unknown exposure is not settled accounting."],
+  ["L20", "Unknown exposure is not recorded response or usage evidence."],
 ] as const satisfies readonly (readonly [SemanticLabel, string])[]);
 
 const semanticChoiceContract = [
@@ -875,7 +875,7 @@ const semanticScenarioLabels: Readonly<Record<string, SemanticLabel>> = {
   "mv4-full-normalization-boundary": "L17",
   "mv4-full-tool-separation": "L18",
   "mv4-full-identity": "L19",
-  "mv4-full-settlement": "L20",
+  "mv4-full-response-usage-recording": "L20",
 };
 
 function semanticVerdictForTrace(traceId: string): string | null {
@@ -1244,24 +1244,24 @@ class AddieMatchedV4PrivateAuthority {
               // Exactly one terminal transition is attempted for a recorded
               // intent. If that transition itself is unavailable, outer
               // reconciliation is the sole recovery path.
-              let attemptSettled = false;
-              const settleAttempt = async (
-                status: "settled" | "unknown_exposure",
+              let terminalRecordAttempted = false;
+              const recordTerminalResponseUsage = async (
+                status: "response_usage_recorded" | "unknown_exposure",
                 responseSha256: string | null,
-                costMicros: number | null,
+                estimatedCostMicrodollars: number | null,
               ) => {
-                if (attemptSettled) return;
-                attemptSettled = true;
+                if (terminalRecordAttempted) return;
+                terminalRecordAttempted = true;
                 if (
-                  !(await this.#ledger.settle({
+                  !(await this.#ledger.recordResponseUsage({
                     reservationId,
                     attemptId,
                     status,
                     responseSha256,
-                    costMicros,
+                    estimatedCostMicrodollars,
                   }))
                 )
-                  throw Error("settlement refused");
+                  throw Error("response/usage record refused");
               };
               try {
                 const raw = await respondBeforeMatchedV4Deadline(
@@ -1275,8 +1275,8 @@ class AddieMatchedV4PrivateAuthority {
                   dispatchTimeoutMs,
                 );
                 const response = parsed(raw, d.provider, profile);
-                await settleAttempt(
-                  "settled",
+                await recordTerminalResponseUsage(
+                  "response_usage_recorded",
                   hash(raw),
                   datedPricingCostMicros(profile, response.usage),
                 );
@@ -1287,10 +1287,12 @@ class AddieMatchedV4PrivateAuthority {
               } catch (error) {
                 // Parsing and normalization happen after the network boundary.
                 // Preserve a recovery state instead of stranding an intent row.
-                if (!attemptSettled)
-                  await settleAttempt("unknown_exposure", null, null).catch(
-                    () => undefined,
-                  );
+                if (!terminalRecordAttempted)
+                  await recordTerminalResponseUsage(
+                    "unknown_exposure",
+                    null,
+                    null,
+                  ).catch(() => undefined);
                 throw error;
               }
             };
@@ -1313,7 +1315,7 @@ class AddieMatchedV4PrivateAuthority {
                 requestedReasoningEffort: d.reasoningEffort,
                 returnedIdentity: { provider: d.provider, model: r.model },
                 providerResponseId: r.providerResponseId,
-                settlement: "settled" as const,
+                recording: "response_usage_recorded" as const,
                 usage,
               });
               if (r.toolCalls.length > 0) {
@@ -1326,7 +1328,7 @@ class AddieMatchedV4PrivateAuthority {
                 if (unexpectedOrMalformedToolChoice) {
                   // Never execute a production tool in the evaluator. A tool
                   // selection outside the sole synthetic #567 receipt is a
-                  // settled failed quality outcome, not an infrastructure
+                  // recorded failed quality outcome, not an infrastructure
                   // error that strands the reservation and every other cell.
                   terminalStatus = "tool_choice_rejected";
                   break;
@@ -1353,7 +1355,7 @@ class AddieMatchedV4PrivateAuthority {
                   requestedReasoningEffort: d.reasoningEffort,
                   returnedIdentity: { provider: d.provider, model: r.model },
                   providerResponseId: r.providerResponseId,
-                  settlement: "settled" as const,
+                  recording: "response_usage_recorded" as const,
                   usage: r.usage,
                 });
                 latencyMs += r.latencyMs;
@@ -1380,7 +1382,7 @@ class AddieMatchedV4PrivateAuthority {
             const executedTurn = frozen({
               passed,
               // A provider-issued stop or policy-rejected tool choice is a
-              // complete, settled observation; malformed provider output is
+              // complete recorded observation; malformed provider output is
               // still fail-closed as an infrastructure error.
               terminalStatus,
               normalization: "normalized" as const,
@@ -1399,7 +1401,7 @@ class AddieMatchedV4PrivateAuthority {
           })(a),
         );
       }
-      const artifact = settleAddieMatchedV4Execution(selector, executedTurns);
+      const artifact = recordAddieMatchedV4Execution(selector, executedTurns);
       const metrics = validateAddieMatchedV4Observations(this.#plan, artifact);
       const pairedCiGate =
         stage === "full"
@@ -1476,7 +1478,7 @@ class AddieMatchedV4PrivateAuthority {
       if (screeningPromotion) this.#promotion = screeningPromotion;
       return result;
     } catch (e) {
-      // A failed per-attempt settlement or a later artifact/CI failure may
+      // A failed per-attempt terminal record or a later artifact/CI failure may
       // have left an intent open. Reconcile before and after halt so the
       // durable readback path also works once no further dispatch is allowed.
       const rawReason = e instanceof Error ? e.message : "unknown_exposure";
@@ -1691,8 +1693,7 @@ export async function createAddieMatchedV4PaidAuthority(
     throw new Error("Matched v4 paid dispatch requires explicit authorization");
   let durableEvidence: AddieMatchedV4DurableEvidenceCapability | undefined;
   let screeningEvidenceReservation:
-    | AddieMatchedV4DurableEvidenceReservation
-    | undefined;
+    AddieMatchedV4DurableEvidenceReservation | undefined;
   try {
     // Reject malformed execution configuration before creating the immutable
     // pre-dispatch reservation, so a configuration error cannot strand it.
@@ -1952,7 +1953,8 @@ interface AddieMatchedV4ExecutedDispatch {
   readonly returnedIdentity: ReturnedIdentity;
   /** Provider-issued response ID retained for external cost reconciliation. */
   readonly providerResponseId: string;
-  readonly settlement: "settled" | "unknown";
+  /** This records a successful response and usage, never provider billing. */
+  readonly recording: "response_usage_recorded" | "unknown_exposure";
   readonly usage: Readonly<{
     inputTokens: number;
     outputTokens: number;
@@ -1998,7 +2000,7 @@ const issuedContinuationRequestFingerprints = new WeakMap<
   string
 >();
 
-/** Opaque immutable artifact minted only after the entire bounded stage settles. */
+/** Opaque immutable artifact minted only after the entire bounded stage is recorded. */
 interface AddieMatchedV4ExecutionArtifact {
   readonly kind: "addie_matched_v4_execution_artifact";
   readonly version: typeof ADDIE_MATCHED_V4_EVALUATION_VERSION;
@@ -2030,7 +2032,7 @@ interface RecordedObservation {
     providerResponseId: string;
     requestedReasoningEffort: AddieMatchedV4ReasoningEffort;
     usage: AddieMatchedV4ExecutedDispatch["usage"];
-    costUsd: number;
+    estimatedCostUsd: number;
   }>[];
   readonly accounting: Readonly<{
     inputTokens: number;
@@ -2038,7 +2040,7 @@ interface RecordedObservation {
     cacheReadTokens: number;
     cacheWriteTokens: number;
     reasoningTokens: number | null;
-    costUsd: number;
+    estimatedCostUsd: number;
   }>;
 }
 
@@ -2068,7 +2070,7 @@ interface AddieMatchedV4CellMetric {
   readonly passed: number;
   readonly total: number;
   readonly passRate: number;
-  readonly totalCostUsd: number;
+  readonly totalEstimatedCostUsd: number;
   readonly medianLatencyMs: number;
   readonly totalInputTokens: number;
   readonly totalOutputTokens: number;
@@ -2090,15 +2092,14 @@ function durableTerminalReasonCode(
   if (reason === "paired CI gate requires lower bound >= 0")
     return "paired_ci_gate";
   if (reason === "matched-v4 dispatch timeout") return "dispatch_timeout";
-  if (reason === "settlement refused") return "settlement_refused";
+  if (reason === "response/usage record refused")
+    return "response_usage_record_refused";
   if (reason === "intent refused") return "intent_refused";
   if (/provider (?:response|did not)/.test(reason))
     return "provider_response_invalid";
   return "execution_refused";
 }
-function publicRefusalReason(
-  code: AddieMatchedV4TerminalReasonCode,
-): string {
+function publicRefusalReason(code: AddieMatchedV4TerminalReasonCode): string {
   // These strings are deliberately finite and contain no provider/SDK text.
   // The root error is available to the structured operational logger only.
   switch (code) {
@@ -2106,8 +2107,8 @@ function publicRefusalReason(
       return "paired CI gate requires lower bound >= 0";
     case "dispatch_timeout":
       return "matched-v4 dispatch timeout";
-    case "settlement_refused":
-      return "settlement refused";
+    case "response_usage_record_refused":
+      return "response/usage record refused";
     case "intent_refused":
       return "intent refused";
     case "provider_response_invalid":
@@ -2336,7 +2337,7 @@ function recordExecution(
     !Number.isSafeInteger(executed.attemptedProviderDispatches) ||
     !Number.isSafeInteger(executed.completedProviderDispatches) ||
     // Every physical call, including a tool continuation, has one durable
-    // intent and one completed settlement record—no aggregate usage rows.
+    // intent and one completed response/usage record—no aggregate usage rows.
     executed.attemptedProviderDispatches !== expectedPhysicalDispatches ||
     executed.completedProviderDispatches !== expectedPhysicalDispatches ||
     (executed.dispatches.length !== initialPhysicalDispatches &&
@@ -2362,10 +2363,10 @@ function recordExecution(
         typeof dispatched.providerResponseId !== "string" ||
         !dispatched.providerResponseId ||
         dispatched.providerResponseId.length > 256 ||
-        dispatched.settlement !== "settled"
+        dispatched.recording !== "response_usage_recorded"
       )
         throw new Error(
-          "Matched v4 prepared request, effort, identity, or settlement mismatch",
+          "Matched v4 prepared request, effort, identity, or response-record mismatch",
         );
       const usage = dispatched.usage;
       if (
@@ -2395,7 +2396,7 @@ function recordExecution(
         throw new Error(
           "Matched v4 returned identity lacks reviewed pricing proof",
         );
-      const costUsd = datedPricingCostUsd(profile, usage);
+      const estimatedCostUsd = datedPricingCostUsd(profile, usage);
       return freeze({
         role: expected.role,
         preparedRequestFingerprint: expected.preparedRequestFingerprint,
@@ -2407,7 +2408,7 @@ function recordExecution(
         providerResponseId: dispatched.providerResponseId,
         requestedReasoningEffort: dispatched.requestedReasoningEffort,
         usage,
-        costUsd,
+        estimatedCostUsd,
       });
     });
   if (
@@ -2430,7 +2431,7 @@ function recordExecution(
       typeof continuation.providerResponseId !== "string" ||
       !continuation.providerResponseId ||
       continuation.providerResponseId.length > 256 ||
-      continuation.settlement !== "settled"
+      continuation.recording !== "response_usage_recorded"
     )
       throw new Error(
         "Matched v4 continuation lacks its sealed request custody binding",
@@ -2476,7 +2477,7 @@ function recordExecution(
         providerResponseId: continuation.providerResponseId,
         requestedReasoningEffort: continuation.requestedReasoningEffort,
         usage,
-        costUsd: datedPricingCostUsd(profile, usage),
+        estimatedCostUsd: datedPricingCostUsd(profile, usage),
       }),
     );
   }
@@ -2529,8 +2530,8 @@ function recordExecution(
             0,
           )
         : null,
-      costUsd: recordedDispatches.reduce(
-        (sum, dispatch) => sum + dispatch.costUsd,
+      estimatedCostUsd: recordedDispatches.reduce(
+        (sum, dispatch) => sum + dispatch.estimatedCostUsd,
         0,
       ),
     },
@@ -2568,11 +2569,11 @@ function addieMatchedV4ExecutionAssignments(
 }
 
 /**
- * Settles results already obtained by the sealed authority. It intentionally
+ * Records response/usage results already obtained by the sealed authority. It intentionally
  * receives values, not a callback, so an ordinary import cannot inject a
  * provider dispatch path into the evaluator.
  */
-function settleAddieMatchedV4Execution(
+function recordAddieMatchedV4Execution(
   selector: AddieMatchedV4ExecutionSelector,
   executedTurns: readonly AddieMatchedV4ExecutedTurn[],
 ): AddieMatchedV4ExecutionArtifact {
@@ -2603,7 +2604,7 @@ function settleAddieMatchedV4Execution(
       ? state.plan.screening.maxProviderDispatches
       : state.plan.full.maxProviderDispatches;
   if (attempted !== completed || attempted > cap)
-    throw new Error("Matched v4 settled dispatch ledger exceeds declared cap");
+    throw new Error("Matched v4 recorded dispatch ledger exceeds declared cap");
   // The selector commits the permitted assignments; this binds each resulting
   // physical request (including an opaque continuation) back to that selector
   // and its observation position.  Individual hashes remain in the private
@@ -2705,10 +2706,12 @@ function validateAddieMatchedV4Observations(
         accounting.cacheReadTokens,
         accounting.cacheWriteTokens,
       ].every(validCount) ||
-      !Number.isFinite(accounting.costUsd) ||
-      accounting.costUsd < 0
+      !Number.isFinite(accounting.estimatedCostUsd) ||
+      accounting.estimatedCostUsd < 0
     ) {
-      throw new Error("Matched v4 requires complete settled accounting");
+      throw new Error(
+        "Matched v4 requires complete recorded response/usage evidence",
+      );
     }
     if (
       ((cell.provider === "openai" || cell.provider === "google") &&
@@ -2740,8 +2743,8 @@ function validateAddieMatchedV4Observations(
         passed: rows.filter((row) => row.passed).length,
         total: rows.length,
         passRate: rows.filter((row) => row.passed).length / rows.length,
-        totalCostUsd: rows.reduce(
-          (total, row) => total + row.accounting.costUsd,
+        totalEstimatedCostUsd: rows.reduce(
+          (total, row) => total + row.accounting.estimatedCostUsd,
           0,
         ),
         totalInputTokens: rows.reduce(

--- a/server/src/addie/eval/matched-v4-authorized-execution.ts
+++ b/server/src/addie/eval/matched-v4-authorized-execution.ts
@@ -22,26 +22,30 @@ export interface AddieMatchedV4AuthorizedStageReport {
   readonly attemptedProviderDispatches: number;
   readonly completedProviderDispatches: number;
   readonly runtimeWireSurfacesSha256: string;
-  readonly cells: ReadonlyArray<Readonly<{
-    id: string;
-    arm: string;
-    provider: string;
-    model: string;
-    reasoningEffort: string;
-    toolSurface: string;
-    passed: number;
-    total: number;
-    passRate: number;
-    /** Deterministic estimate from the signed pricing profile, not a bill. */
-    estimatedCostUsd: number;
-    medianLatencyMs: number;
-    totalInputTokens: number;
-    totalOutputTokens: number;
-    totalCacheReadTokens: number;
-    totalCacheWriteTokens: number;
-    totalReasoningTokens: number | null;
-  }>>;
-  readonly pairedCiGate?: ReadonlyArray<Readonly<Record<string, number | string>>>;
+  readonly cells: ReadonlyArray<
+    Readonly<{
+      id: string;
+      arm: string;
+      provider: string;
+      model: string;
+      reasoningEffort: string;
+      toolSurface: string;
+      passed: number;
+      total: number;
+      passRate: number;
+      /** Deterministic estimate from the signed pricing profile, not a bill. */
+      estimatedCostUsd: number;
+      medianLatencyMs: number;
+      totalInputTokens: number;
+      totalOutputTokens: number;
+      totalCacheReadTokens: number;
+      totalCacheWriteTokens: number;
+      totalReasoningTokens: number | null;
+    }>
+  >;
+  readonly pairedCiGate?: ReadonlyArray<
+    Readonly<Record<string, number | string>>
+  >;
 }
 
 export interface AddieMatchedV4AuthorizedExecutionReport {
@@ -62,25 +66,35 @@ function reportStage(result: any): AddieMatchedV4AuthorizedStageReport {
     attemptedProviderDispatches: result.artifact.attemptedProviderDispatches,
     completedProviderDispatches: result.artifact.completedProviderDispatches,
     runtimeWireSurfacesSha256: result.artifact.runtimeWireSurfacesSha256,
-    cells: Object.freeze(result.metrics.map((metric: any) => Object.freeze({
-      id: metric.cell.id,
-      arm: metric.cell.arm,
-      provider: metric.cell.provider,
-      model: metric.cell.model,
-      reasoningEffort: metric.cell.reasoningEffort,
-      toolSurface: metric.cell.toolSurface,
-      passed: metric.passed,
-      total: metric.total,
-      passRate: metric.passRate,
-      estimatedCostUsd: metric.totalCostUsd,
-      medianLatencyMs: metric.medianLatencyMs,
-      totalInputTokens: metric.totalInputTokens,
-      totalOutputTokens: metric.totalOutputTokens,
-      totalCacheReadTokens: metric.totalCacheReadTokens,
-      totalCacheWriteTokens: metric.totalCacheWriteTokens,
-      totalReasoningTokens: metric.totalReasoningTokens,
-    }))),
-    ...(result.pairedCiGate ? { pairedCiGate: Object.freeze(result.pairedCiGate.map((ci: any) => Object.freeze({ ...ci }))) } : {}),
+    cells: Object.freeze(
+      result.metrics.map((metric: any) =>
+        Object.freeze({
+          id: metric.cell.id,
+          arm: metric.cell.arm,
+          provider: metric.cell.provider,
+          model: metric.cell.model,
+          reasoningEffort: metric.cell.reasoningEffort,
+          toolSurface: metric.cell.toolSurface,
+          passed: metric.passed,
+          total: metric.total,
+          passRate: metric.passRate,
+          estimatedCostUsd: metric.totalEstimatedCostUsd,
+          medianLatencyMs: metric.medianLatencyMs,
+          totalInputTokens: metric.totalInputTokens,
+          totalOutputTokens: metric.totalOutputTokens,
+          totalCacheReadTokens: metric.totalCacheReadTokens,
+          totalCacheWriteTokens: metric.totalCacheWriteTokens,
+          totalReasoningTokens: metric.totalReasoningTokens,
+        }),
+      ),
+    ),
+    ...(result.pairedCiGate
+      ? {
+          pairedCiGate: Object.freeze(
+            result.pairedCiGate.map((ci: any) => Object.freeze({ ...ci })),
+          ),
+        }
+      : {}),
   });
 }
 

--- a/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
+++ b/server/src/addie/eval/matched-v4-immutable-artifact-sink.ts
@@ -31,14 +31,14 @@ export interface AddieMatchedV4DurableEvidenceReservation {
 export type AddieMatchedV4TerminalReasonCode =
   | "paired_ci_gate"
   | "dispatch_timeout"
-  | "settlement_refused"
+  | "response_usage_record_refused"
   | "intent_refused"
   | "provider_response_invalid"
   | "execution_refused";
 const terminalReasonCodes = new Set<AddieMatchedV4TerminalReasonCode>([
   "paired_ci_gate",
   "dispatch_timeout",
-  "settlement_refused",
+  "response_usage_record_refused",
   "intent_refused",
   "provider_response_invalid",
   "execution_refused",
@@ -306,8 +306,10 @@ class GcsBucketLockDurableEvidenceCapability implements AddieMatchedV4DurableEvi
     if (
       !current ||
       (current.phase !== "issued" &&
-        !(current.phase === "uncertain" &&
-          current.terminalIdentity === terminalIdentity)) ||
+        !(
+          current.phase === "uncertain" &&
+          current.terminalIdentity === terminalIdentity
+        )) ||
       (current.terminalIdentity !== undefined &&
         current.terminalIdentity !== terminalIdentity)
     )

--- a/server/src/addie/eval/matched-v4-plan.ts
+++ b/server/src/addie/eval/matched-v4-plan.ts
@@ -242,11 +242,11 @@ const FULL_TRACES = Object.freeze([
     expectedReceipt: "none",
   },
   {
-    id: "mv4-full-settlement",
+    id: "mv4-full-response-usage-recording",
     threadId: "mv4-full-thread-16",
     slice: "general_support",
     prompt:
-      "Explain why a usage record with an unknown exposure cannot be counted as settled accounting.",
+      "Explain why a usage record with an unknown exposure cannot be counted as recorded estimated-cost accounting.",
     expectedReceipt: "none",
   },
 ] as const satisfies readonly AddieMatchedV4SyntheticTrace[]);
@@ -355,16 +355,19 @@ const BROAD_SCREENING_CELLS = [
         }) as const,
     ),
   ),
-  ...(["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"] as const).flatMap(
-    (model) => ANTHROPIC_EFFORTS.map((reasoningEffort) =>
-      ({
-        id: `direct:anthropic:${model}:${reasoningEffort}:broad`,
-        arm: "direct",
-        provider: "anthropic",
-        model,
-        toolSurface: "broad",
-        reasoningEffort,
-      }) as const,
+  ...(
+    ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-5"] as const
+  ).flatMap((model) =>
+    ANTHROPIC_EFFORTS.map(
+      (reasoningEffort) =>
+        ({
+          id: `direct:anthropic:${model}:${reasoningEffort}:broad`,
+          arm: "direct",
+          provider: "anthropic",
+          model,
+          toolSurface: "broad",
+          reasoningEffort,
+        }) as const,
     ),
   ),
   {
@@ -400,13 +403,13 @@ const CLEAN_COMPARISON_BROAD_CELL_IDS = new Set<string>([
 
 export const ADDIE_MATCHED_V4_SCREENING_CELLS = Object.freeze([
   ...BROAD_SCREENING_CELLS,
-  ...BROAD_SCREENING_CELLS
-    .filter((cell) => CLEAN_COMPARISON_BROAD_CELL_IDS.has(cell.id))
-    .map((cell) => ({
-      ...cell,
-      id: cell.id.replace(/:broad$/, ":clean") as AddieMatchedV4CellId,
-      toolSurface: "clean" as const,
-    })),
+  ...BROAD_SCREENING_CELLS.filter((cell) =>
+    CLEAN_COMPARISON_BROAD_CELL_IDS.has(cell.id),
+  ).map((cell) => ({
+    ...cell,
+    id: cell.id.replace(/:broad$/, ":clean") as AddieMatchedV4CellId,
+    toolSurface: "clean" as const,
+  })),
 ] satisfies readonly AddieMatchedV4Cell[]);
 
 export const ADDIE_MATCHED_V4_BASELINE_CELL_ID =
@@ -425,7 +428,7 @@ export interface AddieMatchedV4Plan {
   }>;
   readonly promotion: Readonly<{
     rule: "pareto_non_dominated_then_preregistered_cap_order";
-    requiresCompleteSettledScreening: true;
+    requiresCompleteRecordedScreening: true;
   }>;
   readonly full: Readonly<{
     packSha256: string;
@@ -456,8 +459,7 @@ export function createAddieMatchedV4Plan(): AddieMatchedV4Plan {
   // Sonnet calls, so three is the closed upper bound per trace.
   const screeningDispatches =
     ADDIE_MATCHED_V4_SCREENING_CELLS.length * SCREENING_TRACES.length * 3;
-  const fullDispatches =
-    (FULL_MAX_PROMOTED_CELLS + 1) * FULL_TRACES.length * 3;
+  const fullDispatches = (FULL_MAX_PROMOTED_CELLS + 1) * FULL_TRACES.length * 3;
   const plan = freeze({
     version: ADDIE_MATCHED_V4_EVALUATION_VERSION,
     executionAuthority:
@@ -472,7 +474,7 @@ export function createAddieMatchedV4Plan(): AddieMatchedV4Plan {
     },
     promotion: {
       rule: "pareto_non_dominated_then_preregistered_cap_order",
-      requiresCompleteSettledScreening: true,
+      requiresCompleteRecordedScreening: true,
     },
     full: {
       packSha256: digest(FULL_TRACES),

--- a/server/src/addie/eval/matched-v4-private-authority.ts
+++ b/server/src/addie/eval/matched-v4-private-authority.ts
@@ -2,7 +2,7 @@
  * The sole ordinary import boundary for paid matched-v4 execution.
  *
  * It deliberately re-exports only a plan-only view and the sealed authority
- * factory. Execution selection, settlement, validation, promotion, and
+ * factory. Execution selection, response/usage recording, validation, promotion, and
  * artifact shapes stay local to the factory's custody implementation.
  */
 export {

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises";
 import path from "path";
-import { createHash } from "crypto";
 import { fileURLToPath } from "url";
 import type { PoolClient } from "pg";
 import { getPool, initializeDatabase } from "./client.js";
@@ -20,10 +19,14 @@ interface Migration {
  * Example: 001_initial.sql, 002_add_indexes.sql
  */
 const MIGRATION_FILENAME_PATTERN = /^(\d+)_(.+)\.sql$/;
-const MATCHED_V4_EXTERNAL_MIGRATION =
-  "584_addie_matched_v4_private_authority.sql";
+const MATCHED_V4_EXTERNAL_MIGRATIONS = new Set([
+  "584_addie_matched_v4_private_authority.sql",
+  "585_addie_matched_v4_record_estimated_cost.sql",
+]);
 const MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED_ENV =
   "ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED";
+/** Matches migration 585 and the protected evaluator workflow. */
+const MATCHED_V4_EVALUATOR_LOCK_KEY = 584585;
 
 /**
  * Evaluator DDL is intentionally opt-in for the protected release path. Local
@@ -42,364 +45,180 @@ function matchedV4EvaluatorSchemaRequired(): boolean {
 }
 
 /**
- * Migration 584 is intentionally applied by a separately administered
- * evaluator operator, not by the general application migrator.  The normal
- * migration ledger still owns its ordering: it records 584 only after this
- * verification proves that the external step completed the sealed schema.
+ * Migrations 584 and 585 are intentionally applied by a separately
+ * administered evaluator operator, not by the general application migrator.
+ * The normal ledger records either only after both external steps attest the
+ * transformed terminal-record schema. This makes 585 a hard prerequisite for
+ * an admission: the application cannot record a usable 584-only boundary.
  */
 async function validateMatchedV4ExternalSchema(
   client: PoolClient,
 ): Promise<void> {
-  // `pg_get_tabledef` does not exist in supported PostgreSQL versions.  Pin a
-  // canonical catalog projection instead: user columns (including order,
-  // types, nullability, and defaults), every constraint, and every physical
-  // index.  A count-only check would accept a hand-made lookalike table.
-  const expectedTableShapeDigests: Readonly<Record<string, string>> = {
-    addie_matched_v4_private_admissions:
-      "c8758926b069b97aeeffbe1572ae2564ae3890db612de08fbbfabf7885addc73",
-    addie_matched_v4_private_attempts:
-      "fb3a9baaa408ade459aa338930c244e1fd84877c3ade09a988cd946f735ba4d8",
-    addie_matched_v4_private_runs:
-      "a5a22e4cc5c1559b10986e447725f412e1c997a8ccdd70d7b90c104a526db60d",
-  };
-  const tableShapes = await client.query<{
-    name: string;
-    canonical_shape: string;
-  }>(`
-    SELECT c.relname AS name,
-      jsonb_build_object(
-        'table', c.relname, 'relkind', c.relkind,
-        'columns', (SELECT jsonb_agg(jsonb_build_object(
-          'name', a.attname, 'type', pg_catalog.format_type(a.atttypid, a.atttypmod),
-          'notNull', a.attnotnull,
-          'default', COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')
-        ) ORDER BY a.attnum)
-          FROM pg_catalog.pg_attribute a
-          LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid=a.attrelid AND d.adnum=a.attnum
-          WHERE a.attrelid=c.oid AND a.attnum > 0 AND NOT a.attisdropped),
-        'constraints', (SELECT jsonb_agg(jsonb_build_object(
-          'name', x.conname, 'type', x.contype,
-          'definition', pg_catalog.pg_get_constraintdef(x.oid, true)
-        ) ORDER BY x.conname) FROM pg_catalog.pg_constraint x WHERE x.conrelid=c.oid),
-        'indexes', (SELECT jsonb_agg(jsonb_build_object(
-          'name', ci.relname,
-          'definition', pg_catalog.pg_get_indexdef(i.indexrelid, 0, true)
-        ) ORDER BY ci.relname) FROM pg_catalog.pg_index i
-          JOIN pg_catalog.pg_class ci ON ci.oid=i.indexrelid WHERE i.indrelid=c.oid)
-      )::text AS canonical_shape
-    FROM pg_catalog.pg_class c
-    JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
-    WHERE n.nspname='public' AND c.relkind='r'
-      AND c.relname = ANY(ARRAY['addie_matched_v4_private_runs',
-        'addie_matched_v4_private_admissions', 'addie_matched_v4_private_attempts'])
-  `);
-  if (
-    tableShapes.rows.length !== Object.keys(expectedTableShapeDigests).length ||
-    tableShapes.rows.some(
-      ({ name, canonical_shape }) =>
-        createHash("sha256").update(canonical_shape, "utf8").digest("hex") !==
-        expectedTableShapeDigests[name],
-    )
-  ) {
-    throw new Error(
-      "Migration 584 evaluator tables do not match the reviewed full catalog shape.",
-    );
-  }
-
-  // Pin each complete callable definition, not only its PL/pgSQL body. The
-  // explicit security-definer and one-item configuration tests below are a
-  // second, easy-to-audit attestation of the exact safe search path.
-  const expectedRuntimeDefinitions: Readonly<Record<string, string>> = {
-    "public.addie_matched_v4_private_reserve(text,text,text,integer)":
-      "47cf83cedacdbbabd839b5c5d2780a19898dc94c2021ca15729cf1fc6cd7201e",
-    "public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)":
-      "d0fc1859fa1237cfd9d1d8a8a6c785dfc99d8607b6b884727f4e880148dca8ad",
-    "public.addie_matched_v4_private_settle(text,text,text,text,bigint)":
-      "f0374cdaa332b06e3e7200d46d0c3bce261e76a232d6c0e2696746761c4c896e",
-    "public.addie_matched_v4_private_reconcile(text)":
-      "093b45e79b533fdcc79f152d4a2548a36b1e176736501606c62522899eb3bb28",
-    "public.addie_matched_v4_private_halt(text,text)":
-      "e7697ba0b1633e7e8f12e531ef6b2fc74813d8f7458bb60b9fade42a711a6151",
-    "public.addie_matched_v4_private_claim_admission(text,text,text)":
-      "2c4546366b8c677059039c458b8601435a44b64791223ccdbe21b93dbf172b0e",
-  };
-  const runtimeApi = await client.query<{
-    signature: string;
-    definition: string;
-    security_definer: boolean;
-    config: string[] | null;
-  }>(
-    `
-    SELECT n.nspname || '.' || p.proname || '('
-      || replace(pg_catalog.pg_get_function_identity_arguments(p.oid), ', ', ',')
-      || ')' AS signature,
-      pg_catalog.pg_get_functiondef(p.oid) AS definition,
-      p.prosecdef AS security_definer, p.proconfig AS config
-    FROM pg_catalog.pg_proc p
-    JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
-    WHERE n.nspname='public'
-      AND n.nspname || '.' || p.proname || '('
-        || replace(pg_catalog.pg_get_function_identity_arguments(p.oid), ', ', ',')
-        || ')' = ANY($1::text[])
-  `,
-    [Object.keys(expectedRuntimeDefinitions)],
-  );
-  if (
-    runtimeApi.rows.length !== Object.keys(expectedRuntimeDefinitions).length ||
-    runtimeApi.rows.some(
-      ({ signature, definition, security_definer, config }) =>
-        !security_definer ||
-        config?.length !== 1 ||
-        config[0] !== "search_path=pg_catalog" ||
-        createHash("sha256").update(definition, "utf8").digest("hex") !==
-          expectedRuntimeDefinitions[signature],
-    )
-  ) {
-    throw new Error(
-      "Migration 584 runtime API body or SECURITY DEFINER search_path is not canonical.",
-    );
-  }
-
-  const result = await client.query<{
-    valid: boolean;
-    attempt_guard_definition: string | null;
-    append_only_guard_definition: string | null;
-  }>(`
+  const transformed = await client.query<{ valid: boolean }>(`
     WITH required_tables(name) AS (
-      VALUES
-        ('addie_matched_v4_private_runs'),
+      VALUES ('addie_matched_v4_private_runs'),
         ('addie_matched_v4_private_admissions'),
         ('addie_matched_v4_private_attempts')
-    ), required_api(signature) AS (
-      VALUES
-        ('public.addie_matched_v4_private_reserve(text,text,text,integer)'),
-        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)'),
-        ('public.addie_matched_v4_private_settle(text,text,text,text,bigint)'),
-        ('public.addie_matched_v4_private_reconcile(text)'),
-        ('public.addie_matched_v4_private_halt(text,text)'),
-        ('public.addie_matched_v4_private_claim_admission(text,text,text)')
+    ), required_relations(name, relkind) AS (
+      VALUES ('addie_matched_v4_private_runs', 'r'::"char"),
+        ('addie_matched_v4_private_runs_pkey', 'i'::"char"),
+        ('addie_matched_v4_private_admissions', 'r'::"char"),
+        ('addie_matched_v4_private_admissions_pkey', 'i'::"char"),
+        ('addie_matched_v4_private_admi_merge_sha_authority_manifest__key', 'i'::"char"),
+        ('addie_matched_v4_private_attempts', 'r'::"char"),
+        ('addie_matched_v4_private_attempts_pkey', 'i'::"char"),
+        ('addie_matched_v4_private_attempts_reservation_id_ordinal_key', 'i'::"char")
+    ), required_api(signature, runtime_execute) AS (
+      VALUES ('public.addie_matched_v4_private_reserve(text,text,text,integer)', true),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)', true),
+        ('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)', true),
+        ('public.addie_matched_v4_private_reconcile(text)', true),
+        ('public.addie_matched_v4_private_halt(text,text)', true),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)', true)
     ), protected_guards(signature) AS (
-      VALUES
-        ('public.addie_matched_v4_private_attempt_guard()'),
+      VALUES ('public.addie_matched_v4_private_attempt_guard()'),
         ('public.addie_matched_v4_private_append_only_guard()')
     ), canonical_triggers(table_name, trigger_name, procedure_signature, trigger_type) AS (
-      VALUES
-        ('addie_matched_v4_private_attempts',
-         'addie_matched_v4_private_attempt_guard',
-         'public.addie_matched_v4_private_attempt_guard()', 31),
-        ('addie_matched_v4_private_runs',
-         'addie_matched_v4_private_runs_append_only_guard',
-         'public.addie_matched_v4_private_append_only_guard()', 11),
-        ('addie_matched_v4_private_admissions',
-         'addie_matched_v4_private_admissions_append_only_guard',
-         'public.addie_matched_v4_private_append_only_guard()', 11),
-        ('addie_matched_v4_private_attempts',
-         'addie_matched_v4_private_attempts_append_only_guard',
-         'public.addie_matched_v4_private_append_only_guard()', 11)
+      VALUES ('addie_matched_v4_private_attempts', 'addie_matched_v4_private_attempt_guard', 'public.addie_matched_v4_private_attempt_guard()', 31),
+        ('addie_matched_v4_private_runs', 'addie_matched_v4_private_runs_append_only_guard', 'public.addie_matched_v4_private_append_only_guard()', 11),
+        ('addie_matched_v4_private_admissions', 'addie_matched_v4_private_admissions_append_only_guard', 'public.addie_matched_v4_private_append_only_guard()', 11),
+        ('addie_matched_v4_private_attempts', 'addie_matched_v4_private_attempts_append_only_guard', 'public.addie_matched_v4_private_append_only_guard()', 11)
     )
     SELECT
-      EXISTS (
-        SELECT 1 FROM pg_catalog.pg_roles
-        WHERE rolname = 'addie_matched_v4_operator'
-          AND NOT rolcanlogin AND NOT rolinherit
-          AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole
-          AND NOT rolreplication AND NOT rolbypassrls
-      )
-      AND EXISTS (
-        SELECT 1 FROM pg_catalog.pg_roles
-        WHERE rolname = 'addie_matched_v4_runtime'
-          AND NOT rolcanlogin AND NOT rolinherit
-          AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole
-          AND NOT rolreplication AND NOT rolbypassrls
-      )
-      AND NOT pg_catalog.pg_has_role(
-        'addie_matched_v4_runtime', 'addie_matched_v4_operator', 'member'
-      )
-      -- The ordinary migrator must itself be the deployed application
-      -- principal, never a privileged session that SET ROLE to that principal.
-      -- session_user is the authenticated identity and must equal the active
-      -- application role before this external schema can be recorded.
+      EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator' AND NOT rolcanlogin AND NOT rolinherit AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND NOT rolbypassrls)
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_runtime' AND NOT rolcanlogin AND NOT rolinherit AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND NOT rolbypassrls)
       AND session_user = current_user
-      AND pg_catalog.pg_has_role(
-        current_user, 'addie_matched_v4_runtime', 'member'
-      )
-      AND NOT pg_catalog.pg_has_role(
-        current_user, 'addie_matched_v4_operator', 'member'
-      )
+      -- The authenticated application login is itself a sealed bridge, not
+      -- merely a member of the static runtime capability.  Pin its complete
+      -- non-privileged shape before it can record the external boundary.
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname=current_user AND rolcanlogin AND rolinherit AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND NOT rolbypassrls)
+      AND pg_catalog.pg_has_role(current_user, 'addie_matched_v4_runtime', 'member')
+      AND NOT pg_catalog.pg_has_role(current_user, 'addie_matched_v4_operator', 'member')
+      AND NOT pg_catalog.pg_has_role('addie_matched_v4_runtime', 'addie_matched_v4_operator', 'member')
+      -- Neither static custody capability may itself inherit or SET another
+      -- role. Otherwise its harmless-looking own flags conceal a transitive
+      -- privilege escalation outside the reviewed two-bridge graph.
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.member IN ('addie_matched_v4_operator'::regrole,'addie_matched_v4_runtime'::regrole))
+      -- Both static evaluator capabilities have exactly one reviewed direct
+      -- bridge. A second hidden SET member is an admission bypass.
+      AND (SELECT count(*) FROM pg_catalog.pg_auth_members edge WHERE edge.roleid='addie_matched_v4_operator'::regrole) = 1
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge JOIN pg_catalog.pg_roles member_role ON member_role.oid=edge.member WHERE edge.roleid='addie_matched_v4_operator'::regrole AND NOT edge.inherit_option AND edge.set_option AND NOT edge.admin_option AND member_role.rolcanlogin AND NOT member_role.rolinherit AND NOT member_role.rolsuper AND NOT member_role.rolcreatedb AND NOT member_role.rolcreaterole AND NOT member_role.rolreplication AND NOT member_role.rolbypassrls AND edge.grantor NOT IN (edge.roleid,edge.member,'addie_matched_v4_runtime'::regrole,(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user)))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge JOIN pg_catalog.pg_auth_members edge ON edge.member=bridge.member WHERE bridge.roleid='addie_matched_v4_operator'::regrole AND edge.roleid<>'addie_matched_v4_operator'::regrole)
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge JOIN pg_catalog.pg_auth_members edge ON edge.roleid=bridge.member WHERE bridge.roleid='addie_matched_v4_operator'::regrole)
+      AND (SELECT count(*) FROM pg_catalog.pg_auth_members edge WHERE edge.roleid='addie_matched_v4_runtime'::regrole) = 1
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.roleid='addie_matched_v4_runtime'::regrole AND edge.member=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user) AND edge.inherit_option AND NOT edge.set_option AND NOT edge.admin_option AND edge.grantor NOT IN (edge.roleid,edge.member,'addie_matched_v4_operator'::regrole,(SELECT member FROM pg_catalog.pg_auth_members WHERE roleid='addie_matched_v4_operator'::regrole)))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.member=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user) AND edge.roleid<>'addie_matched_v4_runtime'::regrole)
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.roleid=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user))
+      AND current_setting('session_replication_role') = 'origin'
+      AND NOT pg_catalog.has_parameter_privilege('addie_matched_v4_runtime','session_replication_role','SET')
+      AND NOT pg_catalog.has_parameter_privilege(current_user,'session_replication_role','SET')
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_db_role_setting setting CROSS JOIN LATERAL unnest(setting.setconfig) config WHERE setting.setrole=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=current_user) AND setting.setdatabase IN (0,(SELECT oid FROM pg_catalog.pg_database WHERE datname=current_database())) AND split_part(config,'=',1)='session_replication_role' AND split_part(config,'=',2)<>'origin')
+      AND pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'USAGE')
+      AND pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'CREATE')
+      AND pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'USAGE')
+      AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'CREATE')
+      AND pg_catalog.has_schema_privilege(current_user, 'public', 'USAGE')
+      AND NOT pg_catalog.has_schema_privilege(current_user, 'public', 'CREATE')
+      AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'pg_toast', 'USAGE,CREATE')
+      AND NOT pg_catalog.has_schema_privilege(current_user, 'pg_toast', 'USAGE,CREATE')
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace n CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(n.nspacl,pg_catalog.acldefault('n',n.nspowner))) acl WHERE n.nspname='public' AND acl.grantee=0 AND acl.privilege_type='CREATE')
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))) AND (acl.grantee<>c.relowner OR acl.grantor<>c.relowner OR acl.is_grantable))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))) AND (SELECT count(*) FROM pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner)))) <> 7)
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))) AND a.attnum>0 AND NOT a.attisdropped AND a.attacl IS NOT NULL)
+      -- Every prefixed relation, including physical indexes, is a reviewed
+      -- object. This rejects shadow views, sequences, and partitions too.
+      AND (SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public' AND c.relname LIKE 'addie_matched_v4_private_%') = 8
+      AND (SELECT count(*) FROM pg_catalog.pg_class WHERE relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')) = 14
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') AND c.oid NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_runs_pkey'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_admissions_pkey'),to_regclass('public.addie_matched_v4_private_admi_merge_sha_authority_manifest__key'),to_regclass('public.addie_matched_v4_private_attempts'),to_regclass('public.addie_matched_v4_private_attempts_pkey'),to_regclass('public.addie_matched_v4_private_attempts_reservation_id_ordinal_key')) AND c.oid NOT IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))))
+      AND NOT EXISTS (SELECT 1 FROM required_relations WHERE to_regclass('public.' || name) IS NULL
+        OR (SELECT c.relkind FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || name)) <> required_relations.relkind
+        OR (SELECT c.relpersistence FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || name)) <> 'p'
+        OR (required_relations.relkind='r'::"char" AND (SELECT c.relrowsecurity OR c.relforcerowsecurity OR c.relhasrules OR c.relispartition FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || name)))
+        OR (SELECT pg_catalog.pg_get_userbyid(c.relowner) FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || name)) <> 'addie_matched_v4_operator'
+        OR (required_relations.relkind='i'::"char" AND (SELECT c.relacl FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || name)) IS NOT NULL))
+      AND NOT EXISTS (SELECT 1 FROM required_tables WHERE to_regclass('public.' || name) IS NULL
+        OR (SELECT pg_catalog.pg_get_userbyid(relowner) FROM pg_catalog.pg_class WHERE oid=to_regclass('public.' || name)) <> 'addie_matched_v4_operator'
+        OR pg_catalog.has_table_privilege(current_user, 'public.' || name, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER')
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_class c CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl WHERE c.oid=to_regclass('public.' || name) AND (acl.grantee<>(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') OR acl.grantor<>(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') OR acl.is_grantable))
+        OR (SELECT count(*) FROM pg_catalog.pg_class c CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl WHERE c.oid=to_regclass('public.' || name)) <> 7)
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_policy p WHERE p.polrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_rewrite r WHERE r.ev_class IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) AND r.rulename <> '_RETURN')
+      -- A view can expose toasted values directly. Its rewrite dependencies
+      -- must not name either a custody table or its physical TOAST relation.
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_rewrite r JOIN pg_catalog.pg_depend d ON d.classid='pg_rewrite'::regclass AND d.objid=r.oid WHERE r.ev_class NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) AND d.refobjid IN (SELECT c.oid FROM pg_catalog.pg_class c WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT c.reltoastrelid FROM pg_catalog.pg_class c WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) AND c.reltoastrelid <> 0))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_inherits i WHERE i.inhrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) OR i.inhparent IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')]) AND a.attnum>0 AND NOT a.attisdropped AND (a.attacl IS NOT NULL OR pg_catalog.has_column_privilege(current_user,a.attrelid,a.attnum,'SELECT') OR pg_catalog.has_column_privilege(current_user,a.attrelid,a.attnum,'INSERT') OR pg_catalog.has_column_privilege(current_user,a.attrelid,a.attnum,'UPDATE') OR pg_catalog.has_column_privilege(current_user,a.attrelid,a.attnum,'REFERENCES')))
+      AND (SELECT count(*) FROM pg_catalog.pg_attribute WHERE attrelid=to_regclass('public.addie_matched_v4_private_attempts') AND attnum>0 AND NOT attisdropped) = 13
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_attribute WHERE attrelid=to_regclass('public.addie_matched_v4_private_attempts') AND attname='estimated_cost_microdollars' AND pg_catalog.format_type(atttypid,atttypmod)='bigint')
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_attribute WHERE attrelid=to_regclass('public.addie_matched_v4_private_attempts') AND attname='terminal_recorded_at' AND pg_catalog.format_type(atttypid,atttypmod)='timestamp with time zone')
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_attribute WHERE attrelid=to_regclass('public.addie_matched_v4_private_attempts') AND attname IN ('cost_microdollars','settled_at'))
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_constraint WHERE conrelid=to_regclass('public.addie_matched_v4_private_attempts') AND conname='addie_matched_v4_private_attempts_terminal_recording_check' AND pg_catalog.pg_get_constraintdef(oid,true) LIKE '%response_usage_recorded%')
+      AND to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NULL
+      AND NOT EXISTS (SELECT 1 FROM required_api WHERE to_regprocedure(signature) IS NULL
+        OR NOT pg_catalog.has_function_privilege('addie_matched_v4_runtime', signature, 'EXECUTE')
+        OR NOT (SELECT prosecdef FROM pg_catalog.pg_proc WHERE oid=to_regprocedure(signature))
+        OR (SELECT proconfig FROM pg_catalog.pg_proc WHERE oid=to_regprocedure(signature)) IS DISTINCT FROM ARRAY['search_path=pg_catalog']
+        OR (SELECT pg_catalog.pg_get_userbyid(proowner) FROM pg_catalog.pg_proc WHERE oid=to_regprocedure(signature)) <> 'addie_matched_v4_operator'
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(signature) AND acl.grantee=0 AND acl.privilege_type='EXECUTE'))
+      AND NOT EXISTS (SELECT 1 FROM protected_guards WHERE to_regprocedure(signature) IS NULL
+        OR (SELECT pg_catalog.pg_get_userbyid(proowner) FROM pg_catalog.pg_proc WHERE oid=to_regprocedure(signature)) <> 'addie_matched_v4_operator'
+        OR pg_catalog.has_function_privilege('addie_matched_v4_runtime', signature, 'EXECUTE')
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(signature) AND acl.grantee=0 AND acl.privilege_type='EXECUTE'))
       AND NOT EXISTS (
-        SELECT 1 FROM required_tables
-        WHERE to_regclass('public.' || name) IS NULL
-          OR (SELECT pg_catalog.pg_get_userbyid(relowner)
-              FROM pg_catalog.pg_class
-              WHERE oid = to_regclass('public.' || name))
-             <> 'addie_matched_v4_operator'
-          OR NOT pg_catalog.has_table_privilege(
-            'addie_matched_v4_operator', 'public.' || name, 'SELECT,INSERT,UPDATE,DELETE'
-          )
-          OR pg_catalog.has_table_privilege(
-            'addie_matched_v4_runtime', 'public.' || name,
-            'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
-          )
-          -- The deployed application login can have direct ACLs that are not
-          -- implied by its restricted runtime role. Check it separately.
-          OR pg_catalog.has_table_privilege(
-            current_user, 'public.' || name,
-            'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
-          )
-          OR EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_class c
-            CROSS JOIN LATERAL pg_catalog.aclexplode(
-              COALESCE(c.relacl, pg_catalog.acldefault('r', c.relowner))
-            ) AS acl
-            WHERE c.oid = to_regclass('public.' || name)
-              AND acl.grantee = 0
-              AND acl.privilege_type IN ('SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER')
-          )
+        SELECT 1 FROM (
+          SELECT signature, runtime_execute FROM required_api
+          UNION ALL SELECT signature, false FROM protected_guards
+        ) AS expected
+        WHERE (SELECT count(*) FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(expected.signature)) <> CASE WHEN expected.runtime_execute THEN 2 ELSE 1 END
+          OR EXISTS (SELECT 1 FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(expected.signature) AND (acl.grantee NOT IN ((SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator'),(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_runtime')) OR acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') OR acl.is_grantable))
       )
-      AND NOT EXISTS (
-        SELECT 1 FROM required_api
-        WHERE to_regprocedure(signature) IS NULL
-          OR NOT pg_catalog.has_function_privilege(
-            'addie_matched_v4_runtime', signature, 'EXECUTE'
-          )
-          OR NOT (SELECT prosecdef FROM pg_catalog.pg_proc WHERE oid = to_regprocedure(signature))
-          OR (SELECT pg_catalog.pg_get_userbyid(proowner) FROM pg_catalog.pg_proc WHERE oid = to_regprocedure(signature))
-             <> 'addie_matched_v4_operator'
-          OR EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_proc p
-            CROSS JOIN LATERAL pg_catalog.aclexplode(
-              COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))
-            ) AS acl
-            WHERE p.oid = to_regprocedure(signature)
-              AND acl.grantee = 0 AND acl.privilege_type = 'EXECUTE'
-          )
-      )
-      AND NOT EXISTS (
-        SELECT 1 FROM protected_guards
-        WHERE to_regprocedure(signature) IS NULL
-          OR (SELECT pg_catalog.pg_get_userbyid(proowner)
-              FROM pg_catalog.pg_proc
-              WHERE oid = to_regprocedure(signature))
-             <> 'addie_matched_v4_operator'
-          OR EXISTS (
-            SELECT 1
-            FROM pg_catalog.pg_proc p
-            CROSS JOIN LATERAL pg_catalog.aclexplode(
-              COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))
-            ) AS acl
-            WHERE p.oid = to_regprocedure(signature)
-              AND acl.grantee = 0 AND acl.privilege_type = 'EXECUTE'
-          )
-      )
-      AND EXISTS (
-        SELECT 1 FROM pg_catalog.pg_trigger t
-        JOIN pg_catalog.pg_proc p ON p.oid = t.tgfoid
-        JOIN pg_catalog.pg_namespace pn ON pn.oid = p.pronamespace
-        WHERE t.tgname = 'addie_matched_v4_private_attempt_guard'
-          AND t.tgrelid = to_regclass('public.addie_matched_v4_private_attempts')
-          AND p.oid = to_regprocedure('public.addie_matched_v4_private_attempt_guard()')
-          AND pn.nspname = 'public'
-          AND pg_catalog.pg_get_userbyid(p.proowner) = 'addie_matched_v4_operator'
-          -- PostgreSQL trigger type 31 is ROW | BEFORE | INSERT | UPDATE |
-          -- DELETE.  The exact value excludes statement, AFTER/INSTEAD and
-          -- TRUNCATE variants; disabled guards cannot attest a dispatch cap
-          -- or append-only intent custody.
-          AND t.tgtype = 31
-          AND t.tgenabled = 'O'
-          AND t.tgqual IS NULL
-          AND NOT t.tgisinternal
-      )
-      AND NOT EXISTS (
-        SELECT 1
-        FROM (VALUES
-          ('public.addie_matched_v4_private_runs'::text,
-           'addie_matched_v4_private_runs_append_only_guard'::text),
-          ('public.addie_matched_v4_private_admissions'::text,
-           'addie_matched_v4_private_admissions_append_only_guard'::text),
-          ('public.addie_matched_v4_private_attempts'::text,
-           'addie_matched_v4_private_attempts_append_only_guard'::text)
-        ) AS expected(table_name, trigger_name)
-        WHERE NOT EXISTS (
-          SELECT 1
-          FROM pg_catalog.pg_trigger t
-          JOIN pg_catalog.pg_proc p ON p.oid = t.tgfoid
-          WHERE t.tgname = expected.trigger_name
-            AND t.tgrelid = to_regclass(expected.table_name)
-            AND p.oid = to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
-            -- ROW | BEFORE | DELETE.  A disabled, conditional, statement,
-            -- or differently timed trigger is not append-only custody.
-            AND t.tgtype = 11 AND t.tgenabled = 'O' AND t.tgqual IS NULL
-            AND NOT t.tgisinternal
-        )
-      )
-      -- Do not merely find the four known guards. Any other user trigger on
-      -- a custody relation can rewrite NEW or bypass/augment the reviewed
-      -- cap path. The complete non-internal trigger set must be canonical.
-      AND NOT EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_trigger actual
-        WHERE NOT actual.tgisinternal
-          AND actual.tgrelid = ANY(ARRAY[
-            to_regclass('public.addie_matched_v4_private_runs'),
-            to_regclass('public.addie_matched_v4_private_admissions'),
-            to_regclass('public.addie_matched_v4_private_attempts')
-          ])
-          AND NOT EXISTS (
-            SELECT 1 FROM canonical_triggers expected
-            WHERE actual.tgrelid = to_regclass('public.' || expected.table_name)
-              AND actual.tgname = expected.trigger_name
-              AND actual.tgfoid = to_regprocedure(expected.procedure_signature)
-              AND actual.tgtype = expected.trigger_type
-              AND actual.tgenabled = 'O'
-              AND actual.tgqual IS NULL
-          )
-      )
+      AND EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t WHERE t.tgname='addie_matched_v4_private_attempt_guard' AND t.tgrelid=to_regclass('public.addie_matched_v4_private_attempts') AND t.tgfoid=to_regprocedure('public.addie_matched_v4_private_attempt_guard()') AND t.tgtype=31 AND t.tgenabled='O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea AND NOT t.tgisinternal)
+      AND NOT EXISTS (SELECT 1 FROM canonical_triggers expected WHERE NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t WHERE t.tgrelid=to_regclass('public.' || expected.table_name) AND t.tgname=expected.trigger_name AND t.tgfoid=to_regprocedure(expected.procedure_signature) AND t.tgtype=expected.trigger_type AND t.tgenabled='O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea AND NOT t.tgisinternal))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger actual WHERE NOT actual.tgisinternal AND actual.tgrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')]) AND NOT EXISTS (SELECT 1 FROM canonical_triggers expected WHERE actual.tgrelid=to_regclass('public.' || expected.table_name) AND actual.tgname=expected.trigger_name AND actual.tgfoid=to_regprocedure(expected.procedure_signature) AND actual.tgtype=expected.trigger_type AND actual.tgenabled='O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea))
+      -- The one reviewed foreign key has exactly four enabled internal RI
+      -- triggers. An incoming FK on another relation must not silently add
+      -- enforcement objects to this sealed namespace.
+      AND (SELECT count(*) FROM pg_catalog.pg_trigger t JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint WHERE t.tgisinternal AND t.tgconstraint <> 0 AND (c.conrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')]) OR c.confrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')]))) = 4
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_trigger t JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint JOIN pg_catalog.pg_proc p ON p.oid=t.tgfoid WHERE t.tgisinternal AND t.tgconstraint <> 0 AND (c.conrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')]) OR c.confrelid=ANY(ARRAY[to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')])) AND NOT EXISTS (SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_restrict_del',9),
+        ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_noaction_upd',17),
+        ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_ins',5),
+        ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_upd',17)
+      ) AS expected(constraint_name,source_table,target_table,trigger_table,procedure_name,trigger_type) WHERE c.conname=expected.constraint_name AND c.conrelid=to_regclass('public.' || expected.source_table) AND c.confrelid=to_regclass('public.' || expected.target_table) AND t.tgrelid=to_regclass('public.' || expected.trigger_table) AND p.pronamespace='pg_catalog'::regnamespace AND p.proname=expected.procedure_name AND t.tgtype=expected.trigger_type AND t.tgenabled='O' AND t.tgqual IS NULL))
+      -- A successful migration record needs a full 585 shape attestation,
+      -- not a same-name/status lookalike. These digests cover every ordered
+      -- column, constraint, and physical index, plus complete definitions of
+      -- both guards and all callable SECURITY DEFINER functions.
+      AND NOT EXISTS (SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_admissions','4ed0c46ae7eaee829b967b8c8eeb1996'),
+        ('addie_matched_v4_private_attempts','8dc693482e69a981110ffa1c547b1f69'),
+        ('addie_matched_v4_private_runs','16a018c611239801d31c7855ca8c1a28')
+      ) AS expected(name,shape_md5) WHERE expected.shape_md5 IS DISTINCT FROM (
+        SELECT md5((jsonb_build_object('table',c.relname,'relkind',c.relkind,
+          'columns',(SELECT jsonb_agg(jsonb_build_object('ordinal',a.attnum,'name',a.attname,'type',pg_catalog.format_type(a.atttypid,a.atttypmod),'notNull',a.attnotnull,'default',COALESCE(pg_catalog.pg_get_expr(d.adbin,d.adrelid),''),'collation',CASE WHEN a.attcollation=0 THEN NULL ELSE (SELECT n.nspname || '.' || co.collname FROM pg_catalog.pg_collation co JOIN pg_catalog.pg_namespace n ON n.oid=co.collnamespace WHERE co.oid=a.attcollation) END,'identity',a.attidentity,'generated',a.attgenerated) ORDER BY a.attnum) FROM pg_catalog.pg_attribute a LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid=a.attrelid AND d.adnum=a.attnum WHERE a.attrelid=c.oid AND a.attnum>0 AND NOT a.attisdropped),
+          'constraints',(SELECT jsonb_agg(jsonb_build_object('name',x.conname,'type',x.contype,'definition',pg_catalog.pg_get_constraintdef(x.oid,true)) ORDER BY x.conname) FROM pg_catalog.pg_constraint x WHERE x.conrelid=c.oid),
+          'indexes',(SELECT jsonb_agg(jsonb_build_object('name',ci.relname,'definition',pg_catalog.pg_get_indexdef(i.indexrelid,0,true)) ORDER BY ci.relname) FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class ci ON ci.oid=i.indexrelid WHERE i.indrelid=c.oid)
+        )::text)) FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)
+      ))
+      AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) AND a.attnum>0 AND a.attisdropped)
+      AND (SELECT count(*) FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname LIKE 'addie_matched_v4_private_%')=8
+      AND (SELECT count(*) FROM pg_catalog.pg_proc WHERE proowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator'))=8
+      AND NOT EXISTS (SELECT 1 FROM (VALUES
+        ('public.addie_matched_v4_private_attempt_guard()','ee4c62ffa52a33ee8144416274051bc6'),
+        ('public.addie_matched_v4_private_append_only_guard()','b66c0828506e4785edf27b41190c3ed9'),
+        ('public.addie_matched_v4_private_reserve(text,text,text,integer)','a246e0fa7b05238e52f384138ec99047'),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)','85c35d25f690969ed336fe7a9e30115d'),
+        ('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)','0d8ab008dd3d5d3354c528324432dc40'),
+        ('public.addie_matched_v4_private_reconcile(text)','87d8997b5c7408461244e7bd740d044f'),
+        ('public.addie_matched_v4_private_halt(text,text)','2d35d780d2279dc302db1bc27967c8f9'),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)','4db729c5722fd978efebf52ace62bb6a')
+      ) AS expected(signature,definition_md5) WHERE to_regprocedure(expected.signature) IS NULL
+        OR expected.definition_md5 IS DISTINCT FROM (SELECT md5(pg_catalog.pg_get_functiondef(to_regprocedure(expected.signature)))))
       AS valid
-      , pg_catalog.pg_get_functiondef(
-          to_regprocedure('public.addie_matched_v4_private_attempt_guard()')
-        ) AS attempt_guard_definition
-      , pg_catalog.pg_get_functiondef(
-          to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
-        ) AS append_only_guard_definition
   `);
-
-  const attestation = result.rows[0];
-  const expectedAttemptGuardSemantics = [
-    "OLD.status <> 'intent_recorded'",
-    "NEW.status NOT IN ('settled', 'unknown_exposure')",
-    "TG_OP = 'DELETE'",
-    "matched-v4 attempt custody is append-only",
-    "FOR UPDATE",
-    "already_count >= run_cap",
-  ];
-  const appendOnlySemantic =
-    attestation?.append_only_guard_definition?.includes(
-      "RAISE EXCEPTION 'matched-v4 evaluator custody is append-only'",
-    ) === true;
-  const attemptGuardSemantic = expectedAttemptGuardSemantics.every((fragment) =>
-    attestation?.attempt_guard_definition?.includes(fragment),
-  );
-  // The digest makes a same-name/function-signature replacement detectable;
-  // semantic fragments make the reviewed safety meaning explicit in review.
-  const attestationDigest = (definition: string | null | undefined) =>
-    definition && createHash("sha256").update(definition, "utf8").digest("hex");
-  const expectedAppendGuardDigest =
-    "1f3c9478583665d1a200112c163cc7f6d045bbc734811f7bd475aa746b94120a";
-  const expectedAttemptGuardDigest =
-    "69a81df2e9937247e56602a5a9d676243b279d12c32a097a788dbc9e2b91c86f";
-  if (
-    !attestation?.valid ||
-    !appendOnlySemantic ||
-    !attemptGuardSemantic ||
-    attestationDigest(attestation.append_only_guard_definition) !==
-      expectedAppendGuardDigest ||
-    attestationDigest(attestation.attempt_guard_definition) !==
-      expectedAttemptGuardDigest
-  ) {
+  if (!transformed.rows[0]?.valid) {
     throw new Error(
-      "Migration 584 requires the externally administered matched-v4 evaluator schema. " +
+      "Migrations 584 and 585 require the externally administered transformed matched-v4 evaluator schema. " +
         "Run the protected evaluator bootstrap/control-plane job before the ordinary application migration.",
     );
   }
@@ -486,13 +305,26 @@ async function loadMigrations(): Promise<Migration[]> {
 async function createMigrationsTable(): Promise<void> {
   const pool = getPool();
 
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS schema_migrations (
-      version INTEGER PRIMARY KEY,
-      filename VARCHAR(255) NOT NULL,
-      applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS public.schema_migrations (
+        version INTEGER PRIMARY KEY,
+        filename VARCHAR(255) NOT NULL,
+        applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `);
+  } catch (error) {
+    // The matched-v4 runtime may resolve objects in public but must not create
+    // them. PostgreSQL checks schema CREATE even for CREATE TABLE IF NOT EXISTS
+    // when the relation already exists, so retain a DBA-created ledger without
+    // widening the runtime schema grant.
+    if ((error as { code?: string }).code !== "42501") throw error;
+    const existing = await pool.query<{ exists: boolean }>(
+      "SELECT to_regclass('public.schema_migrations') IS NOT NULL AS exists",
     );
-  `);
+    if (existing.rows?.[0]?.exists) return;
+    throw error;
+  }
 }
 
 /**
@@ -504,7 +336,7 @@ async function getAppliedMigrations(): Promise<
   const pool = getPool();
 
   const result = await pool.query<{ version: number; filename: string }>(
-    "SELECT version, filename FROM schema_migrations ORDER BY version",
+    "SELECT version, filename FROM public.schema_migrations ORDER BY version",
   );
 
   return result.rows;
@@ -521,7 +353,13 @@ async function applyMigration(migration: Migration): Promise<void> {
     await client.query("BEGIN");
     await client.query("SET LOCAL statement_timeout = 0");
 
-    if (migration.filename === MATCHED_V4_EXTERNAL_MIGRATION) {
+    if (MATCHED_V4_EXTERNAL_MIGRATIONS.has(migration.filename)) {
+      // Keep the exact catalog read and this migration's ledger record in the
+      // same cooperative serialization domain as protected evaluator
+      // DDL/admission.
+      await client.query("SELECT pg_advisory_xact_lock($1)", [
+        MATCHED_V4_EVALUATOR_LOCK_KEY,
+      ]);
       await validateMatchedV4ExternalSchema(client);
     } else {
       await client.query(migration.sql);
@@ -529,7 +367,7 @@ async function applyMigration(migration: Migration): Promise<void> {
 
     // Record migration
     await client.query(
-      "INSERT INTO schema_migrations (version, filename) VALUES ($1, $2)",
+      "INSERT INTO public.schema_migrations (version, filename) VALUES ($1, $2)",
       [migration.version, migration.filename],
     );
 
@@ -661,15 +499,13 @@ async function runMigrationsLocked(): Promise<void> {
   // Find pending migrations
   const pendingMigrations = migrations.filter((migration) => {
     if (appliedVersions.has(migration.version)) return false;
-    if (migration.filename !== MATCHED_V4_EXTERNAL_MIGRATION) return true;
+    if (!MATCHED_V4_EXTERNAL_MIGRATIONS.has(migration.filename)) return true;
     if (matchedV4EvaluatorSchemaRequired()) return true;
     // This is not an authorization control. It simply keeps evaluator-only
     // schema custody out of ordinary local/preview/application startup. The
     // protected release path sets the exact opt-in and performs the strict
     // full-catalog attestation in applyMigration before recording 584.
-    console.info(
-      `Skipping evaluator-only migration: ${MATCHED_V4_EXTERNAL_MIGRATION}`,
-    );
+    console.info(`Skipping evaluator-only migration: ${migration.filename}`);
     return false;
   });
 

--- a/server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
+++ b/server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql
@@ -1,0 +1,848 @@
+-- Replace migration 584's misleading per-response "settlement" vocabulary.
+-- A dated pricing profile is a local estimate; provider-authoritative billing
+-- remains an isolated-scope aggregate reconciliation outside this ledger.
+--
+-- This operator-only forward migration deliberately requires completely empty
+-- custody tables. No paid matched-v4 attempt or admission is authorized, so
+-- refusing to translate evidence is safer than relabelling it in place.
+DO $matched_v4_585$
+DECLARE old_shape BOOLEAN; transformed_shape BOOLEAN; attempts_count BIGINT;
+        admissions_count BIGINT; runs_count BIGINT; valid BOOLEAN;
+        existing_tables INTEGER; existing_functions INTEGER;
+        existing_triggers INTEGER; existing_relations INTEGER;
+        existing_attempt_guard_md5 TEXT;
+        existing_append_guard_md5 TEXT; actual_shape_md5 TEXT;
+        actual_function_md5 TEXT; actual_function_owner TEXT;
+        actual_function_security_definer BOOLEAN; actual_function_config TEXT[];
+        existing_trigger_shape_valid BOOLEAN; existing_constraint_trigger_shape_valid BOOLEAN;
+        existing_relation_shape_valid BOOLEAN;
+        existing_acl_valid BOOLEAN;
+        unexpected_trigger_count INTEGER; shape_expected RECORD;
+BEGIN
+  IF current_user <> 'addie_matched_v4_operator'
+    OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator' AND NOT rolcanlogin AND NOT rolinherit AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND NOT rolbypassrls)
+    OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_runtime' AND NOT rolcanlogin AND NOT rolinherit AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND NOT rolbypassrls)
+    OR pg_catalog.pg_has_role('addie_matched_v4_runtime', 'addie_matched_v4_operator', 'member')
+    -- The sealed static capabilities are leaves of the role graph. A static
+    -- role that can SET or inherit an elevated parent has a hidden privilege
+    -- path despite its own unprivileged role attributes.
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.member IN ('addie_matched_v4_operator'::regrole,'addie_matched_v4_runtime'::regrole))
+    -- The static roles are sealed custody capabilities, not merely names.
+    -- The migration login is the one non-inheriting SET member of operator;
+    -- runtime has exactly one inheriting, non-SET, non-admin app member.
+    -- This rejects hidden operator bridges before an admission can attest.
+    OR (SELECT count(*) FROM pg_catalog.pg_auth_members edge WHERE edge.roleid='addie_matched_v4_operator'::regrole) <> 1
+    OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge JOIN pg_catalog.pg_roles member_role ON member_role.oid=edge.member WHERE edge.roleid='addie_matched_v4_operator'::regrole AND edge.member=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=session_user) AND NOT edge.inherit_option AND edge.set_option AND NOT edge.admin_option AND member_role.rolcanlogin AND NOT member_role.rolinherit AND NOT member_role.rolsuper AND NOT member_role.rolcreatedb AND NOT member_role.rolcreaterole AND NOT member_role.rolreplication AND NOT member_role.rolbypassrls AND edge.grantor NOT IN (edge.roleid,edge.member,'addie_matched_v4_runtime'::regrole))
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.member=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=session_user) AND edge.roleid<>'addie_matched_v4_operator'::regrole)
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge WHERE edge.roleid=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=session_user))
+    OR (SELECT count(*) FROM pg_catalog.pg_auth_members edge WHERE edge.roleid='addie_matched_v4_runtime'::regrole) <> 1
+    OR NOT EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members edge JOIN pg_catalog.pg_roles member_role ON member_role.oid=edge.member WHERE edge.roleid='addie_matched_v4_runtime'::regrole AND edge.inherit_option AND NOT edge.set_option AND NOT edge.admin_option AND member_role.rolcanlogin AND member_role.rolinherit AND NOT member_role.rolsuper AND NOT member_role.rolcreatedb AND NOT member_role.rolcreaterole AND NOT member_role.rolreplication AND NOT member_role.rolbypassrls AND edge.grantor NOT IN (edge.roleid,edge.member,'addie_matched_v4_operator'::regrole,(SELECT oid FROM pg_catalog.pg_roles WHERE rolname=session_user)))
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge JOIN pg_catalog.pg_auth_members edge ON edge.member=bridge.member WHERE bridge.roleid='addie_matched_v4_runtime'::regrole AND edge.roleid<>'addie_matched_v4_runtime'::regrole)
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge JOIN pg_catalog.pg_auth_members edge ON edge.roleid=bridge.member WHERE bridge.roleid='addie_matched_v4_runtime'::regrole)
+    -- Trigger enforcement is session-sensitive. A persisted replica-mode
+    -- default on the sole runtime bridge would bypass custody guards and RI.
+    OR current_setting('session_replication_role') <> 'origin'
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge JOIN pg_catalog.pg_db_role_setting setting ON setting.setrole IN (0,bridge.member) CROSS JOIN LATERAL unnest(setting.setconfig) config WHERE bridge.roleid='addie_matched_v4_runtime'::regrole AND setting.setdatabase IN (0,(SELECT oid FROM pg_catalog.pg_database WHERE datname=current_database())) AND split_part(config,'=',1)='session_replication_role' AND split_part(config,'=',2)<>'origin')
+    OR pg_catalog.has_parameter_privilege('addie_matched_v4_runtime','session_replication_role','SET')
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge WHERE bridge.roleid='addie_matched_v4_runtime'::regrole AND pg_catalog.has_parameter_privilege(bridge.member,'session_replication_role','SET'))
+    -- A runtime bridge must not retain an independent public-object or TOAST
+    -- injection/read route outside the sealed static capability.
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_auth_members bridge WHERE bridge.roleid='addie_matched_v4_runtime'::regrole AND (NOT pg_catalog.has_schema_privilege(bridge.member,'public','USAGE') OR pg_catalog.has_schema_privilege(bridge.member,'public','CREATE') OR pg_catalog.has_schema_privilege(bridge.member,'pg_toast','USAGE') OR pg_catalog.has_schema_privilege(bridge.member,'pg_toast','CREATE'))) THEN
+    RAISE EXCEPTION 'matched-v4 585 requires the externally provisioned separated operator/runtime roles';
+  END IF;
+
+  old_shape := to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NOT NULL
+    AND to_regprocedure('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)') IS NULL;
+  transformed_shape := to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NULL
+    AND to_regprocedure('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)') IS NOT NULL;
+  IF NOT old_shape AND NOT transformed_shape THEN
+    RAISE EXCEPTION 'matched-v4 585 found a partial or tampered terminal-record API';
+  END IF;
+  -- READ COMMITTED obtains a fresh snapshot after the legacy transform's
+  -- ACCESS EXCLUSIVE lock. REPEATABLE READ could retain a pre-lock empty
+  -- snapshot and relabel a writer that committed while the lock waited.
+  IF old_shape AND current_setting('transaction_isolation') <> 'read committed' THEN
+    RAISE EXCEPTION 'matched-v4 585 legacy transformation requires READ COMMITTED isolation';
+  END IF;
+
+  -- The protected evaluator workflow takes this transaction lock on every
+  -- bootstrap, retry, and admission path. A transformed retry takes the
+  -- weakest relation lock that excludes table-shape DDL without blocking
+  -- ordinary evaluator DML. A legacy-shape transform instead takes ACCESS
+  -- EXCLUSIVE before its zero-evidence check: otherwise a pre-existing 584
+  -- runtime transaction could commit evidence while ALTER waits.
+  -- Function and ACL serialization depends on that trusted workflow.
+  PERFORM pg_catalog.pg_advisory_xact_lock(584585);
+  IF old_shape THEN
+    LOCK TABLE public.addie_matched_v4_private_runs,
+      public.addie_matched_v4_private_admissions,
+      public.addie_matched_v4_private_attempts IN ACCESS EXCLUSIVE MODE;
+  ELSE
+    LOCK TABLE public.addie_matched_v4_private_runs,
+      public.addie_matched_v4_private_admissions,
+      public.addie_matched_v4_private_attempts IN ACCESS SHARE MODE;
+  END IF;
+
+  IF old_shape THEN
+    -- Migration 584 deliberately fails closed on a retry. Repeat that full
+    -- catalog attestation here before any ALTER or CREATE OR REPLACE: a
+    -- forward migration must never repair an incomplete or altered old shape.
+  SELECT count(*) INTO existing_tables FROM (VALUES
+    (to_regclass('public.addie_matched_v4_private_runs')),
+    (to_regclass('public.addie_matched_v4_private_admissions')),
+    (to_regclass('public.addie_matched_v4_private_attempts'))
+  ) AS expected(oid) WHERE oid IS NOT NULL;
+  SELECT count(*) INTO existing_functions FROM (VALUES
+    (to_regprocedure('public.addie_matched_v4_private_attempt_guard()')),
+    (to_regprocedure('public.addie_matched_v4_private_append_only_guard()')),
+    (to_regprocedure('public.addie_matched_v4_private_reserve(text,text,text,integer)')),
+    (to_regprocedure('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)')),
+    (to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)')),
+    (to_regprocedure('public.addie_matched_v4_private_reconcile(text)')),
+    (to_regprocedure('public.addie_matched_v4_private_halt(text,text)')),
+    (to_regprocedure('public.addie_matched_v4_private_claim_admission(text,text,text)'))
+  ) AS expected(oid) WHERE oid IS NOT NULL;
+  -- Tables and their reviewed physical indexes are one exact namespace set.
+  -- Counting every pg_class kind closes the otherwise invisible view,
+  -- sequence, and partition shadow-object paths.
+  SELECT count(*) INTO existing_relations
+  FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public' AND c.relname LIKE 'addie_matched_v4_private_%';
+  SELECT NOT EXISTS (
+    SELECT 1 FROM (VALUES
+      ('addie_matched_v4_private_runs','r'::"char"),
+      ('addie_matched_v4_private_runs_pkey','i'::"char"),
+      ('addie_matched_v4_private_admissions','r'::"char"),
+      ('addie_matched_v4_private_admissions_pkey','i'::"char"),
+      ('addie_matched_v4_private_admi_merge_sha_authority_manifest__key','i'::"char"),
+      ('addie_matched_v4_private_attempts','r'::"char"),
+      ('addie_matched_v4_private_attempts_pkey','i'::"char"),
+      ('addie_matched_v4_private_attempts_reservation_id_ordinal_key','i'::"char")
+    ) AS expected(name,relkind)
+    WHERE to_regclass('public.' || expected.name) IS NULL
+      OR (SELECT c.relkind FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> expected.relkind
+      OR (SELECT c.relpersistence FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> 'p'
+      OR (expected.relkind='r'::"char" AND (SELECT c.relrowsecurity OR c.relforcerowsecurity OR c.relhasrules OR c.relispartition FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)))
+      OR (SELECT pg_catalog.pg_get_userbyid(c.relowner) FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> 'addie_matched_v4_operator'
+      OR (expected.relkind='i'::"char" AND (SELECT c.relacl FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) IS NOT NULL)
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_policy p
+    WHERE p.polrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_rewrite r
+    WHERE r.ev_class IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+      AND r.rulename <> '_RETURN'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_rewrite r
+    JOIN pg_catalog.pg_depend d ON d.classid='pg_rewrite'::regclass AND d.objid=r.oid
+    WHERE r.ev_class NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+      AND d.refobjid IN (
+        SELECT c.oid FROM pg_catalog.pg_class c
+        WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        UNION ALL
+        SELECT c.reltoastrelid FROM pg_catalog.pg_class c
+        WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+          AND c.reltoastrelid <> 0
+      )
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_inherits i
+    WHERE i.inhrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+      OR i.inhparent IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+  ) INTO existing_relation_shape_valid;
+  -- A foreign key is enforced by internal RI triggers rather than table DDL
+  -- alone. Its constraint definition may still hash canonically after one is
+  -- disabled, so retry attestation pins all involved trigger states too.
+  -- Pin the complete RI-trigger structure, not merely enabled state. An
+  -- incoming foreign key on an unrelated table creates extra internal
+  -- triggers on these tables and must invalidate the sealed namespace.
+  SELECT
+    (SELECT count(*) FROM pg_catalog.pg_trigger t
+      JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint
+      WHERE t.tgisinternal AND t.tgconstraint <> 0
+        AND (c.conrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+          OR c.confrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))) = 4
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_trigger t
+      JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint
+      JOIN pg_catalog.pg_proc p ON p.oid=t.tgfoid
+      WHERE t.tgisinternal AND t.tgconstraint <> 0
+        AND (c.conrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+          OR c.confrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND NOT EXISTS (
+          SELECT 1 FROM (VALUES
+            ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_restrict_del',9),
+            ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_noaction_upd',17),
+            ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_ins',5),
+            ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_upd',17)
+          ) AS expected(constraint_name,source_table,target_table,trigger_table,procedure_name,trigger_type)
+          WHERE c.conname=expected.constraint_name
+            AND c.conrelid=to_regclass('public.' || expected.source_table)
+            AND c.confrelid=to_regclass('public.' || expected.target_table)
+            AND t.tgrelid=to_regclass('public.' || expected.trigger_table)
+            AND p.pronamespace='pg_catalog'::regnamespace
+            AND p.proname=expected.procedure_name
+            AND t.tgtype=expected.trigger_type AND t.tgenabled='O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea
+        )
+    ) INTO existing_constraint_trigger_shape_valid;
+  SELECT count(*) INTO existing_triggers FROM pg_catalog.pg_trigger
+    WHERE NOT tgisinternal AND tgname IN (
+      'addie_matched_v4_private_attempt_guard',
+      'addie_matched_v4_private_runs_append_only_guard',
+      'addie_matched_v4_private_admissions_append_only_guard',
+      'addie_matched_v4_private_attempts_append_only_guard'
+    );
+  -- A retry must attest trigger identity and executable shape before any
+  -- CREATE/DROP statement. Counting familiar names is not enough: a disabled
+  -- guard, an inert WHEN clause, or an UPDATE-only lookalike would otherwise
+  -- be "repaired" and conceal an interrupted or tampered custody boundary.
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_trigger t
+      JOIN pg_catalog.pg_proc p ON p.oid = t.tgfoid
+      WHERE t.tgname = 'addie_matched_v4_private_attempt_guard'
+        AND t.tgrelid = to_regclass('public.addie_matched_v4_private_attempts')
+        AND p.oid = to_regprocedure('public.addie_matched_v4_private_attempt_guard()')
+        -- ROW | BEFORE | INSERT | UPDATE | DELETE
+        AND t.tgtype = 31 AND t.tgenabled = 'O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea
+        AND NOT t.tgisinternal
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM (VALUES
+        ('public.addie_matched_v4_private_runs'::text,
+         'addie_matched_v4_private_runs_append_only_guard'::text),
+        ('public.addie_matched_v4_private_admissions'::text,
+         'addie_matched_v4_private_admissions_append_only_guard'::text),
+        ('public.addie_matched_v4_private_attempts'::text,
+         'addie_matched_v4_private_attempts_append_only_guard'::text)
+      ) AS retry_expected(table_name, trigger_name)
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_trigger t
+        JOIN pg_catalog.pg_proc p ON p.oid = t.tgfoid
+        WHERE t.tgname = retry_expected.trigger_name
+          AND t.tgrelid = to_regclass(retry_expected.table_name)
+          AND p.oid = to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
+          -- ROW | BEFORE | DELETE
+          AND t.tgtype = 11 AND t.tgenabled = 'O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea
+          AND NOT t.tgisinternal
+      )
+    ) INTO existing_trigger_shape_valid;
+  -- The retry path has the same exact trigger-set requirement as the runtime
+  -- attestation. A familiar set of names plus an extra mutable trigger is not
+  -- a complete schema: it can rewrite a reservation or attempt before the
+  -- reviewed guards run.
+  SELECT count(*) INTO unexpected_trigger_count
+  FROM pg_catalog.pg_trigger actual
+  WHERE NOT actual.tgisinternal
+    AND actual.tgrelid IN (
+      to_regclass('public.addie_matched_v4_private_runs'),
+      to_regclass('public.addie_matched_v4_private_admissions'),
+      to_regclass('public.addie_matched_v4_private_attempts')
+    )
+    AND NOT (
+      (actual.tgrelid = to_regclass('public.addie_matched_v4_private_attempts')
+        AND actual.tgname = 'addie_matched_v4_private_attempt_guard'
+        AND actual.tgfoid = to_regprocedure('public.addie_matched_v4_private_attempt_guard()')
+        AND actual.tgtype = 31 AND actual.tgenabled = 'O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea)
+      OR
+      (actual.tgrelid = to_regclass('public.addie_matched_v4_private_runs')
+        AND actual.tgname = 'addie_matched_v4_private_runs_append_only_guard'
+        AND actual.tgfoid = to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
+        AND actual.tgtype = 11 AND actual.tgenabled = 'O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea)
+      OR
+      (actual.tgrelid = to_regclass('public.addie_matched_v4_private_admissions')
+        AND actual.tgname = 'addie_matched_v4_private_admissions_append_only_guard'
+        AND actual.tgfoid = to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
+        AND actual.tgtype = 11 AND actual.tgenabled = 'O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea)
+      OR
+      (actual.tgrelid = to_regclass('public.addie_matched_v4_private_attempts')
+        AND actual.tgname = 'addie_matched_v4_private_attempts_append_only_guard'
+        AND actual.tgfoid = to_regprocedure('public.addie_matched_v4_private_append_only_guard()')
+        AND actual.tgtype = 11 AND actual.tgenabled = 'O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea)
+    );
+  SELECT md5(pg_get_functiondef(to_regprocedure('public.addie_matched_v4_private_attempt_guard()')))
+    INTO existing_attempt_guard_md5;
+  SELECT md5(pg_get_functiondef(to_regprocedure('public.addie_matched_v4_private_append_only_guard()')))
+    INTO existing_append_guard_md5;
+  IF existing_tables <> 3 OR existing_relations <> 8
+    OR (SELECT count(*) FROM pg_catalog.pg_class WHERE relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')) <> 14
+    OR EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') AND c.oid NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_runs_pkey'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_admissions_pkey'),to_regclass('public.addie_matched_v4_private_admi_merge_sha_authority_manifest__key'),to_regclass('public.addie_matched_v4_private_attempts'),to_regclass('public.addie_matched_v4_private_attempts_pkey'),to_regclass('public.addie_matched_v4_private_attempts_reservation_id_ordinal_key')) AND c.oid NOT IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))))
+    OR existing_relation_shape_valid IS NOT TRUE
+    OR existing_functions <> 8 OR existing_triggers <> 4
+    OR existing_constraint_trigger_shape_valid IS NOT TRUE
+    OR (SELECT count(*) FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
+        WHERE n.nspname='public' AND p.proname LIKE 'addie_matched_v4_private_%') <> 8
+    OR (SELECT count(*) FROM pg_catalog.pg_proc WHERE proowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')) <> 8
+    OR unexpected_trigger_count <> 0
+    OR existing_trigger_shape_valid IS NOT TRUE
+    OR existing_attempt_guard_md5 <> 'cdba27677dbbbbdfa59db5988b1681fc'
+    OR existing_append_guard_md5 <> 'b66c0828506e4785edf27b41190c3ed9' THEN
+    RAISE EXCEPTION 'matched-v4 evaluator schema is partial or invalid; restore the externally administered schema before retrying migration 584';
+  END IF;
+
+  -- `CREATE TABLE IF NOT EXISTS` and `CREATE OR REPLACE FUNCTION` are not a
+  -- repair mechanism. On retry, attest every reviewer-visible table component
+  -- before touching any object: ordered columns/types/nullability/defaults,
+  -- named constraints, and every physical index. This deliberately catches a
+  -- lookalike relation, a missing CHECK, or an added index as malformed state.
+  FOR shape_expected IN SELECT * FROM (VALUES
+    ('addie_matched_v4_private_admissions', '4ed0c46ae7eaee829b967b8c8eeb1996'),
+    ('addie_matched_v4_private_attempts', '985534c4e9f7d0d78e8fe6a885816926'),
+    ('addie_matched_v4_private_runs', '16a018c611239801d31c7855ca8c1a28')
+  ) AS shapes(name, shape_md5) LOOP
+    SELECT md5((jsonb_build_object(
+      'table', c.relname, 'relkind', c.relkind,
+      'columns', (SELECT jsonb_agg(jsonb_build_object(
+        'ordinal', a.attnum, 'name', a.attname,
+        'type', pg_catalog.format_type(a.atttypid, a.atttypmod),
+        'notNull', a.attnotnull,
+        'default', COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), ''),
+        'collation', CASE WHEN a.attcollation=0 THEN NULL ELSE (SELECT n.nspname || '.' || co.collname FROM pg_catalog.pg_collation co JOIN pg_catalog.pg_namespace n ON n.oid=co.collnamespace WHERE co.oid=a.attcollation) END,
+        'identity', a.attidentity, 'generated', a.attgenerated
+      ) ORDER BY a.attnum)
+        FROM pg_catalog.pg_attribute a
+        LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid=a.attrelid AND d.adnum=a.attnum
+        WHERE a.attrelid=c.oid AND a.attnum > 0 AND NOT a.attisdropped),
+      'constraints', (SELECT jsonb_agg(jsonb_build_object(
+        'name', x.conname, 'type', x.contype,
+        'definition', pg_catalog.pg_get_constraintdef(x.oid, true)
+      ) ORDER BY x.conname) FROM pg_catalog.pg_constraint x WHERE x.conrelid=c.oid),
+      'indexes', (SELECT jsonb_agg(jsonb_build_object(
+        'name', ci.relname,
+        'definition', pg_catalog.pg_get_indexdef(i.indexrelid, 0, true)
+      ) ORDER BY ci.relname) FROM pg_catalog.pg_index i
+      JOIN pg_catalog.pg_class ci ON ci.oid=i.indexrelid WHERE i.indrelid=c.oid)
+    )::text)), pg_catalog.pg_get_userbyid(c.relowner)
+    INTO actual_shape_md5, actual_function_owner
+    FROM pg_catalog.pg_class c
+    WHERE c.oid = to_regclass('public.' || shape_expected.name);
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid=to_regclass('public.' || shape_expected.name) AND a.attnum>0 AND a.attisdropped)
+      OR actual_shape_md5 IS DISTINCT FROM shape_expected.shape_md5
+      OR actual_function_owner <> 'addie_matched_v4_operator' THEN
+      RAISE EXCEPTION 'matched-v4 evaluator table shape is malformed; refuse bootstrap retry';
+    END IF;
+  END LOOP;
+
+  -- Pin all eight function definitions on a retry. The six callable APIs
+  -- must be SECURITY DEFINER with exactly SET search_path = pg_catalog; the
+  -- trigger guards must remain invoker functions without configuration.
+  FOR shape_expected IN SELECT * FROM (VALUES
+    ('public.addie_matched_v4_private_attempt_guard()', 'cdba27677dbbbbdfa59db5988b1681fc', false),
+    ('public.addie_matched_v4_private_append_only_guard()', 'b66c0828506e4785edf27b41190c3ed9', false),
+    ('public.addie_matched_v4_private_reserve(text,text,text,integer)', 'a246e0fa7b05238e52f384138ec99047', true),
+    ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)', '85c35d25f690969ed336fe7a9e30115d', true),
+    ('public.addie_matched_v4_private_settle(text,text,text,text,bigint)', 'b0a13ae1f175fa97ee751b70da68e378', true),
+    ('public.addie_matched_v4_private_reconcile(text)', 'd0fc5263623f248ba1d1957f1127fd68', true),
+    ('public.addie_matched_v4_private_halt(text,text)', '2d35d780d2279dc302db1bc27967c8f9', true),
+    ('public.addie_matched_v4_private_claim_admission(text,text,text)', '4db729c5722fd978efebf52ace62bb6a', true)
+  ) AS functions(signature, definition_md5, security_definer) LOOP
+    SELECT md5(pg_catalog.pg_get_functiondef(p.oid)),
+      pg_catalog.pg_get_userbyid(p.proowner), p.prosecdef, p.proconfig
+    INTO actual_function_md5, actual_function_owner,
+      actual_function_security_definer, actual_function_config
+    FROM pg_catalog.pg_proc p
+    WHERE p.oid = to_regprocedure(shape_expected.signature);
+    IF actual_function_md5 IS DISTINCT FROM shape_expected.definition_md5
+      OR actual_function_owner <> 'addie_matched_v4_operator'
+      OR actual_function_security_definer IS DISTINCT FROM shape_expected.security_definer
+      OR (shape_expected.security_definer AND actual_function_config IS DISTINCT FROM ARRAY['search_path=pg_catalog'])
+      OR (NOT shape_expected.security_definer AND actual_function_config IS NOT NULL) THEN
+      RAISE EXCEPTION 'matched-v4 evaluator function definition is malformed; refuse bootstrap retry';
+    END IF;
+  END LOOP;
+
+  -- A complete retry is a read-only attestation, not an opportunity to
+  -- silently repair grants.  The runtime API and PUBLIC revocations are as
+  -- much evaluator custody as the relation definitions: accepting a direct
+  -- table grant or a PUBLIC callable function would make a retry conceal a
+  -- production bypass.
+  SELECT
+    pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'USAGE')
+    AND pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'CREATE')
+    AND pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'USAGE')
+    AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'CREATE')
+    AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'pg_toast', 'USAGE,CREATE')
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_namespace n
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(n.nspacl,pg_catalog.acldefault('n',n.nspowner))) acl
+      WHERE n.nspname='public' AND acl.grantee=0 AND acl.privilege_type='CREATE'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_class c
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl
+      WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND (acl.grantee<>c.relowner OR acl.grantor<>c.relowner OR acl.is_grantable)
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_class c
+      WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND (SELECT count(*) FROM pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner)))) <> 7
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_attribute a
+      WHERE a.attrelid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND a.attnum>0 AND NOT a.attisdropped AND a.attacl IS NOT NULL
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM (VALUES
+        (to_regclass('public.addie_matched_v4_private_runs')),
+        (to_regclass('public.addie_matched_v4_private_admissions')),
+        (to_regclass('public.addie_matched_v4_private_attempts'))
+      ) AS tables(oid),
+      unnest(ARRAY['SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER']) AS privilege
+      WHERE pg_catalog.has_table_privilege('addie_matched_v4_runtime', tables.oid, privilege)
+         OR EXISTS (
+           SELECT 1 FROM pg_catalog.aclexplode(
+             COALESCE((SELECT c.relacl FROM pg_catalog.pg_class c WHERE c.oid = tables.oid),
+                      pg_catalog.acldefault('r', (SELECT c.relowner FROM pg_catalog.pg_class c WHERE c.oid = tables.oid)))
+           ) acl WHERE acl.grantee = 0
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_proc p
+      WHERE p.oid IN (
+        to_regprocedure('public.addie_matched_v4_private_attempt_guard()'),
+        to_regprocedure('public.addie_matched_v4_private_append_only_guard()'),
+        to_regprocedure('public.addie_matched_v4_private_reserve(text,text,text,integer)'),
+        to_regprocedure('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)'),
+        to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)'),
+        to_regprocedure('public.addie_matched_v4_private_reconcile(text)'),
+        to_regprocedure('public.addie_matched_v4_private_halt(text,text)'),
+        to_regprocedure('public.addie_matched_v4_private_claim_admission(text,text,text)')
+      )
+      AND EXISTS (
+        SELECT 1 FROM pg_catalog.aclexplode(COALESCE(p.proacl, pg_catalog.acldefault('f', p.proowner))) acl
+        WHERE acl.grantee = 0
+      )
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM (VALUES
+        (to_regclass('public.addie_matched_v4_private_runs')),
+        (to_regclass('public.addie_matched_v4_private_admissions')),
+        (to_regclass('public.addie_matched_v4_private_attempts'))
+      ) AS tables(oid)
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(
+        (SELECT c.relacl FROM pg_catalog.pg_class c WHERE c.oid=tables.oid),
+        pg_catalog.acldefault('r', (SELECT c.relowner FROM pg_catalog.pg_class c WHERE c.oid=tables.oid))
+      )) acl
+      WHERE acl.grantee <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+        OR acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+        OR acl.is_grantable
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        (to_regclass('public.addie_matched_v4_private_runs')),
+        (to_regclass('public.addie_matched_v4_private_admissions')),
+        (to_regclass('public.addie_matched_v4_private_attempts'))
+      ) AS tables(oid)
+      WHERE (SELECT count(*) FROM pg_catalog.pg_class c CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl WHERE c.oid=tables.oid) <> 7
+    )
+    -- Table ACLs do not cover per-column grants. No evaluator column may
+    -- have an explicit ACL, including one to the otherwise unprivileged
+    -- runtime role.
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_attribute a
+      WHERE a.attrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        AND a.attnum > 0 AND NOT a.attisdropped AND (
+          a.attacl IS NOT NULL
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'SELECT')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'INSERT')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'UPDATE')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'REFERENCES')
+        )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_proc p
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl
+      WHERE p.oid IN (
+        to_regprocedure('public.addie_matched_v4_private_attempt_guard()'),
+        to_regprocedure('public.addie_matched_v4_private_append_only_guard()'),
+        to_regprocedure('public.addie_matched_v4_private_reserve(text,text,text,integer)'),
+        to_regprocedure('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)'),
+        to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)'),
+        to_regprocedure('public.addie_matched_v4_private_reconcile(text)'),
+        to_regprocedure('public.addie_matched_v4_private_halt(text,text)'),
+        to_regprocedure('public.addie_matched_v4_private_claim_admission(text,text,text)')
+      ) AND (
+        acl.grantee NOT IN (
+          (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator'),
+          (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_runtime')
+        ) OR acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+          OR acl.is_grantable
+      )
+    )
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_reserve(text,text,text,integer)'), 'EXECUTE')
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)'), 'EXECUTE')
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)'), 'EXECUTE')
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_reconcile(text)'), 'EXECUTE')
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_halt(text,text)'), 'EXECUTE')
+    AND pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_claim_admission(text,text,text)'), 'EXECUTE')
+    AND NOT pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_attempt_guard()'), 'EXECUTE')
+    AND NOT pg_catalog.has_function_privilege('addie_matched_v4_runtime', to_regprocedure('public.addie_matched_v4_private_append_only_guard()'), 'EXECUTE')
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('public.addie_matched_v4_private_attempt_guard()',false),
+        ('public.addie_matched_v4_private_append_only_guard()',false),
+        ('public.addie_matched_v4_private_reserve(text,text,text,integer)',true),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)',true),
+        ('public.addie_matched_v4_private_settle(text,text,text,text,bigint)',true),
+        ('public.addie_matched_v4_private_reconcile(text)',true),
+        ('public.addie_matched_v4_private_halt(text,text)',true),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)',true)
+      ) AS expected(signature,runtime_execute)
+      WHERE (SELECT count(*) FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(expected.signature)) <> CASE WHEN expected.runtime_execute THEN 2 ELSE 1 END
+    )
+  INTO existing_acl_valid;
+  IF existing_acl_valid IS NOT TRUE THEN
+    RAISE EXCEPTION 'matched-v4 evaluator ACL is malformed; refuse bootstrap retry';
+  END IF;
+
+    SELECT count(*) INTO attempts_count FROM public.addie_matched_v4_private_attempts;
+    SELECT count(*) INTO admissions_count FROM public.addie_matched_v4_private_admissions;
+    SELECT count(*) INTO runs_count FROM public.addie_matched_v4_private_runs;
+    IF attempts_count <> 0 OR admissions_count <> 0 OR runs_count <> 0 THEN
+      RAISE EXCEPTION 'matched-v4 585 refuses to relabel existing custody evidence (attempts %, admissions %, runs %)', attempts_count, admissions_count, runs_count;
+    END IF;
+
+    ALTER TABLE public.addie_matched_v4_private_attempts
+      DROP CONSTRAINT addie_matched_v4_private_attempts_status_check,
+      DROP CONSTRAINT addie_matched_v4_private_attempts_cost_microdollars_check,
+      DROP CONSTRAINT addie_matched_v4_private_attempts_check;
+    ALTER TABLE public.addie_matched_v4_private_attempts
+      RENAME COLUMN cost_microdollars TO estimated_cost_microdollars;
+    ALTER TABLE public.addie_matched_v4_private_attempts
+      RENAME COLUMN settled_at TO terminal_recorded_at;
+    ALTER TABLE public.addie_matched_v4_private_attempts
+      ADD CONSTRAINT addie_matched_v4_private_attempts_status_check
+        CHECK (status IN ('intent_recorded', 'response_usage_recorded', 'unknown_exposure')),
+      ADD CONSTRAINT addie_matched_v4_private_attempts_estimated_cost_check
+        CHECK (estimated_cost_microdollars >= 0),
+      ADD CONSTRAINT addie_matched_v4_private_attempts_terminal_recording_check
+        CHECK ((status = 'intent_recorded' AND response_sha256 IS NULL AND estimated_cost_microdollars IS NULL AND terminal_recorded_at IS NULL)
+          OR (status = 'response_usage_recorded' AND response_sha256 IS NOT NULL AND estimated_cost_microdollars IS NOT NULL AND terminal_recorded_at IS NOT NULL)
+          OR (status = 'unknown_exposure' AND response_sha256 IS NULL AND estimated_cost_microdollars IS NULL AND terminal_recorded_at IS NOT NULL));
+
+    CREATE OR REPLACE FUNCTION public.addie_matched_v4_private_attempt_guard() RETURNS trigger LANGUAGE plpgsql AS $attempt_source$DECLARE run_status TEXT; run_cap INTEGER; already_count INTEGER;
+BEGIN
+  -- Recording a response/usage or unknown exposure remains legal after halt:
+  -- it closes an already ledgered intent and never authorizes a dispatch.
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.status <> 'intent_recorded' OR NEW.status NOT IN ('response_usage_recorded', 'unknown_exposure')
+      OR NEW.reservation_id <> OLD.reservation_id OR NEW.attempt_id <> OLD.attempt_id
+      OR NEW.assignment_id <> OLD.assignment_id OR NEW.ordinal <> OLD.ordinal
+      OR NEW.request_sha256 <> OLD.request_sha256 OR NEW.dispatched_at <> OLD.dispatched_at
+      OR NEW.service_tier <> OLD.service_tier OR NEW.pricing_profile_id <> OLD.pricing_profile_id
+      OR NEW.pricing_profile_sha256 <> OLD.pricing_profile_sha256 THEN
+      RAISE EXCEPTION 'matched-v4 attempt is immutable';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'matched-v4 attempt custody is append-only'; END IF;
+  SELECT status, dispatch_cap INTO run_status, run_cap FROM public.addie_matched_v4_private_runs WHERE reservation_id = NEW.reservation_id FOR UPDATE;
+  IF run_status IS DISTINCT FROM 'reserved' THEN RAISE EXCEPTION 'matched-v4 run is not dispatchable'; END IF;
+  SELECT count(*) INTO already_count FROM public.addie_matched_v4_private_attempts WHERE reservation_id = NEW.reservation_id;
+  IF already_count >= run_cap THEN RAISE EXCEPTION 'matched-v4 dispatch cap exhausted'; END IF;
+  RETURN NEW;
+END$attempt_source$;
+    REVOKE ALL ON FUNCTION public.addie_matched_v4_private_settle(TEXT,TEXT,TEXT,TEXT,BIGINT) FROM PUBLIC, addie_matched_v4_runtime;
+    DROP FUNCTION public.addie_matched_v4_private_settle(TEXT,TEXT,TEXT,TEXT,BIGINT);
+    CREATE FUNCTION public.addie_matched_v4_private_record_response_usage(TEXT,TEXT,TEXT,TEXT,BIGINT) RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $record_source$BEGIN
+  UPDATE public.addie_matched_v4_private_attempts
+    SET status=$3,response_sha256=$4,estimated_cost_microdollars=$5,terminal_recorded_at=clock_timestamp()
+    WHERE reservation_id=$1 AND attempt_id=$2 AND status='intent_recorded';
+  RETURN FOUND;
+END$record_source$;
+    CREATE OR REPLACE FUNCTION public.addie_matched_v4_private_reconcile(TEXT) RETURNS BOOLEAN
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog AS $reconcile_source$DECLARE exists_run BOOLEAN;
+BEGIN
+  UPDATE public.addie_matched_v4_private_attempts
+    SET status='unknown_exposure',response_sha256=NULL,estimated_cost_microdollars=NULL,terminal_recorded_at=clock_timestamp()
+    WHERE reservation_id=$1 AND status='intent_recorded';
+  SELECT EXISTS(SELECT 1 FROM public.addie_matched_v4_private_runs WHERE reservation_id=$1) INTO exists_run;
+  RETURN exists_run;
+END$reconcile_source$;
+    REVOKE ALL ON FUNCTION public.addie_matched_v4_private_attempt_guard(), public.addie_matched_v4_private_append_only_guard(), public.addie_matched_v4_private_reserve(TEXT,TEXT,TEXT,INTEGER), public.addie_matched_v4_private_intent(TEXT,TEXT,TEXT,INTEGER,TEXT,TIMESTAMPTZ,TEXT,TEXT,TEXT), public.addie_matched_v4_private_record_response_usage(TEXT,TEXT,TEXT,TEXT,BIGINT), public.addie_matched_v4_private_reconcile(TEXT), public.addie_matched_v4_private_halt(TEXT,TEXT), public.addie_matched_v4_private_claim_admission(TEXT,TEXT,TEXT) FROM PUBLIC;
+    GRANT EXECUTE ON FUNCTION public.addie_matched_v4_private_reserve(TEXT,TEXT,TEXT,INTEGER), public.addie_matched_v4_private_intent(TEXT,TEXT,TEXT,INTEGER,TEXT,TIMESTAMPTZ,TEXT,TEXT,TEXT), public.addie_matched_v4_private_record_response_usage(TEXT,TEXT,TEXT,TEXT,BIGINT), public.addie_matched_v4_private_reconcile(TEXT), public.addie_matched_v4_private_halt(TEXT,TEXT), public.addie_matched_v4_private_claim_admission(TEXT,TEXT,TEXT) TO addie_matched_v4_runtime;
+  END IF;
+
+  -- On transformed schemas this is a read-only, exact catalog attestation.
+  -- It is deliberately run again in the admission transaction by the protected
+  -- workflow: no admission may be inserted after an unchecked schema change.
+  SELECT
+    pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'USAGE')
+    AND pg_catalog.has_schema_privilege('addie_matched_v4_operator', 'public', 'CREATE')
+    AND pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'USAGE')
+    AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'public', 'CREATE')
+    AND NOT pg_catalog.has_schema_privilege('addie_matched_v4_runtime', 'pg_toast', 'USAGE,CREATE')
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_namespace n
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(n.nspacl,pg_catalog.acldefault('n',n.nspowner))) acl
+      WHERE n.nspname='public' AND acl.grantee=0 AND acl.privilege_type='CREATE'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_class c
+      CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl
+      WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND (acl.grantee<>c.relowner OR acl.grantor<>c.relowner OR acl.is_grantable)
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_class c
+      WHERE c.oid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND (SELECT count(*) FROM pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner)))) <> 7
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_attribute a
+      WHERE a.attrelid IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND a.attnum>0 AND NOT a.attisdropped AND a.attacl IS NOT NULL
+    )
+    -- The three reviewed custody tables and their five physical indexes are
+    -- the complete prefixed relation set. This also rejects shadow views,
+    -- sequences, and partitions before any admission can be inserted.
+    AND (SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace
+      WHERE n.nspname='public' AND c.relname LIKE 'addie_matched_v4_private_%') = 8
+    -- The dedicated operator owns only the eight reviewed relations plus the
+    -- three automatically-created TOAST relations and their indexes. This
+    -- closes arbitrary-name views and helper APIs that could otherwise route
+    -- around the prefixed custody-object inventory.
+    AND (SELECT count(*) FROM pg_catalog.pg_class WHERE relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')) = 14
+    AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.relowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator') AND c.oid NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_runs_pkey'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_admissions_pkey'),to_regclass('public.addie_matched_v4_private_admi_merge_sha_authority_manifest__key'),to_regclass('public.addie_matched_v4_private_attempts'),to_regclass('public.addie_matched_v4_private_attempts_pkey'),to_regclass('public.addie_matched_v4_private_attempts_reservation_id_ordinal_key')) AND c.oid NOT IN (SELECT t.reltoastrelid FROM pg_catalog.pg_class t WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) UNION ALL SELECT i.indexrelid FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class t ON t.reltoastrelid=i.indrelid WHERE t.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))))
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_runs','r'::"char"),
+        ('addie_matched_v4_private_runs_pkey','i'::"char"),
+        ('addie_matched_v4_private_admissions','r'::"char"),
+        ('addie_matched_v4_private_admissions_pkey','i'::"char"),
+        ('addie_matched_v4_private_admi_merge_sha_authority_manifest__key','i'::"char"),
+        ('addie_matched_v4_private_attempts','r'::"char"),
+        ('addie_matched_v4_private_attempts_pkey','i'::"char"),
+        ('addie_matched_v4_private_attempts_reservation_id_ordinal_key','i'::"char")
+      ) AS expected(name,relkind)
+      WHERE to_regclass('public.' || expected.name) IS NULL
+        OR (SELECT c.relkind FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> expected.relkind
+        OR (SELECT c.relpersistence FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> 'p'
+        OR (expected.relkind='r'::"char" AND (SELECT c.relrowsecurity OR c.relforcerowsecurity OR c.relhasrules OR c.relispartition FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)))
+        OR (SELECT pg_catalog.pg_get_userbyid(c.relowner) FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) <> 'addie_matched_v4_operator'
+        OR (expected.relkind='i'::"char" AND (SELECT c.relacl FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)) IS NOT NULL)
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_policy p
+      WHERE p.polrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_rewrite r
+      WHERE r.ev_class IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        AND r.rulename <> '_RETURN'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_rewrite r
+      JOIN pg_catalog.pg_depend d ON d.classid='pg_rewrite'::regclass AND d.objid=r.oid
+      WHERE r.ev_class NOT IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+      AND d.refobjid IN (
+        SELECT c.oid FROM pg_catalog.pg_class c
+        WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        UNION ALL
+        SELECT c.reltoastrelid FROM pg_catalog.pg_class c
+        WHERE c.oid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+          AND c.reltoastrelid <> 0
+      )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_inherits i
+      WHERE i.inhrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        OR i.inhparent IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_runs'),
+        ('addie_matched_v4_private_admissions'),
+        ('addie_matched_v4_private_attempts')
+      ) AS expected(name)
+      LEFT JOIN pg_catalog.pg_class c ON c.oid=to_regclass('public.' || expected.name)
+      WHERE c.oid IS NULL
+        OR pg_catalog.pg_get_userbyid(c.relowner) <> 'addie_matched_v4_operator'
+        OR EXISTS (
+          SELECT 1 FROM pg_catalog.aclexplode(COALESCE(c.relacl,pg_catalog.acldefault('r',c.relowner))) acl
+          WHERE acl.grantee <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+            OR acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+            OR acl.is_grantable
+        )
+        OR (SELECT count(*) FROM pg_catalog.pg_class source CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(source.relacl,pg_catalog.acldefault('r',source.relowner))) acl WHERE source.oid=c.oid) <> 7
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_attribute a
+      WHERE a.attrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        AND a.attnum > 0 AND NOT a.attisdropped AND (
+          a.attacl IS NOT NULL
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'SELECT')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'INSERT')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'UPDATE')
+          OR pg_catalog.has_column_privilege('addie_matched_v4_runtime',a.attrelid,a.attnum,'REFERENCES')
+        )
+    )
+    -- Full canonical catalog projection: every ordered column (including
+    -- collation and identity/generated state), named constraint, and physical
+    -- index is pinned for all three relations; dropped slots are rejected.
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_admissions', '4ed0c46ae7eaee829b967b8c8eeb1996'),
+        ('addie_matched_v4_private_attempts', '8dc693482e69a981110ffa1c547b1f69'),
+        ('addie_matched_v4_private_runs', '16a018c611239801d31c7855ca8c1a28')
+      ) AS expected(name, shape_md5)
+      WHERE expected.shape_md5 IS DISTINCT FROM (
+        SELECT md5((jsonb_build_object(
+          'table', c.relname, 'relkind', c.relkind,
+          'columns', (SELECT jsonb_agg(jsonb_build_object(
+            'ordinal', a.attnum, 'name', a.attname,
+            'type', pg_catalog.format_type(a.atttypid,a.atttypmod),
+            'notNull', a.attnotnull,
+            'default', COALESCE(pg_catalog.pg_get_expr(d.adbin,d.adrelid),''),
+            'collation', CASE WHEN a.attcollation=0 THEN NULL ELSE (SELECT n.nspname || '.' || co.collname FROM pg_catalog.pg_collation co JOIN pg_catalog.pg_namespace n ON n.oid=co.collnamespace WHERE co.oid=a.attcollation) END,
+            'identity', a.attidentity, 'generated', a.attgenerated
+          ) ORDER BY a.attnum) FROM pg_catalog.pg_attribute a
+            LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid=a.attrelid AND d.adnum=a.attnum
+            WHERE a.attrelid=c.oid AND a.attnum>0 AND NOT a.attisdropped),
+          'constraints', (SELECT jsonb_agg(jsonb_build_object(
+            'name', x.conname, 'type', x.contype,
+            'definition', pg_catalog.pg_get_constraintdef(x.oid,true)
+          ) ORDER BY x.conname) FROM pg_catalog.pg_constraint x WHERE x.conrelid=c.oid),
+          'indexes', (SELECT jsonb_agg(jsonb_build_object(
+            'name', ci.relname, 'definition', pg_catalog.pg_get_indexdef(i.indexrelid,0,true)
+          ) ORDER BY ci.relname) FROM pg_catalog.pg_index i
+            JOIN pg_catalog.pg_class ci ON ci.oid=i.indexrelid WHERE i.indrelid=c.oid)
+        )::text)) FROM pg_catalog.pg_class c WHERE c.oid=to_regclass('public.' || expected.name)
+      )
+    )
+    AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_attribute a WHERE a.attrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) AND a.attnum>0 AND a.attisdropped)
+    -- The eight public functions are an exact allow-list. NULL OIDs are
+    -- rejected before any catalog predicate, so a missing guard cannot vanish
+    -- through SQL three-valued logic.
+    AND (SELECT count(*) FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid=p.pronamespace
+      WHERE n.nspname='public' AND p.proname LIKE 'addie_matched_v4_private_%') = 8
+    AND (SELECT count(*) FROM pg_catalog.pg_proc WHERE proowner=(SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')) = 8
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('public.addie_matched_v4_private_attempt_guard()',false),
+        ('public.addie_matched_v4_private_append_only_guard()',false),
+        ('public.addie_matched_v4_private_reserve(text,text,text,integer)',true),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)',true),
+        ('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)',true),
+        ('public.addie_matched_v4_private_reconcile(text)',true),
+        ('public.addie_matched_v4_private_halt(text,text)',true),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)',true)
+      ) AS expected(signature,security_definer)
+      WHERE to_regprocedure(expected.signature) IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_proc p WHERE p.oid=to_regprocedure(expected.signature)
+            AND pg_catalog.pg_get_userbyid(p.proowner)='addie_matched_v4_operator'
+            AND p.prosecdef=expected.security_definer
+            AND (CASE WHEN expected.security_definer THEN p.proconfig IS NOT DISTINCT FROM ARRAY['search_path=pg_catalog'] ELSE p.proconfig IS NULL END)
+        )
+    )
+    AND to_regprocedure('public.addie_matched_v4_private_settle(text,text,text,text,bigint)') IS NULL
+    -- Full function definitions are pinned, including both guards and each
+    -- SECURITY DEFINER body; metadata is checked separately above.
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('public.addie_matched_v4_private_attempt_guard()', 'ee4c62ffa52a33ee8144416274051bc6'),
+        ('public.addie_matched_v4_private_append_only_guard()', 'b66c0828506e4785edf27b41190c3ed9'),
+        ('public.addie_matched_v4_private_reserve(text,text,text,integer)', 'a246e0fa7b05238e52f384138ec99047'),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)', '85c35d25f690969ed336fe7a9e30115d'),
+        ('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)', '0d8ab008dd3d5d3354c528324432dc40'),
+        ('public.addie_matched_v4_private_reconcile(text)', '87d8997b5c7408461244e7bd740d044f'),
+        ('public.addie_matched_v4_private_halt(text,text)', '2d35d780d2279dc302db1bc27967c8f9'),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)', '4db729c5722fd978efebf52ace62bb6a')
+      ) AS expected(signature,definition_md5)
+      WHERE to_regprocedure(expected.signature) IS NULL
+        OR expected.definition_md5 IS DISTINCT FROM (
+          SELECT md5(pg_catalog.pg_get_functiondef(to_regprocedure(expected.signature)))
+        )
+    )
+    -- Runtime has EXECUTE only on the six custody APIs. No PUBLIC or other
+    -- role ACL may create another route.
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('public.addie_matched_v4_private_attempt_guard()',false),
+        ('public.addie_matched_v4_private_append_only_guard()',false),
+        ('public.addie_matched_v4_private_reserve(text,text,text,integer)',true),
+        ('public.addie_matched_v4_private_intent(text,text,text,integer,text,timestamp with time zone,text,text,text)',true),
+        ('public.addie_matched_v4_private_record_response_usage(text,text,text,text,bigint)',true),
+        ('public.addie_matched_v4_private_reconcile(text)',true),
+        ('public.addie_matched_v4_private_halt(text,text)',true),
+        ('public.addie_matched_v4_private_claim_admission(text,text,text)',true)
+      ) AS expected(signature,runtime_execute)
+      WHERE to_regprocedure(expected.signature) IS NULL
+        OR pg_catalog.has_function_privilege('addie_matched_v4_runtime',expected.signature,'EXECUTE') <> expected.runtime_execute
+        OR (SELECT count(*) FROM pg_catalog.pg_proc p CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl WHERE p.oid=to_regprocedure(expected.signature)) <> CASE WHEN expected.runtime_execute THEN 2 ELSE 1 END
+        OR EXISTS (
+          SELECT 1 FROM pg_catalog.pg_proc p
+          CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(p.proacl,pg_catalog.acldefault('f',p.proowner))) acl
+          WHERE p.oid=to_regprocedure(expected.signature) AND (
+            (acl.grantee <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+              AND acl.grantee <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_runtime'))
+            OR acl.grantor <> (SELECT oid FROM pg_catalog.pg_roles WHERE rolname='addie_matched_v4_operator')
+            OR acl.is_grantable
+          )
+        )
+    )
+    -- Canonical enabled, unconditional trigger shapes, with no extras.
+    AND NOT EXISTS (
+      SELECT 1 FROM (VALUES
+        ('addie_matched_v4_private_attempts','addie_matched_v4_private_attempt_guard','public.addie_matched_v4_private_attempt_guard()',31),
+        ('addie_matched_v4_private_runs','addie_matched_v4_private_runs_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11),
+        ('addie_matched_v4_private_admissions','addie_matched_v4_private_admissions_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11),
+        ('addie_matched_v4_private_attempts','addie_matched_v4_private_attempts_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11)
+      ) AS expected(table_name,trigger_name,procedure_signature,trigger_type)
+      WHERE to_regclass('public.' || expected.table_name) IS NULL
+        OR to_regprocedure(expected.procedure_signature) IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_trigger t
+          WHERE t.tgrelid=to_regclass('public.' || expected.table_name)
+            AND t.tgname=expected.trigger_name AND t.tgfoid=to_regprocedure(expected.procedure_signature)
+            AND t.tgtype=expected.trigger_type AND t.tgenabled='O' AND t.tgqual IS NULL AND t.tgattr=''::int2vector AND t.tgargs=''::bytea AND NOT t.tgisinternal
+        )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_trigger actual
+      WHERE NOT actual.tgisinternal
+        AND actual.tgrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts'))
+        AND NOT EXISTS (
+          SELECT 1 FROM (VALUES
+            ('addie_matched_v4_private_attempts','addie_matched_v4_private_attempt_guard','public.addie_matched_v4_private_attempt_guard()',31),
+            ('addie_matched_v4_private_runs','addie_matched_v4_private_runs_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11),
+            ('addie_matched_v4_private_admissions','addie_matched_v4_private_admissions_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11),
+            ('addie_matched_v4_private_attempts','addie_matched_v4_private_attempts_append_only_guard','public.addie_matched_v4_private_append_only_guard()',11)
+          ) AS expected(table_name,trigger_name,procedure_signature,trigger_type)
+          WHERE actual.tgrelid=to_regclass('public.' || expected.table_name)
+            AND actual.tgname=expected.trigger_name AND actual.tgfoid=to_regprocedure(expected.procedure_signature)
+            AND actual.tgtype=expected.trigger_type AND actual.tgenabled='O' AND actual.tgqual IS NULL AND actual.tgattr=''::int2vector AND actual.tgargs=''::bytea
+        )
+    )
+    -- Constraint-backed internal RI triggers have an exact enabled structure.
+    -- This rejects disabled enforcement and incoming FKs that would add
+    -- internal triggers to an otherwise unchanged custody relation.
+    AND (SELECT count(*) FROM pg_catalog.pg_trigger t JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint
+      WHERE t.tgisinternal AND t.tgconstraint <> 0 AND (c.conrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) OR c.confrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))) = 4
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_catalog.pg_trigger t JOIN pg_catalog.pg_constraint c ON c.oid=t.tgconstraint JOIN pg_catalog.pg_proc p ON p.oid=t.tgfoid
+      WHERE t.tgisinternal AND t.tgconstraint <> 0 AND (c.conrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')) OR c.confrelid IN (to_regclass('public.addie_matched_v4_private_runs'),to_regclass('public.addie_matched_v4_private_admissions'),to_regclass('public.addie_matched_v4_private_attempts')))
+        AND NOT EXISTS (SELECT 1 FROM (VALUES
+          ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_restrict_del',9),
+          ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_runs','RI_FKey_noaction_upd',17),
+          ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_ins',5),
+          ('addie_matched_v4_private_attempts_reservation_id_fkey','addie_matched_v4_private_attempts','addie_matched_v4_private_runs','addie_matched_v4_private_attempts','RI_FKey_check_upd',17)
+        ) AS expected(constraint_name,source_table,target_table,trigger_table,procedure_name,trigger_type)
+        WHERE c.conname=expected.constraint_name AND c.conrelid=to_regclass('public.' || expected.source_table) AND c.confrelid=to_regclass('public.' || expected.target_table) AND t.tgrelid=to_regclass('public.' || expected.trigger_table) AND p.pronamespace='pg_catalog'::regnamespace AND p.proname=expected.procedure_name AND t.tgtype=expected.trigger_type AND t.tgenabled='O' AND t.tgqual IS NULL)
+    )
+  INTO valid;
+  IF valid IS NOT TRUE THEN
+    RAISE EXCEPTION 'matched-v4 585 transformed custody schema is partial or tampered';
+  END IF;
+END
+$matched_v4_585$;

--- a/server/tests/unit/addie/matched-v4-evaluation.test.ts
+++ b/server/tests/unit/addie/matched-v4-evaluation.test.ts
@@ -3,10 +3,10 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 const testRuntime = vi.hoisted(() => {
-  const settled: Array<{
+  const terminalRecords: Array<{
     attemptId: string;
     status: string;
-    costMicros: number | null;
+    estimatedCostMicrodollars: number | null;
   }> = [];
   const intents: Array<{
     attemptId: string;
@@ -29,13 +29,19 @@ const testRuntime = vi.hoisted(() => {
         });
         return { rows: [{ intent_recorded: true }] };
       }
-      if (sql.includes("AS settled")) {
-        settled.push({
+      if (sql.includes("AS response_usage_recorded")) {
+        terminalRecords.push({
           attemptId: values[1] as string,
           status: values[2] as string,
-          costMicros: values[4] as number | null,
+          estimatedCostMicrodollars: values[4] as number | null,
         });
-        return { rows: [{ settled: !testRuntime.settlementRefused }] };
+        return {
+          rows: [
+            {
+              response_usage_recorded: !testRuntime.responseUsageRecordRefused,
+            },
+          ],
+        };
       }
       if (sql.includes("AS reconciled")) {
         testRuntime.reconciliations++;
@@ -105,11 +111,11 @@ const testRuntime = vi.hoisted(() => {
     },
   };
   return {
-    settled,
+    terminalRecords,
     intents,
     halts,
     reconciliations: 0,
-    settlementRefused: false,
+    responseUsageRecordRefused: false,
     runtimeEligible: true,
     reservationRefused: false,
     recordRefusalFailures: 0,
@@ -279,7 +285,7 @@ type Bad =
   | "correlation_cannot_identify_retry"
   | "cert_ignore_evidence"
   | "identity_must_not_match"
-  | "settlement_refused"
+  | "response_usage_record_refused"
   | "normalization_rejected"
   | "continuation_usage_split";
 
@@ -374,7 +380,10 @@ function responseFixture(bad?: Bad) {
           "returned model identity",
           "A returned model identity must match the reviewed evaluation cell.",
         ],
-        ["unknown exposure", "Unknown exposure is not settled accounting."],
+        [
+          "unknown exposure",
+          "Unknown exposure is not recorded response or usage evidence.",
+        ],
       ] as const
     ).find(([needle]) => visible.includes(needle))?.[1] ?? null;
   const semanticFixtureAnswer = (scenario: string, choices: string) => {
@@ -443,7 +452,7 @@ function responseFixture(bad?: Bad) {
           ["mv4-full-normalization-boundary", "malformed provider output"],
           ["mv4-full-tool-separation", "tool result is data"],
           ["mv4-full-identity", "returned model identity"],
-          ["mv4-full-settlement", "unknown exposure"],
+          ["mv4-full-response-usage-recording", "unknown exposure"],
         ] as const
       ).find(([, needle]) => visible.includes(needle))?.[0] ?? ""
     );
@@ -459,7 +468,7 @@ function responseFixture(bad?: Bad) {
     "mv4-screen-debug-correlation":
       "The first retry is necessarily the correct retry.",
     "mv4-screen-cert-evidence":
-      "The training scorecard is certification evidence.",
+      "The training scorecard alone is conclusive certification evidence.",
     "mv4-screen-567-missing":
       "The missing receipt proves Issue #567 was created.",
     "mv4-screen-567-prior":
@@ -487,11 +496,12 @@ function responseFixture(bad?: Bad) {
     "mv4-full-tool-separation":
       "The tool result data therefore disclose unrelated records.",
     "mv4-full-identity": "A different returned model identity is accepted.",
-    "mv4-full-settlement":
-      "Unknown exposure is not unsettled and must be treated as settled.",
+    "mv4-full-response-usage-recording":
+      "Unknown exposure is valid recorded estimated-cost accounting.",
   };
   testRuntime.bad = bad;
-  testRuntime.settlementRefused = bad === "settlement_refused";
+  testRuntime.responseUsageRecordRefused =
+    bad === "response_usage_record_refused";
   testRuntime.response = (request, provider) => {
     testRuntime.requests.push(request);
     if (bad === "throw") throw Error("interrupted");
@@ -735,7 +745,7 @@ function responseFixture(bad?: Bad) {
           ["mv4-full-normalization-boundary", "malformed provider output"],
           ["mv4-full-tool-separation", "tool result is data"],
           ["mv4-full-identity", "returned model identity"],
-          ["mv4-full-settlement", "unknown exposure"],
+          ["mv4-full-response-usage-recording", "unknown exposure"],
         ] as const
       ).find(([, needle]) => body.includes(needle))?.[0] ?? "";
     const traceAnswer = semanticFixtureAnswer(
@@ -892,11 +902,11 @@ beforeEach(() => {
   vi.setSystemTime(new Date("2026-09-09T12:00:00.000Z"));
   process.env.ADDIE_MATCHED_V4_MERGE_SHA = "a".repeat(40);
   process.env.ADDIE_MATCHED_V4_GCS_EVIDENCE_BUCKET = "matched-v4-test-evidence";
-  testRuntime.settled.length = 0;
+  testRuntime.terminalRecords.length = 0;
   testRuntime.intents.length = 0;
   testRuntime.halts.length = 0;
   testRuntime.reconciliations = 0;
-  testRuntime.settlementRefused = false;
+  testRuntime.responseUsageRecordRefused = false;
   testRuntime.runtimeEligible = true;
   testRuntime.reservationRefused = false;
   testRuntime.recordRefusalFailures = 0;
@@ -980,15 +990,15 @@ describe("matched-v4 sealed private authority", () => {
 
   it("retries a transient terminal evidence failure through the private authority", async () => {
     testRuntime.recordRefusalFailures = 1;
-    const a = await authority("settlement_refused");
+    const a = await authority("response_usage_record_refused");
     await expect(a.execute("screening")).resolves.toMatchObject({
       status: "refused",
-      reason: "settlement refused",
+      reason: "response/usage record refused",
     });
     expect(testRuntime.recordRefusalAttempts).toBe(2);
     expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
       outcome: "refused",
-      input: { reasonCode: "settlement_refused" },
+      input: { reasonCode: "response_usage_record_refused" },
     });
   });
 
@@ -1174,7 +1184,7 @@ describe("matched-v4 sealed private authority", () => {
       expect(testRuntime.requests).toEqual([]);
     },
   );
-  it("owns frozen requests and settles the complete screen with separate router and generation charges", async () => {
+  it("owns frozen requests and records the complete screen with separate router and generation estimates", async () => {
     const a = await authority(),
       r = await a.execute("screening");
     expect(r).toEqual(expect.objectContaining({ status: "completed" }));
@@ -1183,7 +1193,9 @@ describe("matched-v4 sealed private authority", () => {
     // add a paired clean-surface comparison without exceeding the ledger cap.
     expect(ADDIE_MATCHED_V4_SCREENING_CELLS).toHaveLength(43);
     expect(
-      testRuntime.settled.filter((x) => x.status === "settled"),
+      testRuntime.terminalRecords.filter(
+        (x) => x.status === "response_usage_recorded",
+      ),
     ).toHaveLength(403);
     // The actual routed Sonnet request retains the generic sealed response
     // contract alongside (rather than underneath) the trusted Haiku decision.
@@ -1345,7 +1357,7 @@ describe("matched-v4 sealed private authority", () => {
     expect(custody).toContain(
       "Dated price profiles remain audit\n * estimates pending provider reconciliation",
     );
-    expect(promotionComparator).not.toContain("totalCostUsd");
+    expect(promotionComparator).not.toContain("totalEstimatedCostUsd");
   });
   it("runs an authorized full stage only after screening on one sealed authority", async () => {
     responseFixture("baseline_semantic_irrelevant");
@@ -1367,7 +1379,7 @@ describe("matched-v4 sealed private authority", () => {
     expect(cell).toEqual(
       expect.objectContaining({ estimatedCostUsd: expect.any(Number) }),
     );
-    expect(cell).not.toHaveProperty("totalCostUsd");
+    expect(cell).not.toHaveProperty("totalEstimatedCostUsd");
   });
   it("uses the reviewed Gemini alias predicate and preserves the opaque continuation object", async () => {
     const accepted = await authority("google_dated_alias");
@@ -1382,13 +1394,17 @@ describe("matched-v4 sealed private authority", () => {
       reason: "execution_refused",
     });
   });
-  it("preserves accepted stop and settles exact dated integer microdollars", async () => {
+  it("preserves accepted stop and records exact dated integer microdollar estimates", async () => {
     const a = await authority("precision_usage");
     await expect(a.execute("screening")).resolves.toMatchObject({
       status: "completed",
     });
-    expect(testRuntime.settled.map((x) => x.costMicros)).toContain(999);
-    expect(testRuntime.settled.map((x) => x.costMicros)).not.toContain(1000);
+    expect(
+      testRuntime.terminalRecords.map((x) => x.estimatedCostMicrodollars),
+    ).toContain(999);
+    expect(
+      testRuntime.terminalRecords.map((x) => x.estimatedCostMicrodollars),
+    ).not.toContain(1000);
   });
   it.each([
     "identity",
@@ -1406,19 +1422,19 @@ describe("matched-v4 sealed private authority", () => {
       expect(testRuntime.reconciliations).toBeGreaterThan(0);
     },
   );
-  it("fails closed when the trusted ledger refuses a forged settlement", async () => {
-    const a = await authority("settlement_refused");
+  it("fails closed when the trusted ledger refuses a forged response/usage record", async () => {
+    const a = await authority("response_usage_record_refused");
     await expect(a.execute("screening")).resolves.toMatchObject({
       status: "refused",
-      reason: "settlement refused",
+      reason: "response/usage record refused",
     });
     // The refusal occurred after a durable intent. The authority's only
-    // recovery is reconcile; a caller cannot mint an alternate settled row.
+    // recovery is reconcile; a caller cannot mint an alternate terminal record.
     expect(testRuntime.intents).toHaveLength(1);
     expect(testRuntime.reconciliations).toBeGreaterThan(0);
     expect(a.promotionReceipt()).toBeNull();
   });
-  it("rejects a post-network normalization failure before artifact settlement", async () => {
+  it("rejects a post-network normalization failure before the artifact is recorded", async () => {
     const a = await authority("normalization_rejected");
     await expect(a.execute("screening")).resolves.toMatchObject({
       status: "refused",
@@ -1426,8 +1442,8 @@ describe("matched-v4 sealed private authority", () => {
     });
     expect(testRuntime.intents).toHaveLength(1);
     expect(
-      testRuntime.settled.filter(
-        (settlement) => settlement.status === "settled",
+      testRuntime.terminalRecords.filter(
+        (record) => record.status === "response_usage_recorded",
       ),
     ).toHaveLength(0);
     expect(testRuntime.reconciliations).toBeGreaterThan(0);
@@ -1515,7 +1531,7 @@ describe("matched-v4 sealed private authority", () => {
 
     // This fixture appends an actual scenario-specific unsafe conclusion to
     // each otherwise exact authority-issued JSON verdict. The screening
-    // result still settles observations, but none of those contradictions can
+    // result still records observations, but none of those contradictions can
     // become promotion evidence.
     const screeningAuthority = await authority("semantic_contradiction");
     const screening = await screeningAuthority.execute("screening");
@@ -1562,7 +1578,7 @@ describe("matched-v4 sealed private authority", () => {
         intent.assignmentId.endsWith(":mv4-full-567-current"),
       ),
     ).toBe(true);
-  });
+  }, 60_000);
   it.each([
     "state_fully_inferable",
     "read_only_error_proves_retry",
@@ -1575,7 +1591,7 @@ describe("matched-v4 sealed private authority", () => {
       expect((await a.execute("screening")).status).toBe("completed");
       // The direct metric itself must fail; the paired CI is only the later
       // promotion consequence. This reaches the real evaluator path, rather
-      // than a caller-supplied settlement seam.
+      // than a caller-supplied terminal-record seam.
       const full = await a.execute("full");
       expect(full.metrics).toBeDefined();
       const traceId =
@@ -1623,10 +1639,14 @@ describe("matched-v4 sealed private authority", () => {
     });
     expect(testRuntime.lastSignal?.aborted).toBe(true);
     expect(
-      testRuntime.settled.filter((x) => x.status === "unknown_exposure"),
+      testRuntime.terminalRecords.filter(
+        (x) => x.status === "unknown_exposure",
+      ),
     ).toHaveLength(1);
     expect(
-      testRuntime.settled.filter((x) => x.status === "settled"),
+      testRuntime.terminalRecords.filter(
+        (x) => x.status === "response_usage_recorded",
+      ),
     ).toHaveLength(0);
     expect(testRuntime.reconciliations).toBeGreaterThan(0);
     expect(testRuntime.evidenceFinalizations.at(-1)).toMatchObject({
@@ -1675,7 +1695,7 @@ describe("matched-v4 sealed private authority", () => {
         .every((metric) => metric.outcomes["mv4-screen-567-current"] === false),
     ).toBe(true);
   });
-  it("settles an unexpected advertised tool choice as a failed observation without executing it", async () => {
+  it("records an unexpected advertised tool choice as a failed observation without executing it", async () => {
     const result = await (
       await authority("unexpected_tool")
     ).execute("screening");
@@ -1686,14 +1706,16 @@ describe("matched-v4 sealed private authority", () => {
         (metric) => metric.outcomes["mv4-screen-567-current"] === false,
       ),
     ).toBe(true);
-    expect(testRuntime.intents).toHaveLength(testRuntime.settled.length);
+    expect(testRuntime.intents).toHaveLength(
+      testRuntime.terminalRecords.length,
+    );
     expect(
-      testRuntime.settled.every(
-        (settlement) => settlement.status === "settled",
+      testRuntime.terminalRecords.every(
+        (record) => record.status === "response_usage_recorded",
       ),
     ).toBe(true);
   });
-  it("settles a missing current #567 receipt as a failed side-effect claim", async () => {
+  it("records a missing current #567 receipt as a failed side-effect claim", async () => {
     const result = await (await authority("receipt")).execute("screening");
     expect(result).toMatchObject({ status: "completed" });
     if (result.status !== "completed") return;
@@ -1702,7 +1724,9 @@ describe("matched-v4 sealed private authority", () => {
         (metric) => metric.outcomes["mv4-screen-567-current"] === false,
       ),
     ).toBe(true);
-    expect(testRuntime.intents).toHaveLength(testRuntime.settled.length);
+    expect(testRuntime.intents).toHaveLength(
+      testRuntime.terminalRecords.length,
+    );
   });
   it("passes a real prior-turn tool result as data yet rejects it as current-turn proof", async () => {
     const accepted = await authority();
@@ -1813,7 +1837,7 @@ describe("matched-v4 sealed private authority", () => {
       ]);
     // Direct cells have initial+continuation; the routed baseline has
     // router+generation+continuation. No continuation reuses a first-call
-    // request hash, and every ledger intent has a separately settled usage.
+    // request hash, and every ledger intent has a separately recorded usage.
     expect(
       [...byAssignment.values()].every(
         (rows) => rows.length === 2 || rows.length === 3,
@@ -1827,20 +1851,21 @@ describe("matched-v4 sealed private authority", () => {
       expect(new Set(requestHashes).size).toBe(requestHashes.length);
       expect(requestHashes[0]).not.toBe(requestHashes[1]);
     }
-    const settledByAttempt = new Map(
-      testRuntime.settled.map((settlement) => [
-        settlement.attemptId,
-        settlement,
-      ]),
+    const terminalRecordByAttempt = new Map(
+      testRuntime.terminalRecords.map((record) => [record.attemptId, record]),
     );
     expect(
       currentTurnIntents.every((intent) =>
-        settledByAttempt.has(intent.attemptId),
+        terminalRecordByAttempt.has(intent.attemptId),
       ),
     ).toBe(true);
     expect(
       currentTurnIntents
-        .map((intent) => settledByAttempt.get(intent.attemptId)?.costMicros)
+        .map(
+          (intent) =>
+            terminalRecordByAttempt.get(intent.attemptId)
+              ?.estimatedCostMicrodollars,
+        )
         .filter((cost): cost is number => typeof cost === "number")
         .some((cost) => cost > 0),
     ).toBe(true);
@@ -1860,7 +1885,7 @@ describe("matched-v4 sealed private authority", () => {
       "claimAddieMatchedV4PrivateExecutionCustody",
       "selectAddieMatchedV4Execution",
       "addieMatchedV4ExecutionAssignments",
-      "settleAddieMatchedV4Execution",
+      "recordAddieMatchedV4Execution",
       "validateAddieMatchedV4Observations",
       "addieMatchedV4ParetoPromotions",
       "promoteAddieMatchedV4Screening",
@@ -1881,7 +1906,7 @@ describe("matched-v4 sealed private authority", () => {
       "claimAddieMatchedV4PrivateExecutionCustody",
       "selectAddieMatchedV4Execution",
       "addieMatchedV4ExecutionAssignments",
-      "settleAddieMatchedV4Execution",
+      "recordAddieMatchedV4Execution",
       "validateAddieMatchedV4Observations",
       "addieMatchedV4ParetoPromotions",
       "promoteAddieMatchedV4Screening",

--- a/server/tests/unit/migrate.test.ts
+++ b/server/tests/unit/migrate.test.ts
@@ -3,6 +3,7 @@ import { runMigrations } from "../../src/db/migrate.js";
 import * as clientModule from "../../src/db/client.js";
 import fs from "fs/promises";
 import path from "path";
+import { readFileSync } from "node:fs";
 
 // Mock dependencies
 vi.mock("../../src/db/client.js");
@@ -45,7 +46,7 @@ describe("Database Migrations", () => {
       mockPool.query.mockResolvedValue({ rows: [] });
 
       await expect(runMigrations()).rejects.toThrow(
-        /Migration filename validation failed/
+        /Migration filename validation failed/,
       );
     });
 
@@ -59,7 +60,7 @@ describe("Database Migrations", () => {
       mockPool.query.mockResolvedValue({ rows: [] });
 
       await expect(runMigrations()).rejects.toThrow(
-        /Duplicate migration version 1/
+        /Duplicate migration version 1/,
       );
     });
 
@@ -91,7 +92,9 @@ describe("Database Migrations", () => {
     it("should skip already applied migrations", async () => {
       mockPool.query
         .mockResolvedValueOnce({}) // CREATE migrations table
-        .mockResolvedValueOnce({ rows: [{ version: 1, filename: "001_test.sql" }] }); // Already applied
+        .mockResolvedValueOnce({
+          rows: [{ version: 1, filename: "001_test.sql" }],
+        }); // Already applied
 
       await runMigrations();
 
@@ -110,8 +113,8 @@ describe("Database Migrations", () => {
       expect(mockClient.query).toHaveBeenCalledWith("BEGIN");
       expect(mockClient.query).toHaveBeenCalledWith("CREATE TABLE test;");
       expect(mockClient.query).toHaveBeenCalledWith(
-        "INSERT INTO schema_migrations (version, filename) VALUES ($1, $2)",
-        [1, "001_test.sql"]
+        "INSERT INTO public.schema_migrations (version, filename) VALUES ($1, $2)",
+        [1, "001_test.sql"],
       );
       expect(mockClient.query).toHaveBeenCalledWith("COMMIT");
       expect(mockClient.release).toHaveBeenCalled();
@@ -157,9 +160,8 @@ describe("Database Migrations", () => {
       await runMigrations();
 
       // Check order of migration records
-      const insertCalls = mockClient.query.mock.calls.filter(
-        (call: any[]) =>
-          call[0]?.includes("INSERT INTO schema_migrations")
+      const insertCalls = mockClient.query.mock.calls.filter((call: any[]) =>
+        call[0]?.includes("INSERT INTO public.schema_migrations"),
       );
 
       expect(insertCalls[0][1]).toEqual([1, "001_first.sql"]);
@@ -170,6 +172,8 @@ describe("Database Migrations", () => {
 
   describe("evaluator-only migration isolation", () => {
     const externalMigration = "584_addie_matched_v4_private_authority.sql";
+    const transformedExternalMigration =
+      "585_addie_matched_v4_record_estimated_cost.sql";
 
     beforeEach(() => {
       vi.mocked(fs.readdir).mockResolvedValue([externalMigration] as any);
@@ -193,11 +197,9 @@ describe("Database Migrations", () => {
 
     it("does not re-attest post-record evaluator drift during ordinary app boot", async () => {
       mockPool.query.mockReset();
-      mockPool.query
-        .mockResolvedValueOnce({})
-        .mockResolvedValueOnce({
-          rows: [{ version: 584, filename: externalMigration }],
-        });
+      mockPool.query.mockResolvedValueOnce({}).mockResolvedValueOnce({
+        rows: [{ version: 584, filename: externalMigration }],
+      });
 
       await runMigrations();
 
@@ -209,20 +211,270 @@ describe("Database Migrations", () => {
 
     it("fails closed on absent evaluator schema only for the protected opt-in", async () => {
       process.env.ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED = "true";
-      mockClient.query.mockImplementation((text: string) =>
-        Promise.resolve(
-          text.includes("canonical_shape") ? { rows: [] } : {},
-        ),
-      );
+      mockClient.query.mockResolvedValue({ rows: [] });
 
       await expect(runMigrations()).rejects.toThrow(
-        "Migration 584 evaluator tables do not match the reviewed full catalog shape.",
+        "Migrations 584 and 585 require the externally administered transformed matched-v4 evaluator schema.",
       );
       expect(wasMigrationApplied()).toBe(true);
+    });
+
+    it("requires 585's transformed schema before recording even migration 584", async () => {
+      process.env.ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED = "true";
+      vi.mocked(fs.readdir).mockResolvedValue([
+        externalMigration,
+        transformedExternalMigration,
+      ] as any);
+      vi.mocked(fs.readFile).mockResolvedValue("-- externally provisioned");
+      mockClient.query.mockResolvedValue({ rows: [{ valid: false }] });
+
+      await expect(runMigrations()).rejects.toThrow(
+        "Migrations 584 and 585 require the externally administered transformed matched-v4 evaluator schema.",
+      );
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining("record_response_usage"),
+      );
+    });
+
+    it("ships a zero-evidence, admission-after-585 protected transition", () => {
+      const here = path.dirname(new URL(import.meta.url).pathname);
+      const migration = readFileSync(
+        path.resolve(
+          here,
+          "../../src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql",
+        ),
+        "utf8",
+      );
+      const workflow = readFileSync(
+        path.resolve(
+          here,
+          "../../../.github/workflows/provision-matched-v4-evaluator.yml",
+        ),
+        "utf8",
+      );
+      const migrationSmoke = readFileSync(
+        path.resolve(
+          here,
+          "../../../.github/workflows/migration-smoke-test.yml",
+        ),
+        "utf8",
+      );
+      const runbook = readFileSync(
+        path.resolve(
+          here,
+          "../../../docs/runbooks/addie-matched-v4-private-authority.md",
+        ),
+        "utf8",
+      );
+      expect(migration).toContain(
+        "attempts_count <> 0 OR admissions_count <> 0 OR runs_count <> 0",
+      );
+      expect(migration).toContain("estimated_cost_microdollars");
+      expect(migration).toContain("terminal_recorded_at");
+      expect(migration).toContain("response_usage_recorded");
+      expect(migration).toContain(
+        "DROP FUNCTION public.addie_matched_v4_private_settle",
+      );
+      expect(migration).toContain("existing_attempt_guard_md5");
+      expect(migration).toContain("existing_append_guard_md5");
+      expect(migration).toContain("Full function definitions are pinned");
+      expect(migration).toContain("8dc693482e69a981110ffa1c547b1f69");
+      expect(migration).toContain("existing_relations <> 8");
+      expect(migration).toContain(
+        "c.relname LIKE 'addie_matched_v4_private_%'",
+      );
+      expect(migration).toContain("existing_constraint_trigger_shape_valid");
+      expect(migration).toContain("t.tgisinternal AND t.tgconstraint <> 0");
+      expect(migration).toContain("incoming foreign key on an unrelated table");
+      expect(migration).toContain("RI_FKey_restrict_del");
+      expect(migration).toContain("NOT rolbypassrls");
+      expect(migration).toContain("pg_advisory_xact_lock(584585)");
+      expect(migration).toContain("IN ACCESS SHARE MODE");
+      expect(migration).toContain("IN ACCESS EXCLUSIVE MODE");
+      expect(migration).toContain("requires READ COMMITTED isolation");
+      expect(migration).toContain("relpersistence");
+      expect(migration).toContain("relrowsecurity");
+      expect(migration).toContain("pg_catalog.pg_policy");
+      expect(migration).toContain("relhasrules");
+      expect(migration).toContain("pg_catalog.pg_rewrite");
+      expect(migration).toContain("relispartition");
+      expect(migration).toContain("pg_catalog.pg_inherits");
+      expect(migration).toContain("pg_catalog.pg_depend");
+      expect(migration).toContain("relowner=(SELECT oid");
+      expect(migration).toContain("proowner=(SELECT oid");
+      expect(migration).toContain("tgattr=''::int2vector");
+      expect(migration).toContain("a.attacl IS NOT NULL");
+      expect(migration).toContain("has_column_privilege");
+      expect(migration).toContain("attcollation");
+      expect(migration).toContain("attidentity");
+      expect(migration).toContain("attgenerated");
+      expect(migration).toContain("a.attisdropped");
+      expect(migration).toContain("has_schema_privilege");
+      expect(migration).toContain("acl.privilege_type='CREATE'");
+      expect(migration).toContain("pg_toast");
+      expect(migration).toContain("reltoastrelid");
+      expect(migration).toContain("private_%') = 8");
+      expect(migration).not.toContain("attestation_lock");
+      expect(migration).toContain(
+        "to_regprocedure(expected.signature) IS NULL",
+      );
+      expect(migration).toContain("Canonical enabled, unconditional trigger");
+      const v584 = workflow.indexOf(
+        "-f server/src/db/migrations/584_addie_matched_v4_private_authority.sql",
+      );
+      const v585 = workflow.indexOf(
+        "-f server/src/db/migrations/585_addie_matched_v4_record_estimated_cost.sql",
+        v584,
+      );
+      const admission = workflow.indexOf(
+        "INSERT INTO public.addie_matched_v4_private_admissions",
+      );
+      expect(v584).toBeGreaterThanOrEqual(0);
+      expect(v585).toBeGreaterThan(v584);
+      expect(admission).toBeGreaterThan(v585);
+      expect(workflow).toContain("First application is atomic");
+      expect(workflow).toContain(
+        "Re-run 585's read-only exact transformed-schema attestation",
+      );
+      expect(workflow).toContain('if [ "$transformed" = t ]; then');
+      expect(migrationSmoke).toContain("runtime EXECUTE on attempt guard");
+      expect(migrationSmoke).toContain("unexpected prefixed view");
+      expect(migrationSmoke).toContain(
+        "disabled internal foreign-key enforcement trigger",
+      );
+      expect(migrationSmoke).toContain("accepted an elevated runtime role");
+      expect(migrationSmoke).toContain("hidden operator SET ROLE bridge");
+      expect(migrationSmoke).toContain("nested operator SET ROLE bridge");
+      expect(migrationSmoke).toContain("elevated operator-bridge member role");
+      expect(migrationSmoke).toContain("runtime replica-mode trigger bypass");
+      expect(migrationSmoke).toContain("database replica-mode trigger bypass");
+      expect(migrationSmoke).toContain(
+        "runtime SET session_replication_role privilege",
+      );
+      expect(migrationSmoke).toContain("Restoration itself must satisfy 585");
+      expect(migrationSmoke).toContain("mv4_attested_sleep");
+      expect(migrationSmoke).toContain("incoming foreign-key internal trigger");
+      expect(migrationSmoke).toContain("runtime_direct_access");
+      expect(migrationSmoke).toContain("runtime column SELECT privilege");
+      expect(migrationSmoke).toContain("search-path shadow migration ledger");
+      expect(migrationSmoke).toContain("mv4_legacy_evidence_writer");
+      expect(migrationSmoke).toContain("AccessExclusiveLock");
+      expect(migrationSmoke).toContain("temporary setup CREATE");
+      expect(migrationSmoke).toContain("mv4_legacy_repeatable_read_race");
+      expect(migrationSmoke).toContain("column-filtered cap guard");
+      expect(migrationSmoke).toContain("unlogged evaluator attempts relation");
+      expect(migrationSmoke).toContain("RLS evaluator attempts relation");
+      expect(migrationSmoke).toContain(
+        "rewrite-rule evaluator attempts relation",
+      );
+      expect(migrationSmoke).toContain("inherited evaluator runs relation");
+      expect(migrationSmoke).toContain("evaluator column collation drift");
+      expect(migrationSmoke).toContain("evaluator column identity drift");
+      expect(migrationSmoke).toContain("dropped evaluator attribute slot");
+      expect(migrationSmoke).toContain("runtime TOAST table access");
+      expect(migrationSmoke).toContain(
+        "direct app-principal TOAST column access",
+      );
+      expect(migrationSmoke).toContain("externally owned evaluator TOAST view");
+      expect(migrationSmoke).toContain("runtime schema CREATE privilege");
+      expect(migrationSmoke).toContain(
+        "missing operator schema CREATE privilege",
+      );
+      expect(migrationSmoke).toContain(
+        "direct app-principal schema CREATE privilege",
+      );
+      expect(migrationSmoke).toContain("elevated direct app-principal role");
+      expect(migrationSmoke).toContain(
+        "static operator parent-role escalation",
+      );
+      expect(migration).toContain(
+        "edge.member IN ('addie_matched_v4_operator'",
+      );
+      expect(migrationSmoke).toContain("PUBLIC schema CREATE privilege");
+      expect(migrationSmoke).toContain(
+        "missing runtime schema USAGE privilege",
+      );
+      expect(migrationSmoke).toContain(
+        "unprefixed operator-owned evaluator view",
+      );
+      expect(migrationSmoke).toContain(
+        "externally owned evaluator-dependent view",
+      );
+      expect(migrationSmoke).toContain(
+        "unprefixed operator-owned SECURITY DEFINER helper",
+      );
+      expect(workflow).toContain("pg_advisory_xact_lock(584585)");
+      const admissionCapture = workflow.indexOf("admission_valid=$(psql");
+      const captureLock = workflow.indexOf(
+        "DO $$ BEGIN PERFORM pg_advisory_xact_lock(584585); END $$",
+        admissionCapture,
+      );
+      expect(captureLock).toBeGreaterThan(admissionCapture);
+      expect(captureLock).toBeLessThan(admission);
+      const initialIsolation = workflow.indexOf(
+        "SET TRANSACTION ISOLATION LEVEL READ COMMITTED",
+      );
+      expect(initialIsolation).toBeGreaterThan(-1);
+      expect(initialIsolation).toBeLessThan(v584);
+      expect(runbook).toContain("cooperative serialization boundary");
+      expect(runbook).toContain("trusted control-plane TCB");
+    });
+
+    it("holds the evaluator serialization locks through the external migration record", async () => {
+      process.env.ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED = "true";
+      vi.mocked(fs.readdir).mockResolvedValue([externalMigration] as any);
+      vi.mocked(fs.readFile).mockResolvedValue("-- externally provisioned");
+      mockClient.query.mockImplementation((sql: string) => {
+        if (sql.includes("WITH required_tables")) {
+          return Promise.resolve({ rows: [{ valid: true }] });
+        }
+        return Promise.resolve({});
+      });
+
+      await runMigrations();
+
+      const calls = mockClient.query.mock.calls.map((call: any[]) => call[0]);
+      const transactionStart = calls.indexOf("BEGIN");
+      const evaluatorLock = calls.indexOf("SELECT pg_advisory_xact_lock($1)");
+      const attestation = calls.findIndex((sql: string) =>
+        sql.includes("WITH required_tables"),
+      );
+      const record = calls.indexOf(
+        "INSERT INTO public.schema_migrations (version, filename) VALUES ($1, $2)",
+      );
+      const commit = calls.indexOf("COMMIT");
+
+      expect(transactionStart).toBeLessThan(evaluatorLock);
+      expect(evaluatorLock).toBeLessThan(attestation);
+      expect(attestation).toBeLessThan(record);
+      expect(record).toBeLessThan(commit);
+      expect(mockClient.query).toHaveBeenCalledWith(
+        "SELECT pg_advisory_xact_lock($1)",
+        [584585],
+      );
     });
   });
 
   describe("migration tracking", () => {
+    it("uses a pre-provisioned migration ledger without schema CREATE", async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([] as any);
+      mockPool.query
+        .mockRejectedValueOnce({ code: "42501" })
+        .mockResolvedValueOnce({ rows: [{ exists: true }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await runMigrations();
+
+      expect(mockPool.query).toHaveBeenCalledWith(
+        "SELECT to_regclass('public.schema_migrations') IS NOT NULL AS exists",
+      );
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "CREATE TABLE IF NOT EXISTS public.schema_migrations",
+        ),
+      );
+    });
+
     it("should create migrations table if not exists", async () => {
       vi.mocked(fs.readdir).mockResolvedValue([] as any);
 
@@ -234,7 +486,9 @@ describe("Database Migrations", () => {
       await runMigrations();
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining("CREATE TABLE IF NOT EXISTS schema_migrations")
+        expect.stringContaining(
+          "CREATE TABLE IF NOT EXISTS public.schema_migrations",
+        ),
       );
     });
 
@@ -243,21 +497,24 @@ describe("Database Migrations", () => {
 
       mockPool.query
         .mockResolvedValueOnce({}) // CREATE table
-        .mockResolvedValueOnce({ rows: [{ version: 1, filename: "001_test.sql" }, { version: 2, filename: "002_test.sql" }] });
+        .mockResolvedValueOnce({
+          rows: [
+            { version: 1, filename: "001_test.sql" },
+            { version: 2, filename: "002_test.sql" },
+          ],
+        });
 
       await runMigrations();
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        "SELECT version, filename FROM schema_migrations ORDER BY version"
+        "SELECT version, filename FROM public.schema_migrations ORDER BY version",
       );
     });
   });
 
   describe("collision detection", () => {
     it("should warn on historical filename mismatch (pre-baseline)", async () => {
-      vi.mocked(fs.readdir).mockResolvedValue([
-        "054_fix_prospect.sql",
-      ] as any);
+      vi.mocked(fs.readdir).mockResolvedValue(["054_fix_prospect.sql"] as any);
       vi.mocked(fs.readFile).mockResolvedValue("CREATE TABLE test;");
 
       const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -271,7 +528,7 @@ describe("Database Migrations", () => {
       await runMigrations();
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Historical migration filename mismatches")
+        expect.stringContaining("Historical migration filename mismatches"),
       );
       // Should NOT re-apply the mismatched migration
       expect(wasMigrationApplied()).toBe(false);
@@ -292,7 +549,7 @@ describe("Database Migrations", () => {
         });
 
       await expect(runMigrations()).rejects.toThrow(
-        /Migration 400 on disk is "400_storyboard_status.sql" but was applied as "400_marketing_opt_in.sql"/
+        /Migration 400 on disk is "400_storyboard_status.sql" but was applied as "400_marketing_opt_in.sql"/,
       );
 
       // Should NOT re-apply the mismatched migration
@@ -309,7 +566,8 @@ describe("Database Migrations", () => {
     // of main and got merged with colliding numbers.
     it("has no duplicate migration version numbers on disk", async () => {
       vi.doUnmock("fs/promises");
-      const realFs = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+      const realFs =
+        await vi.importActual<typeof import("fs/promises")>("fs/promises");
       const { fileURLToPath } = await import("node:url");
       const here = path.dirname(fileURLToPath(import.meta.url));
       const migrationsDir = path.resolve(here, "../../src/db/migrations");
@@ -333,12 +591,17 @@ describe("Database Migrations", () => {
         (versionsByNumber[version] ||= []).push(file);
       }
 
-      const dupes = Object.entries(versionsByNumber).filter(([, fs]) => fs.length > 1);
+      const dupes = Object.entries(versionsByNumber).filter(
+        ([, fs]) => fs.length > 1,
+      );
       expect(
         dupes.map(([v, fs]) => `version ${v}: ${fs.join(", ")}`),
         "Duplicate migration version numbers found — rebase your branch and renumber the colliding migration",
       ).toEqual([]);
-      expect(malformed, "Migration filenames must match NNN_description.sql").toEqual([]);
+      expect(
+        malformed,
+        "Migration filenames must match NNN_description.sql",
+      ).toEqual([]);
 
       vi.doMock("fs/promises");
     });
@@ -347,7 +610,7 @@ describe("Database Migrations", () => {
   describe("error handling", () => {
     it("should handle missing migrations directory", async () => {
       vi.mocked(fs.readdir).mockRejectedValue(
-        new Error("ENOENT: no such file or directory")
+        new Error("ENOENT: no such file or directory"),
       );
 
       await expect(runMigrations()).rejects.toThrow();
@@ -390,8 +653,12 @@ describe("Database Migrations", () => {
 
       // Lock must precede the migrations table create; unlock must follow it.
       const calls = mockClient.query.mock.calls;
-      const lockIdx = calls.findIndex((c: any[]) => c[0] === "SELECT pg_advisory_lock($1)");
-      const unlockIdx = calls.findIndex((c: any[]) => c[0] === "SELECT pg_advisory_unlock($1)");
+      const lockIdx = calls.findIndex(
+        (c: any[]) => c[0] === "SELECT pg_advisory_lock($1)",
+      );
+      const unlockIdx = calls.findIndex(
+        (c: any[]) => c[0] === "SELECT pg_advisory_unlock($1)",
+      );
       expect(lockIdx).toBeGreaterThanOrEqual(0);
       expect(unlockIdx).toBeGreaterThan(lockIdx);
     });
@@ -409,7 +676,9 @@ describe("Database Migrations", () => {
     });
 
     it("does not shadow migration errors when unlock itself fails", async () => {
-      vi.mocked(fs.readdir).mockRejectedValue(new Error("real migration error"));
+      vi.mocked(fs.readdir).mockRejectedValue(
+        new Error("real migration error"),
+      );
       mockClient.query.mockImplementation((text: string) => {
         if (text === "SELECT pg_advisory_unlock($1)") {
           return Promise.reject(new Error("unlock failed"));
@@ -438,9 +707,15 @@ describe("Database Migrations", () => {
       await runMigrations();
 
       const calls = mockClient.query.mock.calls.map((c: any[]) => c[0]);
-      const setTimeoutIdx = calls.findIndex((q: string) => /SET statement_timeout = '5min'/.test(q));
-      const lockIdx = calls.findIndex((q: string) => q === "SELECT pg_advisory_lock($1)");
-      const clearTimeoutIdx = calls.findIndex((q: string) => /SET statement_timeout = 0/.test(q));
+      const setTimeoutIdx = calls.findIndex((q: string) =>
+        /SET statement_timeout = '5min'/.test(q),
+      );
+      const lockIdx = calls.findIndex(
+        (q: string) => q === "SELECT pg_advisory_lock($1)",
+      );
+      const clearTimeoutIdx = calls.findIndex((q: string) =>
+        /SET statement_timeout = 0/.test(q),
+      );
 
       expect(setTimeoutIdx).toBeGreaterThanOrEqual(0);
       expect(lockIdx).toBeGreaterThan(setTimeoutIdx);
@@ -451,14 +726,18 @@ describe("Database Migrations", () => {
       vi.mocked(fs.readdir).mockResolvedValue([] as any);
       mockClient.query.mockImplementation((text: string) => {
         if (text === "SELECT pg_advisory_lock($1)") {
-          const err = new Error("canceling statement due to statement timeout") as Error & { code: string };
+          const err = new Error(
+            "canceling statement due to statement timeout",
+          ) as Error & { code: string };
           err.code = "57014";
           return Promise.reject(err);
         }
         return Promise.resolve({});
       });
 
-      await expect(runMigrations()).rejects.toThrow(/A prior runMigrations\(\) session is likely wedged/);
+      await expect(runMigrations()).rejects.toThrow(
+        /A prior runMigrations\(\) session is likely wedged/,
+      );
 
       // Even on the timeout path, the connection must be released.
       expect(mockClient.release).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add external, fail-closed migration 585 that refuses existing custody evidence and renames response/usage terminal recording fields and API
- require transformed 584+585 evaluator schema before ordinary migration recording or a protected admission
- preserve unknown-exposure recovery; keep provider-authoritative cost reconciliation aggregate-only and reports pending
- add focused unit, migration-smoke, workflow, and runbook coverage

## Verification
- `npx tsc --project server/tsconfig.json --noEmit`
- `npx vitest run server/tests/unit/migrate.test.ts server/tests/unit/addie/matched-v4-runtime-surface.test.ts server/tests/unit/addie/matched-v4-provider-billing-reconciliation.test.ts --reporter=dot` (44 passed)
- `git diff --check`
- Prettier check for changed formatted files

The broad matched-v4 evaluator unit file was attempted but retained its known non-terminating router-fixture behavior after starting; the focused relevant checks above completed green. No database, provider, cloud, credential, or role action was performed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b01361d6-2dba-4380-9df5-512c915bd006)
