### PR TITLE
fix(profile): clarify domain verification records

### DIFF
--- a/server/public/member-profile.html
+++ b/server/public/member-profile.html
@@ -897,9 +897,9 @@
                Self-service mirror of the admin "Linked Domains" card; lets
                members switch the primary without filing a support ticket. -->
           <div id="linked-domains-section" style="display: none;">
-            <h2>Linked Domains</h2>
+            <h2>Linked domains</h2>
             <p style="color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-3);">
-              Domains your organization has verified via SSO. The primary domain drives auto-membership inference (employees signing up with this domain auto-link to your org) and seeds your brand identity.
+              Domains your organization has verified through WorkOS. The primary domain drives auto-membership inference (employees signing up with this domain auto-link to your org) and seeds your brand identity.
             </p>
             <div id="linked-domains-list" style="margin-bottom: var(--space-4);"></div>
 
@@ -908,6 +908,7 @@
               <div style="font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-2);">Add a domain</div>
               <p style="font-size: var(--text-sm); color: var(--color-text-secondary); margin: 0 0 var(--space-3) 0;">
                 Prove your organization controls a new domain via a DNS TXT record. After verification you can set it as primary.
+                For provider-specific instructions or to remove a pending domain, <a id="manage-domains-link" href="/team" target="_blank" rel="noopener" style="color: var(--color-primary-600);">open the WorkOS domain manager</a>.
               </p>
               <div style="display: flex; gap: var(--space-2); align-items: stretch; flex-wrap: wrap;">
                 <input type="text" id="add-domain-input" placeholder="example.com" autocomplete="off" style="flex: 1 1 240px; min-width: 200px; padding: var(--space-2) var(--space-3); border: 1px solid var(--color-gray-300); border-radius: var(--radius-md); font-size: var(--text-sm); background: var(--color-bg-card); color: var(--color-text);">
@@ -917,9 +918,9 @@
 
               <!-- TXT record callout, shown after a challenge is issued -->
               <div id="add-domain-challenge" style="display: none; margin-top: var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-3);">
-                <div style="font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-2);">Publish this DNS TXT record</div>
+                <div style="font-weight: var(--font-semibold); color: var(--color-text-heading); margin-bottom: var(--space-2);">Publish this DNS TXT record for <span id="add-domain-challenge-domain"></span></div>
                 <p style="font-size: var(--text-sm); color: var(--color-text-secondary); margin: 0 0 var(--space-2) 0;">
-                  Add a TXT record at <code id="add-domain-host" style="background: var(--color-bg-subtle); padding: 1px 4px; border-radius: 3px;"></code> with the value below. DNS propagation can take 5–15 minutes.
+                  Add a TXT record at <code id="add-domain-host" style="background: var(--color-bg-subtle); padding: 1px 4px; border-radius: 3px;"></code> with the full value below, including the required <code>verification_token=</code> prefix. DNS propagation can take 5–15 minutes.
                 </p>
                 <div style="position: relative;">
                   <pre id="add-domain-token" style="background: var(--color-gray-900); color: var(--color-gray-100); padding: var(--space-3); border-radius: var(--radius-md); font-size: var(--text-sm); overflow-x: auto; margin: 0;"></pre>
@@ -1758,7 +1759,15 @@
     async function loadLinkedDomains() {
       const section = document.getElementById('linked-domains-section');
       const addCard = document.getElementById('linked-domains-add');
+      const manageDomainsLink = document.getElementById('manage-domains-link');
       const isAdmin = currentOrgRole === 'owner' || currentOrgRole === 'admin';
+      if (manageDomainsLink && currentOrgId) {
+        manageDomainsLink.href = '/team?org=' + encodeURIComponent(currentOrgId);
+        if (!manageDomainsLink.dataset.portalBound) {
+          manageDomainsLink.addEventListener('click', openWorkosDomainManager);
+          manageDomainsLink.dataset.portalBound = 'true';
+        }
+      }
       try {
         const resp = await fetch(buildApiUrl('/api/me/organization/domains'), { credentials: 'include' });
         if (!resp.ok) {
@@ -1787,6 +1796,7 @@
 
     function renderLinkedDomains(domains) {
       const list = document.getElementById('linked-domains-list');
+      const canManageDomains = currentOrgRole === 'owner' || currentOrgRole === 'admin';
       list.innerHTML = domains.map(function(d) {
         const verifiedBadge = d.verified
           ? '<span style="display: inline-block; padding: 2px 8px; background: var(--color-success-100, #dcfce7); color: var(--color-success-700, #15803d); border-radius: var(--radius-sm); font-size: 11px; font-weight: var(--font-medium);">Verified</span>'
@@ -1796,14 +1806,17 @@
           : '';
         const sourceLabel = d.source ? '<span style="color: var(--color-text-muted); font-size: var(--text-xs);">' + escapeHtml(d.source) + '</span>' : '';
         let action = '';
-        if (!d.verified) {
-          action = '<button type="button" onclick="verifyLinkedDomain(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Verify DNS</button>';
-        } else if (!d.is_primary) {
-          action = '<button type="button" onclick="setLinkedDomainPrimary(\'' + escapeHtml(d.domain) + '\', this)" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Set Primary</button>';
+        if (!d.verified && canManageDomains) {
+          action = '<div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">' +
+            '<button type="button" data-domain-action="show-record" data-domain="' + escapeHtml(d.domain) + '" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Show DNS record</button>' +
+            '<button type="button" data-domain-action="verify" data-domain="' + escapeHtml(d.domain) + '" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Verify DNS</button>' +
+          '</div>';
+        } else if (d.verified && !d.is_primary && canManageDomains) {
+          action = '<button type="button" data-domain-action="set-primary" data-domain="' + escapeHtml(d.domain) + '" style="padding: var(--space-2) var(--space-4); background: var(--color-bg-subtle); color: var(--color-text-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer;">Set primary</button>';
         }
         return (
-          '<div style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-2);">' +
-            '<div style="font-weight: var(--font-medium); color: var(--color-text-heading); flex-grow: 1;">' + escapeHtml(d.domain) + '</div>' +
+          '<div style="display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; padding: var(--space-3) var(--space-4); background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: var(--space-2);">' +
+            '<div style="font-weight: var(--font-medium); color: var(--color-text-heading); flex: 1 1 180px; overflow-wrap: anywhere;">' + escapeHtml(d.domain) + '</div>' +
             '<div style="display: flex; gap: var(--space-2); align-items: center;">' +
               verifiedBadge + primaryBadge + sourceLabel +
             '</div>' +
@@ -1811,6 +1824,59 @@
           '</div>'
         );
       }).join('');
+      list.querySelectorAll('[data-domain-action]').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          const domain = btn.dataset.domain;
+          if (!domain) return;
+          if (btn.dataset.domainAction === 'show-record') {
+            addLinkedDomain(domain, btn);
+          } else if (btn.dataset.domainAction === 'verify') {
+            verifyLinkedDomain(domain, btn);
+          } else if (btn.dataset.domainAction === 'set-primary') {
+            setLinkedDomainPrimary(domain, btn);
+          }
+        });
+      });
+    }
+
+    async function openWorkosDomainManager(event) {
+      event.preventDefault();
+      const link = event.currentTarget;
+      if (!currentOrgId) return;
+
+      // Open synchronously so browsers treat this as a user-initiated popup,
+      // then sever the opener before navigating to the external portal.
+      const portalWindow = window.open('', '_blank');
+      if (portalWindow) portalWindow.opener = null;
+      const originalText = link.textContent;
+      link.textContent = 'Opening WorkOS...';
+      link.setAttribute('aria-busy', 'true');
+      try {
+        const response = await fetch('/api/organizations/' + encodeURIComponent(currentOrgId) + '/domain-verification-link', {
+          method: 'POST',
+          credentials: 'include',
+        });
+        const data = await response.json().catch(function() { return {}; });
+        if (!response.ok || !data.link) {
+          throw new Error(data.message || data.error || 'Failed to open domain management');
+        }
+        const portalUrl = new URL(data.link);
+        if (portalUrl.protocol !== 'https:') {
+          throw new Error('WorkOS returned an invalid domain-management link');
+        }
+        if (!portalWindow) {
+          throw new Error('Your browser blocked the WorkOS window. Allow popups and try again.');
+        }
+        portalWindow.location.replace(portalUrl.href);
+      } catch (err) {
+        if (portalWindow) portalWindow.close();
+        const errEl = document.getElementById('add-domain-error');
+        errEl.textContent = err.message || 'Failed to open domain management';
+        errEl.style.display = 'block';
+      } finally {
+        link.textContent = originalText;
+        link.removeAttribute('aria-busy');
+      }
     }
 
     // Tracks the domain whose challenge is currently displayed in the
@@ -1818,12 +1884,23 @@
     // which domain to confirm.
     let pendingChallengeDomain = null;
 
-    async function addLinkedDomain() {
+    // WorkOS returns the token itself through the API, while its DNS lookup
+    // expects the TXT payload in key=value form. Keep the display/copy value
+    // complete, but tolerate a future API response that is already formatted.
+    function formatWorkosVerificationValue(token) {
+      const trimmed = typeof token === 'string' ? token.trim() : '';
+      if (!trimmed || trimmed.startsWith('verification_token=')) return trimmed;
+      return 'verification_token=' + trimmed;
+    }
+
+    async function addLinkedDomain(domainOverride, triggerButton) {
       const input = document.getElementById('add-domain-input');
-      const btn = document.getElementById('add-domain-btn');
+      const btn = triggerButton || document.getElementById('add-domain-btn');
       const errEl = document.getElementById('add-domain-error');
       const challengeEl = document.getElementById('add-domain-challenge');
-      const raw = (input.value || '').trim();
+      const raw = typeof domainOverride === 'string'
+        ? domainOverride.trim()
+        : (input.value || '').trim();
       if (!raw) {
         errEl.style.display = 'block';
         errEl.textContent = 'Enter a domain';
@@ -1855,8 +1932,9 @@
         }
         pendingChallengeDomain = data.domain;
         var prefix = data.verification_prefix || '';
+        document.getElementById('add-domain-challenge-domain').textContent = data.domain;
         document.getElementById('add-domain-host').textContent = data.dns_record_name || (prefix ? prefix + '.' + data.domain : data.domain);
-        document.getElementById('add-domain-token').textContent = data.verification_token || '';
+        document.getElementById('add-domain-token').textContent = formatWorkosVerificationValue(data.dns_record_value || data.verification_token);
         document.getElementById('add-domain-verify-status').textContent = '';
         challengeEl.style.display = 'block';
         await loadLinkedDomains();
@@ -2222,7 +2300,7 @@
         // value as verification_token. Show the fully-qualified record name
         // so DNS hosts that don't auto-append the apex are unambiguous.
         var prefix = data.verification_prefix || '';
-        var token = data.verification_token || '';
+        var token = formatWorkosVerificationValue(data.dns_record_value || data.verification_token);
         var fqdn = prefix ? prefix + '.' + data.domain : data.domain;
         document.getElementById('domain-claim-record-name').textContent = fqdn;
         document.getElementById('domain-claim-record-value').textContent = token;
@@ -2395,7 +2473,7 @@
           throw new Error(data.message || data.error || 'Failed to issue challenge.');
         }
         var prefix = data.verification_prefix || '';
-        var token = data.verification_token || '';
+        var token = formatWorkosVerificationValue(data.dns_record_value || data.verification_token);
         var fqdn = prefix ? prefix + '.' + data.domain : data.domain;
         document.getElementById('cross-org-claim-record-name').textContent = fqdn;
         document.getElementById('cross-org-claim-record-value').textContent = token;

--- a/server/tests/unit/member-domain-verification-ui.test.ts
+++ b/server/tests/unit/member-domain-verification-ui.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  join(process.cwd(), 'server/public/member-profile.html'),
+  'utf8',
+);
+
+function extractFunction(name: string): (value: unknown) => string {
+  const start = source.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`Missing ${name}`);
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  let end = brace;
+  for (; end < source.length; end += 1) {
+    if (source[end] === '{') depth += 1;
+    else if (source[end] === '}' && --depth === 0) {
+      end += 1;
+      break;
+    }
+  }
+  return new Function(`${source.slice(start, end)}; return ${name};`)() as (value: unknown) => string;
+}
+
+describe('member profile domain verification guidance', () => {
+  it('renders a copy-ready WorkOS TXT value with the required prefix', () => {
+    const formatValue = extractFunction('formatWorkosVerificationValue');
+
+    expect(formatValue('token-123')).toBe('verification_token=token-123');
+    expect(formatValue(' verification_token=token-123 ')).toBe('verification_token=token-123');
+    expect(formatValue(null)).toBe('');
+    expect(source).toContain('including the required <code>verification_token=</code> prefix');
+  });
+
+  it('maps pending domains back to their challenge and WorkOS manager', () => {
+    expect(source).toContain('id="add-domain-challenge-domain"');
+    expect(source).toContain('>Show DNS record</button>');
+    expect(source).toContain('data-domain-action="show-record"');
+    expect(source).toContain("btn.addEventListener('click'");
+    expect(source).not.toContain("onclick=\"addLinkedDomain(\\'");
+    expect(source).toContain('id="manage-domains-link"');
+    expect(source).toContain("manageDomainsLink.href = '/team?org='");
+    expect(source).toContain("manageDomainsLink.addEventListener('click', openWorkosDomainManager)");
+    expect(source).toContain("'/domain-verification-link'");
+    expect(source).toContain("portalUrl.protocol !== 'https:'");
+  });
+
+  it('shows privileged domain actions only to organization admins', () => {
+    expect(source).toContain("const canManageDomains = currentOrgRole === 'owner' || currentOrgRole === 'admin'");
+    expect(source).toContain('if (!d.verified && canManageDomains)');
+    expect(source).toContain('d.verified && !d.is_primary && canManageDomains');
+  });
+});


### PR DESCRIPTION
## Summary
- show copy-ready WorkOS TXT values with the required verification_token= prefix across profile domain-claim flows
- let admins reopen the correct challenge for each pending domain and open the WorkOS domain manager directly
- use safe event binding, owner/admin action gating, and responsive domain rows

## Testing
- focused server Vitest regression: 3 passed
- production Docker build: passed
- headless Chrome flow at narrow viewport: passed, including challenge mapping, prefixed value, and no horizontal overflow
- expert code, security, and UX reviews: approved
- pre-commit general unit suite: 1,059 passed; full server-unit sweep reached its 10-minute local hook timeout without a reported failure, so required CI is the authoritative full gate
- changeset scope check: passed; no changeset required for app-only UI work

## Risk
Low. The server API and authorization boundary are unchanged; this updates client-side presentation and privileged action wiring.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/14391c02-ff98-44ab-96e3-0cecec35ea84)
