### PR TITLE
feat(addie): pilot Gemini 3.7 Direct in web chat

### DIFF
--- a/docs/runbooks/addie-gemini-direct.md
+++ b/docs/runbooks/addie-gemini-direct.md
@@ -1,4 +1,8 @@
-# Gemini 3.7 Direct web pilot
+---
+title: Gemini 3.7 Direct web pilot
+description: "Operate the Addie Gemini 3.7 Direct pilot, compare routing, latency, cost and outcomes, and roll back safely."
+"og:title": "AdCP — Gemini 3.7 Direct web pilot"
+---
 
 Experiment `gemini-3.7-direct-v1` compares the existing web routing and response
 stack (normally Haiku → Sonnet, with quick matches) against Gemini 3.7 without

--- a/docs/runbooks/addie-gemini-direct.md
+++ b/docs/runbooks/addie-gemini-direct.md
@@ -1,0 +1,93 @@
+# Gemini 3.7 Direct web pilot
+
+Experiment `gemini-3.7-direct-v1` compares the existing web routing and response
+stack (normally Haiku → Sonnet, with quick matches) against Gemini 3.7 without
+an up-front router call. This measures the model and architecture together.
+
+## Rollout
+
+The runtime defaults to off. `fly.toml` selects the first stage, **staff**, on
+deployment. It sends new site-admin conversations to Gemini; it is a delivery pilot,
+not a randomized comparison. Existing conversations retain control. Once a
+thread has an assignment, it persists across workers, restarts, and percentage
+changes.
+
+After reviewing staff outcomes, enable the randomized cohort:
+
+```sh
+fly secrets set -a adcp-docs ADDIE_GEMINI_DIRECT_MODE=eligible ADDIE_GEMINI_DIRECT_PERCENT=10
+```
+
+This assigns 10% of authenticated users to treatment in new conversations using
+a stable user hash. The remaining eligible users are control. Staff-pilot and
+pre-existing conversation cohorts remain separate in the results.
+
+Rollback takes precedence over saved assignments:
+
+```sh
+fly secrets set -a adcp-docs ADDIE_GEMINI_DIRECT_MODE=off
+```
+
+Fly applies these settings through a rolling restart. In-flight turns finish;
+subsequent requests on restarted workers use control. Set the mode back to
+`staff` or `eligible` to resume saved assignments. `PERCENT=0` stops enrolling
+new treatment conversations in eligible mode; use `MODE=off` for rollback.
+
+## Treatment behavior
+
+- Exact model: `gemini-3.7-flash`, low thinking, 8,192 output tokens, ordinary
+  ten-step tool loop. Native Google streaming retains signed continuation parts.
+- Documentation and schema tools start active. `load_tool_group` can load one
+  additional authorized read-only group: industry research, community discussion,
+  group discovery, or agent/publisher directory. Definitions and handlers must
+  already be registered for the request. Loading a group grants no permissions.
+- `handoff_to_addie` transfers unsupported work to the existing routed workflow
+  without asking the user to repeat the request. Gemini cannot dispatch mutation
+  handlers. Its spent time and settled usage remain attributed to treatment.
+- Attachments, active certification, sponsored intelligence, interrupted-turn
+  retries, and explicit GitHub creation requests use control. These turns retain
+  their assigned arm and record an exclusion reason.
+- Provider failure can fall back to control before any Gemini answer is
+  delivered. Both providers use normal production accounting and cost caps.
+  Cap exhaustion does not trigger a fallback that bypasses the cap.
+- Saved tool results are historical text on later Gemini turns. Current-turn
+  function calls retain the adapter's opaque Google signatures. Server-owned
+  action receipts and mutation reservations stay on the existing control path.
+
+## Results and review
+
+While signed in as a site admin, open
+`https://agenticadvertising.org/api/addie/chat/experiment`.
+It reports users/turns, incomplete turns, failures, fallbacks, first visible
+response time, median/p95 total time, router time, estimated cost, tool errors,
+ratings, and marked resolutions, grouped by arm, cohort, and exclusion reason.
+
+Timing starts at HTTP handler entry and includes context preparation, routing,
+tool discovery, tool execution, provider continuations, fallback, and reply
+persistence. Streaming answers remain buffered until the logical response is
+accepted, as required by the existing receipt/delivery boundary. Estimates use
+the live pricing registry and include router cache usage. Failed dispatches can
+lack usage receipts: `incomplete_usage` exposes these cases; their cost is a
+lower bound, not zero-cost success. Cost per marked resolution depends on manual
+outcome coverage and should not be treated as a complete resolution rate.
+
+`addie_chat_experiment_turns.assistant_message_id` links outcomes to existing
+thread messages and feedback. Use the existing Addie conversation review view;
+review a sample from each arm without model labels for correctness, useful
+completion, unnecessary clarification, and unsupported success claims. Compare
+eligible, non-excluded turns within the same cohort. Small staff samples establish
+delivery readiness, not a quality or latency win.
+
+Stop treatment for unauthorized actions or fabricated action confirmations.
+Investigate repeated quality/error regressions or p95 total time more than 20%
+worse than control. Expand into teaching or consequential actions only after
+their permission, progress, and receipt workflows are checked independently.
+
+## Release dependency found during implementation
+
+As of 2026-09-10, main's existing Deploy workflow depends on successful protected
+matched-v4 evaluator provisioning. Run `34478760809` failed because its database,
+principal, and manifest inputs were empty; Deploy was skipped. The web experiment
+uses the ordinary application database and existing Gemini credential, but cannot
+activate until that release dependency is resolved. This change does not bypass
+the protected workflow or provision another evaluator service.

--- a/fly.toml
+++ b/fly.toml
@@ -26,6 +26,10 @@ primary_region = 'iad'
   BASE_URL = "https://agenticadvertising.org"
   # Disabled - migrations now run via release_command
   RUN_MIGRATIONS = "false"
+  # First stage: new staff web conversations only. Set MODE=eligible for the
+  # 10% user A/B after reviewing staff outcomes; MODE=off rolls back all turns.
+  ADDIE_GEMINI_DIRECT_MODE = "staff"
+  ADDIE_GEMINI_DIRECT_PERCENT = "10"
   PUBLISHER_CRAWL_QUEUE_ENABLED = "true"
   # Bounded, evaluation-only Luna router shadow. The runtime additionally
   # fails closed unless the channel is public and non-shared and the HMAC and

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -144,10 +144,7 @@ const SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS = 16_384;
 function addieModelOutputControls(
   model: string,
   maxOutputTokens?: number,
-): { maxOutputTokens: number; reasoning?: { effort: 'low' | 'medium' } } {
-  if (model === GOOGLE_ROUTER_MODEL) {
-    return { maxOutputTokens: maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS, reasoning: { effort: 'low' } };
-  }
+): { maxOutputTokens: number; reasoning?: { effort: 'medium' } } {
   if (/^claude-sonnet-5(?:-|$)/.test(model)) {
     return {
       maxOutputTokens: Math.min(
@@ -1335,7 +1332,11 @@ export class AddieClaudeClient {
   }
 
   private executionPolicy(options: ProcessMessageOptions | undefined) {
+    // In isolated modes, absence of a policy must remain absence: the shared
+    // executor deliberately denies every handler until a caller opts in.
+    if (!options?.directToolSession) return options?.toolExecutionPolicy;
     return async (request: Parameters<NonNullable<ProcessMessageOptions['toolExecutionPolicy']>>[0]) => {
+      if (isIsolatedExecution(options) && !options.toolExecutionPolicy) return { allowed: false };
       if (options?.directToolSession && (!options.directToolSession.visibleToolNames().has(request.toolName)
         || isSideEffectTool(request.toolName))) return { allowed: false };
       return options?.toolExecutionPolicy ? options.toolExecutionPolicy(request) : { allowed: true };
@@ -1440,7 +1441,9 @@ export class AddieClaudeClient {
         maxOutputTokens ?? SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS,
       )
       : maxOutputTokens;
-    const controls = addieModelOutputControls(effectiveModel, safeMaxOutputTokens);
+    const controls = this.productionGeminiDirect && effectiveModel === GOOGLE_ROUTER_MODEL
+      ? { maxOutputTokens: safeMaxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS, reasoning: { effort: 'low' as const } }
+      : addieModelOutputControls(effectiveModel, safeMaxOutputTokens);
     return {
       model: effectiveModel,
       system: systemBlocks.map((block) => ({

--- a/server/src/addie/claude-client.ts
+++ b/server/src/addie/claude-client.ts
@@ -65,6 +65,10 @@ import type {
   PreparedModelInvocation,
 } from './model-providers/model-provider.js';
 import { attemptSiblingModelFallback } from './model-providers/model-fallback.js';
+import type { DirectToolSession } from './gemini-direct-tools.js';
+import { isSideEffectTool } from './side-effect-claims.js';
+import { GOOGLE_ROUTER_MODEL } from './model-providers/google-generate-content-provider.js';
+import type { CostEvent } from './claude-cost-tracker.js';
 import {
   AnthropicModelProvider,
   type AnthropicMessagesTransport,
@@ -140,7 +144,10 @@ const SONNET_5_MAX_NONSTREAMING_OUTPUT_TOKENS = 16_384;
 function addieModelOutputControls(
   model: string,
   maxOutputTokens?: number,
-): { maxOutputTokens: number; reasoning?: { effort: 'medium' } } {
+): { maxOutputTokens: number; reasoning?: { effort: 'low' | 'medium' } } {
+  if (model === GOOGLE_ROUTER_MODEL) {
+    return { maxOutputTokens: maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS, reasoning: { effort: 'low' } };
+  }
   if (/^claude-sonnet-5(?:-|$)/.test(model)) {
     return {
       maxOutputTokens: Math.min(
@@ -219,11 +226,20 @@ function boundedContentTypes(
 }
 
 /** Build the provider-neutral form of historical turns for live orchestration. */
-function toModelMessages(turns: MessageTurn[]): ModelMessage[] {
+function toModelMessages(turns: MessageTurn[], historicalToolsAsText = false): ModelMessage[] {
   const messages: ModelMessage[] = [];
   let toolIdCounter = 0;
 
   for (const turn of turns) {
+    if (historicalToolsAsText && turn.toolCalls?.length) {
+      // Persisted conversation history has no provider-owned thought signatures.
+      // Keep its evidence as text; only this invocation's adapter can issue live
+      // tool-call continuations. Original receipt records remain server-owned.
+      messages.push({ role: turn.role, content: [{ type: 'text',
+        text: `${turn.content}\n\nEarlier tool results (historical context):\n${JSON.stringify(turn.toolCalls)}`,
+      }] });
+      continue;
+    }
     if (turn.role === 'assistant' && turn.toolCalls && turn.toolCalls.length > 0) {
       const content: ModelMessageContent[] = [];
       if (turn.content.trim()) content.push({ type: 'text', text: turn.content });
@@ -601,6 +617,10 @@ export interface UserScopedToolsResult {
  * Options for message processing
  */
 export interface ProcessMessageOptions {
+  /** Server-created read-only capability session for the Gemini Direct pilot. */
+  directToolSession?: DirectToolSession;
+  /** Aggregate settled usage, including calls preceding a failed continuation. */
+  onUsageAccounted?: (event: CostEvent) => void;
   /** Request-local execution mode. Evaluation, replay, and shadow suppress operational side effects. */
   executionMode?: AddieExecutionMode;
   /** Exclude provider-managed tools such as web search for this request only. */
@@ -1016,9 +1036,9 @@ interface PayloadDebugStats {
 }
 
 /**
- * Injectable provider seam for isolated full-response evaluation. Alternate
- * providers remain barred from production delivery until provider-specific
- * accounting and rollout gates are in place.
+ * Injectable provider seam for isolated full-response evaluation. Production
+ * Google delivery additionally requires the bounded Gemini Direct factory and
+ * a request-local read-only tool session.
  */
 export interface AddieModelProviderBinding {
   provider: ModelProvider;
@@ -1027,6 +1047,7 @@ export interface AddieModelProviderBinding {
 }
 
 export class AddieClaudeClient {
+  private productionGeminiDirect = false;
   private readonly modelProvider: ModelProvider;
   private readonly exactlyOnceModelProvider: ModelProvider;
   private model: string;
@@ -1297,6 +1318,37 @@ export class AddieClaudeClient {
     return fork;
   }
 
+  /** Narrow production entry point; the pilot cannot dispatch mutation tools. */
+  forkForGeminiDirect(provider: ModelProvider): AddieClaudeClient {
+    if (provider.id !== 'google') throw new Error('Gemini Direct requires the Google provider');
+    const fork = this.forkForIsolatedProvider(GOOGLE_ROUTER_MODEL, { provider });
+    fork.productionGeminiDirect = true;
+    return fork;
+  }
+
+  private assertProductionProvider(model: string, options?: ProcessMessageOptions): void {
+    if (isIsolatedExecution(options) || this.modelProvider.id === 'anthropic') return;
+    if (this.productionGeminiDirect && model === GOOGLE_ROUTER_MODEL
+      && options?.directToolSession && options.allowedToolNames && options.costScope
+      && !options.inputAttachments?.length) return;
+    throw new Error('Alternate Addie model providers are restricted to isolated execution');
+  }
+
+  private executionPolicy(options: ProcessMessageOptions | undefined) {
+    return async (request: Parameters<NonNullable<ProcessMessageOptions['toolExecutionPolicy']>>[0]) => {
+      if (options?.directToolSession && (!options.directToolSession.visibleToolNames().has(request.toolName)
+        || isSideEffectTool(request.toolName))) return { allowed: false };
+      return options?.toolExecutionPolicy ? options.toolExecutionPolicy(request) : { allowed: true };
+    };
+  }
+
+  private invocationSystemBlocks(blocks: ModelSystemBlock[], tools: ModelToolDefinition[], options?: ProcessMessageOptions) {
+    if (!options?.directToolSession) return blocks;
+    const current = this.buildSystemBlocks(tools.map(tool => tool.name), options.directToolSession.selectedToolSetNames(), options.requestContext);
+    // Retain any history-trimming warning appended during initial assembly.
+    return [...current, ...blocks.slice(current.length)];
+  }
+
   /** Assemble the shared prompt, tool surface, history, and attachments for either delivery mode. */
   private prepareFirstInvocation(
     userMessage: string,
@@ -1353,7 +1405,7 @@ export class AddieClaudeClient {
     }
 
     const modelMessages = appendModelInputAttachments(
-      toModelMessages(messageTurnsResult.messages),
+      toModelMessages(messageTurnsResult.messages, this.modelProvider.id === 'google'),
       options?.inputAttachments,
     );
     const modelTools = buildModelToolDefinitions(allTools);
@@ -1467,9 +1519,7 @@ export class AddieClaudeClient {
     const requestedModel = options?.modelOverride ?? this.model;
     const githubIssueCreationRequested = options?.githubIssueCreationRequested
       ?? isGithubIssueCreationRequested(userMessage, threadContext);
-    if (operationalExecution && this.modelProvider.id !== 'anthropic') {
-      throw new Error('Alternate Addie model providers are restricted to isolated execution');
-    }
+    this.assertProductionProvider(requestedModel, options);
 
     // #2950: warn when a caller has neither `costScope` nor explicit
     // `uncapped: true`. Silent default meant a future user-facing
@@ -1571,7 +1621,7 @@ export class AddieClaudeClient {
         executionMode: options?.executionMode ?? 'production',
         policy: githubIssueCreationExecutionPolicy(
           githubIssueCreationRequested,
-          options?.toolExecutionPolicy,
+          this.executionPolicy(options),
         ),
         reserveSideEffect: options?.reserveSideEffect,
         notificationContext: {
@@ -1593,10 +1643,13 @@ export class AddieClaudeClient {
       : await getCurrentConfigVersionId();
 
     const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    let usageRecorded = false;
     const recordAccumulatedCost = async () => {
-      if (!operationalExecution || !options?.costScope) return;
+      if (usageRecorded || !operationalExecution) return;
+      usageRecorded = true;
       for (const event of modelLoop.accountedUsage) {
-        await recordCost(options.costScope.userId, event);
+        options?.onUsageAccounted?.(event);
+        if (options?.costScope) await recordCost(options.costScope.userId, event);
       }
     };
 
@@ -1622,6 +1675,10 @@ export class AddieClaudeClient {
     let modelFallbackReason: ModelFallbackReason | null = null;
 
     while (modelLoop.hasRemaining) {
+      if (options?.directToolSession?.handoffRequested()) {
+        await recordAccumulatedCost();
+        throw new Error('gemini_direct_handoff');
+      }
       const activeTurn = modelLoop.beginNext();
       iteration = activeTurn.iteration;
 
@@ -1630,14 +1687,16 @@ export class AddieClaudeClient {
       let response!: ModelResponse;
       let reusedEmptyResponse = false;
       const recoveryInvocation = modelLoop.emptyResponseRecovery.prepareInvocation();
-      const invocationTools = recoveryInvocation.toolsAllowed ? modelTools : [];
+      const invocationTools = recoveryInvocation.toolsAllowed
+        ? modelTools.filter(tool => !options?.directToolSession
+          || options.directToolSession.visibleToolNames().has(tool.name)) : [];
       let invocationAttempt = 0;
       let lastModelRequest: ModelRequest | undefined;
       const invokeProvider = async (exactlyOnce: boolean, model = activeModel) => {
         invocationAttempt++;
         const modelRequest = this.buildModelRequest(
           model,
-          systemBlocks,
+          this.invocationSystemBlocks(systemBlocks, invocationTools, options),
           invocationTools,
           modelMessages,
           recoveryInvocation.toolsAllowed && requestWebSearchEnabled,
@@ -1743,6 +1802,7 @@ export class AddieClaudeClient {
             response = fallbackResponse;
             reusedEmptyResponse = true;
           } else {
+            await recordAccumulatedCost();
             if (!lastModelRequest) {
               throw invocationError;
             }
@@ -2047,9 +2107,7 @@ export class AddieClaudeClient {
     const requestedModel = options?.modelOverride ?? this.model;
     const githubIssueCreationRequested = options?.githubIssueCreationRequested
       ?? isGithubIssueCreationRequested(userMessage, threadContext);
-    if (operationalExecution && this.modelProvider.id !== 'anthropic') {
-      throw new Error('Alternate Addie model providers are restricted to isolated execution');
-    }
+    this.assertProductionProvider(requestedModel, options);
 
     // #2950: matching fail-closed warn on the stream path.
     if (operationalExecution && !options?.costScope && !options?.uncapped) {
@@ -2138,6 +2196,17 @@ export class AddieClaudeClient {
     let totalReceivedDeltas = 0;
     let streamErrorEmitted = false;
 
+    const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
+    let usageRecorded = false;
+    const recordAccumulatedCost = async () => {
+      if (usageRecorded || !operationalExecution) return;
+      usageRecorded = true;
+      for (const event of modelLoop.accountedUsage) {
+        options?.onUsageAccounted?.(event);
+        if (options?.costScope) await recordCost(options.costScope.userId, event);
+      }
+    };
+
     try {
 
     // Timing metrics
@@ -2179,7 +2248,7 @@ export class AddieClaudeClient {
       executionMode: options?.executionMode ?? 'production',
       policy: githubIssueCreationExecutionPolicy(
         githubIssueCreationRequested,
-        options?.toolExecutionPolicy,
+        this.executionPolicy(options),
       ),
       reserveSideEffect: options?.reserveSideEffect,
       notificationContext: {
@@ -2200,19 +2269,13 @@ export class AddieClaudeClient {
         'Addie Stream: Trimmed conversation history to fit context limit'
       );
     }
-    const modelLoop = new ModelTurnLoopState(options?.maxIterations ?? DEFAULT_MAX_ITERATIONS);
-    const recordAccumulatedCost = async () => {
-      if (!operationalExecution || !options?.costScope) return;
-      for (const event of modelLoop.accountedUsage) {
-        await recordCost(options.costScope.userId, event);
-      }
-    };
     let iteration = 0;
     let lastProviderModel: string | undefined;
     let activeModel = effectiveModel;
     let modelFallbackReason: ModelFallbackReason | null = null;
 
       while (modelLoop.hasRemaining) {
+        if (options?.directToolSession?.handoffRequested()) return;
         const activeTurn = modelLoop.beginNext();
         iteration = activeTurn.iteration;
 
@@ -2228,17 +2291,19 @@ export class AddieClaudeClient {
         // is complete.
         // A failed sample is therefore safe to discard even after provider
         // deltas arrive. This loop never restarts the surrounding logical turn.
-        const maxStreamRetries = isExactlyOnceExecution(options) ? 0 : 3;
+        const maxStreamRetries = isExactlyOnceExecution(options) || this.productionGeminiDirect ? 0 : 3;
         let streamRetryCount = 0;
         let streamSucceeded = false;
         let receivedDeltaCount = 0;
 
         while (!streamSucceeded && streamRetryCount <= maxStreamRetries) {
           const recoveryInvocation = modelLoop.emptyResponseRecovery.prepareInvocation();
-          const invocationTools = recoveryInvocation.toolsAllowed ? modelTools : [];
+          const invocationTools = recoveryInvocation.toolsAllowed
+            ? modelTools.filter(tool => !options?.directToolSession
+              || options.directToolSession.visibleToolNames().has(tool.name)) : [];
           const modelRequest = this.buildModelRequest(
             activeModel,
-            systemBlocks,
+            this.invocationSystemBlocks(systemBlocks, invocationTools, options),
             invocationTools,
             modelMessages,
             false,
@@ -2333,7 +2398,9 @@ export class AddieClaudeClient {
                   error: streamError,
                 },
                 async (model) => {
-                  const fallbackTools = recoveryInvocation.toolsAllowed ? modelTools : [];
+                  const fallbackTools = recoveryInvocation.toolsAllowed
+                    ? modelTools.filter(tool => !options?.directToolSession
+                      || options.directToolSession.visibleToolNames().has(tool.name)) : [];
                   const fallbackRequest = this.buildModelRequest(
                     model,
                     systemBlocks,
@@ -2807,6 +2874,7 @@ export class AddieClaudeClient {
         };
       }
     } finally {
+      await recordAccumulatedCost();
       if (certificationLeaseHeartbeat) clearInterval(certificationLeaseHeartbeat);
       if (operationalExecution) {
         await releaseCertificationReserve(options?.costScope?.userId, certificationLeaseId);

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.46';
+export const CODE_VERSION = '2026.09.47';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/gemini-direct-experiment.ts
+++ b/server/src/addie/gemini-direct-experiment.ts
@@ -1,0 +1,317 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { query } from '../db/client.js';
+import { createLogger } from '../logger.js';
+import type { AddieClaudeClient, AddieResponse, ProcessMessageOptions, RequestTools, StreamEvent } from './claude-client.js';
+import type { CostEvent } from './claude-cost-tracker.js';
+import { createGeminiDirectTools } from './gemini-direct-tools.js';
+import { GoogleGenerateContentProvider, GOOGLE_ROUTER_MODEL } from './model-providers/google-generate-content-provider.js';
+import { resolveModelCostPricing } from './model-cost-pricing.js';
+
+const logger = createLogger('addie-gemini-direct');
+export const GEMINI_DIRECT_EXPERIMENT = 'gemini-3.7-direct-v1';
+const CONTEXT_KEY = 'gemini_direct_v1';
+type Client = Pick<AddieClaudeClient, 'processMessage' | 'processMessageStream'>
+  & Partial<Pick<AddieClaudeClient, 'getRegisteredTools' | 'forkForGeminiDirect'>>;
+export interface WebToolSelection {
+  requestTools: RequestTools;
+  selectedToolSets: string[];
+  allowedToolNames: string[];
+  unavailableHint: string;
+  routerMs?: number;
+  routerUsage?: CostEvent;
+  routerUsageComplete?: boolean;
+}
+type Assignment = { arm: 'control' | 'gemini'; cohort: 'staff' | 'eligible' | 'existing'; bucket: number };
+const clients = new WeakMap<Client, AddieClaudeClient>();
+
+/** Stable across workers/restarts. Raising the percentage only enrolls new threads. */
+export function geminiDirectAssignment(userId: string, staff: boolean, existing: boolean, env = process.env): Assignment | null {
+  const mode = env.ADDIE_GEMINI_DIRECT_MODE;
+  if (mode !== 'staff' && mode !== 'eligible') return null;
+  if (mode === 'staff' && !staff) return null;
+  const percent = Number(env.ADDIE_GEMINI_DIRECT_PERCENT ?? '10');
+  if (!Number.isInteger(percent) || percent < 0 || percent > 100) return null;
+  const bucket = createHash('sha256').update(`${GEMINI_DIRECT_EXPERIMENT}:${userId}`).digest().readUInt32BE(0) % 10_000;
+  return {
+    arm: existing ? 'control' : mode === 'staff' || bucket < percent * 100 ? 'gemini' : 'control',
+    cohort: existing ? 'existing' : mode,
+    bucket,
+  };
+}
+
+function validAssignment(value: unknown): value is Assignment {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Assignment;
+  return ['control', 'gemini'].includes(candidate.arm)
+    && ['staff', 'eligible', 'existing'].includes(candidate.cohort)
+    && Number.isInteger(candidate.bucket) && candidate.bucket >= 0 && candidate.bucket < 10_000;
+}
+
+class ExperimentTurn {
+  readonly id = randomUUID();
+  readonly usage: CostEvent[] = [];
+  providerCalls = 0;
+  routerMs = 0;
+  firstVisibleMs: number | null = null;
+  fallbackReason: string | null = null;
+  usageComplete = true;
+  fallbackToolErrors = 0;
+
+  constructor(readonly startedAt: number, readonly assignment: Assignment) {}
+
+  options(options?: ProcessMessageOptions): ProcessMessageOptions {
+    return {
+      ...options,
+      onInvocationPrepared: async snapshot => {
+        this.providerCalls++;
+        await options?.onInvocationPrepared?.(snapshot);
+      },
+      onUsageAccounted: event => {
+        this.usage.push(event);
+        options?.onUsageAccounted?.(event);
+      },
+    };
+  }
+
+  routed(selection: WebToolSelection | null) {
+    this.routerMs += selection?.routerMs ?? 0;
+    if (selection?.routerUsage) {
+      this.usage.push(selection.routerUsage);
+      this.providerCalls++;
+    }
+    if (selection?.routerUsageComplete === false) this.usageComplete = false;
+  }
+
+  visible() {
+    this.firstVisibleMs ??= Date.now() - this.startedAt;
+  }
+
+  async finish(response?: AddieResponse, messageId?: string, failed = false) {
+    if (messageId && this.firstVisibleMs === null) this.visible();
+    const execution = response?.model_execution;
+    let costMicros = 0;
+    for (const event of this.usage) {
+      const pricing = resolveModelCostPricing(event.provider, event.model);
+      if (pricing) costMicros += pricing.estimateCostMicros(event.usage);
+      else this.usageComplete = false;
+    }
+    try {
+      await query(`UPDATE addie_chat_experiment_turns SET
+        completed_at = NOW(), first_visible_ms = $2, total_ms = $3, router_ms = $4,
+        provider_calls = $5, estimated_cost_micros = $6, usage_complete = $7,
+        fallback_reason = $8, actual_provider = $9, actual_model = $10,
+        failed = $11, tool_errors = $12, usage = $13::jsonb,
+        assistant_message_id = COALESCE($14, assistant_message_id)
+        WHERE id = $1`, [
+        this.id, this.firstVisibleMs, Date.now() - this.startedAt, this.routerMs,
+        this.providerCalls, costMicros, this.usageComplete, this.fallbackReason,
+        execution?.source === 'provider' ? execution.provider : null,
+        execution?.source === 'provider' ? execution.model : null,
+        failed || !response || response.flagged === true,
+        this.fallbackToolErrors + (response?.tool_executions?.filter(tool => tool.is_error).length ?? 0),
+        JSON.stringify(this.usage), messageId ?? null,
+      ]);
+    } catch (error) {
+      logger.error({ error, turnId: this.id }, 'Failed to save Gemini Direct outcome');
+    }
+  }
+}
+
+function fallbackResponse(response: AddieResponse, handoff: boolean): AddieResponse {
+  return {
+    ...response,
+    model_execution: response.model_execution.source === 'provider' ? {
+      ...response.model_execution,
+      requested_provider: 'google', requested_model: GOOGLE_ROUTER_MODEL,
+      model_resolution: 'fallback',
+      fallback_reason: handoff ? 'primary_capability_unsupported' : 'primary_unavailable',
+    } : {
+      ...response.model_execution, requested_provider: 'google', requested_model: GOOGLE_ROUTER_MODEL,
+    },
+  };
+}
+
+/** Select before routing: the treatment never pays for an up-front router call. */
+export async function prepareGeminiDirectTurn(input: {
+  client: Client;
+  userId?: string;
+  isAdmin: boolean;
+  threadId: string;
+  hasPriorAssistant: boolean;
+  exclusionReason: string | null;
+  startedAt: number;
+  requestTools: RequestTools;
+  baseRequestContext: string;
+  getControlTools: () => Promise<WebToolSelection | null>;
+  /** Evaluation routes must never enroll live experiment traffic. */
+  evaluation?: boolean;
+}) {
+  let controlTools: WebToolSelection | null | undefined;
+  const getControl = async () => controlTools === undefined
+    ? (controlTools = await input.getControlTools()) : controlTools;
+  const ordinary = async () => ({ client: input.client, selection: await getControl(), experiment: undefined as ExperimentTurn | undefined, model: undefined as string | undefined });
+  const proposed = input.userId && !input.evaluation && process.env.GEMINI_API_KEY
+    && input.client.forkForGeminiDirect
+    ? geminiDirectAssignment(input.userId, input.isAdmin, input.hasPriorAssistant) : null;
+  if (!proposed) return ordinary();
+
+  let assignment: Assignment;
+  let experiment: ExperimentTurn;
+  try {
+    // One atomic UPDATE elects the winner even when two requests start together.
+    const assigned = await query<{ assignment: unknown }>(`UPDATE addie_threads SET
+      context = CASE WHEN context ? $2 THEN context ELSE
+        COALESCE(context, '{}'::jsonb) || jsonb_build_object($2::text, $3::jsonb) END
+      WHERE thread_id = $1 RETURNING context -> $2 AS assignment`,
+    [input.threadId, CONTEXT_KEY, JSON.stringify(proposed)]);
+    const stored = assigned.rows[0]?.assignment;
+    if (!validAssignment(stored)) return ordinary();
+    assignment = stored;
+    experiment = new ExperimentTurn(input.startedAt, assignment);
+    await query(`INSERT INTO addie_chat_experiment_turns
+      (id, experiment, thread_id, user_id, arm, cohort, exclusion_reason, started_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, [
+      experiment.id, GEMINI_DIRECT_EXPERIMENT, input.threadId, input.userId,
+      assignment.arm, assignment.cohort, input.exclusionReason, new Date(input.startedAt),
+    ]);
+  } catch (error) {
+    logger.error({ error }, 'Gemini Direct assignment unavailable; retaining control');
+    return ordinary();
+  }
+
+  const treatment = assignment.arm === 'gemini' && !input.exclusionReason;
+  const direct = treatment ? createGeminiDirectTools(input.requestTools, input.client.getRegisteredTools?.() ?? []) : null;
+  let candidate: AddieClaudeClient | undefined;
+  if (direct) {
+    candidate = clients.get(input.client);
+    if (!candidate) {
+      candidate = input.client.forkForGeminiDirect!(new GoogleGenerateContentProvider(process.env.GEMINI_API_KEY!));
+      clients.set(input.client, candidate);
+    }
+  }
+  const selection: WebToolSelection | null = direct ? {
+    requestTools: direct.tools,
+    selectedToolSets: direct.selectedToolSets,
+    allowedToolNames: direct.allowedToolNames,
+    unavailableHint: 'You can load another read-only tool group when needed. For work outside these groups, call handoff_to_addie.',
+  } : await getControl();
+  if (!direct) experiment.routed(selection);
+
+  const controlOptions = async (options?: ProcessMessageOptions) => {
+    const routed = await getControl();
+    experiment.routed(routed);
+    return {
+      tools: routed?.requestTools ?? input.requestTools,
+      options: experiment.options({
+        ...options, modelOverride: undefined, directToolSession: undefined,
+        allowedToolNames: routed?.allowedToolNames,
+        selectedToolSetNames: routed?.selectedToolSets,
+        requestContext: [input.baseRequestContext, routed?.unavailableHint].filter(Boolean).join('\n\n'),
+      }),
+    };
+  };
+  const directOptions = (options?: ProcessMessageOptions): ProcessMessageOptions => experiment.options({
+    ...options, modelOverride: GOOGLE_ROUTER_MODEL, disableServerTools: true,
+    directToolSession: direct!.session,
+    toolExecutionPolicy: async request => ({ allowed: (await direct!.policy(request)).allowed
+      && (!options?.toolExecutionPolicy || (await options.toolExecutionPolicy(request)).allowed) }),
+  });
+
+  const client: Client = {
+    async processMessage(message, history, tools, rules, options) {
+      if (!direct) {
+        try {
+          const response = await input.client.processMessage(message, history, tools, rules, experiment.options(options));
+          await experiment.finish(response);
+          return response;
+        } catch (error) {
+          experiment.usageComplete = false;
+          await experiment.finish(undefined, undefined, true);
+          throw error;
+        }
+      }
+      let response: AddieResponse | undefined;
+      for await (const event of client.processMessageStream(message, history, tools, options)) {
+        if (event.type === 'done') response = event.response;
+        if (event.type === 'stream_error' || event.type === 'error') throw new Error('Addie provider response failed');
+      }
+      if (!response) throw new Error('Addie provider response missing');
+      // JSON delivery becomes visible after the route persists the reply.
+      experiment.firstVisibleMs = null;
+      return response;
+    },
+    async *processMessageStream(message, history, tools, options) {
+      let response: AddieResponse | undefined;
+      try {
+        if (direct && candidate) {
+          const buffered: StreamEvent[] = [];
+          let failed = false;
+          try {
+            for await (const event of candidate.processMessageStream(message, history, tools, directOptions(options))) {
+              buffered.push(event);
+              if (event.type === 'done') response = event.response;
+              if (event.type === 'error' || event.type === 'stream_error') failed = true;
+            }
+          } catch { failed = true; }
+          const handoff = direct.session.handoffRequested();
+          const localFailure = response?.model_execution.source === 'local'
+            && ['provider_error', 'stream_interrupted'].includes(response.model_execution.reason);
+          if (!failed && !handoff && !localFailure && response) {
+            for (const event of buffered) {
+              if (event.type === 'text') experiment.visible();
+              yield event;
+            }
+            return;
+          }
+          experiment.fallbackReason = handoff ? 'capability_handoff' : 'provider_error';
+          experiment.fallbackToolErrors = buffered.filter(event => event.type === 'tool_end' && event.is_error).length;
+          if (failed && !handoff) experiment.usageComplete = false;
+          const fallback = await controlOptions(options);
+          response = undefined;
+          for await (const event of input.client.processMessageStream(message, history, fallback.tools, fallback.options)) {
+            if (event.type === 'text') experiment.visible();
+            if (event.type === 'done') {
+              response = fallbackResponse(event.response, handoff);
+              yield { ...event, response };
+            } else yield event;
+          }
+        } else {
+          for await (const event of input.client.processMessageStream(message, history, tools, experiment.options(options))) {
+            if (event.type === 'text') experiment.visible();
+            if (event.type === 'done') response = event.response;
+            yield event;
+          }
+        }
+      } finally {
+        if (!response) experiment.usageComplete = false;
+        await experiment.finish(response);
+      }
+    },
+  };
+  return { client, selection, experiment, model: direct ? GOOGLE_ROUTER_MODEL : undefined };
+}
+
+/** Read-only staff view; transcript content stays in the existing admin review UI. */
+export async function getGeminiDirectResults() {
+  const result = await query(`SELECT e.arm, e.cohort, e.exclusion_reason,
+    COUNT(*)::int AS turns, COUNT(DISTINCT e.user_id)::int AS users,
+    COUNT(*) FILTER (WHERE completed_at IS NULL)::int AS incomplete,
+    COUNT(*) FILTER (WHERE failed)::int AS failures,
+    COUNT(*) FILTER (WHERE fallback_reason IS NOT NULL)::int AS fallbacks,
+    COUNT(*) FILTER (WHERE NOT usage_complete)::int AS incomplete_usage,
+    ROUND(AVG(first_visible_ms)) AS mean_first_visible_ms,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY total_ms) AS median_total_ms,
+    percentile_cont(0.95) WITHIN GROUP (ORDER BY total_ms) AS p95_total_ms,
+    ROUND(AVG(router_ms)) AS mean_router_ms,
+    SUM(estimated_cost_micros) / 1000000.0 AS estimated_cost_usd,
+    SUM(tool_errors)::int AS tool_errors,
+    COUNT(m.rating)::int AS rated_turns, ROUND(AVG(m.rating), 2) AS mean_rating,
+    COUNT(*) FILTER (WHERE m.outcome = 'resolved')::int AS resolved_turns,
+    SUM(estimated_cost_micros) / 1000000.0 /
+      NULLIF(COUNT(*) FILTER (WHERE m.outcome = 'resolved'), 0) AS estimated_cost_per_marked_resolution_usd
+    FROM addie_chat_experiment_turns e
+    LEFT JOIN addie_thread_messages m ON m.message_id = e.assistant_message_id
+    WHERE experiment = $1
+    GROUP BY e.arm, e.cohort, e.exclusion_reason ORDER BY e.cohort, e.arm`, [GEMINI_DIRECT_EXPERIMENT]);
+  return { experiment: GEMINI_DIRECT_EXPERIMENT, mode: process.env.ADDIE_GEMINI_DIRECT_MODE ?? 'off', cohorts: result.rows };
+}

--- a/server/src/addie/gemini-direct-tools.ts
+++ b/server/src/addie/gemini-direct-tools.ts
@@ -1,0 +1,85 @@
+import type { RequestTools } from './claude-client.js';
+import type { ToolExecutionPolicy } from './model-providers/tool-orchestration.js';
+import { TOOL_SETS } from './tool-sets.js';
+import { isSideEffectTool } from './side-effect-claims.js';
+
+/** Pilot capability boundary. Domain membership alone never grants access. */
+export const GEMINI_DIRECT_GROUPS = [
+  'knowledge', 'schema_reference', 'industry_research',
+  'community_discussions', 'community_group_discovery', 'agent_publisher_directory',
+] as const;
+
+export interface DirectToolSession {
+  visibleToolNames(): ReadonlySet<string>;
+  selectedToolSetNames(): string[];
+  handoffRequested(): boolean;
+}
+
+export function createGeminiDirectTools(requestTools: RequestTools, globalToolNames: readonly string[]) {
+  const globals = new Set(globalToolNames);
+  const registered = new Set(requestTools.tools
+    .filter(tool => requestTools.handlers.has(tool.name))
+    .map(tool => tool.name));
+  const groups = GEMINI_DIRECT_GROUPS.map(name => ({
+    ...TOOL_SETS[name],
+    tools: TOOL_SETS[name].tools.filter(tool => !isSideEffectTool(tool)
+      && (registered.has(tool) || globals.has(tool))),
+  })).filter(group => group.tools.length > 0);
+  const allowed = new Set(groups.flatMap(group => group.tools));
+  const visible = new Set(groups.filter(group => ['knowledge', 'schema_reference'].includes(group.name))
+    .flatMap(group => group.tools));
+  let handoff = false;
+  const loadName = 'load_tool_group';
+  const handoffName = 'handoff_to_addie';
+  for (const name of [loadName, handoffName]) {
+    allowed.add(name);
+    visible.add(name);
+  }
+  const handlers = new Map(requestTools.handlers);
+  handlers.set(loadName, async ({ group }) => {
+    const selected = groups.find(candidate => candidate.name === group);
+    if (!selected) return 'Error: Tool group is unavailable.';
+    // Replace the optional domain to keep the active catalog bounded. Core
+    // documentation/schema tools remain available throughout the turn.
+    for (const candidate of groups) {
+      if (!['knowledge', 'schema_reference'].includes(candidate.name)) {
+        for (const name of candidate.tools) visible.delete(name);
+      }
+    }
+    for (const name of selected.tools) visible.add(name);
+    return JSON.stringify({ available_tools: [...visible] });
+  });
+  handlers.set(handoffName, async () => {
+    handoff = true;
+    return 'The application will continue this request with the full Addie workflow.';
+  });
+  const tools: RequestTools = {
+    tools: [
+      ...requestTools.tools.filter(tool => allowed.has(tool.name)),
+      {
+        name: loadName,
+        description: `Load another authorized read-only tool group for your next step. ${groups
+          .map(group => `${group.name}: ${group.description}`).join('; ')}`,
+        input_schema: {
+          type: 'object', properties: { group: { type: 'string', enum: groups.map(group => group.name) } },
+          required: ['group'], additionalProperties: false,
+        },
+      },
+      {
+        name: handoffName,
+        description: 'Continue through the full Addie workflow when the request needs account changes, payments, messages, certification, administrative actions, or any capability outside the available read-only groups. Call this instead of claiming an action was done or asking the user to repeat their request.',
+        input_schema: { type: 'object', properties: {}, additionalProperties: false },
+      },
+    ],
+    handlers,
+  };
+  const session: DirectToolSession = {
+    visibleToolNames: () => new Set(visible),
+    selectedToolSetNames: () => groups.filter(group => group.tools.some(name => visible.has(name))).map(group => group.name),
+    handoffRequested: () => handoff,
+  };
+  const policy: ToolExecutionPolicy = ({ toolName }) => ({
+    allowed: allowed.has(toolName) && visible.has(toolName) && !isSideEffectTool(toolName),
+  });
+  return { tools, session, policy, allowedToolNames: [...allowed], selectedToolSets: groups.map(group => group.name) };
+}

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,7 +58,7 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "6a8cb276d92d377182a3c9d52216317f10c31753807b5d7c831a41931498d1ba",
+    "server/src/addie/claude-client.ts": "5a3ae29c06be856a2ac5d9565a18836db7e1cd5268ed98389cd0931bf1e5fe92",
     "server/src/addie/request-tool-assembly.ts": "cf4443d27ec69940f22aa9fcf46fdefd3f444762259c2700ac8fa01554ead4da",
     "server/src/addie/request-tool-replay-binding.ts": "3aed4c0bd18032e4418b8fff7e8deb263936b6c75b27941f9818a2a9a87287f2",
     "server/src/addie/prompts.ts": "3ec621f3e97eb9109fb561b94ff625a0639460c84506aa63aeebd57f683790f4",
@@ -66,7 +66,7 @@
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "cb1b76808654a295064cbd8b7dc580e17b9c4a54f80e882543cff5c15086632f",
-    "server/src/routes/addie-chat.ts": "24ef3b25c51e18da8c6f2241e8110457cf3873245f2daafa1c05f0da72c8d4ef",
+    "server/src/routes/addie-chat.ts": "c9fab36425a8bc7f2b404ba7497d2b382552bcc8dbbf3452ca624905d17f96ab",
     "server/src/routes/tavus.ts": "17321c275f89de1ec3e4996c6d7271bf252f7ff1ab1494dad820b090065d0da4",
     "server/src/addie/email-conversation-handler.ts": "d6cf6d3c8621a85c69c6b22b86e6aa78f03b0d532ac8d5162fd40ec6c869f70c",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",
@@ -92,9 +92,9 @@
     "rules_bytes": 154070,
     "tool_reference_bytes": 39435,
     "complete_offline_tool_reference_bytes": 42387,
-    "response_style_bytes": 9053,
-    "system_prompt_bytes": 202572,
-    "system_prompt_sha256": "362d2bd7294ea6bf1ce548e4d11455da709e20bb7e52b3433f5bb855008c45e4"
+    "response_style_bytes": 9056,
+    "system_prompt_bytes": 202575,
+    "system_prompt_sha256": "8496bc8bf0adba0e79c5c1b75af14c78a3cb50c0e7833b1c45c937ae9625e64e"
   },
   "catalog": {
     "missing_runtime_tool_count": 0,
@@ -38661,7 +38661,7 @@
       "prompt_catalog_tools_missing_runtime": -2,
       "always_available_tools": -13,
       "tool_reference_bytes": -4358,
-      "system_prompt_bytes": 541,
+      "system_prompt_bytes": 544,
       "maximum_slack_member_tools": -115,
       "maximum_slack_admin_tools": -182,
       "maximum_slack_public_tools": -8,

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -58,7 +58,7 @@
     }
   },
   "registration_source_sha256": {
-    "server/src/addie/claude-client.ts": "5a3ae29c06be856a2ac5d9565a18836db7e1cd5268ed98389cd0931bf1e5fe92",
+    "server/src/addie/claude-client.ts": "2b68ce12003d76444187db8e73adb7ef6c0ee6c8311badffffda5465deb0fa11",
     "server/src/addie/request-tool-assembly.ts": "cf4443d27ec69940f22aa9fcf46fdefd3f444762259c2700ac8fa01554ead4da",
     "server/src/addie/request-tool-replay-binding.ts": "3aed4c0bd18032e4418b8fff7e8deb263936b6c75b27941f9818a2a9a87287f2",
     "server/src/addie/prompts.ts": "3ec621f3e97eb9109fb561b94ff625a0639460c84506aa63aeebd57f683790f4",

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -58,11 +58,15 @@ export interface GoogleGenerateContentTransport {
       request: GenerateContentParameters,
       options?: { signal?: AbortSignal },
     ): Promise<GenerateContentResponse>;
+    generateContentStream?(
+      request: GenerateContentParameters,
+      options?: { signal?: AbortSignal },
+    ): Promise<AsyncIterable<GenerateContentResponse>>;
   };
 }
 
 export const GOOGLE_GENERATE_CONTENT_CAPABILITIES: ModelProviderCapabilities = Object.freeze({
-  streaming: false,
+  streaming: true,
   structuredOutput: true,
   reasoning: true,
   reasoningEfforts: Object.freeze(['provider_default', 'low', 'medium', 'high'] as const),
@@ -75,6 +79,48 @@ export const GOOGLE_GENERATE_CONTENT_CAPABILITIES: ModelProviderCapabilities = O
 const MAX_GOOGLE_RESPONSE_PARTS = 1_000;
 const MAX_GOOGLE_CONTINUATION_BYTES = 2 * 1024 * 1024;
 const googleContinuationParts = new WeakMap<object, Readonly<Part>>();
+
+/** Preserve original parts (including empty signed parts) across streamed chunks. */
+async function collectGoogleStream(
+  chunks: AsyncIterable<GenerateContentResponse>,
+  options: ModelRespondOptions,
+): Promise<GenerateContentResponse> {
+  const result = {} as GenerateContentResponse;
+  const parts: Part[] = [];
+  let bytes = 0;
+  for await (const chunk of chunks) {
+    if (options.signal?.aborted) throw options.signal.reason;
+    for (const key of ['responseId', 'modelVersion'] as const) {
+      if (chunk[key] !== undefined) {
+        if (result[key] && result[key] !== chunk[key]) throw new Error('Google stream identity changed');
+        result[key] = chunk[key];
+      }
+    }
+    if (chunk.usageMetadata) result.usageMetadata = chunk.usageMetadata;
+    if (chunk.promptFeedback) result.promptFeedback = chunk.promptFeedback;
+    if (chunk.candidates !== undefined) {
+      if (chunk.candidates.length !== 1) throw new Error('Google stream requires one candidate');
+      const candidate = chunk.candidates[0];
+      const previous = result.candidates?.[0];
+      if (previous?.finishReason && candidate.content?.parts?.length) {
+        throw new Error('Google stream continued after completion');
+      }
+      for (const part of candidate.content?.parts ?? []) {
+        bytes += Buffer.byteLength(JSON.stringify(part), 'utf8');
+        if (parts.length >= MAX_GOOGLE_RESPONSE_PARTS || bytes > MAX_GOOGLE_CONTINUATION_BYTES) {
+          throw new Error('Google stream exceeds content limit');
+        }
+        parts.push(part);
+        options.onStreamProgress?.({ type: 'content_delta' });
+      }
+      result.candidates = [{
+        ...previous, ...candidate,
+        ...(parts.length > 0 && { content: { role: candidate.content?.role ?? previous?.content?.role, parts } }),
+      }];
+    }
+  }
+  return result;
+}
 
 function deepFreeze<T>(value: T): T {
   if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
@@ -448,7 +494,7 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     apiKey: string,
     transport?: GoogleGenerateContentTransport,
   ) {
-    // The ordinary adapter is permanently router-only. Gemini 3.8 request
+    // The ordinary adapter accepts the reviewed Gemini 3.7 model. Gemini 3.8 request
     // construction is a pure helper consumed inside the sealed authority;
     // no public constructor or factory can opt an injected transport into the
     // evaluator's paid model scope.
@@ -470,6 +516,10 @@ export class GoogleGenerateContentProvider implements ModelProvider {
               ...request.config,
               abortSignal: options?.signal,
             },
+          }),
+          generateContentStream: (request, options) => client.models.generateContentStream({
+            ...request,
+            config: { ...request.config, abortSignal: options?.signal },
           }),
         },
       };
@@ -505,15 +555,18 @@ export class GoogleGenerateContentProvider implements ModelProvider {
     options: ModelRespondOptions = {},
   ): AsyncIterable<NormalizedModelEvent> {
     validateModelCapabilities(this.id, this.capabilities, request, { streaming: options.stream });
+    if (options.stream && !this.transport.models.generateContentStream) {
+      throw new Error('Google transport does not support streaming');
+    }
     const prepared = this.prepare(request);
     if (options.signal?.aborted) throw options.signal.reason;
     await options.beforeDispatch?.(prepared);
     let response: GenerateContentResponse;
     try {
-      response = await this.transport.models.generateContent(
-        prepared.providerRequest as unknown as GenerateContentParameters,
-        { signal: options.signal },
-      );
+      const payload = prepared.providerRequest as unknown as GenerateContentParameters;
+      response = options.stream
+        ? await collectGoogleStream(await this.transport.models.generateContentStream!(payload, { signal: options.signal }), options)
+        : await this.transport.models.generateContent(payload, { signal: options.signal });
     } catch (error) {
       // Do not expose provider error fields here. The runner receives a
       // constant-message adapter error plus the only safe receipt field.

--- a/server/src/addie/router.ts
+++ b/server/src/addie/router.ts
@@ -57,6 +57,8 @@ import {
  * Execution plan types
  */
 export type ExecutionPlanBase = {
+  /** Settled router usage for end-to-end architecture experiments. */
+  cost_event?: import('./claude-cost-tracker.js').CostEvent;
   /** How the decision was made: 'quick_match' (pattern) or 'llm' (model router) */
   decision_method: "quick_match" | "llm";
   /** Time spent making the routing decision (ms) */
@@ -1318,6 +1320,7 @@ export class AddieRouter {
 
       const plan: ExecutionPlan = {
         ...parsedPlan,
+        cost_event: { provider: response.provider, model: response.model, usage: response.usage },
         decision_method: "llm",
         latency_ms: latencyMs,
         tokens_input: response.usage.inputTokens,

--- a/server/src/addie/rules/response-style.md
+++ b/server/src/addie/rules/response-style.md
@@ -2,12 +2,13 @@
 
 ## Evidence Boundaries Override Style
 
-When a documentation, schema, search, or profile lookup tool is called in the current turn, its returned facts are the complete evidence boundary for claims that depend on that lookup. Do not use factual material from the Knowledge rules, other system context, or model memory to make the answer broader or more helpful, even when that material is accurate.
+When this turn calls a documentation, schema, search, or profile lookup, use only its returned facts for claims that depend on it. Do not broaden the answer with Knowledge rules, other system context, or model memory, even if accurate.
 
-- If a successful result provides one fact, answer with that fact and stop. Do not add workflow steps, comparisons, examples, versions, page names, links, or organization labels that the returned result did not provide.
+- If a result provides one fact, answer with that fact and stop. Add no workflow steps, comparisons, examples, versions, page names, links, or organization labels absent from the result.
 - If the lookup is empty or fails, lead with the short limitation required by Constraints and stop. Do not name a supposedly relevant version, page, or link unless a successful result in this turn supplied it.
+- In requested drafts or worked examples, mark missing values as unknown placeholders. Do not invent payload fields, timestamps, lookup results, or completed actions to make an example look complete.
 
-This evidence policy overrides the style guidance below about answering concepts from the rules and not leading with tool limitations. Those style rules apply only when no lookup was attempted in the current turn.
+This overrides the guidance below about answering concepts from rules and not leading with tool limitations. That guidance applies only when this turn attempted no lookup.
 
 ## Naming Conventions
 CRITICAL: Use correct naming:

--- a/server/src/addie/stream-tool-checkpoints.ts
+++ b/server/src/addie/stream-tool-checkpoints.ts
@@ -1,3 +1,4 @@
+import type { ModelProviderId } from './model-providers/model-provider.js';
 import type { CreateMessageInput, ThreadService } from './thread-service.js';
 import type {
   ToolExecution,
@@ -50,6 +51,7 @@ export function buildToolResultCheckpoint(input: {
   threadId: string;
   execution: ToolExecution;
   requestedModel: string;
+  requestedProvider?: ModelProviderId;
   clientRequestId?: string;
 }): CreateMessageInput {
   return {
@@ -61,7 +63,7 @@ export function buildToolResultCheckpoint(input: {
     model: input.requestedModel,
     model_execution: {
       source: 'local',
-      requested_provider: 'anthropic',
+      requested_provider: input.requestedProvider ?? 'anthropic',
       requested_model: input.requestedModel,
       reason: 'stream_interrupted',
     },
@@ -79,6 +81,7 @@ export function buildToolIntentCheckpoint(input: {
   toolName: string;
   parameters: Record<string, unknown>;
   requestedModel: string;
+  requestedProvider?: ModelProviderId;
   clientRequestId?: string;
 }): CreateMessageInput {
   return {
@@ -95,7 +98,7 @@ export function buildToolIntentCheckpoint(input: {
     model: input.requestedModel,
     model_execution: {
       source: 'local',
-      requested_provider: 'anthropic',
+      requested_provider: input.requestedProvider ?? 'anthropic',
       requested_model: input.requestedModel,
       reason: 'stream_interrupted',
     },
@@ -117,6 +120,7 @@ export async function reserveToolIntentCheckpoint(
     toolName: string;
     parameters: Record<string, unknown>;
     requestedModel: string;
+    requestedProvider?: ModelProviderId;
     clientRequestId?: string;
   },
 ): Promise<void> {

--- a/server/src/db/migrations/586_addie_gemini_direct_experiment.sql
+++ b/server/src/db/migrations/586_addie_gemini_direct_experiment.sql
@@ -1,0 +1,29 @@
+-- Product A/B outcomes; no transcript copy or separate evaluation infrastructure.
+CREATE TABLE IF NOT EXISTS addie_chat_experiment_turns (
+  id UUID PRIMARY KEY,
+  experiment TEXT NOT NULL,
+  thread_id UUID NOT NULL REFERENCES addie_threads(thread_id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  arm TEXT NOT NULL CHECK (arm IN ('control', 'gemini')),
+  cohort TEXT NOT NULL CHECK (cohort IN ('staff', 'eligible', 'existing')),
+  exclusion_reason TEXT,
+  started_at TIMESTAMPTZ NOT NULL,
+  completed_at TIMESTAMPTZ,
+  first_visible_ms INTEGER,
+  total_ms INTEGER,
+  router_ms INTEGER,
+  provider_calls INTEGER,
+  estimated_cost_micros BIGINT,
+  usage_complete BOOLEAN NOT NULL DEFAULT FALSE,
+  fallback_reason TEXT,
+  actual_provider TEXT,
+  actual_model TEXT,
+  failed BOOLEAN,
+  tool_errors INTEGER,
+  usage JSONB,
+  assistant_message_id UUID REFERENCES addie_thread_messages(message_id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_addie_chat_experiment_turns_experiment
+  ON addie_chat_experiment_turns (experiment, started_at);
+CREATE INDEX IF NOT EXISTS idx_addie_chat_experiment_turns_thread
+  ON addie_chat_experiment_turns (thread_id);

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -22,6 +22,8 @@ import {
   type ExecutionPlan,
   type RoutingContext,
 } from "../addie/router.js";
+import { prepareGeminiDirectTurn, getGeminiDirectResults } from "../addie/gemini-direct-experiment.js";
+import type { CostEvent } from "../addie/claude-cost-tracker.js";
 import { createProductionRouter } from "../addie/router-runtime.js";
 import {
   classifyActiveCertificationProgress,
@@ -315,7 +317,7 @@ export function buildTieredAccess(memberTools: RequestTools, isAuth: boolean, is
 
 type WebChatRouter = Pick<AddieRouter, 'quickMatch' | 'route'>;
 type WebChatClient = Pick<AddieClaudeClient, 'processMessage' | 'processMessageStream'>
-  & Partial<Pick<AddieClaudeClient, 'getRegisteredTools'>>;
+  & Partial<Pick<AddieClaudeClient, 'getRegisteredTools' | 'forkForGeminiDirect'>>;
 export type WebChatRequestThreadService = Pick<ReturnType<typeof getThreadService>,
   | 'getOrCreateThread'
   | 'getThreadByExternalId'
@@ -329,6 +331,9 @@ export type WebChatRequestThreadService = Pick<ReturnType<typeof getThreadServic
 >;
 
 export interface RoutedWebTools {
+  routerMs?: number;
+  routerUsage?: CostEvent;
+  routerUsageComplete?: boolean;
   requestTools: RequestTools;
   selectedToolSets: string[];
   allowedToolNames: string[];
@@ -353,6 +358,7 @@ export async function selectRoutedWebTools(input: {
   sponsoredIntelligenceContextKind?: SponsoredIntelligenceContextKind | null;
   threadMessages?: string[];
 }): Promise<RoutedWebTools> {
+  const routingStarted = Date.now();
   let plan: ExecutionPlan | null = null;
   const routerAvailable = input.router !== null;
 
@@ -399,6 +405,9 @@ export async function selectRoutedWebTools(input: {
     // custom handler. The client applies this list to global definitions too.
     allowedToolNames,
     unavailableHint: selection.unavailableHint,
+    routerMs: Date.now() - routingStarted,
+    routerUsage: plan?.cost_event,
+    routerUsageComplete: !routerAvailable || plan?.decision_method === 'quick_match' || !!plan?.cost_event,
   };
 }
 
@@ -1107,6 +1116,18 @@ export function createAddieChatRouter(options?: {
   // API ROUTES (mounted at /api/addie/chat)
   // =========================================================================
 
+  apiRouter.get('/experiment', optionalAuth, async (req, res) => {
+    if (!req.user || !await isWebUserAAOAdmin(req.user.id)) {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+    try {
+      return res.json(await getGeminiDirectResults());
+    } catch (error) {
+      logger.error({ error }, 'Failed to load Addie experiment results');
+      return res.status(503).json({ error: 'Experiment results unavailable' });
+    }
+  });
+
   // POST /api/addie/chat - Send a message and get a response
   // optionalAuth runs first so rate limiters can check auth status
   apiRouter.post(
@@ -1319,25 +1340,42 @@ export function createAddieChatRouter(options?: {
           entry.addie_thread_id === externalId || entry.addie_thread_id === thread.thread_id,
         ),
       );
-      const routedWebTools = isAuth
-        ? await selectRoutedWebTools({
-            message: messageToProcess,
-            memberContext,
-            threadId: thread.thread_id,
-            isAAOAdmin,
-            requestTools: tieredAccess.requestTools,
-            router: resolveRouter(),
-            globalToolNames: activeChatClient.getRegisteredTools?.(),
-            activeCertificationKind,
-            sponsoredIntelligenceContextKind: hasCachedSiSession(externalId)
-              ? 'session'
-              : siAgents.length > 0
-                ? 'discovery'
-                : null,
+      const experimentTurn = await prepareGeminiDirectTurn({
+        client: activeChatClient,
+        userId: req.user?.id,
+        isAdmin: isAAOAdmin,
+        threadId: thread.thread_id,
+        hasPriorAssistant: threadMessages.some(message => message.role === 'assistant'),
+        exclusionReason: attachments.length > 0 ? 'attachments'
+          : hasThreadCertificationContext || activeCertificationKind ? 'certification'
+          : hasCachedSiSession(externalId) || siAgents.length > 0 ? 'sponsored_intelligence'
+          : githubIssueCreationRequested ? 'github_mutation' : null,
+        startedAt: startTime,
+        requestTools: tieredAccess.requestTools,
+        baseRequestContext: requestContext,
+        evaluation: options?.evaluationMode,
+        getControlTools: async () => isAuth
+          ? await selectRoutedWebTools({
+              message: messageToProcess,
+              memberContext,
+              threadId: thread.thread_id,
+              isAAOAdmin,
+              requestTools: tieredAccess.requestTools,
+              router: resolveRouter(),
+              globalToolNames: activeChatClient.getRegisteredTools?.(),
+              activeCertificationKind,
+              sponsoredIntelligenceContextKind: hasCachedSiSession(externalId)
+                ? 'session'
+                : siAgents.length > 0
+                  ? 'discovery'
+                  : null,
             threadMessages: contextMessages.slice(-6).map((turn) => `${turn.user}: ${turn.text}`),
           })
-        : null;
-      const { processOptions, effectiveModel } = tieredAccess;
+        : null,
+      });
+      const routedWebTools = experimentTurn.selection;
+      const { processOptions } = tieredAccess;
+      const effectiveModel = experimentTurn.model ?? tieredAccess.effectiveModel;
       const requestTools = routedWebTools?.requestTools ?? tieredAccess.requestTools;
 
       // Cost-cap scope (#2790 / #2945 f/u). Authenticated callers key
@@ -1356,7 +1394,7 @@ export function createAddieChatRouter(options?: {
       // Process with Claude
       let response: AddieResponse;
       try {
-        response = await activeChatClient.processMessage(messageToProcess, contextMessages, requestTools, undefined, {
+        response = await experimentTurn.client.processMessage(messageToProcess, contextMessages, requestTools, undefined, {
           ...processOptions,
           requestContext: [requestContext, routedWebTools?.unavailableHint].filter(Boolean).join('\n\n'),
           selectedToolSetNames: routedWebTools?.selectedToolSets,
@@ -1372,6 +1410,7 @@ export function createAddieChatRouter(options?: {
               toolName,
               parameters,
               requestedModel: effectiveModel,
+              requestedProvider: experimentTurn.model ? 'google' : 'anthropic',
             });
           },
           ...(options?.evaluationMode ? { executionMode: 'evaluation' as const } : {}),
@@ -1399,7 +1438,7 @@ export function createAddieChatRouter(options?: {
           flagged: true,
           flag_reason: `Error: ${error instanceof Error ? error.message : "Unknown"}`,
           model_execution: {
-            source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'provider_error',
+            source: 'local', requested_provider: experimentTurn.model ? 'google' : 'anthropic', requested_model: effectiveModel, reason: 'provider_error',
           },
         };
       }
@@ -1464,6 +1503,8 @@ export function createAddieChatRouter(options?: {
         config_version_id: response.config_version_id,
       });
 
+      await experimentTurn.experiment?.finish(response, assistantMessage.message_id);
+
       // Check for SI session started (from connect_to_si_agent tool)
       const siSession = withSiAnonymousCapability(
         extractSiSessionFromToolExecutions(response.tool_executions),
@@ -1522,6 +1563,7 @@ export function createAddieChatRouter(options?: {
     let heartbeat: ReturnType<typeof setInterval> | null = null;
     let claimedTurn: { threadId: string; clientRequestId: string; leaseId: string } | null = null;
     let terminalResponse: AddieResponse | undefined;
+    let requestedProviderForAttempt: 'anthropic' | 'google' = 'anthropic';
     let requestedModelForAttempt = req.user ? AddieModelConfig.chat : AddieModelConfig.anonymousChat;
 
     // Handle client disconnect
@@ -1861,30 +1903,49 @@ export function createAddieChatRouter(options?: {
           entry.addie_thread_id === externalId || entry.addie_thread_id === thread.thread_id,
         ),
       );
-      const routedWebTools = isAuth
-        ? await selectRoutedWebTools({
-            message: messageToProcess,
-            memberContext,
-            threadId: thread.thread_id,
-            isAAOAdmin,
-            requestTools: tieredAccess.requestTools,
-            router: resolveRouter(),
-            globalToolNames: activeChatClient.getRegisteredTools?.(),
-            activeCertificationKind,
-            sponsoredIntelligenceContextKind: hasCachedSiSession(externalId)
-              ? 'session'
-              : siAgents.length > 0
-                ? 'discovery'
-                : null,
+      const experimentTurn = await prepareGeminiDirectTurn({
+        client: activeChatClient,
+        userId: req.user?.id,
+        isAdmin: isAAOAdmin,
+        threadId: thread.thread_id,
+        hasPriorAssistant: threadMessages.some(message => message.role === 'assistant'),
+        exclusionReason: attachments.length > 0 ? 'attachments'
+          : hasThreadCertCtx || activeCertificationKind ? 'certification'
+          : hasCachedSiSession(externalId) || siAgents.length > 0 ? 'sponsored_intelligence'
+          : retryRequested ? 'interrupted_turn_retry'
+          : githubIssueCreationRequested ? 'github_mutation' : null,
+        startedAt: startTime,
+        requestTools: tieredAccess.requestTools,
+        baseRequestContext: requestContext,
+        evaluation: options?.evaluationMode,
+        getControlTools: async () => isAuth
+          ? await selectRoutedWebTools({
+              message: messageToProcess,
+              memberContext,
+              threadId: thread.thread_id,
+              isAAOAdmin,
+              requestTools: tieredAccess.requestTools,
+              router: resolveRouter(),
+              globalToolNames: activeChatClient.getRegisteredTools?.(),
+              activeCertificationKind,
+              sponsoredIntelligenceContextKind: hasCachedSiSession(externalId)
+                ? 'session'
+                : siAgents.length > 0
+                  ? 'discovery'
+                  : null,
             threadMessages: contextMessages.slice(-6).map((turn) => `${turn.user}: ${turn.text}`),
           })
-        : null;
-      const { processOptions, effectiveModel } = tieredAccess;
+        : null,
+      });
+      const routedWebTools = experimentTurn.selection;
+      const { processOptions } = tieredAccess;
+      const effectiveModel = experimentTurn.model ?? tieredAccess.effectiveModel;
       const requestTools = routedWebTools?.requestTools ?? tieredAccess.requestTools;
       const replayPolicy = blockCheckpointedToolReplays(
         retryCheckpointToolCalls,
       );
       requestedModelForAttempt = effectiveModel;
+      requestedProviderForAttempt = experimentTurn.model ? 'google' : 'anthropic';
       const preTurnCertification = userId && certificationModuleContext.moduleId
         ? await getCertificationModuleExperience(userId, certificationModuleContext.moduleId)
         : null;
@@ -1924,7 +1985,7 @@ export function createAddieChatRouter(options?: {
         ? { userId: req.user.id, tier: await resolveUserTierFromDb(req.user.id) }
         : null;
 
-      for await (const event of activeChatClient.processMessageStream(messageToProcess, contextMessages, requestTools, {
+      for await (const event of experimentTurn.client.processMessageStream(messageToProcess, contextMessages, requestTools, {
         ...processOptions,
         ...(certificationCompletionTurn ? { maxIterations: 3, maxMessages: 12 } : {}),
         requestContext: [requestContext, routedWebTools?.unavailableHint].filter(Boolean).join('\n\n'),
@@ -1943,6 +2004,7 @@ export function createAddieChatRouter(options?: {
             toolName,
             parameters,
             requestedModel: effectiveModel,
+            requestedProvider: experimentTurn.model ? 'google' : 'anthropic',
             clientRequestId: clientRequestId || undefined,
           });
         },
@@ -1972,6 +2034,7 @@ export function createAddieChatRouter(options?: {
               threadId: thread.thread_id,
               execution: event.execution,
               requestedModel: effectiveModel,
+              requestedProvider: experimentTurn.model ? 'google' : 'anthropic',
               clientRequestId: clientRequestId || undefined,
             }));
           } catch (checkpointError) {
@@ -2029,7 +2092,7 @@ export function createAddieChatRouter(options?: {
             content: 'Reply interrupted before completion. The learner can safely retry this turn.',
             model: effectiveModel,
             model_execution: {
-              source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'stream_interrupted',
+              source: 'local', requested_provider: requestedProviderForAttempt, requested_model: effectiveModel, reason: 'stream_interrupted',
             },
             flagged: true,
             flag_reason: `stream_interrupted: ${event.reason}`,
@@ -2073,7 +2136,7 @@ export function createAddieChatRouter(options?: {
               flagged: true,
               flag_reason: `stream_interrupted: ${event.error}`,
               model_execution: {
-                source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'stream_interrupted',
+                source: 'local', requested_provider: requestedProviderForAttempt, requested_model: effectiveModel, reason: 'stream_interrupted',
               },
               client_request_id: claimedTurn.clientRequestId,
               delivery_status: 'interrupted',
@@ -2100,7 +2163,7 @@ export function createAddieChatRouter(options?: {
           tools_used: toolsUsed.length > 0 ? toolsUsed : undefined,
           model: effectiveModel,
           model_execution: {
-            source: 'local', requested_provider: 'anthropic', requested_model: effectiveModel, reason: 'no_provider_response',
+            source: 'local', requested_provider: requestedProviderForAttempt, requested_model: effectiveModel, reason: 'no_provider_response',
           },
           flagged: true,
           flag_reason: 'stream_interrupted: ended_without_done',
@@ -2208,6 +2271,7 @@ export function createAddieChatRouter(options?: {
         client_turn_lease_id: claimedTurn?.leaseId,
         finalize_client_turn_status: claimedTurn ? 'completed' : undefined,
       });
+      await experimentTurn.experiment?.finish(response, assistantMessage.message_id);
       claimedTurn = null;
 
       const completionExecution = response?.tool_executions?.find(execution =>
@@ -2364,7 +2428,7 @@ export function createAddieChatRouter(options?: {
             flag_reason: 'stream_interrupted: route_error',
             model_execution: {
               source: 'local',
-              requested_provider: terminalResponse?.model_execution.requested_provider ?? 'anthropic',
+              requested_provider: terminalResponse?.model_execution.requested_provider ?? requestedProviderForAttempt,
               requested_model: terminalResponse?.model_execution.requested_model ?? requestedModelForAttempt,
               reason: 'stream_interrupted',
             },

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -239,6 +239,7 @@ import {
   prepareRequestWithMemberTools,
 } from '../../src/routes/addie-chat.js';
 import { issueAnonymousSessionCapability } from '../../src/routes/helpers/anonymous-session-capability.js';
+import * as geminiExperiment from '../../src/addie/gemini-direct-experiment.js';
 
 afterAll(() => {
   if (originalApiKey === undefined) {
@@ -562,6 +563,50 @@ describe('Addie chat conversation object authorization', () => {
         is_error: true,
       })],
     }));
+  });
+
+  it.each(['/', '/stream'])('delivers the selected Gemini turn through %s and persists its model and outcome', async endpoint => {
+    mocks.getThreadByExternalId.mockResolvedValue({
+      thread_id: 'thread_attacker', channel: 'web',
+      external_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489', user_type: 'workos', user_id: 'user_attacker',
+    });
+    mocks.getThreadMessages.mockResolvedValue([]);
+    const response = {
+      ...successfulModelResponse('Gemini response'),
+      model_execution: { source: 'provider' as const, requested_provider: 'google' as const,
+        requested_model: 'gemini-3.7-flash', provider: 'google' as const, model: 'gemini-3.7-flash',
+        model_resolution: 'exact' as const, fallback_reason: null },
+    };
+    const finish = vi.fn();
+    const candidate = {
+      processMessage: vi.fn().mockResolvedValue(response),
+      processMessageStream: vi.fn(async function* () {
+        yield { type: 'text' as const, text: response.text };
+        yield { type: 'done' as const, response };
+      }),
+    };
+    const prepare = vi.spyOn(geminiExperiment, 'prepareGeminiDirectTurn').mockResolvedValue({
+      client: candidate, model: 'gemini-3.7-flash',
+      selection: { requestTools: { tools: [], handlers: new Map() }, allowedToolNames: ['search_docs'],
+        selectedToolSets: ['knowledge'], unavailableHint: 'Available docs.' },
+      experiment: { finish },
+    } as unknown as Awaited<ReturnType<typeof geminiExperiment.prepareGeminiDirectTurn>>);
+    try {
+      const res = await request(mountChatRouter()).post(endpoint).send({
+        message: 'Explain AdCP', conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+      });
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('Gemini response');
+      expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user_attacker', exclusionReason: null, hasPriorAssistant: false }));
+      expect(mocks.processMessage).not.toHaveBeenCalled();
+      expect(mocks.processMessageStream).not.toHaveBeenCalled();
+      expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'assistant', model: 'gemini-3.7-flash', model_execution: response.model_execution }));
+      expect(finish).toHaveBeenCalledWith(expect.objectContaining({ text: 'Gemini response' }), 'message_assistant');
+    } finally { prepare.mockRestore(); }
+  });
+
+  it('restricts experiment outcomes to site admins', async () => {
+    expect((await request(mountChatRouter()).get('/experiment')).status).toBe(403);
   });
 
   it('denies a cross-user conversation UUID through the streaming path before side effects', async () => {

--- a/server/tests/unit/addie/gemini-direct-experiment.test.ts
+++ b/server/tests/unit/addie/gemini-direct-experiment.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GenerateContentParameters, GenerateContentResponse, Part } from '@google/genai';
+
+const mocks = vi.hoisted(() => ({ query: vi.fn(), recordCost: vi.fn(), checkCostCap: vi.fn() }));
+vi.mock('../../../src/db/client.js', () => ({ query: mocks.query }));
+vi.mock('../../../src/db/addie-db.js', () => ({ AddieDatabase: class {} }));
+vi.mock('../../../src/addie/error-notifier.js', () => ({ notifySystemError: vi.fn(), notifyToolError: vi.fn() }));
+vi.mock('../../../src/addie/config-version.js', () => ({ getCurrentConfigVersionId: vi.fn().mockResolvedValue(123) }));
+vi.mock('../../../src/addie/rules/index.js', () => ({
+  loadCoreRules: () => 'You are Addie.', loadScopedRules: () => '',
+  loadConstraintRules: () => 'Use tools honestly.', loadResponseStyle: () => 'Answer clearly.',
+  invalidateRulesCache: vi.fn(),
+}));
+vi.mock('../../../src/addie/claude-cost-tracker.js', () => ({
+  recordCost: mocks.recordCost, checkCostCap: mocks.checkCostCap,
+  releaseCertificationReserve: vi.fn(), renewCertificationReserve: vi.fn(),
+  formatCapExceededMessage: () => 'Daily cap reached.',
+}));
+
+import { AddieClaudeClient, type AddieResponse, type ProcessMessageOptions, type StreamEvent } from '../../../src/addie/claude-client.js';
+import { GoogleGenerateContentProvider, GOOGLE_ROUTER_MODEL } from '../../../src/addie/model-providers/google-generate-content-provider.js';
+import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
+import { createGeminiDirectTools } from '../../../src/addie/gemini-direct-tools.js';
+import { geminiDirectAssignment, prepareGeminiDirectTurn } from '../../../src/addie/gemini-direct-experiment.js';
+import { AddieModelConfig } from '../../../src/config/models.js';
+
+function receipt(parts: Part[], id = 'google-response'): GenerateContentResponse {
+  return {
+    responseId: id, modelVersion: GOOGLE_ROUTER_MODEL,
+    candidates: [{ content: { role: 'model', parts }, finishReason: 'STOP' }],
+    usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 10, thoughtsTokenCount: 5 },
+  } as GenerateContentResponse;
+}
+const call = (name: string, args: Record<string, unknown> = {}): Part => ({
+  functionCall: { id: `call-${name}`, name, args }, thoughtSignature: 'opaque-signature',
+});
+const answer: AddieResponse = {
+  text: 'The full workflow answered.', tools_used: [], tool_executions: [],
+  model_execution: { source: 'provider', requested_provider: 'anthropic', requested_model: AddieModelConfig.chat,
+    provider: 'anthropic', model: AddieModelConfig.chat, model_resolution: 'exact', fallback_reason: null },
+};
+const options: ProcessMessageOptions = { costScope: { userId: 'user-test', tier: 'member_free' } };
+
+function fixture(responses: GenerateContentResponse[]) {
+  const dispatch = vi.fn(async function* (_payload: GenerateContentParameters) {
+    const next = responses.shift();
+    if (!next) throw new Error('No response');
+    yield next;
+  });
+  const provider = new GoogleGenerateContentProvider('unused', {
+    models: { generateContent: vi.fn(), generateContentStream: async (payload: GenerateContentParameters) => dispatch(payload) },
+  });
+  const client = new AddieClaudeClient('unused');
+  const handlers = new Map(['search_docs', 'get_schema', 'get_recent_news', 'send_invoice'].map(name => [name, vi.fn().mockResolvedValue('A verified fact.')]));
+  for (const [name, handler] of handlers) client.registerTool({ name, description: name, input_schema: { type: 'object', properties: {} } }, handler);
+  const fork = client.forkForGeminiDirect(provider);
+  vi.spyOn(client, 'forkForGeminiDirect').mockReturnValue(fork);
+  const control = vi.spyOn(client, 'processMessageStream').mockImplementation(async function* (_message, _history, _tools, processOptions) {
+    processOptions?.onUsageAccounted?.({ provider: 'anthropic', model: AddieModelConfig.chat, usage: { inputTokens: 5, outputTokens: 3 } });
+    yield { type: 'text', text: answer.text };
+    yield { type: 'done', response: answer };
+  });
+  const getControlTools = vi.fn().mockResolvedValue({
+    requestTools: { tools: [], handlers: new Map() }, selectedToolSets: ['knowledge'],
+    allowedToolNames: ['search_docs'], unavailableHint: 'Control catalog.', routerMs: 123,
+  });
+  const input = {
+    client, userId: 'user-test', isAdmin: true, threadId: 'thread-test', hasPriorAssistant: false,
+    exclusionReason: null, startedAt: Date.now(), requestTools: { tools: [], handlers: new Map() },
+    baseRequestContext: 'Trusted member context.', getControlTools,
+  };
+  return { client, fork, provider, dispatch, handlers, control, input, getControlTools };
+}
+
+async function run(input: Parameters<typeof prepareGeminiDirectTurn>[0]) {
+  const turn = await prepareGeminiDirectTurn(input);
+  const events: StreamEvent[] = [];
+  for await (const event of turn.client.processMessageStream('Help with AdCP.', [], turn.selection?.requestTools, {
+    ...options, allowedToolNames: turn.selection?.allowedToolNames, selectedToolSetNames: turn.selection?.selectedToolSets,
+  })) events.push(event);
+  return { turn, events, response: events.find(event => event.type === 'done')?.response };
+}
+
+beforeEach(() => {
+  vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'staff');
+  vi.stubEnv('GEMINI_API_KEY', 'unused');
+  mocks.recordCost.mockReset().mockResolvedValue(undefined);
+  mocks.checkCostCap.mockReset().mockResolvedValue({ ok: true });
+  const assignments = new Map<string, unknown>();
+  mocks.query.mockReset().mockImplementation(async (sql: string, parameters: unknown[]) => {
+    if (sql.startsWith('UPDATE addie_threads')) {
+      const thread = String(parameters[0]);
+      if (!assignments.has(thread)) assignments.set(thread, JSON.parse(String(parameters[2])));
+      return { rows: [{ assignment: assignments.get(thread) }] };
+    }
+    return { rows: [] };
+  });
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe('Gemini Direct production integration', () => {
+  it('executes real shared-loop tools with production accounting and skips the router', async () => {
+    const f = fixture([receipt([call('search_docs')]), receipt([{ text: 'A verified fact.' }], 'answer')]);
+    const result = await run(f.input);
+    expect(result.response?.model_execution).toMatchObject({ source: 'provider', provider: 'google', model: GOOGLE_ROUTER_MODEL });
+    expect(f.handlers.get('search_docs')).toHaveBeenCalledOnce();
+    expect(f.dispatch).toHaveBeenCalledTimes(2);
+    expect(f.getControlTools).not.toHaveBeenCalled();
+    expect(f.control).not.toHaveBeenCalled();
+    expect(mocks.recordCost).toHaveBeenCalledExactlyOnceWith('user-test', expect.objectContaining({ provider: 'google', usage: { inputTokens: 40, outputTokens: 30, reasoningTokens: 10 } }));
+    const second = f.dispatch.mock.calls[1][0] as GenerateContentParameters;
+    expect(JSON.stringify(second.contents)).toContain('opaque-signature');
+    expect(JSON.stringify(second.contents)).toContain('functionResponse');
+  });
+
+  it('loads authorized domains on demand and keeps writes out of every invocation', async () => {
+    const f = fixture([
+      receipt([call('load_tool_group', { group: 'industry_research' })]),
+      receipt([call('get_recent_news')], 'news'), receipt([{ text: 'A verified fact.' }], 'answer'),
+    ]);
+    await run(f.input);
+    const names = (index: number) => f.dispatch.mock.calls[index][0].config?.tools?.flatMap(tool => tool.functionDeclarations?.map(fn => fn.name) ?? []);
+    expect(names(0)).not.toContain('get_recent_news');
+    expect(names(1)).toContain('get_recent_news');
+    expect(names(1)).not.toContain('send_invoice');
+    expect(f.handlers.get('get_recent_news')).toHaveBeenCalledOnce();
+    expect(f.handlers.get('send_invoice')).not.toHaveBeenCalled();
+  });
+
+  it('blocks a model calling an unloaded tool even when its handler exists', async () => {
+    const f = fixture([receipt([call('get_recent_news')]), receipt([{ text: 'No news lookup was performed.' }], 'answer')]);
+    const result = await run(f.input);
+    expect(f.handlers.get('get_recent_news')).not.toHaveBeenCalled();
+    expect(result.response?.tool_executions[0]).toMatchObject({ blocked_by_policy: true, is_error: true });
+  });
+
+  it('hands unsupported work to control, charges the Gemini step, and retains treatment attribution', async () => {
+    const f = fixture([receipt([call('handoff_to_addie')])]);
+    const result = await run(f.input);
+    expect(f.dispatch).toHaveBeenCalledOnce();
+    expect(f.getControlTools).toHaveBeenCalledOnce();
+    expect(f.control).toHaveBeenCalledOnce();
+    expect(result.response?.model_execution).toMatchObject({ requested_provider: 'google', provider: 'anthropic', model_resolution: 'fallback', fallback_reason: 'primary_capability_unsupported' });
+    expect(mocks.recordCost).toHaveBeenCalledOnce();
+    expect(f.control.mock.calls[0][3]).toMatchObject({ modelOverride: undefined, directToolSession: undefined, allowedToolNames: ['search_docs'] });
+    const outcome = mocks.query.mock.calls.filter(([sql]) => sql.startsWith('UPDATE addie_chat_experiment_turns')).at(-1)?.[1];
+    expect(outcome[7]).toBe('capability_handoff');
+    expect(JSON.parse(outcome[12]).map((event: { provider: string }) => event.provider)).toEqual(['google', 'anthropic']);
+  });
+
+  it('falls back after a failed continuation without losing settled usage or exposing a partial answer', async () => {
+    const f = fixture([receipt([call('search_docs')])]);
+    const result = await run(f.input);
+    expect(result.response?.text).toBe(answer.text);
+    expect(f.dispatch).toHaveBeenCalledTimes(2);
+    expect(f.handlers.get('search_docs')).toHaveBeenCalledOnce();
+    expect(mocks.recordCost).toHaveBeenCalledOnce();
+    expect(result.events.filter(event => event.type === 'text')).toEqual([{ type: 'text', text: answer.text }]);
+    const outcome = mocks.query.mock.calls.filter(([sql]) => sql.startsWith('UPDATE addie_chat_experiment_turns')).at(-1)?.[1];
+    expect(outcome[6]).toBe(false); // A failed dispatch may have unreported usage.
+  });
+
+  it('does not bypass cost admission through fallback', async () => {
+    mocks.checkCostCap.mockResolvedValue({ ok: false });
+    const f = fixture([]);
+    const result = await run(f.input);
+    expect(result.response?.model_execution).toMatchObject({ reason: 'cost_cap_exceeded' });
+    expect(f.dispatch).not.toHaveBeenCalled();
+    expect(f.control).not.toHaveBeenCalled();
+  });
+
+  it.each(['attachments', 'certification', 'interrupted_turn_retry', 'github_mutation'])('keeps excluded %s turns on control', async exclusionReason => {
+    const f = fixture([]);
+    await run({ ...f.input, exclusionReason });
+    expect(f.dispatch).not.toHaveBeenCalled();
+    expect(f.control).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the ordinary alternate-provider guard and requires a bounded production session', async () => {
+    const f = fixture([]);
+    const isolated = f.client.forkForIsolatedProvider(GOOGLE_ROUTER_MODEL, { provider: f.provider });
+    await expect(isolated.processMessage('Hello', [], undefined, undefined, options)).rejects.toThrow('restricted to isolated');
+    await expect(collect(f.fork.processMessageStream('Hello', [], undefined, options))).rejects.toThrow('restricted to isolated');
+    expect(f.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('provides the same direct path to non-streaming callers', async () => {
+    const f = fixture([receipt([{ text: 'A verified fact.' }])]);
+    const turn = await prepareGeminiDirectTurn(f.input);
+    const response = await turn.client.processMessage('Hello', [], turn.selection?.requestTools, undefined, { ...options, allowedToolNames: turn.selection?.allowedToolNames });
+    expect(response.text).toBe('A verified fact.');
+    expect(f.getControlTools).not.toHaveBeenCalled();
+  });
+
+  it('continues a saved conversation without fabricating Google tool signatures', async () => {
+    const f = fixture([receipt([{ text: 'The earlier result was a verified fact.' }])]);
+    const turn = await prepareGeminiDirectTurn(f.input);
+    const response = await turn.client.processMessage('What did the lookup say?', [{
+      user: 'Addie', text: 'A verified fact.',
+      toolCalls: [{ name: 'search_docs', input: {}, result: 'A verified fact.' }],
+    }], turn.selection?.requestTools, undefined, { ...options, allowedToolNames: turn.selection?.allowedToolNames });
+    expect(response.model_execution).toMatchObject({ provider: 'google' });
+    const contents = JSON.stringify(f.dispatch.mock.calls[0][0].contents);
+    expect(contents).toContain('Earlier tool results');
+    expect(contents).not.toContain('functionCall');
+    expect(f.handlers.get('search_docs')).not.toHaveBeenCalled();
+  });
+});
+
+async function collect(events: AsyncIterable<StreamEvent>) { for await (const _event of events) { /* exhaust */ } }
+
+describe('assignment and rollback', () => {
+  it('is stable per user with a roughly 10% cohort, including across threads', () => {
+    const env = { ADDIE_GEMINI_DIRECT_MODE: 'eligible', ADDIE_GEMINI_DIRECT_PERCENT: '10' };
+    const assignments = Array.from({ length: 1000 }, (_, index) => geminiDirectAssignment(`user-${index}`, false, false, env));
+    const treated = assignments.filter(value => value?.arm === 'gemini').length;
+    expect(treated).toBeGreaterThan(60);
+    expect(treated).toBeLessThan(140);
+    expect(geminiDirectAssignment('user-42', false, false, env)).toEqual(assignments[42]);
+  });
+
+  it('atomically retains an existing thread assignment during concurrent requests and rollout changes', async () => {
+    const f = fixture([]);
+    const [first, concurrent] = await Promise.all([prepareGeminiDirectTurn(f.input), prepareGeminiDirectTurn(f.input)]);
+    expect(first.model).toBe(GOOGLE_ROUTER_MODEL);
+    expect(concurrent.model).toBe(GOOGLE_ROUTER_MODEL);
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_PERCENT', '0');
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'eligible');
+    const later = await prepareGeminiDirectTurn({ ...f.input, hasPriorAssistant: true });
+    expect(later.model).toBe(GOOGLE_ROUTER_MODEL);
+    expect(mocks.query.mock.calls[0][0]).toContain('CASE WHEN context ? $2');
+  });
+
+  it('kill switch and evaluation mode use control without experiment writes', async () => {
+    const f = fixture([]);
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'off');
+    expect((await prepareGeminiDirectTurn(f.input)).model).toBeUndefined();
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'staff');
+    expect((await prepareGeminiDirectTurn({ ...f.input, evaluation: true })).model).toBeUndefined();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('keeps pre-existing conversations on control and fails closed on assignment persistence errors', async () => {
+    const f = fixture([]);
+    expect((await prepareGeminiDirectTurn({ ...f.input, hasPriorAssistant: true })).model).toBeUndefined();
+    mocks.query.mockRejectedValue(new Error('Database unavailable'));
+    expect((await prepareGeminiDirectTurn(f.input)).model).toBeUndefined();
+  });
+
+  it('does not expose groups whose user-scoped handlers are absent', () => {
+    const direct = createGeminiDirectTools({ tools: [], handlers: new Map() }, ['search_docs']);
+    expect(direct.allowedToolNames).toEqual(['search_docs', 'load_tool_group', 'handoff_to_addie']);
+  });
+});
+
+describe('native Google streaming', () => {
+  it('combines streamed text, preserves signed empty parts, and uses final usage', async () => {
+    const progress = vi.fn();
+    const provider = new GoogleGenerateContentProvider('unused', { models: {
+      generateContent: vi.fn(),
+      generateContentStream: async () => (async function* () {
+        yield { responseId: 'stream', modelVersion: GOOGLE_ROUTER_MODEL, candidates: [{ content: { role: 'model', parts: [{ text: 'Hello' }] } }] } as GenerateContentResponse;
+        yield receipt([{ text: '', thoughtSignature: 'signed-empty' }], 'stream');
+      })(),
+    } });
+    const response = await collectModelResponse(provider.respond({ model: GOOGLE_ROUTER_MODEL, system: [], tools: [], messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }], maxOutputTokens: 100 }, { stream: true, onStreamProgress: progress }));
+    expect(response.content).toEqual([{ type: 'text', text: 'Hello' }, { type: 'text', text: '' }]);
+    expect(response.usage.outputTokens).toBe(15);
+    expect(progress).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['missing_finish', 'changed_identity', 'missing_usage'])('rejects %s before any partial tool request can execute', async fault => {
+    const response = receipt([call('search_docs')]);
+    if (fault === 'missing_finish') delete response.candidates![0].finishReason;
+    if (fault === 'missing_usage') delete response.usageMetadata;
+    const provider = new GoogleGenerateContentProvider('unused', { models: {
+      generateContent: vi.fn(), generateContentStream: async () => (async function* () {
+        if (fault === 'changed_identity') yield { responseId: 'different', modelVersion: GOOGLE_ROUTER_MODEL } as GenerateContentResponse;
+        yield response;
+      })(),
+    } });
+    const emitted: string[] = [];
+    await expect((async () => {
+      for await (const event of provider.respond({ model: GOOGLE_ROUTER_MODEL, system: [], tools: [],
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'Search' }] }], maxOutputTokens: 100,
+      }, { stream: true })) emitted.push(event.type);
+    })()).rejects.toThrow();
+    expect(emitted).toEqual([]);
+  });
+});

--- a/server/tests/unit/addie/gemini-direct-experiment.test.ts
+++ b/server/tests/unit/addie/gemini-direct-experiment.test.ts
@@ -105,6 +105,7 @@ describe('Gemini Direct production integration', () => {
     expect(result.response?.model_execution).toMatchObject({ source: 'provider', provider: 'google', model: GOOGLE_ROUTER_MODEL });
     expect(f.handlers.get('search_docs')).toHaveBeenCalledOnce();
     expect(f.dispatch).toHaveBeenCalledTimes(2);
+    expect(f.dispatch.mock.calls[0][0].config?.thinkingConfig?.thinkingLevel).toBe('LOW');
     expect(f.getControlTools).not.toHaveBeenCalled();
     expect(f.control).not.toHaveBeenCalled();
     expect(mocks.recordCost).toHaveBeenCalledExactlyOnceWith('user-test', expect.objectContaining({ provider: 'google', usage: { inputTokens: 40, outputTokens: 30, reasoningTokens: 10 } }));

--- a/server/tests/unit/addie/model-provider-openai-google.test.ts
+++ b/server/tests/unit/addie/model-provider-openai-google.test.ts
@@ -564,14 +564,13 @@ describe('GoogleGenerateContentProvider', () => {
     });
   });
 
-  it('fails closed when streaming transport is requested', async () => {
-    const provider = new GoogleGenerateContentProvider(
-      'unused',
-      {} as GoogleGenerateContentTransport,
-    );
+  it('fails before dispatch when an injected transport has no streaming implementation', async () => {
+    const generateContent = vi.fn();
+    const provider = new GoogleGenerateContentProvider('unused', { models: { generateContent } });
     await expect(collectModelResponse(
       provider.respond(request(GOOGLE_ROUTER_MODEL), { stream: true }),
-    )).rejects.toBeInstanceOf(UnsupportedModelCapabilityError);
+    )).rejects.toThrow('does not support streaming');
+    expect(generateContent).not.toHaveBeenCalled();
   });
 
   it('builds the exact frozen generateContent request', () => {

--- a/server/tests/unit/addie/stream-tool-checkpoints.test.ts
+++ b/server/tests/unit/addie/stream-tool-checkpoints.test.ts
@@ -16,6 +16,16 @@ const execution = {
 } as const;
 
 describe('stream tool checkpoints', () => {
+  it('retains the requested Google identity through read checkpoints and control-handoff reservations', () => {
+    const identity = { threadId: 'thread-1', requestedModel: 'gemini-3.7-flash', requestedProvider: 'google' as const };
+    for (const checkpoint of [
+      buildToolResultCheckpoint({ ...identity, execution }),
+      buildToolIntentCheckpoint({ ...identity, toolName: execution.tool_name, parameters: execution.parameters }),
+    ]) {
+      expect(checkpoint.model_execution).toMatchObject({ requested_provider: 'google', requested_model: 'gemini-3.7-flash' });
+    }
+  });
+
   it('stores one complete tool-use/result pair without partial assistant prose', () => {
     expect(buildToolResultCheckpoint({
       threadId: 'thread-1',

--- a/server/tests/unit/rules-loader.test.ts
+++ b/server/tests/unit/rules-loader.test.ts
@@ -36,7 +36,7 @@ describe('Rules Loader', () => {
     const style = loadResponseStyle();
     expect(style).toContain('# Response Style');
     expect(style).toContain('## Evidence Boundaries Override Style');
-    expect(style).toContain('Those style rules apply only when no lookup was attempted');
+    expect(style).toContain('That guidance applies only when this turn attempted no lookup');
     expect(style).toContain('## Concise and Helpful');
     expect(style).toContain('## Naming Conventions');
   });
@@ -107,9 +107,10 @@ describe('Rules Loader', () => {
     const style = loadResponseStyle();
 
     expect(rules).toContain('treat its returned content as the evidence boundary for the answer');
-    expect(style).toContain('returned facts are the complete evidence boundary');
-    expect(style).toContain('Do not use factual material from the Knowledge rules');
+    expect(style).toContain('use only its returned facts for claims that depend on it');
+    expect(style).toContain('Do not broaden the answer with Knowledge rules');
     expect(style).toContain('If the lookup is empty or fails, lead with the short limitation');
+    expect(style).toContain('mark missing values as unknown placeholders');
   });
 
   it('routes Prebid Sales Agent build questions to the owning project without guessing', () => {


### PR DESCRIPTION
Addie web chat currently routes authenticated turns through the Anthropic response path. This adds a staff pilot of Gemini 3.7 Direct versus the existing Haiku → Sonnet stack, with stable assignment and a subsequent 10% eligible-user A/B setting.

Gemini starts with documentation/schema tools and loads additional authorized read-only groups on demand. It uses native Google streaming and the shared production execution/accounting loop. Unsupported work hands off to the routed workflow; mutations remain on control. Attachments, certification, sponsored intelligence, interrupted retries, and explicit GitHub creation requests are excluded. Fallback time, settled costs, and requested/actual provider identity stay attributed to treatment.

The admin-only `/api/addie/chat/experiment` endpoint reports latency including routing, cost, errors, fallbacks, ratings, and marked resolutions. Thread assignment is atomic; migration 586 stores outcomes linked to existing messages. `fly.toml` selects staff mode on deployment. `MODE=off` overrides saved assignments. The runbook documents rollout and review criteria.

Validation:

- Complete CI test suite passes in shards; TypeScript, generated tool inventory, and security checks pass.
- 425 focused deterministic tests pass across delivery, authorization, tool execution, routing, provider fallback, accounting, and evidence boundaries.
- PostgreSQL 16 checks cover migration replay, outcome queries, and 20 concurrent assignments.
- Three live Gemini 3.7 checks with production prompts and synthetic handlers pass documentation lookup, domain discovery, and handoff. The final low-thinking run cost approximately $0.086. These are smoke checks, not a production quality comparison.

Release dependency: this PR has not activated production. Main's existing protected matched-v4 provisioning [run 34478760809](https://github.com/adcontextprotocol/adcp/actions/runs/34478760809) failed with empty database/principal/manifest inputs, so Deploy was skipped. This product experiment uses the ordinary application database and existing Gemini key. It does not bypass that deployment dependency or add evaluator infrastructure.
