### PR TITLE
fix(deploy): separate app releases from optional evaluator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,9 @@ name: Deploy
 
 on:
   workflow_run:
-    # Deploy is sequenced from the protected evaluator provision rather than
-    # polling it from Build Check. This prevents a protected-approval delay
-    # from losing the sole deploy trigger for an otherwise valid main SHA.
-    workflows: [Provision matched-v4 evaluator schema]
+    # Ordinary releases follow Build Check with paid evaluation disabled.
+    # Evaluator-enabled releases still wait for protected provisioning.
+    workflows: [Build Check, Provision matched-v4 evaluator schema]
     types: [completed]
     branches: [main]
 
@@ -24,17 +23,29 @@ jobs:
   # here instead of shipping a container that crashloops on boot.
   preflight:
     name: Preflight
-    # workflow_run has access to deployment secrets, so only trust a successful
-    # protected-provision continuation from this repository's main branch.
+    # Both secret-bearing paths require a trusted successful main run. The
+    # repository variable selects exactly one path; unknown values deploy neither.
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'workflow_run' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (
+        (
+          github.event.workflow_run.name == 'Build Check' &&
+          github.event.workflow_run.event == 'push' &&
+          (vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == '' || vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'false')
+        ) ||
+        (
+          github.event.workflow_run.name == 'Provision matched-v4 evaluator schema' &&
+          github.event.workflow_run.event == 'workflow_run' &&
+          vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'true'
+        )
+      )
     runs-on: ubuntu-latest
     outputs:
       deploy_current: ${{ steps.current-main.outputs.deploy_current }}
       evaluator_provisioned: ${{ steps.evaluator-provision.outputs.evaluator_provisioned }}
+      evaluator_required: ${{ vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,7 +90,7 @@ jobs:
 
       - name: Require the triggering protected evaluator provision
         id: evaluator-provision
-        if: steps.current-main.outputs.deploy_current == 'true'
+        if: steps.current-main.outputs.deploy_current == 'true' && vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PROVISION_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -97,7 +108,7 @@ jobs:
   deploy:
     name: Deploy to Fly.io
     needs: preflight
-    if: needs.preflight.outputs.deploy_current == 'true' && needs.preflight.outputs.evaluator_provisioned == 'true'
+    if: needs.preflight.outputs.deploy_current == 'true' && (needs.preflight.outputs.evaluator_required == 'false' || needs.preflight.outputs.evaluator_provisioned == 'true')
     runs-on: ubuntu-latest
     steps:
       # This must precede every flyctl invocation. In particular, staging the
@@ -122,6 +133,7 @@ jobs:
           fi
 
       - name: Recheck triggering evaluator provision immediately before protected deploy use
+        if: needs.preflight.outputs.evaluator_required == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PROVISION_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -140,6 +152,7 @@ jobs:
       # already-verified deploy is releasing; the app never receives the
       # operator/control-plane PostgreSQL connection.
       - name: Stage exact matched-v4 admission SHA for ordinary runtime
+        if: needs.preflight.outputs.evaluator_required == 'true'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -152,6 +165,18 @@ jobs:
           flyctl secrets set --stage \
             ADDIE_MATCHED_V4_MERGE_SHA="$TESTED_SHA" \
             ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=true
+
+      # Explicitly overwrite any prior evaluator opt-in secrets. "disabled"
+      # cannot satisfy the paid authority's required 40-character merged SHA.
+      - name: Disable evaluator admission for ordinary app release
+        if: needs.preflight.outputs.evaluator_required == 'false'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          flyctl secrets set --stage \
+            ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=false \
+            ADDIE_MATCHED_V4_MERGE_SHA=disabled
 
       - name: Reject publisher crawl queue secret override
         env:

--- a/.github/workflows/provision-matched-v4-evaluator.yml
+++ b/.github/workflows/provision-matched-v4-evaluator.yml
@@ -69,6 +69,8 @@ jobs:
 
   provision:
     needs: verify-origin-main
+    # Ordinary app releases do not acquire the protected operator environment.
+    if: vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'true'
     environment: matched-v4-evaluator-operator
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/runbooks/addie-gemini-direct.md
+++ b/docs/runbooks/addie-gemini-direct.md
@@ -87,11 +87,14 @@ Investigate repeated quality/error regressions or p95 total time more than 20%
 worse than control. Expand into teaching or consequential actions only after
 their permission, progress, and receipt workflows are checked independently.
 
-## Release dependency found during implementation
+## Deployment
 
-As of 2026-09-10, main's existing Deploy workflow depends on successful protected
-matched-v4 evaluator provisioning. Run `34478760809` failed because its database,
-principal, and manifest inputs were empty; Deploy was skipped. The web experiment
-uses the ordinary application database and existing Gemini credential, but cannot
-activate until that release dependency is resolved. This change does not bypass
-the protected workflow or provision another evaluator service.
+The pilot uses the ordinary application database and existing Gemini credential.
+Leave the repository variable `ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED` unset or
+`false` to deploy after the successful main build with paid evaluation disabled.
+The ordinary release applies migration 586 and skips evaluator migrations 584
+and 585. It explicitly replaces any prior evaluator admission settings.
+
+The protected evaluator release path remains available with that variable set
+to `true`; it requires the separate operator configuration described in the
+[evaluator runbook](./addie-matched-v4-private-authority.md).

--- a/docs/runbooks/addie-matched-v4-private-authority.md
+++ b/docs/runbooks/addie-matched-v4-private-authority.md
@@ -4,6 +4,21 @@ description: "Deploy the sealed Addie matched-v4 evaluator authority with extern
 "og:title": "AdCP — Matched v4 evaluator authority deployment"
 ---
 
+Ordinary application releases follow a successful main `Build Check`. They set
+`ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=false` and overwrite
+`ADDIE_MATCHED_V4_MERGE_SHA=disabled`, so they neither apply evaluator migrations
+nor admit paid evaluation. This is the default when the repository variable
+`ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED` is unset or `false`.
+
+Set that repository variable to `true` only when enabling the evaluator release
+path described below. That path waits for protected provisioning; it cannot
+fall back to an ordinary deploy on provisioning failure. The protected operator
+job is skipped without this opt-in. Both paths retain current-main checks and
+the normal migration, health, and machine-convergence gates. Other variable
+values select neither deployment path.
+
+## Evaluator releases
+
 The matched-v4 evaluator ledger uses two externally administered PostgreSQL
 roles. Before deploying migrations 584 and 585, an administrator must run the protected
 provision workflow using the distinct, non-superuser `migration_principal`
@@ -87,7 +102,7 @@ the transformed schema attests; ordinary local, preview, and app migration
 boots skip evaluator-only migrations and never re-attest their catalog after
 they are recorded.
 
-The enforced order is: successful Build Check → no-secret coordinator →
+For evaluator-enabled releases, the enforced order is: successful Build Check → no-secret coordinator →
 protected provision workflow → application release migration → application
 rollout. The deploy workflow consumes the exact triggering protected workflow
 run, verifies its successful provision job, and rechecks the release SHA

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,8 @@ primary_region = 'iad'
 [deploy]
   # The external matched-v4 evaluator bootstrap is run from a protected
   # deployment control plane. App machines receive no operator credential;
-  # this ordinary migrator validates and records that completed schema.
+  # this migrator records that schema only on an evaluator-enabled release.
+  # Ordinary releases skip evaluator-only migrations.
   release_command = "node dist/db/migrate.js"
   release_command_timeout = "15m"
   strategy = "rolling"

--- a/server/tests/unit/addie/matched-v4-evaluation.test.ts
+++ b/server/tests/unit/addie/matched-v4-evaluation.test.ts
@@ -1164,8 +1164,9 @@ describe("matched-v4 sealed private authority", () => {
       '.name == "provision" and .conclusion == "success"',
     );
     expect(deployWorkflow).toContain(
-      "workflows: [Provision matched-v4 evaluator schema]",
+      "workflows: [Build Check, Provision matched-v4 evaluator schema]",
     );
+    expect(workflow).toContain("if: vars.ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED == 'true'");
   });
   it("is plan-only by default", () => {
     expect(createAddieMatchedV4PrivateAuthorityPlanOnly()).toMatchObject({
@@ -1978,6 +1979,10 @@ describe("matched-v4 sealed private authority", () => {
       /plain inert configuration/,
     );
     expect(proxyTrap).not.toHaveBeenCalled();
+    process.env.ADDIE_MATCHED_V4_MERGE_SHA = "disabled";
+    await expect(
+      createAddieMatchedV4PaidAuthority(paidInput()),
+    ).rejects.toThrow(/paid authority construction refused/);
     delete process.env.ADDIE_MATCHED_V4_MERGE_SHA;
     await expect(
       createAddieMatchedV4PaidAuthority(paidInput()),

--- a/server/tests/unit/deploy-workflow.test.ts
+++ b/server/tests/unit/deploy-workflow.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { runInNewContext } from 'node:vm';
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+type Step = { name: string; if?: string; run?: string };
+type Workflow = { jobs: Record<string, { if: string; steps: Step[] }> };
+const readWorkflow = (name: string): Workflow => parse(readFileSync(
+  new URL(`../../../.github/workflows/${name}.yml`, import.meta.url), 'utf8',
+));
+const deploy = readWorkflow('deploy');
+const provision = readWorkflow('provision-matched-v4-evaluator');
+const repository = 'adcontextprotocol/adcp';
+
+// These workflow conditions use the common boolean/equality subset of JS and
+// GitHub expressions. Evaluate the actual checked-in conditions against events.
+function accepts(mode: string, name = 'Build Check', event = 'push', overrides = {}) {
+  return runInNewContext(deploy.jobs.preflight.if, {
+    vars: { ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED: mode },
+    github: { repository, event: { workflow_run: {
+      name, event, conclusion: 'success', head_branch: 'main',
+      head_repository: { full_name: repository }, ...overrides,
+    } } },
+  }, { timeout: 100 });
+}
+
+describe('application and protected evaluator deployment', () => {
+  it.each(['', 'false'])('deploys successful main builds in ordinary mode %j', mode => {
+    expect(accepts(mode)).toBe(true);
+    expect(accepts(mode, 'Provision matched-v4 evaluator schema', 'workflow_run')).toBe(false);
+  });
+
+  it('waits for the protected workflow when evaluator deployment is enabled', () => {
+    expect(accepts('true')).toBe(false);
+    expect(accepts('true', 'Provision matched-v4 evaluator schema', 'workflow_run')).toBe(true);
+  });
+
+  it.each([
+    { conclusion: 'failure' }, { conclusion: 'cancelled' }, { conclusion: 'skipped' },
+    { head_branch: 'feature' }, { head_repository: { full_name: 'untrusted/fork' } },
+  ])('rejects untrusted or unsuccessful events: %j', overrides => {
+    expect(accepts('', 'Build Check', 'push', overrides)).toBe(false);
+    expect(accepts('true', 'Provision matched-v4 evaluator schema', 'workflow_run', overrides)).toBe(false);
+  });
+
+  it('rejects wrong event types, other workflows, and invalid rollout settings', () => {
+    expect(accepts('', 'Build Check', 'pull_request')).toBe(false);
+    expect(accepts('', 'Build Check', 'workflow_dispatch')).toBe(false);
+    expect(accepts('', 'Another workflow')).toBe(false);
+    expect(accepts('true', 'Provision matched-v4 evaluator schema', 'push')).toBe(false);
+    expect(accepts('typo')).toBe(false);
+  });
+
+  it.each([
+    ['true', 'false', '', true], ['false', 'false', '', false],
+    ['true', 'true', '', false], ['true', 'true', 'false', false],
+    ['true', 'true', 'true', true], ['false', 'true', 'true', false],
+  ])('requires current main and the selected prerequisite: %s/%s/%s',
+    (deploy_current, evaluator_required, evaluator_provisioned, allowed) => {
+      expect(runInNewContext(deploy.jobs.deploy.if, {
+        needs: { preflight: { outputs: { deploy_current, evaluator_required, evaluator_provisioned } } },
+      }, { timeout: 100 })).toBe(allowed);
+    });
+
+  it.each(['', 'false', 'typo', 'true'])('acquires operator environment only on opt-in: %j', mode => {
+    expect(runInNewContext(provision.jobs.provision.if, {
+      vars: { ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED: mode },
+    }, { timeout: 100 })).toBe(mode === 'true');
+  });
+
+  it('stages mutually exclusive runtime settings before deployment', () => {
+    const steps = deploy.jobs.deploy.steps;
+    const ordinary = steps.find(s => s.name === 'Disable evaluator admission for ordinary app release')!;
+    const protectedStep = steps.find(s => s.name === 'Stage exact matched-v4 admission SHA for ordinary runtime')!;
+    const recheck = steps.find(s => s.name === 'Recheck triggering evaluator provision immediately before protected deploy use')!;
+    for (const mode of ['true', 'false']) {
+      const context = { needs: { preflight: { outputs: { evaluator_required: mode } } } };
+      expect(runInNewContext(ordinary.if!, context, { timeout: 100 })).toBe(mode === 'false');
+      expect(runInNewContext(protectedStep.if!, context, { timeout: 100 })).toBe(mode === 'true');
+      expect(runInNewContext(recheck.if!, context, { timeout: 100 })).toBe(mode === 'true');
+    }
+    const staged = (step: Step) => execFileSync('bash', ['-c',
+      `flyctl() { printf '%s\\n' "$@"; }\n${step.run}`,
+    ], { encoding: 'utf8', env: { PATH: process.env.PATH, TESTED_SHA: 'a'.repeat(40) } }).trim().split('\n');
+    expect(staged(ordinary)).toEqual(['secrets', 'set', '--stage',
+      'ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=false', 'ADDIE_MATCHED_V4_MERGE_SHA=disabled']);
+    expect(staged(protectedStep)).toEqual(['secrets', 'set', '--stage',
+      `ADDIE_MATCHED_V4_MERGE_SHA=${'a'.repeat(40)}`, 'ADDIE_MATCHED_V4_EVALUATOR_SCHEMA_REQUIRED=true']);
+    const deployIndex = steps.findIndex(s => s.name === 'Deploy');
+    expect(steps.indexOf(ordinary)).toBeLessThan(deployIndex);
+    expect(steps.indexOf(protectedStep)).toBeLessThan(deployIndex);
+    expect(steps.indexOf(recheck)).toBeLessThan(steps.indexOf(protectedStep));
+  });
+});


### PR DESCRIPTION
Ordinary production releases currently wait for optional matched-v4 evaluator provisioning. Missing operator settings therefore block every app deploy, including the merged Gemini 3.7 staff pilot (#7408).

This makes ordinary releases follow a successful main Build Check with evaluator schema migration disabled and any prior paid-admission SHA explicitly overwritten with `disabled`. Set the repository variable `ADDIE_MATCHED_V4_EVALUATOR_DEPLOY_ENABLED=true` to select the protected evaluator release path. That path still requires successful provisioning and its immediate pre-deploy recheck; a provisioning failure cannot fall back to an ordinary release. The operator job acquires its protected environment only when opted in.

Both paths retain trusted-source and current-main checks, ordinary migrations, rolling deployment, health checks, and machine convergence. Documentation explains the two release modes. No application runtime or evaluator authorization logic changes.

Validation: 20 workflow tests pass covering event provenance, failed/skipped builds, mode selection, incomplete provisioning, and exact staged Fly settings using a stub CLI. Two existing authority/coordinator checks pass, including refusal to construct paid authority with the new `disabled` SHA. No live model calls or production setting changes were made for this follow-up.

Release evidence: #7408 merged as `72e5ef386721bec289dc788e796ebcde25ee1da4` and passed its main Build Check. The subsequent [protected provision run](https://github.com/adcontextprotocol/adcp/actions/runs/34492270902) failed with all eight required operator inputs empty, and [Deploy](https://github.com/adcontextprotocol/adcp/actions/runs/34492486875) was skipped. Production remains healthy on the previous release; the Gemini pilot is not live.
