### PR TITLE
fix(deploy): reserve concurrency only for accepted releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,6 @@ permissions:
   actions: read
   contents: read
 
-concurrency:
-  group: fly-deploy
-  cancel-in-progress: false
-
 jobs:
   # Preflight: cheap sanity checks that must pass before we spend the
   # Fly build/deploy budget. If main has a broken state (e.g. two PRs
@@ -109,6 +105,11 @@ jobs:
     name: Deploy to Fly.io
     needs: preflight
     if: needs.preflight.outputs.deploy_current == 'true' && (needs.preflight.outputs.evaluator_required == 'false' || needs.preflight.outputs.evaluator_provisioned == 'true')
+    # Acquire the shared deploy slot only after preflight accepts this run.
+    # Ignored workflow completions must not replace a pending valid release.
+    concurrency:
+      group: fly-deploy
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       # This must precede every flyctl invocation. In particular, staging the

--- a/server/tests/unit/deploy-workflow.test.ts
+++ b/server/tests/unit/deploy-workflow.test.ts
@@ -5,7 +5,8 @@ import { parse } from 'yaml';
 import { describe, expect, it } from 'vitest';
 
 type Step = { name: string; if?: string; run?: string };
-type Workflow = { jobs: Record<string, { if: string; steps: Step[] }> };
+type Concurrency = { group: string; 'cancel-in-progress': boolean };
+type Workflow = { concurrency?: Concurrency; jobs: Record<string, { if: string; steps: Step[]; concurrency?: Concurrency }> };
 const readWorkflow = (name: string): Workflow => parse(readFileSync(
   new URL(`../../../.github/workflows/${name}.yml`, import.meta.url), 'utf8',
 ));
@@ -26,6 +27,14 @@ function accepts(mode: string, name = 'Build Check', event = 'push', overrides =
 }
 
 describe('application and protected evaluator deployment', () => {
+  it('reserves the deploy slot only for jobs accepted by preflight', () => {
+    expect(deploy.concurrency).toBeUndefined();
+    expect(deploy.jobs.preflight.concurrency).toBeUndefined();
+    expect(deploy.jobs.deploy.concurrency).toEqual({
+      group: 'fly-deploy', 'cancel-in-progress': false,
+    });
+  });
+
   it.each(['', 'false'])('deploys successful main builds in ordinary mode %j', mode => {
     expect(accepts(mode)).toBe(true);
     expect(accepts(mode, 'Provision matched-v4 evaluator schema', 'workflow_run')).toBe(false);


### PR DESCRIPTION
An ignored evaluator-completion workflow can occupy the pending `fly-deploy` slot before its preflight condition is evaluated. During #7409's release, [run 34517864792](https://github.com/adcontextprotocol/adcp/actions/runs/34517864792) waited in that slot even though the ordinary release path would skip it. GitHub's [default concurrency behavior](https://docs.github.com/en/actions/concepts/workflows-and-actions/concurrency) lets a newly queued run replace the existing pending run, so an ignored completion could displace a valid release.

Move the same shared concurrency group onto the deployment job, after preflight accepts the run. Actual deployments remain serialized and active deployments are not cancelled. Ignored and failed preflight runs cannot acquire the deploy slot. No change to evaluator authorization, runtime settings, or application code.

Validation: all 21 deployment workflow tests pass, including lock placement and the existing source, mode, provisioning, and staged-setting checks.
