### PR TITLE
fix(deploy): trim unindexed Addie cache from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,10 @@ rm /repos/clone.sh
 # Only markdown/MDX files are indexed by search_repos at runtime. Keep this
 # in sync with EXTERNAL_REPOS indexPatterns if non-markdown sources are added.
 find /repos -type f ! \( -name "*.md" -o -name "*.mdx" \) -delete
+# AdCP's indexPatterns only include README.md, CHANGELOG.md and docs/**.
+# Its released dist/docs snapshots otherwise add nearly 1 GB of unindexed
+# duplicates to this cache. Public release artifacts remain in /app/dist.
+find /repos/adcp -type f ! \( -path "/repos/adcp/docs/*" -o -path "/repos/adcp/README.md" -o -path "/repos/adcp/CHANGELOG.md" \) -delete
 find /repos -type d -empty -delete
 CLONE
 
@@ -185,6 +189,13 @@ RUN npm run verify:training-agent-runtime
 
 # Copy pre-cloned repos (warm cache for Addie)
 COPY --from=repos /repos ./.addie-repos
+
+# Fly unpacks images onto an 8 GiB root filesystem. Reserve space for the
+# base image and runtime writes; fail the build before the release migration
+# if growing artifacts or dependencies consume that headroom again.
+RUN app_mib=$(du -sm /app | cut -f1) \
+ && echo "Runtime application size: ${app_mib} MiB (limit: 7168 MiB)" \
+ && test "$app_mib" -le 7168
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ rm /repos/clone.sh
 # in sync with EXTERNAL_REPOS indexPatterns if non-markdown sources are added.
 find /repos -type f ! \( -name "*.md" -o -name "*.mdx" \) -delete
 # AdCP's indexPatterns only include README.md, CHANGELOG.md and docs/**.
-# Its released dist/docs snapshots otherwise add nearly 1 GB of unindexed
+# Its released dist/docs snapshots otherwise add hundreds of MiB of unindexed
 # duplicates to this cache. Public release artifacts remain in /app/dist.
 find /repos/adcp -type f ! \( -path "/repos/adcp/docs/*" -o -path "/repos/adcp/README.md" -o -path "/repos/adcp/CHANGELOG.md" \) -delete
 find /repos -type d -empty -delete
@@ -194,8 +194,8 @@ COPY --from=repos /repos ./.addie-repos
 # base image and runtime writes; fail the build before the release migration
 # if growing artifacts or dependencies consume that headroom again.
 RUN app_mib=$(du -sm /app | cut -f1) \
- && echo "Runtime application size: ${app_mib} MiB (limit: 7168 MiB)" \
- && test "$app_mib" -le 7168
+ && echo "Runtime application size: ${app_mib} MiB (limit: 7424 MiB)" \
+ && test "$app_mib" -le 7424
 
 # Set environment variables
 ENV NODE_ENV=production


### PR DESCRIPTION
Fly release 3934 failed before migrations because its image could not be unpacked within the 8 GB limit. The AdCP repository warm cache carries archived Markdown snapshots that `search_repos` never indexes; the running image contains 501 MiB in that unused cache subtree alone.

Trim the AdCP cache to its configured README, changelog, and docs paths. All public versioned schemas, compliance bundles, protocol downloads, and configured documentation snapshots remain under `/app/dist` with their existing bytes. Add a build-time 7424 MiB application-size ceiling to leave room for the base image and runtime writes.

Validation:

- Full production Docker build, including all external repository clones: **7,401,962,904 bytes** uncompressed; `/app` uses **7,206 MiB**, below the 7,424 MiB guard.
- Training-agent runtime schema guard passes; all configured documentation versions pass the runtime indexing smoke check.
- Applying the exact Docker filter to real source docs preserves all **377 indexed documents and 6,092 headings** byte for byte; unused archive files are removed.
- A pinned `3.2.0-beta.6` schema has the same SHA-256 in the final image, committed release, and current production response.
- Local precommit checks and typechecking passed. All 33 GitHub CI checks passed; no CodeQL review findings.

No application routing or provider behavior changes.
