### PR TITLE
feat(schema): add DOOH geo location and inventory summary fields

### DIFF
--- a/.changeset/dooh-inventory-geo.md
+++ b/.changeset/dooh-inventory-geo.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": minor
+---
+
+Add structured DOOH/OOH location fields: `dooh_placement_attributes.location` (`lat`/`lon`/`address`) on `placement.json`, `placement-definition.json`, and `canonical-placement.json` for concrete single-screen placements, and a new `dooh_inventory_summary.venue_counts[]` on `product.json`/`canonical-product.json` for aggregate network geography. Closes #5538. All fields are optional and additive; location is disclosure metadata, not placement identity.

--- a/docs/creative/channels/dooh.mdx
+++ b/docs/creative/channels/dooh.mdx
@@ -256,7 +256,60 @@ Proof-of-play reporting uses `plays` for the raw playout count and `impressions`
 }
 ```
 
-Exact structured coordinates and venue-coverage fields remain tracked in [#5538](https://github.com/adcontextprotocol/adcp/issues/5538); coordinates are metadata, not property or placement identity.
+## Structured location for planning and mapping
+
+Coordinates and street address are location metadata, not placement identity: a missing, imprecise, or later-corrected `location` MUST NOT change `placement_id` or `identifiers[]`. Two disclosure shapes cover the concrete and aggregate cases from [#5538](https://github.com/adcontextprotocol/adcp/issues/5538):
+
+For a concrete single-screen or single-venue placement, disclose `dooh_placement_attributes.location`:
+
+```json
+{
+  "kind": "seller_inline",
+  "placement_id": "screen_grand_central_01",
+  "name": "Grand Central concourse screen",
+  "mode": "targetable",
+  "identifiers": [
+    { "type": "screen_id", "value": "space:1234931339" },
+    { "type": "venue_id", "value": "publisher:grand_central" },
+    { "type": "openooh_venue_type", "value": "openooh-1.1:20501" }
+  ],
+  "dooh_placement_attributes": {
+    "location": {
+      "lat": 40.7527,
+      "lon": -73.9772,
+      "address": {
+        "line1": "89 E 42nd St",
+        "city": "New York",
+        "region": "US-NY",
+        "postal_code": "10017",
+        "country": "US"
+      }
+    }
+  }
+}
+```
+
+`location` uses `lat`/`lon`, matching OpenRTB 2.6 and OpenOOH geo field naming used by DOOH data partners and measurement currencies, rather than this spec's general `lng` convention. All fields are optional; disclose what is actually known.
+
+For a network or regional product where per-screen location is not practical to disclose, use the product-level `dooh_inventory_summary.venue_counts[]` aggregate instead:
+
+```json
+{
+  "dooh_inventory_summary": {
+    "venue_counts": [
+      {
+        "geo_level": "metro",
+        "system": "nielsen_dma",
+        "geo_code": "501",
+        "venue_type": "openooh-1.1:20501",
+        "count": 87
+      }
+    ]
+  }
+}
+```
+
+`geo_level`/`system`/`geo_code` reuse the same vocabulary as `forecast-dimension-geo.json`. The two disclosure shapes are not mutually exclusive: a product may disclose concrete placement locations, an aggregate summary, or both. `coverage_polygon` remains deferred until sellers demonstrate reliable fill-rate; if added later, it will reuse the existing `catchment.json` GeoJSON geometry pattern rather than a new polygon primitive.
 
 If loop position, share of voice, or scheduling changes what the buyer can purchase, expose it as a distinct product or public placement with the applicable commercial terms. Put canonical slot and loop duration on `dooh_placement_attributes`. Existing fixed-allocation DOOH offers can also declare `pricing_options[].parameters` on a `flat_rate` option with `type: "dooh"`, plus `sov_percentage`, `min_plays_per_hour`, `venue_package`, `duration_hours`, and `daypart`. The deprecated pricing-layer copy of `loop_duration_seconds`, when present on a migrated offer, must agree with the placement declaration. Guaranteed-only offers use the `sales-guaranteed` profile.
 

--- a/static/schemas/source/core/canonical-placement.json
+++ b/static/schemas/source/core/canonical-placement.json
@@ -16,6 +16,40 @@
       "required": ["width", "height"],
       "additionalProperties": false
     },
+    "CanonicalDoohAddress": {
+      "title": "Canonical DOOH Address",
+      "type": "object",
+      "description": "Structured street address for a DOOH/OOH placement, for display and geocoding fallback when coordinates are absent or imprecise.",
+      "properties": {
+        "line1": { "type": "string", "description": "Street address line (e.g., '89 E 42nd St')." },
+        "city": { "type": "string", "description": "City name." },
+        "region": { "type": "string", "description": "State, province, or region. ISO 3166-2 subdivision code preferred (e.g., 'US-NY')." },
+        "postal_code": { "type": "string", "description": "Postal or ZIP code." },
+        "country": { "type": "string", "pattern": "^[A-Z]{2}$", "description": "ISO 3166-1 alpha-2 country code." }
+      },
+      "additionalProperties": false
+    },
+    "CanonicalDoohLocation": {
+      "title": "Canonical DOOH Location",
+      "type": "object",
+      "description": "Disclosed geographic location of an installed DOOH/OOH placement, for buyer planning, mapping, and verification. Location metadata only: missing, imprecise, or later-corrected coordinates MUST NOT change placement_id or identifiers[]. All fields optional; disclose what the seller actually knows.",
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Latitude in decimal degrees (WGS 84)."
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Longitude in decimal degrees (WGS 84). Uses `lon`, matching OpenRTB 2.6 and OpenOOH geo field naming used by DOOH data partners and measurement currencies, rather than this spec's general targeting.json `lng` convention."
+        },
+        "address": { "$ref": "#/definitions/CanonicalDoohAddress" }
+      },
+      "additionalProperties": false
+    },
     "CanonicalDoohPlacementAttributes": {
       "title": "Canonical DOOH Placement Attributes",
       "type": "object",
@@ -35,7 +69,8 @@
         "motion": {
           "$ref": "/schemas/enums/dooh-motion-type.json",
           "description": "Physical motion capability of a visual DOOH screen, not an accepted-format declaration. Omit for audio-only placements."
-        }
+        },
+        "location": { "$ref": "#/definitions/CanonicalDoohLocation" }
       },
       "x-adcp-validation": {
         "verifier_constraints": {

--- a/static/schemas/source/core/canonical-product.json
+++ b/static/schemas/source/core/canonical-product.json
@@ -30,6 +30,7 @@
     "pricing_options": { "type": "array", "items": { "$ref": "/schemas/core/canonical-pricing-option.json" }, "minItems": 1 },
     "forecast": { "$ref": "/schemas/core/canonical-delivery-forecast.json" },
     "reporting_capabilities": { "$ref": "/schemas/core/canonical-reporting-capabilities.json" },
+    "dooh_inventory_summary": { "$ref": "/schemas/core/dooh-inventory-summary.json" },
     "measurement_terms": {
       "$ref": "/schemas/core/canonical-measurement-terms.json",
       "description": "Default billing measurement and makegood terms inherited by a direct purchase unless a negotiated proposal replaces them."

--- a/static/schemas/source/core/dooh-inventory-summary.json
+++ b/static/schemas/source/core/dooh-inventory-summary.json
@@ -16,11 +16,16 @@
         },
         "system": {
           "type": "string",
-          "description": "Classification system for metro or postal_area rows (e.g., 'nielsen_dma'), matching forecast-dimension-geo.json's system vocabulary. Omit for country and region rows."
+          "description": "Classification system for metro or postal_area rows. Metro rows use metro-system.json values such as 'nielsen_dma'; native postal rows use country-local postal-system.json values such as 'zip' with country 'US'; deprecated legacy postal rows may use legacy-postal-system.json values such as 'us_zip'. Omit for country and region rows."
+        },
+        "country": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "ISO 3166-1 alpha-2 country code. Required for native postal_area rows; omitted for legacy postal rows, metro rows, country rows, and region rows."
         },
         "geo_code": {
           "type": "string",
-          "description": "Geographic code within geo_level and system, using forecast-dimension-geo.json's conventions: ISO 3166-1 alpha-2 for country ('US'), ISO 3166-2 for region ('US-CA'), system-specific code for metro/postal_area ('501', '10001')."
+          "description": "Geographic code within geo_level and system, matching forecast-dimension-geo.json's conventions: ISO 3166-1 alpha-2 for country ('US'), ISO 3166-2 with country prefix for region ('US-CA'), system-specific code for metro/postal_area ('501', '10001')."
         },
         "venue_type": {
           "type": "string",
@@ -36,11 +41,51 @@
       "allOf": [
         {
           "if": {
+            "properties": { "geo_level": { "const": "country" } },
+            "required": ["geo_level"]
+          },
+          "then": {
+            "properties": {
+              "geo_code": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$",
+                "description": "ISO 3166-1 alpha-2 country code."
+              }
+            },
+            "not": {
+              "anyOf": [{ "required": ["system"] }, { "required": ["country"] }]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "geo_level": { "const": "region" } },
+            "required": ["geo_level"]
+          },
+          "then": {
+            "properties": {
+              "geo_code": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}-[A-Z0-9]{1,3}$",
+                "description": "ISO 3166-2 subdivision code."
+              }
+            },
+            "not": {
+              "anyOf": [{ "required": ["system"] }, { "required": ["country"] }]
+            }
+          }
+        },
+        {
+          "if": {
             "properties": { "geo_level": { "const": "metro" } },
             "required": ["geo_level"]
           },
           "then": {
-            "required": ["system"]
+            "properties": {
+              "system": { "$ref": "/schemas/enums/metro-system.json" }
+            },
+            "required": ["system"],
+            "not": { "required": ["country"] }
           }
         },
         {
@@ -49,7 +94,16 @@
             "required": ["geo_level"]
           },
           "then": {
-            "required": ["system"]
+            "anyOf": [
+              { "$ref": "/schemas/core/postal-country-system.json" },
+              {
+                "properties": {
+                  "system": { "$ref": "/schemas/enums/legacy-postal-system.json" }
+                },
+                "required": ["system"],
+                "not": { "required": ["country"] }
+              }
+            ]
           }
         }
       ],

--- a/static/schemas/source/core/dooh-inventory-summary.json
+++ b/static/schemas/source/core/dooh-inventory-summary.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/core/dooh-inventory-summary.json",
+  "title": "DOOH Inventory Summary",
+  "description": "Aggregate geographic footprint for a DOOH/OOH network product, for network/regional products where per-screen location disclosure via placement dooh_placement_attributes.location is not practical. The two are not mutually exclusive: a product may disclose concrete placement locations, an aggregate summary, or both.",
+  "type": "object",
+  "definitions": {
+    "DoohVenueCount": {
+      "title": "DOOH Venue Count",
+      "type": "object",
+      "description": "Aggregate count of venues or screens for one geography/venue-type breakout row.",
+      "properties": {
+        "geo_level": {
+          "$ref": "/schemas/enums/geo-level.json",
+          "description": "Geographic level for this breakout row, reusing forecast-dimension-geo.json's vocabulary."
+        },
+        "system": {
+          "type": "string",
+          "description": "Classification system for metro or postal_area rows (e.g., 'nielsen_dma'), matching forecast-dimension-geo.json's system vocabulary. Omit for country and region rows."
+        },
+        "geo_code": {
+          "type": "string",
+          "description": "Geographic code within geo_level and system, using forecast-dimension-geo.json's conventions: ISO 3166-1 alpha-2 for country ('US'), ISO 3166-2 for region ('US-CA'), system-specific code for metro/postal_area ('501', '10001')."
+        },
+        "venue_type": {
+          "type": "string",
+          "description": "OpenOOH Venue Taxonomy enumeration ID for this row, prefixed with the taxonomy authority and version for unambiguous interchange (e.g., 'openooh-1.1:20501'), matching the identifier-types.json openooh_venue_type convention. Omit when the row aggregates across venue types."
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of venues or screens matching this geography/venue-type combination."
+        }
+      },
+      "required": ["geo_level", "geo_code", "count"],
+      "allOf": [
+        {
+          "if": {
+            "properties": { "geo_level": { "const": "metro" } },
+            "required": ["geo_level"]
+          },
+          "then": {
+            "required": ["system"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "geo_level": { "const": "postal_area" } },
+            "required": ["geo_level"]
+          },
+          "then": {
+            "required": ["system"]
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "venue_counts": {
+      "type": "array",
+      "description": "Aggregate venue/screen counts broken out by geography and, optionally, venue type.",
+      "items": { "$ref": "#/definitions/DoohVenueCount" },
+      "minItems": 1
+    }
+  },
+  "required": ["venue_counts"],
+  "additionalProperties": false
+}

--- a/static/schemas/source/core/placement-definition.json
+++ b/static/schemas/source/core/placement-definition.json
@@ -16,6 +16,40 @@
       "required": ["width", "height"],
       "additionalProperties": false
     },
+    "PublisherDoohAddress": {
+      "title": "Publisher DOOH Address",
+      "type": "object",
+      "description": "Structured street address for a DOOH/OOH placement, for display and geocoding fallback when coordinates are absent or imprecise.",
+      "properties": {
+        "line1": { "type": "string", "description": "Street address line (e.g., '89 E 42nd St')." },
+        "city": { "type": "string", "description": "City name." },
+        "region": { "type": "string", "description": "State, province, or region. ISO 3166-2 subdivision code preferred (e.g., 'US-NY')." },
+        "postal_code": { "type": "string", "description": "Postal or ZIP code." },
+        "country": { "type": "string", "pattern": "^[A-Z]{2}$", "description": "ISO 3166-1 alpha-2 country code." }
+      },
+      "additionalProperties": false
+    },
+    "PublisherDoohLocation": {
+      "title": "Publisher DOOH Location",
+      "type": "object",
+      "description": "Disclosed geographic location of an installed DOOH/OOH placement, for buyer planning, mapping, and verification. Location metadata only: missing, imprecise, or later-corrected coordinates MUST NOT change placement_id or identifiers[]. All fields optional; disclose what the seller actually knows.",
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Latitude in decimal degrees (WGS 84)."
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Longitude in decimal degrees (WGS 84). Uses `lon`, matching OpenRTB 2.6 and OpenOOH geo field naming used by DOOH data partners and measurement currencies, rather than this spec's general targeting.json `lng` convention."
+        },
+        "address": { "$ref": "#/definitions/PublisherDoohAddress" }
+      },
+      "additionalProperties": false
+    },
     "PublisherDoohPlacementAttributes": {
       "title": "Publisher DOOH Placement Attributes",
       "type": "object",
@@ -35,7 +69,8 @@
         "motion": {
           "$ref": "/schemas/enums/dooh-motion-type.json",
           "description": "Physical motion capability of a visual DOOH screen, not an accepted-format declaration. Omit for audio-only placements."
-        }
+        },
+        "location": { "$ref": "#/definitions/PublisherDoohLocation" }
       },
       "x-adcp-validation": {
         "verifier_constraints": {

--- a/static/schemas/source/core/placement.json
+++ b/static/schemas/source/core/placement.json
@@ -16,6 +16,40 @@
       "required": ["width", "height"],
       "additionalProperties": false
     },
+    "ProductDoohAddress": {
+      "title": "Product DOOH Address",
+      "type": "object",
+      "description": "Structured street address for a DOOH/OOH placement, for display and geocoding fallback when coordinates are absent or imprecise.",
+      "properties": {
+        "line1": { "type": "string", "description": "Street address line (e.g., '89 E 42nd St')." },
+        "city": { "type": "string", "description": "City name." },
+        "region": { "type": "string", "description": "State, province, or region. ISO 3166-2 subdivision code preferred (e.g., 'US-NY')." },
+        "postal_code": { "type": "string", "description": "Postal or ZIP code." },
+        "country": { "type": "string", "pattern": "^[A-Z]{2}$", "description": "ISO 3166-1 alpha-2 country code." }
+      },
+      "additionalProperties": false
+    },
+    "ProductDoohLocation": {
+      "title": "Product DOOH Location",
+      "type": "object",
+      "description": "Disclosed geographic location of an installed DOOH/OOH placement, for buyer planning, mapping, and verification. Location metadata only: missing, imprecise, or later-corrected coordinates MUST NOT change placement_id or identifiers[]. All fields optional; disclose what the seller actually knows. Network products where per-screen location is not disclosed should use the product-level dooh_inventory_summary aggregate instead.",
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Latitude in decimal degrees (WGS 84)."
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Longitude in decimal degrees (WGS 84). Uses `lon`, matching OpenRTB 2.6 and OpenOOH geo field naming used by DOOH data partners and measurement currencies, rather than this spec's general targeting.json `lng` convention."
+        },
+        "address": { "$ref": "#/definitions/ProductDoohAddress" }
+      },
+      "additionalProperties": false
+    },
     "ProductDoohPlacementAttributes": {
       "title": "Product DOOH Placement Attributes",
       "type": "object",
@@ -35,7 +69,8 @@
         "motion": {
           "$ref": "/schemas/enums/dooh-motion-type.json",
           "description": "Physical motion capability of a visual DOOH screen, not an accepted-format declaration. Omit for audio-only placements."
-        }
+        },
+        "location": { "$ref": "#/definitions/ProductDoohLocation" }
       },
       "x-adcp-validation": {
         "verifier_constraints": {

--- a/static/schemas/source/core/product.json
+++ b/static/schemas/source/core/product.json
@@ -182,6 +182,10 @@
     "reporting_capabilities": {
       "$ref": "/schemas/core/reporting-capabilities.json"
     },
+    "dooh_inventory_summary": {
+      "$ref": "/schemas/core/dooh-inventory-summary.json",
+      "description": "Aggregate DOOH/OOH geographic footprint for network/regional products where per-placement dooh_placement_attributes.location is not practical. See dooh-inventory-summary.json for the full description."
+    },
     "creative_policy": {
       "$ref": "/schemas/core/creative-policy.json"
     },

--- a/tests/placement-catalog-schema.test.cjs
+++ b/tests/placement-catalog-schema.test.cjs
@@ -703,6 +703,111 @@ test('canonical list_products placements preserve DOOH inventory facts', async (
   assert.equal(validate(placement), true, JSON.stringify(validate.errors, null, 2));
 });
 
+test('placement dooh_placement_attributes.location accepts coordinates and address across all three placement schemas', async () => {
+  const location = {
+    lat: 40.7527,
+    lon: -73.9772,
+    address: {
+      line1: '89 E 42nd St',
+      city: 'New York',
+      region: 'US-NY',
+      postal_code: '10017',
+      country: 'US'
+    }
+  };
+
+  const validateProductPlacement = await compile('/schemas/core/placement.json');
+  assert.equal(
+    validateProductPlacement({
+      kind: 'seller_inline',
+      placement_id: 'screen_grand_central_01',
+      name: 'Grand Central concourse screen',
+      mode: 'targetable',
+      dooh_placement_attributes: { location }
+    }),
+    true,
+    JSON.stringify(validateProductPlacement.errors, null, 2)
+  );
+
+  const validatePublisherPlacement = await compile('/schemas/core/placement-definition.json');
+  assert.equal(
+    validatePublisherPlacement({
+      placement_id: 'screen_grand_central_01',
+      name: 'Grand Central concourse screen',
+      property_ids: ['grand_central_network'],
+      dooh_placement_attributes: { location }
+    }),
+    true,
+    JSON.stringify(validatePublisherPlacement.errors, null, 2)
+  );
+
+  const validateCanonicalPlacement = await compile('/schemas/core/canonical-placement.json');
+  assert.equal(
+    validateCanonicalPlacement({
+      kind: 'seller_inline',
+      placement_id: 'screen_grand_central_01',
+      name: 'Grand Central concourse screen',
+      mode: 'targetable',
+      dooh_placement_attributes: { location }
+    }),
+    true,
+    JSON.stringify(validateCanonicalPlacement.errors, null, 2)
+  );
+});
+
+test('placement dooh_placement_attributes.location rejects out-of-range coordinates', async () => {
+  const validate = await compile('/schemas/core/placement.json');
+
+  assert.equal(
+    validate({
+      kind: 'seller_inline',
+      placement_id: 'screen_bad_coords',
+      name: 'Bad coords screen',
+      mode: 'targetable',
+      dooh_placement_attributes: { location: { lat: 200, lon: 0 } }
+    }),
+    false
+  );
+});
+
+test('product dooh_inventory_summary accepts aggregate venue counts and requires system for metro rows', async () => {
+  const validateProduct = await compile('/schemas/core/product.json');
+  const product = validProduct({
+    dooh_inventory_summary: {
+      venue_counts: [
+        { geo_level: 'metro', system: 'nielsen_dma', geo_code: '501', venue_type: 'openooh-1.1:20501', count: 87 }
+      ]
+    }
+  });
+
+  assert.equal(validateProduct(product), true, JSON.stringify(validateProduct.errors, null, 2));
+
+  assert.equal(
+    validateProduct(
+      validProduct({
+        dooh_inventory_summary: {
+          venue_counts: [{ geo_level: 'metro', geo_code: '501', count: 87 }]
+        }
+      })
+    ),
+    false,
+    'metro rows must declare system'
+  );
+
+  const validateCanonicalProduct = await compile('/schemas/core/canonical-product.json');
+  assert.equal(
+    validateCanonicalProduct({
+      product_id: 'metro_network_screens',
+      name: 'Metro network screens',
+      dooh_inventory_summary: {
+        venue_counts: [{ geo_level: 'country', geo_code: 'US', count: 412 }]
+      }
+    }),
+    true,
+    JSON.stringify(validateCanonicalProduct.errors, null, 2)
+  );
+});
+
 test('dooh_placement_attributes rejects invalid motion type', async () => {
   const validate = await compile('/schemas/core/placement.json');
   const placement = {

--- a/tests/placement-catalog-schema.test.cjs
+++ b/tests/placement-catalog-schema.test.cjs
@@ -794,6 +794,30 @@ test('product dooh_inventory_summary accepts aggregate venue counts and requires
     'metro rows must declare system'
   );
 
+  assert.equal(
+    validateProduct(
+      validProduct({
+        dooh_inventory_summary: {
+          venue_counts: [{ geo_level: 'metro', system: 'nielsen', geo_code: '501', count: 87 }]
+        }
+      })
+    ),
+    false,
+    'metro system must be a real metro-system.json enum value, not an arbitrary string'
+  );
+
+  assert.equal(
+    validateProduct(
+      validProduct({
+        dooh_inventory_summary: {
+          venue_counts: [{ geo_level: 'country', geo_code: 'USA', count: 412 }]
+        }
+      })
+    ),
+    false,
+    'country geo_code must be ISO 3166-1 alpha-2, not a 3-letter code'
+  );
+
   const validateCanonicalProduct = await compile('/schemas/core/canonical-product.json');
   assert.equal(
     validateCanonicalProduct({


### PR DESCRIPTION
## Summary

Implements the [#5538](https://github.com/adcontextprotocol/adcp/issues/5538) design direction bokelley approved for the 3.3.0 milestone: structured geographic disclosure for DOOH/OOH placements.

- `dooh_placement_attributes.location` (`lat`, `lon`, `address`) on `placement.json`, `placement-definition.json`, and `canonical-placement.json`, for a concrete single-screen or single-venue placement.
- New `dooh_inventory_summary.venue_counts[]` on `product.json`/`canonical-product.json`, for aggregate network/regional geography where per-screen disclosure isn't practical.

Both shapes match exactly what was proposed and approved in the issue thread ("Decision update — approved for implementation"): `lat`/`lon` (not `lng`, matching OpenRTB 2.6/OpenOOH convention rather than this spec's general `targeting.json` naming), `venue_counts` reusing the existing `geo-level.json`/`forecast-dimension-geo.json` vocabulary, and `coverage_polygon` deliberately deferred pending seller fill-rate evidence.

## Context / reconciliation

`placement.identifiers[]` and `dooh_placement_attributes` (`slot_duration_seconds`, `loop_duration_seconds`, `screen_resolution`, `motion`) — the other two pieces of the approved design — already shipped via #5537/PR #5623, so this PR is scoped to just the remaining gap: structured `location` and the aggregate summary. I also checked PR #5589 (an earlier attempt at this same narrow surface, closed 2026-08-10 as stale/pending reconciliation with the broader #6241 static-OOH work) and confirmed #6241 (merged 2026-08-25) only added delivery-side panel/id_type identifiers for static OOH metrics — it does not carry any planning-time lat/lon/address field, so the gap this PR closes is still real and not superseded by that later work.

## Verification

- `node --test tests/placement-catalog-schema.test.cjs` — added tests for `location` (accepts valid coordinates/address across all three placement schemas; rejects out-of-range lat/lon) and `dooh_inventory_summary` (accepts valid `venue_counts`; rejects a `metro` row missing `system`). Verified real via revert-and-reconfirm: reverting only the schema changes (keeping the new tests) makes the two rejection-case tests fail; restoring passes all 23 tests in the file.
- `npm run test:schemas` (264+ tests across the schema suite) and `npm run test:json-schema` (281 `$schema`-tagged doc examples) both pass.
- Full commit-time `npm run precommit` (unit suite, storyboard matrix, typecheck) — 9166 tests passed.
- `node scripts/check-changeset-protocol-scope.cjs origin/main` and `npx @changesets/cli status --since=upstream/main` confirm the expected `minor` bump.

## Docs

Updated `docs/creative/channels/dooh.mdx`, replacing the "tracked in #5538" placeholder note with both wire shapes (concrete single-screen and aggregate network), matching the examples from the approved design comment.

Closes #5538

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCdwLd3czRX24ESPw7ii7Q