### PR TITLE
fix(addie): preserve Gemini response text and Markdown

### DIFF
--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.47';
+export const CODE_VERSION = '2026.09.48';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/model-providers/google-generate-content-provider.ts
+++ b/server/src/addie/model-providers/google-generate-content-provider.ts
@@ -78,7 +78,7 @@ export const GOOGLE_GENERATE_CONTENT_CAPABILITIES: ModelProviderCapabilities = O
 
 const MAX_GOOGLE_RESPONSE_PARTS = 1_000;
 const MAX_GOOGLE_CONTINUATION_BYTES = 2 * 1024 * 1024;
-const googleContinuationParts = new WeakMap<object, Readonly<Part>>();
+const googleContinuationParts = new WeakMap<object, ReadonlyArray<Readonly<Part>>>();
 
 /** Preserve original parts (including empty signed parts) across streamed chunks. */
 async function collectGoogleStream(
@@ -162,22 +162,22 @@ function textOnly(content: ModelMessageContent[], label: string): string {
   return content.map((block) => block.type === 'text' ? block.text : '').join('');
 }
 
-function rememberGoogleContinuation<T extends object>(content: T, part: Part): T {
-  const serialized = JSON.stringify(part);
+function rememberGoogleContinuation<T extends object>(content: T, parts: ReadonlyArray<Readonly<Part>>): T {
+  const serialized = JSON.stringify(parts);
   if (Buffer.byteLength(serialized, 'utf8') > MAX_GOOGLE_CONTINUATION_BYTES) {
     throw new Error('Google continuation state exceeds size limit');
   }
   const frozen = deepFreeze(content);
-  googleContinuationParts.set(frozen, deepFreeze(structuredClone(part)));
+  googleContinuationParts.set(frozen, deepFreeze(structuredClone(parts)));
   return frozen;
 }
 
-function toGooglePart(content: ModelMessageContent): Part {
+function toGoogleParts(content: ModelMessageContent): Part[] {
   const continuation = googleContinuationParts.get(content);
-  if (continuation) return { ...continuation };
+  if (continuation) return continuation.map(part => ({ ...part }));
   switch (content.type) {
     case 'text':
-      return { text: content.text };
+      return [{ text: content.text }];
     case 'tool_call':
       throw new Error('Google tool-call continuation was not issued by this adapter');
     case 'tool_result': {
@@ -187,7 +187,7 @@ function toGooglePart(content: ModelMessageContent): Part {
       if (!content.toolName?.trim()) {
         throw new Error('Google tool results require the tool name');
       }
-      return {
+      return [{
         functionResponse: {
           id: content.toolCallId,
           name: content.toolName,
@@ -195,7 +195,7 @@ function toGooglePart(content: ModelMessageContent): Part {
             ? { error: content.content }
             : { output: content.content },
         },
-      };
+      }];
     }
     case 'provider_state':
     case 'provider_tool_call':
@@ -232,7 +232,7 @@ function toGoogleContents(messages: ModelRequest['messages']): GenerateContentPa
     }
     return {
       role: message.role === 'assistant' ? 'model' : 'user',
-      parts: message.content.map(toGooglePart),
+      parts: message.content.flatMap(toGoogleParts),
     };
   });
   if (pendingCalls.size > 0) {
@@ -386,6 +386,17 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
   }
   const outputTokens = response.usageMetadata.candidatesTokenCount ?? 0;
   const content: ModelMessageContent[] = [];
+  let textParts: Part[] = [];
+  const flushText = () => {
+    if (textParts.length === 0) return;
+    // Google's text parts are contiguous fragments, not paragraph blocks.
+    // Expose their exact concatenation while keeping every original signed
+    // part (including empty text) for a subsequent provider continuation.
+    content.push(rememberGoogleContinuation({
+      type: 'text', text: textParts.map(part => part.text).join(''),
+    } as const, textParts));
+    textParts = [];
+  };
   for (const part of parts ?? []) {
     const keys = Object.keys(part).filter((key) => part[key as keyof typeof part] !== undefined);
     if (keys.some((key) => !['text', 'functionCall', 'thoughtSignature', 'thought'].includes(key))) {
@@ -418,17 +429,19 @@ export function normalizeGoogleResponse(response: GenerateContentResponse): Mode
         || call.willContinue !== undefined
       ) throw new Error('Malformed Google function call');
       assertPlainJson(call.args, 'Google function-call input');
+      flushText();
       content.push(rememberGoogleContinuation({
         type: 'tool_call',
         id: call.id,
         name: call.name,
         input: call.args,
-      } as const, part));
+      } as const, [part]));
     } else {
       if (typeof part.text !== 'string') throw new Error('Malformed Google text content');
-      content.push(rememberGoogleContinuation({ type: 'text', text: part.text } as const, part));
+      textParts.push(part);
     }
   }
+  flushText();
   if (candidate.content !== undefined && candidate.content.role !== 'model') {
     throw new Error('Malformed Google response role');
   }

--- a/server/src/addie/response-postprocess.ts
+++ b/server/src/addie/response-postprocess.ts
@@ -194,7 +194,7 @@ export function rewritePersonaCollapse(text: string): string {
 
   for (let i = 0; i < parts.length; i += 2) {
     const sentences = splitProseIntoSentences(parts[i]);
-    parts[i] = sentences.filter((s) => !hasPersonaCollapse(s)).join(' ');
+    parts[i] = sentences.filter((s) => !hasPersonaCollapse(s)).join('');
   }
 
   // Collapse whitespace left where sentences were removed.
@@ -291,7 +291,7 @@ export function truncateLongResponseToShortQuestion(
 
     if (isCode) {
       const blockWords = countWords(part);
-      if (kept.length === 0 || cumulativeWords + blockWords <= TRUNCATION_TARGET_WORDS) {
+      if (cumulativeWords === 0 || cumulativeWords + blockWords <= TRUNCATION_TARGET_WORDS) {
         kept.push(part);
         cumulativeWords += blockWords;
       } else {
@@ -306,7 +306,7 @@ export function truncateLongResponseToShortQuestion(
     const proseKept: string[] = [];
     for (const sentence of sentences) {
       const w = countWords(sentence);
-      if (kept.length === 0 && proseKept.length === 0) {
+      if (cumulativeWords === 0) {
         // Always keep the first sentence even if it's already over budget —
         // a one-sentence answer beats no answer.
         proseKept.push(sentence);
@@ -321,7 +321,7 @@ export function truncateLongResponseToShortQuestion(
       cumulativeWords += w;
     }
     if (proseKept.length > 0) {
-      kept.push(proseKept.join(' '));
+      kept.push(proseKept.join(''));
     }
   }
 
@@ -330,22 +330,25 @@ export function truncateLongResponseToShortQuestion(
 }
 
 /**
- * Split prose into sentences, preserving original whitespace separators
- * so the rejoined output reads naturally.
- *
- * Splits on `[.!?]` followed by whitespace, but keeps the terminator with
- * the preceding sentence so reassembly is just `.join(' ')`.
+ * Keep sentence segments byte-for-byte, including their whitespace. Only
+ * punctuation followed by whitespace (or EOF) ends a segment, so decimal,
+ * version and identifier dots stay intact. Concatenation adds no formatting.
  */
 function splitProseIntoSentences(prose: string): string[] {
   if (!prose) return [];
-  // Match: text up to and including a sentence terminator + trailing whitespace.
-  // Final segment may not end in a terminator; capture it separately.
-  const matches = prose.match(/[^.!?]+[.!?]+\s*/g) || [];
-  const consumed = matches.join('');
-  const trailing = prose.slice(consumed.length).trim();
-  const out = matches.map(s => s.trim()).filter(Boolean);
-  if (trailing) out.push(trailing);
-  return out;
+  const segments: string[] = [];
+  let start = 0;
+  for (let index = 0; index < prose.length; index++) {
+    if (!'.!?'.includes(prose[index])) continue;
+    let end = index + 1;
+    if (end < prose.length && !/\s/.test(prose[end])) continue;
+    while (end < prose.length && /\s/.test(prose[end])) end++;
+    segments.push(prose.slice(start, end));
+    start = end;
+    index = end - 1;
+  }
+  if (start < prose.length) segments.push(prose.slice(start));
+  return segments;
 }
 
 /** Test-only exports for the unit test. */

--- a/server/tests/unit/addie/gemini-direct-experiment.test.ts
+++ b/server/tests/unit/addie/gemini-direct-experiment.test.ts
@@ -41,11 +41,11 @@ const answer: AddieResponse = {
 };
 const options: ProcessMessageOptions = { costScope: { userId: 'user-test', tier: 'member_free' } };
 
-function fixture(responses: GenerateContentResponse[]) {
+function fixture(responses: (GenerateContentResponse | GenerateContentResponse[])[]) {
   const dispatch = vi.fn(async function* (_payload: GenerateContentParameters) {
     const next = responses.shift();
     if (!next) throw new Error('No response');
-    yield next;
+    yield* Array.isArray(next) ? next : [next];
   });
   const provider = new GoogleGenerateContentProvider('unused', {
     models: { generateContent: vi.fn(), generateContentStream: async (payload: GenerateContentParameters) => dispatch(payload) },
@@ -99,6 +99,36 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs());
 
 describe('Gemini Direct production integration', () => {
+  it('preserves Markdown and version numbers across real shared-loop stream fragments', async () => {
+    const text = 'In AdCP 3.2 (3.2.0-rc.1), **Reliable Reporting** has three tiers.\n\n'
+      + '- **Core**: Poll `get_media_buy_delivery` and use `reporting_webhook`.\n'
+      + '- **Managed Delivery**: Adds file delivery.\n'
+      + '- **Reconciled Billing**: Adds receipts.\n\n'
+      + 'Enable `media_buy.reporting_delivery` with version `"1.0"`.';
+    const streamed = (parts: Part[], id: string) => parts.map((part, index) => {
+      const chunk = receipt([part], id);
+      if (index < parts.length - 1) {
+        delete chunk.candidates![0].finishReason;
+        delete chunk.usageMetadata;
+      }
+      return chunk;
+    });
+    const toolParts = [{ text: '', thoughtSignature: 'signed-empty' }, call('search_docs')];
+    // Single-character chunks include whitespace-only deltas and split every
+    // Markdown delimiter, API identifier, and decimal/version number.
+    const f = fixture([
+      streamed(toolParts, 'lookup'),
+      streamed(Array.from(text, text => ({ text })), 'answer'),
+    ]);
+    const result = await run(f.input);
+    expect(result.response?.text).toBe(text);
+    expect(result.events.filter(event => event.type === 'text').map(event => event.text).join('')).toBe(text);
+    expect(f.handlers.get('search_docs')).toHaveBeenCalledOnce();
+    expect(f.dispatch.mock.calls[1][0].contents).toEqual(expect.arrayContaining([
+      { role: 'model', parts: toolParts },
+    ]));
+  });
+
   it('executes real shared-loop tools with production accounting and skips the router', async () => {
     const f = fixture([receipt([call('search_docs')]), receipt([{ text: 'A verified fact.' }], 'answer')]);
     const result = await run(f.input);
@@ -255,19 +285,27 @@ describe('assignment and rollback', () => {
 });
 
 describe('native Google streaming', () => {
-  it('combines streamed text, preserves signed empty parts, and uses final usage', async () => {
+  it.each([false, true])('combines text and preserves signed empty continuation parts (stream=%s)', async stream => {
     const progress = vi.fn();
+    const tools = [{ name: 'search_docs', description: 'Search docs', inputSchema: { type: 'object' as const } }];
     const provider = new GoogleGenerateContentProvider('unused', { models: {
-      generateContent: vi.fn(),
+      generateContent: vi.fn().mockResolvedValue(receipt([{ text: 'Hello' }, { text: '', thoughtSignature: 'signed-empty' }], 'stream')),
       generateContentStream: async () => (async function* () {
         yield { responseId: 'stream', modelVersion: GOOGLE_ROUTER_MODEL, candidates: [{ content: { role: 'model', parts: [{ text: 'Hello' }] } }] } as GenerateContentResponse;
         yield receipt([{ text: '', thoughtSignature: 'signed-empty' }], 'stream');
       })(),
     } });
-    const response = await collectModelResponse(provider.respond({ model: GOOGLE_ROUTER_MODEL, system: [], tools: [], messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }], maxOutputTokens: 100 }, { stream: true, onStreamProgress: progress }));
-    expect(response.content).toEqual([{ type: 'text', text: 'Hello' }, { type: 'text', text: '' }]);
+    const response = await collectModelResponse(provider.respond({ model: GOOGLE_ROUTER_MODEL, system: [], tools, messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }], maxOutputTokens: 100 }, { stream, onStreamProgress: progress }));
+    expect(response.content).toEqual([{ type: 'text', text: 'Hello' }]);
+    for (const candidate of [response, provider.snapshotResponse(response)]) {
+      const continuation = provider.prepare({ model: GOOGLE_ROUTER_MODEL, system: [], tools,
+        messages: [{ role: 'assistant', content: candidate.content }], maxOutputTokens: 100 });
+      expect(continuation.providerRequest.contents).toEqual([
+        { role: 'model', parts: [{ text: 'Hello' }, { text: '', thoughtSignature: 'signed-empty' }] },
+      ]);
+    }
     expect(response.usage.outputTokens).toBe(15);
-    expect(progress).toHaveBeenCalledTimes(2);
+    expect(progress).toHaveBeenCalledTimes(stream ? 2 : 0);
   });
 
   it.each(['missing_finish', 'changed_identity', 'missing_usage'])('rejects %s before any partial tool request can execute', async fault => {

--- a/server/tests/unit/addie/response-postprocess.test.ts
+++ b/server/tests/unit/addie/response-postprocess.test.ts
@@ -166,6 +166,11 @@ describe('rewritePersonaCollapse', () => {
     expect(twice).toBe(once);
   });
 
+  it('keeps version numbers and Markdown intact when removing a disclosure', () => {
+    const clean = 'AdCP 3.2 uses `media_buy.reporting_delivery`.\n\n- **Core**: Poll for results.';
+    expect(rewritePersonaCollapse("I'm Claude. " + clean)).toBe(clean);
+  });
+
   it('returns empty when every sentence is a persona-collapse disclosure', () => {
     const input =
       "I'm Claude, an AI assistant made by Anthropic. As a large language model, I have no real-world identity.";
@@ -256,6 +261,19 @@ describe('truncateLongResponseToShortQuestion', () => {
     expect(body).toMatch(/[.!?]$/);
   });
 
+  it('retains an exact Markdown prefix when shortening a versioned protocol explanation', () => {
+    const prefix = 'In AdCP 3.2 (snapshot 3.2.0-rc.1), reporting has three tiers.\n\n'
+      + '- **Core**: Use `get_media_buy_delivery` and `media_buy.reporting_delivery`.\n'
+      + '- **Managed Delivery**: Declares version `"1.0"`.\n\n'
+      + 'See https://example.com/schemas/3.2.0-rc.1/index.json for details.\n\n';
+    const input = prefix + makeProse(250);
+    const output = truncateLongResponseToShortQuestion('Explain reliable reporting.', input);
+    expect(output.endsWith(TRUNCATION_SUFFIX)).toBe(true);
+    const retained = output.slice(0, -TRUNCATION_SUFFIX.length);
+    expect(retained.startsWith(prefix)).toBe(true);
+    expect(input.startsWith(retained)).toBe(true);
+  });
+
   it('keeps the first sentence even if it alone exceeds the target', () => {
     const q = "What is X?";
     // One giant sentence of 200 words.
@@ -275,6 +293,13 @@ describe('truncateLongResponseToShortQuestion', () => {
       const fenceCount = (out.match(/```/g) || []).length;
       expect(fenceCount % 2).toBe(0); // matched pairs only
     }
+  });
+
+  it('preserves leading whitespace and a first fenced block even when it exceeds the target', () => {
+    const code = '```text\n' + makeProse(200) + '\n```';
+    const input = '\n\n' + code + '\n\n' + makeProse(80);
+    const output = truncateLongResponseToShortQuestion('Explain.', input);
+    expect(output).toBe('\n\n' + code + TRUNCATION_SUFFIX);
   });
 
   it('idempotent on already-truncated text', () => {


### PR DESCRIPTION
Gemini staff-pilot replies acquired blank lines inside version numbers, Markdown delimiters, and API identifiers because streamed text parts became separate canonical paragraphs. The response-length limiter also split at every period and rejoined trimmed fragments with spaces, turning `3.2` into `3. 2` and flattening lists.

Coalesce adjacent Google text fragments into one exact text block, while preserving every original signed part for tool continuations and response snapshots. Keep original sentence slices and whitespace when shortening responses or removing persona disclosures. This follows the [Google SDK's text concatenation semantics](https://googleapis.github.io/js-genai/release_docs/classes/types.GenerateContentResponse.html#text). Addie code version is now `2026.09.48`.

Validation:

- Reproduced the formatting failures before the fix with deterministic tests.
- 207 focused provider, production chat-loop, orchestration, and post-processing tests passed in Docker; the 24 Gemini integration tests passed again after adding snapshot-continuation assertions.
- Tests split an answer into single-character chunks (including whitespace and Markdown delimiters), exercise a real shared-loop tool call, and assert exact displayed text and signed continuation parts. Streaming and non-streaming responses are covered.
- Truncation tests preserve an exact original Markdown prefix, version numbers, API identifiers, URLs, and complete fenced code blocks.
- TypeScript and the existing rollout fixture typecheck passed in Docker.

The existing response-length thresholds and staff-only rollout remain in place. No new paid model evaluations were needed for this deterministic bug.
