### PR TITLE
fix(addie): repair web sign-in links

### DIFF
--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -2846,7 +2846,7 @@
 </head>
 <body>
   <div id="impersonation-banner" class="impersonation-banner"></div>
-  <div id="anonymous-banner" class="anonymous-banner">Free preview — <a href="/api/auth/login">sign in</a> to search Slack discussions, validate schemas, and get full-quality answers.</div>
+  <div id="anonymous-banner" class="anonymous-banner">Free preview — <a href="/auth/login?return_to=/chat">sign in</a> to search Slack discussions, validate schemas, and get full-quality answers.</div>
   <div id="adcp-nav"></div>
 
   <!-- SI (Sponsored Intelligence) Chat Modal -->
@@ -5257,7 +5257,7 @@
             const limit = parseInt(response.headers.get('RateLimit-Limit'));
             const limitEl = document.getElementById('messageLimit');
             if (!isNaN(remaining) && !isNaN(limit) && remaining <= 15) {
-              limitEl.innerHTML = `${limit - remaining} of ${limit} free messages used \u00b7 <a href="/api/auth/login">sign in</a> for unlimited`;
+              limitEl.innerHTML = `${limit - remaining} of ${limit} free messages used \u00b7 <a href="/auth/login?return_to=/chat">sign in</a> for unlimited`;
               limitEl.style.display = '';
             }
           }
@@ -6724,7 +6724,7 @@
       async function startVideoCall() {
         if (videoCallActive) return;
         if (!isAuthenticated) {
-          window.location.href = '/api/auth/login';
+          window.location.href = '/auth/login?return_to=/chat';
           return;
         }
 


### PR DESCRIPTION
## Summary
- point Ask Addie sign-in links at the actual `/auth/login` route
- return users to `/chat` after authentication
- update the preview banner, free-message notice, and video-call redirect

## Testing
- `node --test tests/chat-streaming-code-fences.test.cjs tests/certification-experience-ui.test.cjs`
- `npx vitest run --config server/vitest.config.ts server/tests/unit/addie-web-org-selection.test.ts server/tests/unit/client-security-wiring.test.ts`
- pre-commit unit batch: 1,059 tests passed; the subsequent broad server-unit shard exceeded its local 10-minute hook allowance, so required GitHub checks remain the merge gate

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f5810cad-6f89-4b55-a260-040aff6677a7)
