### PR TITLE
fix(addie): give Gemini admins live membership analytics

### DIFF
--- a/docs/aao/addie-tools.mdx
+++ b/docs/aao/addie-tools.mdx
@@ -1860,7 +1860,7 @@ Query community analytics or review flagged conversations (admin only)
 
 ### `query_admin_analytics`
 
-Query one read-only administrative analytics view: platform totals, member-search performance, organizations ranked by user count, or people ranked by engagement.
+Query live, read-only administrative analytics: platform totals, member-search performance, organizations ranked by user count, or people ranked by engagement. For current paying-member counts, use view="platform_stats" and report memberships.active: the exact, uncapped count of active, uncanceled AgenticAdvertising.org memberships, including individual and organization subscriptions. This counts memberships, not people. Use this live view for current totals; documentation and paginated member lists cannot provide an exact current count.
 
 *Source: `server/src/addie/mcp/admin-analytics.ts`*
 

--- a/scripts/addie-tool-surface-budget.json
+++ b/scripts/addie-tool-surface-budget.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 4,
   "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-  "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db",
+  "profile_contract_sha256": "1f743a3ed162a52770460ea81391da6f06037989eba9bf093108f346fb93a8ad",
   "baseline": {
     "id": "2026-08-26-pre-domain-consolidation",
     "metrics": {

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.48';
+export const CODE_VERSION = '2026.09.49';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/gemini-direct-experiment.ts
+++ b/server/src/addie/gemini-direct-experiment.ts
@@ -180,7 +180,7 @@ export async function prepareGeminiDirectTurn(input: {
   }
 
   const treatment = assignment.arm === 'gemini' && !input.exclusionReason;
-  const direct = treatment ? createGeminiDirectTools(input.requestTools, input.client.getRegisteredTools?.() ?? []) : null;
+  const direct = treatment ? createGeminiDirectTools(input.requestTools, input.client.getRegisteredTools?.() ?? [], input.isAdmin) : null;
   let candidate: AddieClaudeClient | undefined;
   if (direct) {
     candidate = clients.get(input.client);

--- a/server/src/addie/gemini-direct-tools.ts
+++ b/server/src/addie/gemini-direct-tools.ts
@@ -2,6 +2,7 @@ import type { RequestTools } from './claude-client.js';
 import type { ToolExecutionPolicy } from './model-providers/tool-orchestration.js';
 import { TOOL_SETS } from './tool-sets.js';
 import { isSideEffectTool } from './side-effect-claims.js';
+import { ADMIN_ANALYTICS_TOOL_NAME } from './mcp/admin-analytics.js';
 
 /** Pilot capability boundary. Domain membership alone never grants access. */
 export const GEMINI_DIRECT_GROUPS = [
@@ -15,7 +16,7 @@ export interface DirectToolSession {
   handoffRequested(): boolean;
 }
 
-export function createGeminiDirectTools(requestTools: RequestTools, globalToolNames: readonly string[]) {
+export function createGeminiDirectTools(requestTools: RequestTools, globalToolNames: readonly string[], isAdmin = false) {
   const globals = new Set(globalToolNames);
   const registered = new Set(requestTools.tools
     .filter(tool => requestTools.handlers.has(tool.name))
@@ -25,8 +26,18 @@ export function createGeminiDirectTools(requestTools: RequestTools, globalToolNa
     tools: TOOL_SETS[name].tools.filter(tool => !isSideEffectTool(tool)
       && (registered.has(tool) || globals.has(tool))),
   })).filter(group => group.tools.length > 0);
+  // Admin access requires both the trusted role and this request's definition
+  // and handler. Global registration must never grant administrative access.
+  if (isAdmin && registered.has(ADMIN_ANALYTICS_TOOL_NAME)) {
+    groups.push({
+      ...TOOL_SETS.admin_conversation_review,
+      description: 'Read-only administrative analytics: live membership and platform totals, search performance, and engagement rankings.',
+      tools: [ADMIN_ANALYTICS_TOOL_NAME],
+    });
+  }
+  const persistentGroups = new Set(['knowledge', 'schema_reference', 'admin_conversation_review']);
   const allowed = new Set(groups.flatMap(group => group.tools));
-  const visible = new Set(groups.filter(group => ['knowledge', 'schema_reference'].includes(group.name))
+  const visible = new Set(groups.filter(group => persistentGroups.has(group.name))
     .flatMap(group => group.tools));
   let handoff = false;
   const loadName = 'load_tool_group';
@@ -40,9 +51,9 @@ export function createGeminiDirectTools(requestTools: RequestTools, globalToolNa
     const selected = groups.find(candidate => candidate.name === group);
     if (!selected) return 'Error: Tool group is unavailable.';
     // Replace the optional domain to keep the active catalog bounded. Core
-    // documentation/schema tools remain available throughout the turn.
+    // documentation/schema and authorized analytics stay available throughout.
     for (const candidate of groups) {
-      if (!['knowledge', 'schema_reference'].includes(candidate.name)) {
+      if (!persistentGroups.has(candidate.name)) {
         for (const name of candidate.tools) visible.delete(name);
       }
     }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -1867,7 +1867,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11163,
+      "wire_schema_bytes": 11546,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -1886,7 +1886,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
+      "wire_schema_sha256": "6c9c27947fd54d380396ef6ca5adbf79ea1238642962a8f55136ccc2ea07d5f6"
     },
     {
       "id": "slack_bolt:admin_dm:routed:admin_events",
@@ -4884,7 +4884,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11163,
+      "wire_schema_bytes": 11546,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -4903,7 +4903,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
+      "wire_schema_sha256": "6c9c27947fd54d380396ef6ca5adbf79ea1238642962a8f55136ccc2ea07d5f6"
     },
     {
       "id": "slack_bolt:admin_working_group:admin_events",
@@ -5747,7 +5747,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -5973,7 +5973,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -10701,7 +10701,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11163,
+      "wire_schema_bytes": 11546,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -10720,7 +10720,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
+      "wire_schema_sha256": "6c9c27947fd54d380396ef6ca5adbf79ea1238642962a8f55136ccc2ea07d5f6"
     },
     {
       "id": "slack_bolt:private_channel_admin:admin_events",
@@ -11564,7 +11564,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -11790,7 +11790,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -16564,7 +16564,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11163,
+      "wire_schema_bytes": 11546,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -16583,7 +16583,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
+      "wire_schema_sha256": "6c9c27947fd54d380396ef6ca5adbf79ea1238642962a8f55136ccc2ea07d5f6"
     },
     {
       "id": "slack_bolt:private_mention_admin:routed:admin_events",
@@ -21826,7 +21826,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 8396,
+      "wire_schema_bytes": 8779,
       "tool_reference_bytes": 4894,
       "tool_reference_sha256": "d1b06376838f8ca42518b679319b2265f202f4b97429bad485ce2adf4916f4f5",
       "overridden_tool_count": 0,
@@ -21842,7 +21842,7 @@
         "review_flagged_conversation"
       ],
       "ordered_tool_names_sha256": "d0518cb4490415bd70923e15a6ee756893c65b99c4c042a26331dec6aefe80b0",
-      "wire_schema_sha256": "044f669c8f6f64e77e7912e4e8fcddf1aac3e004afd575f38dcf9c1ff9ba066b"
+      "wire_schema_sha256": "d2867a16c79bab1a0231b21e1d4520713630e8029841ca6e67aac4ca703c62a6"
     },
     {
       "id": "slack_bolt:public_channel_admin:admin_events",
@@ -22635,7 +22635,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 158130,
+      "wire_schema_bytes": 158513,
       "tool_reference_bytes": 38011,
       "tool_reference_sha256": "b7d09c9f53d7fe03b437a24aa21e4dd5e40969bef7f9276897a1106795dd7eb2",
       "overridden_tool_count": 11,
@@ -22844,7 +22844,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "a60d9e15a94a1f70f8fe7cab849a938a387c52e4f1253183f5ae640e40ccc4f5",
-      "wire_schema_sha256": "459b17ab59f72d15b93862c2e883ecbbb3e31a7bb3cfc45e7e1e2eae0f587f97",
+      "wire_schema_sha256": "70f51562644930a06e42d798d808ae369193b7c8ebaa6869ca94dea6803104f6",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31040,7 +31040,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -31266,7 +31266,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31357,7 +31357,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -31583,7 +31583,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31674,7 +31674,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39400,
       "tool_reference_sha256": "6a0f0ff7d5f449c3041704877d5ed811126b3293701645f40a5f380c3ae69482",
       "overridden_tool_count": 11,
@@ -31900,7 +31900,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -31990,7 +31990,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39273,
       "tool_reference_sha256": "71628fb0ef4d2d21de988f975cad9c968f018567d47c4c0dd8889bdb6e5f4dff",
       "overridden_tool_count": 11,
@@ -32216,7 +32216,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -32308,7 +32308,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 170804,
+      "wire_schema_bytes": 171187,
       "tool_reference_bytes": 39435,
       "tool_reference_sha256": "27c0906adc1ff63ee7d92c37832cddc9d4e994884f2be4d70a50ab8e3240c5c8",
       "overridden_tool_count": 11,
@@ -32534,7 +32534,7 @@
         "save_learner_feedback"
       ],
       "ordered_tool_names_sha256": "7afd4cb3399f9251b59c774c7ca86c61383fe5549cdd2e8a12e42da6e961785b",
-      "wire_schema_sha256": "46d03b09d675ba7866f153f84a1f50e6c8b54b4e535ee108a400f94d6c5a1e31",
+      "wire_schema_sha256": "d47efdf6c71fb9bac5c4a055aae778b8225da0463f2ae1a93f5c595d3bfc7bb9",
       "target_exception_category": "synthetic_all_sets_maximum"
     },
     {
@@ -33870,7 +33870,7 @@
       ],
       "maximum_provider_tool_wire_bytes": 52,
       "maximum_provider_tool_wire_sha256": "41862a9288a9f94aa80bd76a6d113c5217ffb3b495e3b96e9ab3db014d52b275",
-      "wire_schema_bytes": 11163,
+      "wire_schema_bytes": 11546,
       "tool_reference_bytes": 4980,
       "tool_reference_sha256": "2bd2b7e4e365329d0fa8b4aba86ac69573372b96202ea43dc9a992018e6e2099",
       "overridden_tool_count": 0,
@@ -33889,7 +33889,7 @@
         "resolve_escalation"
       ],
       "ordered_tool_names_sha256": "f381bb23172625810e8f295bcd47878ae5ab9fd89cd08c602fdeacace2b0b28b",
-      "wire_schema_sha256": "61298b1cd93fcd7ba9b545f654551ddf0085a1a6fd1962d62ebeb6ad7fe58c65"
+      "wire_schema_sha256": "6c9c27947fd54d380396ef6ca5adbf79ea1238642962a8f55136ccc2ea07d5f6"
     },
     {
       "id": "web_chat:authenticated_admin:routed:admin_events",
@@ -38667,7 +38667,7 @@
       "maximum_slack_public_tools": -8,
       "maximum_slack_member_schema_bytes": -92096,
       "maximum_slack_admin_schema_bytes": -131760,
-      "maximum_slack_public_schema_bytes": -1987,
+      "maximum_slack_public_schema_bytes": -1604,
       "web_anonymous_tools": 0,
       "web_authenticated_admin_tools": -203
     }
@@ -38852,11 +38852,11 @@
       }
     },
     "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-    "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db",
+    "profile_contract_sha256": "1f743a3ed162a52770460ea81391da6f06037989eba9bf093108f346fb93a8ad",
     "status": "within_budget"
   },
   "profile_contract": {
     "profile_ids_sha256": "489a9fbc82dd87bf3109b7c5e164cdc99ed94224db56f13535bf1a12e6fd73de",
-    "profile_contract_sha256": "dd093d73a873271096597133251a7d5690f47cb80ab0d4af54c6953a054654db"
+    "profile_contract_sha256": "1f743a3ed162a52770460ea81391da6f06037989eba9bf093108f346fb93a8ad"
   }
 }

--- a/server/src/addie/mcp/admin-analytics.ts
+++ b/server/src/addie/mcp/admin-analytics.ts
@@ -6,7 +6,7 @@ export const ADMIN_ANALYTICS_TOOL_NAME = 'query_admin_analytics';
 export const ADMIN_ANALYTICS_TOOL: AddieTool = {
   name: 'query_admin_analytics',
   description:
-    'Query one read-only administrative analytics view: platform totals, member-search performance, organizations ranked by user count, or people ranked by engagement.',
+    'Query live, read-only administrative analytics: platform totals, member-search performance, organizations ranked by user count, or people ranked by engagement. For current paying-member counts, use view="platform_stats" and report memberships.active: the exact, uncapped count of active, uncanceled AgenticAdvertising.org memberships, including individual and organization subscriptions. This counts memberships, not people. Use this live view for current totals; documentation and paginated member lists cannot provide an exact current count.',
   usage_hints:
     'Use platform_stats for platform-wide people/organization counts; member_search for search and introduction analytics; organizations_by_users for organization rankings; users_by_engagement for contributor and community-engagement rankings.',
   input_schema: {

--- a/server/tests/unit/addie/gemini-direct-experiment.test.ts
+++ b/server/tests/unit/addie/gemini-direct-experiment.test.ts
@@ -17,12 +17,13 @@ vi.mock('../../../src/addie/claude-cost-tracker.js', () => ({
   formatCapExceededMessage: () => 'Daily cap reached.',
 }));
 
-import { AddieClaudeClient, type AddieResponse, type ProcessMessageOptions, type StreamEvent } from '../../../src/addie/claude-client.js';
+import { AddieClaudeClient, type AddieResponse, type ProcessMessageOptions, type RequestTools, type StreamEvent } from '../../../src/addie/claude-client.js';
 import { GoogleGenerateContentProvider, GOOGLE_ROUTER_MODEL } from '../../../src/addie/model-providers/google-generate-content-provider.js';
 import { collectModelResponse } from '../../../src/addie/model-providers/events.js';
 import { createGeminiDirectTools } from '../../../src/addie/gemini-direct-tools.js';
 import { geminiDirectAssignment, prepareGeminiDirectTurn } from '../../../src/addie/gemini-direct-experiment.js';
 import { AddieModelConfig } from '../../../src/config/models.js';
+import { ADMIN_ANALYTICS_TOOL } from '../../../src/addie/mcp/admin-analytics.js';
 
 function receipt(parts: Part[], id = 'google-response'): GenerateContentResponse {
   return {
@@ -66,7 +67,7 @@ function fixture(responses: (GenerateContentResponse | GenerateContentResponse[]
   });
   const input = {
     client, userId: 'user-test', isAdmin: true, threadId: 'thread-test', hasPriorAssistant: false,
-    exclusionReason: null, startedAt: Date.now(), requestTools: { tools: [], handlers: new Map() },
+    exclusionReason: null, startedAt: Date.now(), requestTools: { tools: [], handlers: new Map() } as RequestTools,
     baseRequestContext: 'Trusted member context.', getControlTools,
   };
   return { client, fork, provider, dispatch, handlers, control, input, getControlTools };
@@ -156,6 +157,64 @@ describe('Gemini Direct production integration', () => {
     expect(names(1)).not.toContain('send_invoice');
     expect(f.handlers.get('get_recent_news')).toHaveBeenCalledOnce();
     expect(f.handlers.get('send_invoice')).not.toHaveBeenCalled();
+  });
+
+  it('gives an authorized admin live counts on the first Gemini invocation without a handoff', async () => {
+    const f = fixture([
+      receipt([call('query_admin_analytics', { view: 'platform_stats' })]),
+      receipt([{ text: 'There are 212 active paying memberships.' }], 'answer'),
+    ]);
+    const analytics = vi.fn().mockResolvedValue('{"memberships":{"active":212}}');
+    f.input.requestTools = {
+      tools: [ADMIN_ANALYTICS_TOOL],
+      handlers: new Map([[ADMIN_ANALYTICS_TOOL.name, analytics]]),
+    };
+    const result = await run(f.input);
+    const names = f.dispatch.mock.calls[0][0].config?.tools?.flatMap(tool => tool.functionDeclarations?.map(fn => fn.name) ?? []);
+    expect(names).toContain('query_admin_analytics');
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({ view: 'platform_stats' });
+    expect(result.response?.text).toBe('There are 212 active paying memberships.');
+    expect(f.getControlTools).not.toHaveBeenCalled();
+    expect(f.control).not.toHaveBeenCalled();
+  });
+
+  it('keeps authorized analytics available after loading a different read-only group', async () => {
+    const f = fixture([
+      receipt([call('load_tool_group', { group: 'industry_research' })]),
+      receipt([call('query_admin_analytics', { view: 'platform_stats' })], 'counts'),
+      receipt([{ text: 'There are 212 active paying memberships.' }], 'answer'),
+    ]);
+    const analytics = vi.fn().mockResolvedValue('{"memberships":{"active":212}}');
+    f.input.requestTools = {
+      tools: [ADMIN_ANALYTICS_TOOL],
+      handlers: new Map([[ADMIN_ANALYTICS_TOOL.name, analytics]]),
+    };
+    await run(f.input);
+    expect(analytics).toHaveBeenCalledOnce();
+    const names = f.dispatch.mock.calls[1][0].config?.tools?.flatMap(tool => tool.functionDeclarations?.map(fn => fn.name) ?? []);
+    expect(names).toContain('query_admin_analytics');
+    expect(names).toContain('get_recent_news');
+    expect(names).not.toContain('send_invoice');
+  });
+
+  it('does not give an enrolled non-admin access to analytics even if supplied a handler', async () => {
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'eligible');
+    vi.stubEnv('ADDIE_GEMINI_DIRECT_PERCENT', '100');
+    const f = fixture([
+      receipt([call('query_admin_analytics', { view: 'platform_stats' })]),
+      receipt([{ text: 'This lookup needs administrator access.' }], 'answer'),
+    ]);
+    f.input.isAdmin = false;
+    const analytics = vi.fn().mockResolvedValue('Must not run.');
+    f.input.requestTools = {
+      tools: [ADMIN_ANALYTICS_TOOL],
+      handlers: new Map([[ADMIN_ANALYTICS_TOOL.name, analytics]]),
+    };
+    const result = await run(f.input);
+    expect(analytics).not.toHaveBeenCalled();
+    const names = f.dispatch.mock.calls[0][0].config?.tools?.flatMap(tool => tool.functionDeclarations?.map(fn => fn.name) ?? []);
+    expect(names).not.toContain('query_admin_analytics');
+    expect(result.response?.tool_executions[0]).toMatchObject({ tool_name: 'query_admin_analytics', is_error: true });
   });
 
   it('blocks a model calling an unloaded tool even when its handler exists', async () => {
@@ -281,6 +340,19 @@ describe('assignment and rollback', () => {
   it('does not expose groups whose user-scoped handlers are absent', () => {
     const direct = createGeminiDirectTools({ tools: [], handlers: new Map() }, ['search_docs']);
     expect(direct.allowedToolNames).toEqual(['search_docs', 'load_tool_group', 'handoff_to_addie']);
+  });
+
+  it.each([
+    { definition: false, handler: false },
+    { definition: true, handler: false },
+    { definition: false, handler: true },
+  ])('requires both an authorized request definition and handler for admin analytics: %j', ({ definition, handler }) => {
+    const direct = createGeminiDirectTools({
+      tools: definition ? [ADMIN_ANALYTICS_TOOL] : [],
+      handlers: new Map(handler ? [[ADMIN_ANALYTICS_TOOL.name, vi.fn()]] : []),
+    }, ['search_docs', ADMIN_ANALYTICS_TOOL.name], true);
+    expect(direct.allowedToolNames).not.toContain(ADMIN_ANALYTICS_TOOL.name);
+    expect(direct.session.visibleToolNames().has(ADMIN_ANALYTICS_TOOL.name)).toBe(false);
   });
 });
 


### PR DESCRIPTION
An administrator asking “how many members are currently paying?” could get a documentation search and no answer from Gemini Direct because its initial tool catalog omitted live admin analytics. A handoff could also lead to a paginated member list instead of an exact total.

Expose the existing read-only `query_admin_analytics` tool immediately when the server verifies admin access and supplies both its request-scoped definition and handler. Keep it available across optional tool-group switches. Global registration alone grants no admin access; other administrative capabilities retain the existing handoff path. Clarify that current paying-membership counts come from the uncapped `platform_stats.memberships.active` total, covering individual and organization subscriptions. Addie code version: `2026.09.49`.

Regenerate the tool reference and runtime inventory for the analytics description change. Refresh the reviewed profile-contract fingerprint for the changed description bytes; all numeric budget ceilings and tool-list fingerprints remain unchanged. This is an application-only change.

Validation: 50 focused tests, full typechecking, and tool-inventory/portability checks pass in Docker. Full PR CI and main Build Check passed; Ladon approved with no findings. Regression coverage exercises initial availability through the real Gemini orchestration loop, group switches, non-admin denial, and missing request definitions/handlers even with global registration.

Production release 3938 was verified on all three machines. Replayed the original question through signed-in Chrome in both a fresh chat and the previously failing conversation. Both answers matched the live database total and used Gemini 3.7 with `query_admin_analytics`: 3.6s and 3.4s, two provider calls each, zero router time, no fallback, and no tool errors.
