### PR TITLE
fix(tmp): backport single-user context privacy to 3.1

### DIFF
--- a/.changeset/restrict-single-user-context-embeddings.md
+++ b/.changeset/restrict-single-user-context-embeddings.md
@@ -1,0 +1,5 @@
+---
+"adcontextprotocol": patch
+---
+
+Restrict Context Match embeddings derived from non-public single-user content and require privacy reduction for free-form context signals.

--- a/docs/trusted-match/ai-mediation.mdx
+++ b/docs/trusted-match/ai-mediation.mdx
@@ -69,14 +69,14 @@ Before the LLM generates its response, StreamHaus sends a **Context Match** requ
     "taxonomy_source": "iab",
     "taxonomy_id": 7,
     "sentiment": "positive",
-    "keywords": ["trail shoes", "rocky terrain", "ankle support"],
+    "keywords": ["trail shoes", "athletic footwear", "outdoor recreation"],
     "language": "en",
-    "summary": "User seeking trail shoe recommendations for rocky terrain with ankle support"
+    "summary": "Shopping context categorized as outdoor athletic footwear"
   }
 }
 ```
 
-No `artifact_refs` — conversation turns are ephemeral. The `context_signals` carry the classified output. The `summary` field is especially useful for LLM-native buyers that evaluate relevance semantically. A platform that operates in a trusted execution environment could alternatively send the full conversation as an `artifact` — the publisher controls the disclosure level.
+No `artifact_refs` — conversation turns are ephemeral. The `context_signals` carry bounded topics and policy-filtered, non-verbatim keywords and summary; they MUST NOT carry an embedding derived from the turn. The `summary` field is useful for LLM-native buyers when it satisfies these privacy-reduction requirements. A platform operating under appropriate governance, including a trusted execution environment where required, could alternatively send the full conversation as an `artifact` — the publisher controls the disclosure level.
 
 </Accordion>
 

--- a/docs/trusted-match/context-and-identity.mdx
+++ b/docs/trusted-match/context-and-identity.mdx
@@ -40,9 +40,9 @@ The publisher sends a Context Match request to the TMP Router, which fans out to
   ],
   "context_signals": {
     "topics": ["632"],
-    "keywords": ["cold brew", "iced coffee", "coffee beans"],
+    "keywords": ["cold brew", "coffee products"],
     "sentiment": "positive",
-    "summary": "Shopper searching for cold brew coffee products"
+    "summary": "Shopping context categorized as coffee products"
   },
   "geo": { "country": "US", "region": "US-CA" }
 }
@@ -112,8 +112,9 @@ The buyer returns an offer per matched package. Each offer carries a `package_id
 - Session tokens
 - IP addresses
 - Any data that could identify a specific user
+- Dense embeddings derived from non-public content authored by or attributable to a single user or session
 
-This is not a policy restriction. It is enforced by the router's context code path, which has no access to identity data — no shared memory, no shared state, no communication channel to the identity code path. [TEE attestation](/docs/trusted-match/privacy-architecture) can make this separation independently verifiable.
+Identity-path separation is enforced by the router's context code path, which has no access to identity data — no shared memory, no shared state, no communication channel to the identity code path. Publishers remain responsible for privacy-reducing user-derived context before it reaches that path. [TEE attestation](/docs/trusted-match/privacy-architecture) can make the router separation independently verifiable.
 
 ## Identity Match
 

--- a/docs/trusted-match/data-protection-roles.mdx
+++ b/docs/trusted-match/data-protection-roles.mdx
@@ -224,7 +224,7 @@ The choice of identity provider is itself a controller-level decision. Selecting
 
 **2. Context Match with full artifacts.**
 
-When a publisher sends full content (`artifact` field) rather than classified signals (`context_signals`), the buyer agent receives the actual content. `context_signals` (pre-classified topics, sentiment, keywords) is the privacy-preserving baseline. Full artifacts exist for cases where the buyer needs to evaluate content directly (e.g., AI assistant conversations where classification alone is insufficient).
+When a publisher sends full content (`artifact` field) rather than classified signals (`context_signals`), the buyer agent receives the actual content. Bounded topics and policy-filtered, non-verbatim keywords or summaries are the privacy-reduced baseline for non-public content attributable to a single user or session; dense embeddings of that content are prohibited. Full artifacts exist for cases where the buyer is governed to evaluate content directly (e.g., AI assistant conversations where classification alone is insufficient).
 
 **3. Cache semantics.**
 
@@ -232,7 +232,7 @@ Identity Match responses include a `ttl_sec` caching contract. During the cache 
 
 **4. Variable pricing on context.**
 
-The Context Match offer can include an `OfferPrice`. Because Context Match carries no identity, this is contextual pricing — not per-user pricing. However, if a publisher's `context_signals` are specific enough to identify an individual (e.g., a unique AI conversation summary), the contextual path could carry de facto identity. Publishers should ensure `context_signals` do not contain PII or uniquely identifying content.
+The Context Match offer can include an `OfferPrice`. Because Context Match carries no identity, this is contextual pricing — not per-user pricing. However, if a publisher's `context_signals` are specific enough to identify an individual (e.g., a unique AI conversation summary), the contextual path could carry de facto identity. Publishers MUST apply the provenance and privacy-reduction requirements in the ContextSignals specification so `context_signals` do not contain PII, uniquely identifying content, or prohibited dense representations of single-user content.
 
 **5. Join delegation.**
 

--- a/docs/trusted-match/privacy-architecture.mdx
+++ b/docs/trusted-match/privacy-architecture.mdx
@@ -47,7 +47,7 @@ TEE is an upgrade path, not a prerequisite. The protocol works without it. Publi
 **From Context Match requests**, a buyer agent learns:
 
 - Which publisher placements and content artifacts exist
-- Content signals via `context_signals` (topics, sentiment, keywords, language, brand safety tier, summary, embedding) — pre-computed by the publisher
+- Privacy-reduced signals via `context_signals` (topics, sentiment, keywords, language, brand safety tier, summary, and, for public or shared content, embedding) — pre-computed by the publisher. Dense embeddings derived from non-public content attributable to a single user or session are prohibited.
 - Geographic context (country, region, metro) — publisher-controlled granularity
 
 **From Identity Match requests**, a buyer agent learns:

--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -56,13 +56,13 @@ Sent by the publisher (via router) to buyer agents. Contains content context. MU
 | `seller_agent_url` | string (URI) | Yes | API endpoint URL of the seller agent issuing this request. The provider resolves the active package set it has synced for this seller against it; an unsynced seller MUST yield an empty offer set, never a fall-back to another seller's set. A single per-placement value carrying no user identity. Compared with AdCP URL canonicalization. Consistent with `seller_agent_url` on the Identity Match request and `agent_url` in `adagents.json`. |
 | `artifact` | Artifact | No | Full content artifact adjacent to this ad opportunity. Same schema as content standards evaluation. The publisher sends the full artifact when they want the buyer to evaluate the actual content. Contractual protections govern buyer use. TEE deployment upgrades contractual trust to cryptographic verification. |
 | `artifact_refs` | List\<ArtifactRef\> | No | Public content references the buyer can resolve independently. Each has a `type` (one of: `url`, `url_hash`, `eidr`, `gracenote`, `isrc`, `gtin`, `rss_guid`, `isbn`, `custom`) and a `value`. For URL-addressable content, the buyer may have pre-classified these. Use `url_hash` when the publisher prefers not to reveal the URL (contextual clean room). |
-| `context_signals` | ContextSignals | No | Pre-computed classifier outputs for the content environment. Use when content is ephemeral (conversation turns, search queries) or to supplement artifact-based matching. Can replace `artifact_refs` entirely. Raw content MUST NOT be included — only classified outputs. The publisher is the classifier boundary. |
+| `context_signals` | ContextSignals | No | Pre-computed classifier outputs for the content environment. Use to supplement artifact-based matching or when content cannot be referenced directly. Ephemeral content that many users encounter (a trending query, a syndicated segment) is shared content; one user's turn or query is not. For non-public content attributable to a single user or session, only the privacy-reduced outputs permitted under [ContextSignals](#contextsignals) may be sent. Raw content MUST NOT be included. The publisher is the classifier and privacy boundary. |
 | `geo` | Geo | No | Coarse geographic location of the viewer. Publisher controls granularity — country for regulatory compliance, region/metro for campaign targeting and valuation. No postcode or coordinates — coarsened to prevent user identification. |
 | `package_ids` | List\<string\> | No | Restrict evaluation to specific packages. When omitted, the provider evaluates all eligible packages for this placement (the common case). Package metadata (formats, catalogs) is synced at media buy time — not sent per request. |
 
 #### ContextSignals
 
-Pre-computed classifier outputs for the content environment. MUST NOT contain raw content (conversation text, article body, URLs). Only classified outputs. The publisher is the classifier boundary.
+Pre-computed classifier outputs for the content environment. MUST NOT contain raw content (conversation text, article body, URLs). Treating a derived value as classifier output does not by itself make that value privacy-preserving: publishers MUST apply the field-specific restrictions below. The publisher is the classifier and privacy boundary.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -70,11 +70,11 @@ Pre-computed classifier outputs for the content environment. MUST NOT contain ra
 | `taxonomy_source` | enum | No | Organization that defines the topic taxonomy. Default: `iab`. |
 | `taxonomy_id` | integer | No | Taxonomy version within the source. For IAB, follows the AdCOM cattax enum: `7` = Content Taxonomy 3.0 (CC-BY-3.0). Default: `7`. |
 | `sentiment` | enum | No | Content sentiment: `positive`, `negative`, `neutral`, `mixed`. |
-| `keywords` | List\<string\> | No | Content keywords extracted by the publisher's classifier. |
+| `keywords` | List\<string\> | No | Content keywords produced by the publisher's classifier. For non-public content attributable to a single user or session, keywords MUST be policy-filtered, MUST NOT reproduce distinctive verbatim phrasing, and MUST NOT include PII or uniquely identifying details. Publishers SHOULD prefer bounded category labels. |
 | `language` | string | No | ISO 639-1 language code. |
 | `content_policies` | List\<string\> | No | Policy IDs from the [AdCP Policy Registry](/docs/governance/policy-registry) that this content satisfies. Routers populate this from the publisher's property governance configuration or content metadata. Buyers filter on policies they require via `required_policies` on packages. This is a **pre-filtering optimization** — contexts missing required policies are excluded before reaching downstream governance. Definitive enforcement happens at the governance layer via [`check_governance`](/docs/governance/campaign/tasks/check_governance). |
-| `summary` | string | No | Natural language summary for relevance judgment. Useful for LLM-native buyers that evaluate semantically. |
-| `embedding` | string | No | Content embedding as base64-encoded int8 vector. Captures semantic content beyond topics and keywords. |
+| `summary` | string | No | Publisher-generated natural language summary for relevance judgment. For non-public content attributable to a single user or session, the summary MUST be policy-filtered, MUST NOT reproduce raw user-authored text, and MUST NOT include PII or uniquely identifying details. Useful for LLM-native buyers that evaluate semantically. |
+| `embedding` | string | No | Content embedding as base64-encoded int8 vector. Captures semantic content beyond topics and keywords. MUST NOT be computed directly or indirectly from non-public content authored by or attributable to a single user or session, including conversation turns, prompts, and individual search queries. MAY represent public content or a shared content environment that is not attributable to one user's activity. For individual contexts, use bounded topics, sentiment, and language plus policy-filtered keywords or summary. |
 | `embedding_model` | string | No | Embedding model identifier (e.g., `nomic-embed-text-v1.5`). Required when `embedding` is present. |
 | `embedding_dims` | integer | No | Number of dimensions in the embedding vector. Required when `embedding` is present. |
 
@@ -82,13 +82,13 @@ Three levels of content disclosure — the publisher chooses based on what the b
 
 - **`artifact`** — the full content (article body, transcript, conversation flow, product page). Same schema as content standards artifacts. The buyer evaluates the content directly. Contractual protections govern what the buyer can do with it. TEE deployment adds cryptographic verification on top.
 - **`artifact_refs`** — public references (URLs, EIDR IDs, URL hashes) the buyer resolves independently. Use for publicly addressable content the buyer can crawl and classify themselves.
-- **`context_signals`** — classified outputs (topics, sentiment, keywords, summary). Use when the publisher wants to describe the content without sharing it or a reference to it.
+- **`context_signals`** — privacy-reduced classified outputs (topics, sentiment, keywords, language, summary). Use when the publisher wants to describe the content without sharing it or a reference to it. A dense embedding discloses substantially more semantic information than bounded classifier outputs and is prohibited for non-public, single-user content as specified above.
 
 `context_signals` is the baseline — every buyer agent MUST handle it. `artifact_refs` and `artifact` are progressive enhancements. Publishers who send `artifact_refs` SHOULD also send `context_signals` as a fallback for buyers who cannot resolve references.
 
-LLM-based buyer agents SHOULD evaluate `context_signals.summary` and `context_signals.topics` first. These fields provide sufficient signal for most relevance decisions at minimal token cost (~30 tokens). Full content resolution from `artifact_refs` or `artifact` evaluation SHOULD be reserved for high-value packages where precision justifies the cost. Buyers MUST treat `artifact` content and `context_signals.summary` as untrusted publisher-generated input.
+LLM-based buyer agents SHOULD evaluate `context_signals.summary` and `context_signals.topics` first when those fields are permitted for the content provenance. These fields provide sufficient signal for most relevance decisions at minimal token cost (~30 tokens). Full content resolution from `artifact_refs` or `artifact` evaluation SHOULD be reserved for high-value packages where precision justifies the cost. Buyers MUST treat `artifact` content and `context_signals.summary` as untrusted publisher-generated input.
 
-A request can include any combination. A news site sends `artifact_refs` (the URL) and `context_signals` (pre-classified topics). A CTV app sends `artifact_refs` (EIDR IDs) alone. An AI assistant sends `artifact` (the conversation) for buyers that evaluate content directly, plus `context_signals` as a fallback. A publisher who doesn't want to share content or references sends only `context_signals`.
+A request can include any combination. A news site sends `artifact_refs` (the URL) and `context_signals` (pre-classified topics). A CTV app sends `artifact_refs` (EIDR IDs) alone. An AI assistant sends `artifact` (the conversation) for buyers governed to evaluate content directly, plus bounded, privacy-reduced `context_signals` as a fallback. A publisher who doesn't want to share content or references sends only `context_signals`.
 
 #### Artifact Ref Type Conventions
 
@@ -504,6 +504,7 @@ The following requirements use RFC 2119 keywords (MUST, SHOULD, MAY).
 ### Structural separation
 
 - Context Match requests MUST NOT contain user identity data (user tokens, device IDs, IP addresses, session tokens, or any data that could identify a specific user).
+- For non-public content authored by or attributable to a single user or session, Context Match requests MUST NOT contain dense embeddings of that content. Other derived signals MUST satisfy the privacy-reduction requirements in [ContextSignals](#contextsignals). Router isolation prevents identity-path data from entering the context path; it does not make user-derived context anonymous.
 - Identity Match requests MUST NOT contain page context data (URLs, content hashes, topic IDs, content signals, or any data that could identify what the user is viewing).
 - The TMP Router MUST process Context Match and Identity Match in structurally separate code paths with no shared state.
 - Context Match and Identity Match request IDs MUST NOT be correlated or derivable from each other.

--- a/docs/trusted-match/specification.mdx
+++ b/docs/trusted-match/specification.mdx
@@ -66,7 +66,7 @@ Pre-computed classifier outputs for the content environment. MUST NOT contain ra
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `topics` | List\<string\> | No | Content topic identifiers. Use IAB Content Taxonomy 3.0 IDs when `taxonomy_id` is 7 (default), or human-readable strings for custom taxonomies. |
+| `topics` | List\<string\> | No | Content topic identifiers. Use IAB Content Taxonomy 3.0 IDs when `taxonomy_id` is 7 (default), or bounded human-readable category labels for custom taxonomies. For non-public content attributable to a single user or session, publishers MUST use standardized taxonomy identifiers or bounded custom category labels; custom topic strings MUST NOT reproduce distinctive verbatim phrasing and MUST NOT include PII or uniquely identifying details. |
 | `taxonomy_source` | enum | No | Organization that defines the topic taxonomy. Default: `iab`. |
 | `taxonomy_id` | integer | No | Taxonomy version within the source. For IAB, follows the AdCOM cattax enum: `7` = Content Taxonomy 3.0 (CC-BY-3.0). Default: `7`. |
 | `sentiment` | enum | No | Content sentiment: `positive`, `negative`, `neutral`, `mixed`. |

--- a/docs/trusted-match/surfaces/ai-assistants.mdx
+++ b/docs/trusted-match/surfaces/ai-assistants.mdx
@@ -33,9 +33,6 @@ When a user sends a message in a conversation, the AI platform sends a Context M
   "property_type": "ai_assistant",
   "placement_id": "chat-inline-recommendation",
   "seller_agent_url": "https://chatplatform.example",
-  "artifact_refs": [
-    { "type": "custom", "value": "turn:b3c9e2" }
-  ],
   "context_signals": {
     "topics": ["479", "483", "592"],
     "taxonomy_source": "iab",
@@ -50,7 +47,7 @@ When a user sends a message in a conversation, the AI platform sends a Context M
 }
 ```
 
-Conversation turns are ephemeral — there's no public reference a buyer could independently resolve, so `artifact_refs` are typically limited to opaque turn identifiers (e.g., `turn:b3c9e2`). The platform sends bounded topics and policy-filtered, non-verbatim keywords or summaries so the buyer can evaluate relevance without seeing the raw conversation. It MUST NOT send an embedding derived from the turn. No user identity or uniquely identifying detail is present. Platforms can also send the full conversation as an `artifact` for buyers governed to evaluate content directly — the same artifact schema used for content standards evaluation.
+Conversation turns are ephemeral — there's no public reference a buyer could independently resolve, so the platform omits `artifact_refs` and sends only privacy-reduced `context_signals`. The platform sends bounded topics and policy-filtered, non-verbatim keywords or summaries so the buyer can evaluate relevance without seeing the raw conversation. It MUST NOT send an embedding derived from the turn. No user identity or uniquely identifying detail is present. Platforms can also send the full conversation as an `artifact` for buyers governed to evaluate content directly — the same artifact schema used for content standards evaluation.
 
 The buyer agent responds with an offer:
 

--- a/docs/trusted-match/surfaces/ai-assistants.mdx
+++ b/docs/trusted-match/surfaces/ai-assistants.mdx
@@ -41,16 +41,16 @@ When a user sends a message in a conversation, the AI platform sends a Context M
     "taxonomy_source": "iab",
     "taxonomy_id": 7,
     "sentiment": "positive",
-    "keywords": ["sneakers", "running", "recommendations"],
+    "keywords": ["trail shoes", "athletic footwear", "outdoor recreation"],
     "language": "en",
     "content_policies": ["csbs"],
-    "summary": "User asking for sneaker recommendations for running and casual wear"
+    "summary": "Shopping context categorized as athletic footwear"
   },
   "geo": { "country": "US" }
 }
 ```
 
-Conversation turns are ephemeral — there's no public reference a buyer could independently resolve, so `artifact_refs` are typically limited to opaque turn identifiers (e.g., `turn:b3c9e2`). The platform sends `context_signals` with pre-computed classifier outputs (topics, sentiment, keywords, summary) so the buyer can evaluate relevance without seeing the raw conversation. No user identity is present. Platforms can also send the full conversation as an `artifact` for buyers that evaluate content directly — the same artifact schema used for content standards evaluation.
+Conversation turns are ephemeral — there's no public reference a buyer could independently resolve, so `artifact_refs` are typically limited to opaque turn identifiers (e.g., `turn:b3c9e2`). The platform sends bounded topics and policy-filtered, non-verbatim keywords or summaries so the buyer can evaluate relevance without seeing the raw conversation. It MUST NOT send an embedding derived from the turn. No user identity or uniquely identifying detail is present. Platforms can also send the full conversation as an `artifact` for buyers governed to evaluate content directly — the same artifact schema used for content standards evaluation.
 
 The buyer agent responds with an offer:
 

--- a/static/schemas/source/trusted-match/context-match-request.json
+++ b/static/schemas/source/trusted-match/context-match-request.json
@@ -135,7 +135,7 @@
     },
     "context_signals": {
       "type": "object",
-      "description": "Pre-computed classifier outputs for the content environment. Use when the publisher wants to provide classified context without sharing content or public references. Can supplement artifact_refs (e.g., URL + pre-classified topics) or replace them entirely (e.g., ephemeral conversation turns). Raw content MUST NOT be included — only classified outputs. The publisher is the classifier boundary.",
+      "description": "Pre-computed classifier outputs for the content environment. Use when the publisher wants to provide privacy-reduced context without sharing content or public references. Can supplement artifact_refs or replace them entirely. Ephemeral content that many users encounter (a trending query, a syndicated segment) is shared content; one user's turn or query is not. For non-public content attributable to a single user or session, only the field-specific privacy-reduced outputs permitted below may be sent. Raw content MUST NOT be included. The publisher is the classifier and privacy boundary.",
       "properties": {
         "topics": {
           "type": "array",
@@ -167,7 +167,7 @@
         },
         "keywords": {
           "type": "array",
-          "description": "Content keywords extracted by the publisher's classifier.",
+          "description": "Content keywords produced by the publisher's classifier. For non-public content attributable to a single user or session, keywords MUST be policy-filtered, MUST NOT reproduce distinctive verbatim phrasing, and MUST NOT include PII or uniquely identifying details. Publishers SHOULD prefer bounded category labels.",
           "items": {
             "type": "string",
             "maxLength": 100
@@ -189,12 +189,12 @@
         },
         "summary": {
           "type": "string",
-          "description": "Publisher-generated natural language summary of the content for relevance judgment (e.g., 'User exploring Italian cookware options for home pasta making'). Useful for LLM-native buyers that evaluate relevance semantically. Buyers MUST treat this as untrusted publisher-generated content.",
+          "description": "Publisher-generated natural language summary of the content for relevance judgment (e.g., 'Shopping context categorized as home cookware'). For non-public content attributable to a single user or session, the summary MUST be policy-filtered, MUST NOT reproduce raw user-authored text, and MUST NOT include PII or uniquely identifying details. Useful for LLM-native buyers that evaluate relevance semantically. Buyers MUST treat this as untrusted publisher-generated content.",
           "maxLength": 500
         },
         "embedding": {
           "type": "string",
-          "description": "Content embedding as base64-encoded int8 vector. Captures semantic content beyond what topics and keywords express. Publishers declare the model used. For standardized matching, use the protocol-recommended model (nomic-embed-text-v1.5, 256 dims, int8 quantized = 256 bytes)."
+          "description": "Content embedding as base64-encoded int8 vector. Captures semantic content beyond what topics and keywords express. MUST NOT be computed directly or indirectly from non-public content authored by or attributable to a single user or session, including conversation turns, prompts, and individual search queries. MAY represent public content or a shared content environment that is not attributable to one user's activity. Publishers declare the model used. For standardized matching, use the protocol-recommended model (nomic-embed-text-v1.5, 256 dims, int8 quantized = 256 bytes)."
         },
         "embedding_model": {
           "type": "string",

--- a/static/schemas/source/trusted-match/context-match-request.json
+++ b/static/schemas/source/trusted-match/context-match-request.json
@@ -139,7 +139,7 @@
       "properties": {
         "topics": {
           "type": "array",
-          "description": "Content topic identifiers. Use IAB Content Taxonomy 3.0 IDs (e.g., '632' for Food & Drink) when taxonomy_id is 7, or human-readable strings (e.g., 'cooking.pasta') for custom taxonomies.",
+          "description": "Content topic identifiers. Use IAB Content Taxonomy 3.0 IDs (e.g., '632' for Food & Drink) when taxonomy_id is 7, or bounded human-readable category labels (e.g., 'cooking.pasta') for custom taxonomies. For non-public content attributable to a single user or session, publishers MUST use standardized taxonomy identifiers or bounded custom category labels; custom topic strings MUST NOT reproduce distinctive verbatim phrasing and MUST NOT include PII or uniquely identifying details.",
           "items": {
             "type": "string"
           },

--- a/tests/trusted-match-context-privacy.test.cjs
+++ b/tests/trusted-match-context-privacy.test.cjs
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const ROOT = path.join(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+test("ContextSignals protects non-public single-user content", () => {
+  const requestSchema = JSON.parse(
+    read("static/schemas/source/trusted-match/context-match-request.json")
+  );
+  const contextSignals = requestSchema.properties.context_signals;
+
+  assert.match(contextSignals.description, /classifier and privacy boundary/);
+  assert.match(
+    contextSignals.description,
+    /Ephemeral content that many users encounter.*is shared content; one user's turn or query is not/
+  );
+  assert.match(
+    contextSignals.properties.embedding.description,
+    /MUST NOT be computed directly or indirectly from non-public content/
+  );
+  assert.match(contextSignals.properties.keywords.description, /MUST be policy-filtered/);
+  assert.match(
+    contextSignals.properties.summary.description,
+    /MUST NOT reproduce raw user-authored text/
+  );
+
+  const specification = read("docs/trusted-match/specification.mdx");
+  assert.match(
+    specification,
+    /Router isolation prevents identity-path data from entering the context path; it does not make user-derived context anonymous\./
+  );
+});

--- a/tests/trusted-match-context-privacy.test.cjs
+++ b/tests/trusted-match-context-privacy.test.cjs
@@ -21,6 +21,10 @@ test("ContextSignals protects non-public single-user content", () => {
     /Ephemeral content that many users encounter.*is shared content; one user's turn or query is not/
   );
   assert.match(
+    contextSignals.properties.topics.description,
+    /MUST use standardized taxonomy identifiers or bounded custom category labels/
+  );
+  assert.match(
     contextSignals.properties.embedding.description,
     /MUST NOT be computed directly or indirectly from non-public content/
   );
@@ -35,4 +39,8 @@ test("ContextSignals protects non-public single-user content", () => {
     specification,
     /Router isolation prevents identity-path data from entering the context path; it does not make user-derived context anonymous\./
   );
+
+  const aiAssistantSurface = read("docs/trusted-match/surfaces/ai-assistants.mdx");
+  assert.match(aiAssistantSurface, /omits `artifact_refs`/);
+  assert.doesNotMatch(aiAssistantSurface, /"value": "turn:/);
 });


### PR DESCRIPTION
## Summary

- backport #7396's finalized single-user Context Match privacy boundary to the 3.1 maintenance line
- prohibit embeddings derived directly or indirectly from non-public single-user/session content
- require privacy-reduced keywords and summaries for the same provenance
- preserve useful bounded category terms in examples and distinguish shared ephemeral content from a single user's turn or query
- align schema descriptions, normative specification, privacy guidance, and examples

Closes #7393.

## Relationship to main

#7396 is the forward port for `main` / 3.2. This PR is based directly on `3.1.x`, where the issue was reported and where triage requested the patch land first.

## Validation

- `npm run build:schemas`
- `npm run test:schemas`
- `node --test tests/trusted-match-context-privacy.test.cjs`
- `npm run test:docs-nav`
- `npm run typecheck`
