### PR TITLE
feat(addie): let web chat users compare Gemini and Sonnet

### DIFF
--- a/server/public/chat-model-selection.js
+++ b/server/public/chat-model-selection.js
@@ -1,0 +1,34 @@
+(function () {
+  'use strict';
+
+  function normalizePreference(value) {
+    return value === 'gemini' || value === 'sonnet' ? value : 'default';
+  }
+
+  function modelName(model) {
+    if (typeof model !== 'string' || !model) return 'Model not recorded';
+    const gemini = model.match(/^gemini-(\d+\.\d+)/);
+    if (gemini) return `Gemini ${gemini[1]}`;
+    if (model.includes('sonnet')) return 'Sonnet';
+    if (model.includes('haiku')) return 'Haiku';
+    if (model.includes('opus')) return 'Opus';
+    return model.slice(0, 80);
+  }
+
+  function appendInfo(container, info) {
+    if (!info) return;
+    const badge = document.createElement('div');
+    badge.className = 'message-model';
+    const actual = info.source === 'local' ? 'System response' : modelName(info.model);
+    const requested = info.selected === 'gemini' ? 'Gemini 3.7' : modelName(info.requested_model);
+    let label = info.fallback && requested !== actual ? `${requested} → ${actual}` : actual;
+    if (Number.isFinite(info.latency_ms) && info.latency_ms >= 0) {
+      label += ` · ${(info.latency_ms / 1000).toFixed(1)}s`;
+    }
+    badge.textContent = label;
+    badge.title = `Selected: ${normalizePreference(info.selected)}. ${info.model || actual}`;
+    container.insertBefore(badge, container.querySelector('.message-feedback'));
+  }
+
+  window.AddieChatModels = { normalizePreference, appendInfo };
+})();

--- a/server/public/chat.html
+++ b/server/public/chat.html
@@ -772,6 +772,38 @@
       }
     }
 
+    .model-selector {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 8px;
+      font-size: 12px;
+      color: var(--color-text-secondary);
+    }
+
+    .model-selector[hidden] { display: none; }
+
+    .model-selector select {
+      padding: 6px 10px;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      background: var(--color-bg-card);
+      color: var(--color-text);
+      font: inherit;
+    }
+
+    .model-selector select:focus-visible {
+      outline: 2px solid var(--color-brand);
+      outline-offset: 2px;
+    }
+
+    .message-model {
+      margin-top: 8px;
+      color: var(--color-text-secondary);
+      font-size: 12px;
+    }
+
     .chat-input {
       flex: 1;
       padding: 12px 16px;
@@ -3053,6 +3085,15 @@
       </div>
 
       <div class="chat-input-container">
+        <div class="model-selector" id="modelSelector" hidden>
+          <label for="modelSelect">Model</label>
+          <select id="modelSelect" aria-describedby="modelSelectionHint">
+            <option value="default">Default</option>
+            <option value="gemini">Gemini 3.7 (beta)</option>
+            <option value="sonnet">Sonnet</option>
+          </select>
+          <span id="modelSelectionHint">Applies to your next message.</span>
+        </div>
         <div class="attachment-tray" id="attachmentTray" aria-live="polite"></div>
         <div class="chat-input-wrapper">
           <input type="file" id="attachmentInput" accept="image/png,image/jpeg,image/gif,image/webp,application/pdf" multiple hidden>
@@ -3086,6 +3127,7 @@
 
   <script src="/nav.js"></script>
   <script src="/external-url.js"></script>
+  <script src="/chat-model-selection.js"></script>
   <script>
     window.siBranding = (() => {
       'use strict';
@@ -3180,6 +3222,10 @@
       const messagesContainer = document.getElementById('messagesContainer');
       const welcomeMessage = document.getElementById('welcomeMessage');
       const chatInput = document.getElementById('chatInput');
+      const modelSelector = document.getElementById('modelSelector');
+      const modelSelect = document.getElementById('modelSelect');
+      const modelSelectionHint = document.getElementById('modelSelectionHint');
+      const { normalizePreference, appendInfo: appendModelInfo } = window.AddieChatModels;
       const attachmentInput = document.getElementById('attachmentInput');
       const attachmentButton = document.getElementById('attachmentButton');
       const attachmentTray = document.getElementById('attachmentTray');
@@ -3273,6 +3319,9 @@
       let isReadOnly = false;
       let impersonationInfo = null;
       let isAuthenticated = false;
+      let modelPreference = 'default';
+      let modelSelectionAvailable = false;
+      let geminiAvailable = false;
       let videoCallActive = false;
       let videoConversationId = null;
       let videoThreadId = null;
@@ -3389,6 +3438,7 @@
 
           const data = await response.json();
           isAuthenticated = true;
+          updateModelSelector();
           videoCallBtn.classList.add('visible');
 
           if (data.impersonation && data.impersonation.active) {
@@ -3558,7 +3608,7 @@
       }
 
       // Add a conversation to active tabs
-      function addActiveTab(id, title, channel = 'web') {
+      function addActiveTab(id, title, channel = 'web', selectedModel) {
         // Check if already in active tabs
         if (activeTabs.some(t => t.id === id)) return;
 
@@ -3571,6 +3621,7 @@
           id,
           title: title || 'New Chat',
           channel,
+          modelPreference: selectedModel,
           isLoading: false,
           unreadCount: 0
         });
@@ -3740,6 +3791,8 @@
         currentTabId = 'home';
         clearCurrentTab();
         conversationId = null;
+        modelPreference = 'default';
+        updateModelSelector();
         currentChannel = 'web';
         lastAssistantMessageId = null;
         clearSessionFeedbackTimer();
@@ -3883,11 +3936,13 @@
           const data = await response.json();
 
           // Render messages and track last assistant message
+          modelPreference = normalizePreference(tab?.modelPreference ?? data.model_preference);
+          updateModelSelector();
           lastAssistantMessageId = null;
           lastAssistantContent = '';
           clearSessionFeedbackTimer();
           data.messages.forEach(msg => {
-            addMessage(msg.content, msg.role, msg.message_id);
+            addMessage(msg.content, msg.role, msg.message_id, [], msg.model_info);
             if (msg.role === 'assistant' && msg.message_id) {
               lastAssistantMessageId = msg.message_id;
               lastAssistantContent = msg.content || '';
@@ -3899,6 +3954,7 @@
               attachments: [],
               messageSource: data.recoverable_turn.message_source || 'typed',
               clientRequestId: data.recoverable_turn.client_request_id,
+              modelPreference: normalizePreference(data.recoverable_turn.model_preference),
               certification: null,
             });
           }
@@ -3945,6 +4001,8 @@
       // Start a new conversation
       function startNewConversation() {
         conversationId = null;
+        modelPreference = 'default';
+        updateModelSelector();
         currentChannel = 'web';
         currentTabId = 'home'; // New chat starts from home
         clearCurrentTab();
@@ -4095,9 +4153,12 @@
       // Check Addie status
       async function checkStatus() {
         try {
-          const response = await fetch('/api/addie/chat/status');
+          const response = await authFetch('/api/addie/chat/status');
           const data = await response.json();
           isReady = data.ready;
+          modelSelectionAvailable = data.model_selection?.enabled === true;
+          geminiAvailable = data.model_selection?.gemini_available === true;
+          updateModelSelector();
           updateStatusIndicator();
         } catch (error) {
           isReady = false;
@@ -4123,10 +4184,21 @@
       }
 
       // Update send button state
+      function updateModelSelector() {
+        modelSelector.hidden = !isAuthenticated || !modelSelectionAvailable || isReadOnly;
+        modelSelect.value = modelPreference;
+        modelSelect.disabled = isLoading || !isReady || isReadOnly;
+        modelSelect.querySelector('[value="gemini"]').disabled = !geminiAvailable;
+        modelSelectionHint.textContent = geminiAvailable
+          ? 'Applies to your next message.'
+          : 'Gemini is temporarily unavailable.';
+      }
+
       function updateSendButton() {
         const hasText = chatInput.value.trim().length > 0;
         const hasAttachments = pendingAttachments.length > 0;
         sendButton.disabled = (!hasText && !hasAttachments) || pendingAttachmentReads > 0 || isLoading || !isReady || isReadOnly;
+        updateModelSelector();
       }
 
       function getAttachmentKind(file) {
@@ -4524,7 +4596,7 @@
       }
 
       // Add message to chat
-      function addMessage(content, role, messageId = null, attachments = []) {
+      function addMessage(content, role, messageId = null, attachments = [], modelInfo = null) {
         // Switch to conversation mode
         const chatContainer = document.getElementById('chatContainer');
         if (chatContainer) chatContainer.classList.add('has-messages');
@@ -4552,6 +4624,7 @@
         setupChatImages(contentDiv);
         const attachmentsEl = renderMessageAttachments(attachments);
         if (attachmentsEl) contentDiv.appendChild(attachmentsEl);
+        if (role === 'assistant') appendModelInfo(contentDiv, modelInfo);
 
         // Add feedback controls for assistant messages
         if (role === 'assistant' && messageId) {
@@ -5176,6 +5249,9 @@
       // Send message with streaming
       async function sendMessage(sendOptions = {}) {
         const retrying = sendOptions.retry === true;
+        const selectedModel = isAuthenticated
+          ? normalizePreference(retrying ? sendOptions.modelPreference : modelPreference)
+          : 'default';
         const message = retrying ? sendOptions.message : chatInput.value.trim();
         const attachmentsToSend = retrying ? (sendOptions.attachments || []) : pendingAttachments.slice();
         if ((!message && attachmentsToSend.length === 0) || isLoading || !isReady || isReadOnly) {
@@ -5217,6 +5293,7 @@
         let messageId = null;
         let pendingSiSession = null;
         let pendingSiAgents = null;
+        let pendingModelInfo = null;
 
         try {
           const response = await authFetch('/api/addie/chat/stream', {
@@ -5228,6 +5305,7 @@
               message,
               conversation_id: conversationId,
               message_source: messageSource,
+              model_preference: selectedModel,
               organization_id: getSelectedOrganizationId(),
               attachments: buildAttachmentPayload(attachmentsToSend),
               client_request_id: clientRequestId,
@@ -5298,7 +5376,7 @@
                   if (isNewConversation && newConversationId) {
                     const titleSource = message || attachmentSummary(attachmentsToSend);
                     const title = titleSource.slice(0, 50) + (titleSource.length > 50 ? '...' : '');
-                    addActiveTab(newConversationId, title, 'web');
+                    addActiveTab(newConversationId, title, 'web', selectedModel);
                     currentTabId = newConversationId;
                     saveCurrentTab(newConversationId);
                     homeTab.classList.remove('active');
@@ -5314,6 +5392,7 @@
                   messageId = data.message_id;
                   conversationId = data.conversation_id;
                   pendingCertification = data.certification || null;
+                  pendingModelInfo = data.model_info || null;
 
                   // Store SI session data - will open modal after stream is completely done
                   if (data.si_session && data.si_session.session_id) {
@@ -5373,6 +5452,7 @@
 
           // Finalize the message with feedback UI
           finalizeStreamingMessage(messageDiv, contentDiv, fullContent, messageId);
+          appendModelInfo(contentDiv, pendingModelInfo);
           appendCertificationStatus(contentDiv, pendingCertification);
           if (messageId) lastAssistantMessageId = messageId;
           lastAssistantContent = fullContent;
@@ -5440,6 +5520,7 @@
               attachments: attachmentsToSend,
               messageSource,
               clientRequestId,
+              modelPreference: selectedModel,
               certification: error.certification,
             });
           } else {
@@ -5457,6 +5538,11 @@
       }
 
       // Event listeners
+      modelSelect.addEventListener('change', () => {
+        modelPreference = normalizePreference(modelSelect.value);
+        if (conversationId) updateTabState(conversationId, { modelPreference });
+      });
+
       chatInput.addEventListener('input', () => {
         autoResize();
         updateSendButton();

--- a/server/src/addie/config-version.ts
+++ b/server/src/addie/config-version.ts
@@ -30,7 +30,7 @@ import { loadRules, loadResponseStyle } from './rules/index.js';
  * Format: YYYY.MM.N where N is incremented for multiple changes in a month
  * Example: 2025.01.1, 2025.01.2, 2025.02.1
  */
-export const CODE_VERSION = '2026.09.49';
+export const CODE_VERSION = '2026.09.50';
 
 // Types
 export interface ConfigVersion {

--- a/server/src/addie/gemini-direct-experiment.ts
+++ b/server/src/addie/gemini-direct-experiment.ts
@@ -6,6 +6,7 @@ import type { CostEvent } from './claude-cost-tracker.js';
 import { createGeminiDirectTools } from './gemini-direct-tools.js';
 import { GoogleGenerateContentProvider, GOOGLE_ROUTER_MODEL } from './model-providers/google-generate-content-provider.js';
 import { resolveModelCostPricing } from './model-cost-pricing.js';
+import type { WebChatModelPreference } from './web-chat-model-selection.js';
 
 const logger = createLogger('addie-gemini-direct');
 export const GEMINI_DIRECT_EXPERIMENT = 'gemini-3.7-direct-v1';
@@ -21,8 +22,13 @@ export interface WebToolSelection {
   routerUsage?: CostEvent;
   routerUsageComplete?: boolean;
 }
-type Assignment = { arm: 'control' | 'gemini'; cohort: 'staff' | 'eligible' | 'existing'; bucket: number };
+type Assignment = { arm: 'control' | 'gemini'; cohort: 'staff' | 'eligible' | 'existing' | 'manual'; bucket: number };
 const clients = new WeakMap<Client, AddieClaudeClient>();
+
+export function geminiDirectAvailable(client: Client | null | undefined): boolean {
+  return ['staff', 'eligible'].includes(process.env.ADDIE_GEMINI_DIRECT_MODE ?? '')
+    && !!process.env.GEMINI_API_KEY && !!client?.forkForGeminiDirect;
+}
 
 /** Stable across workers/restarts. Raising the percentage only enrolls new threads. */
 export function geminiDirectAssignment(userId: string, staff: boolean, existing: boolean, env = process.env): Assignment | null {
@@ -145,41 +151,55 @@ export async function prepareGeminiDirectTurn(input: {
   getControlTools: () => Promise<WebToolSelection | null>;
   /** Evaluation routes must never enroll live experiment traffic. */
   evaluation?: boolean;
+  modelPreference?: WebChatModelPreference;
 }) {
   let controlTools: WebToolSelection | null | undefined;
   const getControl = async () => controlTools === undefined
     ? (controlTools = await input.getControlTools()) : controlTools;
   const ordinary = async () => ({ client: input.client, selection: await getControl(), experiment: undefined as ExperimentTurn | undefined, model: undefined as string | undefined });
-  const proposed = input.userId && !input.evaluation && process.env.GEMINI_API_KEY
-    && input.client.forkForGeminiDirect
-    ? geminiDirectAssignment(input.userId, input.isAdmin, input.hasPriorAssistant) : null;
+  const manual = !!input.userId && !input.evaluation
+    && (input.modelPreference === 'gemini' || input.modelPreference === 'sonnet');
+  const available = geminiDirectAvailable(input.client);
+  const proposed: Assignment | null = manual
+    ? { arm: input.modelPreference === 'gemini' ? 'gemini' : 'control', cohort: 'manual', bucket: 0 }
+    : input.userId && !input.evaluation && available
+      ? geminiDirectAssignment(input.userId, input.isAdmin, input.hasPriorAssistant) : null;
   if (!proposed) return ordinary();
+  const exclusionReason = input.exclusionReason
+    ?? (proposed.arm === 'gemini' && !available ? 'gemini_unavailable' : null);
 
   let assignment: Assignment;
   let experiment: ExperimentTurn;
   try {
-    // One atomic UPDATE elects the winner even when two requests start together.
-    const assigned = await query<{ assignment: unknown }>(`UPDATE addie_threads SET
-      context = CASE WHEN context ? $2 THEN context ELSE
-        COALESCE(context, '{}'::jsonb) || jsonb_build_object($2::text, $3::jsonb) END
-      WHERE thread_id = $1 RETURNING context -> $2 AS assignment`,
-    [input.threadId, CONTEXT_KEY, JSON.stringify(proposed)]);
-    const stored = assigned.rows[0]?.assignment;
-    if (!validAssignment(stored)) return ordinary();
-    assignment = stored;
+    if (manual) {
+      // A voluntary choice applies to this turn only. Never replace the stored
+      // randomized assignment when a user switches models mid-conversation.
+      assignment = proposed;
+    } else {
+      // One atomic UPDATE elects the winner even when two requests start together.
+      const assigned = await query<{ assignment: unknown }>(`UPDATE addie_threads SET
+        context = CASE WHEN context ? $2 THEN context ELSE
+          COALESCE(context, '{}'::jsonb) || jsonb_build_object($2::text, $3::jsonb) END
+        WHERE thread_id = $1 RETURNING context -> $2 AS assignment`,
+      [input.threadId, CONTEXT_KEY, JSON.stringify(proposed)]);
+      const stored = assigned.rows[0]?.assignment;
+      if (!validAssignment(stored)) return ordinary();
+      assignment = stored;
+    }
     experiment = new ExperimentTurn(input.startedAt, assignment);
+    if (assignment.arm === 'gemini' && exclusionReason) experiment.fallbackReason = exclusionReason;
     await query(`INSERT INTO addie_chat_experiment_turns
       (id, experiment, thread_id, user_id, arm, cohort, exclusion_reason, started_at)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, [
       experiment.id, GEMINI_DIRECT_EXPERIMENT, input.threadId, input.userId,
-      assignment.arm, assignment.cohort, input.exclusionReason, new Date(input.startedAt),
+      assignment.arm, assignment.cohort, exclusionReason, new Date(input.startedAt),
     ]);
   } catch (error) {
     logger.error({ error }, 'Gemini Direct assignment unavailable; retaining control');
     return ordinary();
   }
 
-  const treatment = assignment.arm === 'gemini' && !input.exclusionReason;
+  const treatment = assignment.arm === 'gemini' && !exclusionReason;
   const direct = treatment ? createGeminiDirectTools(input.requestTools, input.client.getRegisteredTools?.() ?? [], input.isAdmin) : null;
   let candidate: AddieClaudeClient | undefined;
   if (direct) {
@@ -293,7 +313,20 @@ export async function prepareGeminiDirectTurn(input: {
 
 /** Read-only staff view; transcript content stays in the existing admin review UI. */
 export async function getGeminiDirectResults() {
-  const result = await query(`SELECT e.arm, e.cohort, e.exclusion_reason,
+  // Once a user chooses a model, that conversation's history can influence
+  // every later answer. Keep all its turns out of the randomized cohorts.
+  const result = await query(`WITH reported_turns AS (
+    SELECT e.*, CASE WHEN EXISTS (
+      SELECT 1 FROM addie_chat_experiment_turns manual
+      WHERE manual.experiment = e.experiment AND manual.thread_id = e.thread_id
+        AND manual.cohort = 'manual'
+    ) OR EXISTS (
+      SELECT 1 FROM addie_thread_messages chosen
+      WHERE chosen.thread_id = e.thread_id AND chosen.role = 'user'
+        AND chosen.model_preference IN ('gemini', 'sonnet')
+    ) THEN 'manual' ELSE e.cohort END AS reporting_cohort
+    FROM addie_chat_experiment_turns e WHERE e.experiment = $1
+  ) SELECT e.arm, e.reporting_cohort AS cohort, e.exclusion_reason,
     COUNT(*)::int AS turns, COUNT(DISTINCT e.user_id)::int AS users,
     COUNT(*) FILTER (WHERE completed_at IS NULL)::int AS incomplete,
     COUNT(*) FILTER (WHERE failed)::int AS failures,
@@ -309,9 +342,8 @@ export async function getGeminiDirectResults() {
     COUNT(*) FILTER (WHERE m.outcome = 'resolved')::int AS resolved_turns,
     SUM(estimated_cost_micros) / 1000000.0 /
       NULLIF(COUNT(*) FILTER (WHERE m.outcome = 'resolved'), 0) AS estimated_cost_per_marked_resolution_usd
-    FROM addie_chat_experiment_turns e
+    FROM reported_turns e
     LEFT JOIN addie_thread_messages m ON m.message_id = e.assistant_message_id
-    WHERE experiment = $1
-    GROUP BY e.arm, e.cohort, e.exclusion_reason ORDER BY e.cohort, e.arm`, [GEMINI_DIRECT_EXPERIMENT]);
+    GROUP BY e.arm, e.reporting_cohort, e.exclusion_reason ORDER BY e.reporting_cohort, e.arm`, [GEMINI_DIRECT_EXPERIMENT]);
   return { experiment: GEMINI_DIRECT_EXPERIMENT, mode: process.env.ADDIE_GEMINI_DIRECT_MODE ?? 'off', cohorts: result.rows };
 }

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -66,7 +66,7 @@
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "cb1b76808654a295064cbd8b7dc580e17b9c4a54f80e882543cff5c15086632f",
-    "server/src/routes/addie-chat.ts": "c9fab36425a8bc7f2b404ba7497d2b382552bcc8dbbf3452ca624905d17f96ab",
+    "server/src/routes/addie-chat.ts": "ac6362c43b5bf97545b4ff980c85d3f30926f548e1ade1e43766a8d3cbc4bccc",
     "server/src/routes/tavus.ts": "17321c275f89de1ec3e4996c6d7271bf252f7ff1ab1494dad820b090065d0da4",
     "server/src/addie/email-conversation-handler.ts": "d6cf6d3c8621a85c69c6b22b86e6aa78f03b0d532ac8d5162fd40ec6c869f70c",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/generated/tool-surface-inventory.generated.json
+++ b/server/src/addie/generated/tool-surface-inventory.generated.json
@@ -66,7 +66,7 @@
     "server/src/addie/prompt-assembly.ts": "6c002ae5a52cdd26e13f424f6e00757dff163b3b273a1b4ab069fdb86f4f375f",
     "server/src/addie/register-baseline-tools.ts": "52893917fa19fa8904e1667857a7c4bfc2dc90bd3341e60d1ff45a40400d17aa",
     "server/src/addie/bolt-app.ts": "cb1b76808654a295064cbd8b7dc580e17b9c4a54f80e882543cff5c15086632f",
-    "server/src/routes/addie-chat.ts": "ac6362c43b5bf97545b4ff980c85d3f30926f548e1ade1e43766a8d3cbc4bccc",
+    "server/src/routes/addie-chat.ts": "c2973a41c6ca9827d7db48ac5baf72edb1f7f8b4084219fa31d184d55d4f68ac",
     "server/src/routes/tavus.ts": "17321c275f89de1ec3e4996c6d7271bf252f7ff1ab1494dad820b090065d0da4",
     "server/src/addie/email-conversation-handler.ts": "d6cf6d3c8621a85c69c6b22b86e6aa78f03b0d532ac8d5162fd40ec6c869f70c",
     "server/src/mcp/chat-tool.ts": "a6bbde38fda11337a899fc92b8cabc3617377ae7c648609f34fae098f138f87e",

--- a/server/src/addie/thread-service.ts
+++ b/server/src/addie/thread-service.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'crypto';
 import { query, getPool } from '../db/client.js';
 import { createLogger } from '../logger.js';
 import type { LocalModelResponseReason, ModelExecution, ModelFallbackReason, ModelProviderId, ModelResolution } from './model-providers/model-provider.js';
+import type { WebChatModelPreference } from './web-chat-model-selection.js';
 
 const logger = createLogger('addie-thread-service');
 
@@ -121,6 +122,7 @@ interface CreateMessageInputBase {
   tool_calls?: Array<{ name: string; input: unknown; result: unknown; duration_ms?: number; is_error?: boolean; result_status?: string; github_issue_receipt?: unknown }>;
   knowledge_ids?: number[];
   model?: string;
+  model_preference?: WebChatModelPreference;
   latency_ms?: number;
   tokens_input?: number;
   tokens_output?: number;
@@ -189,6 +191,7 @@ export interface ThreadMessage {
   tool_calls: Array<{ name: string; input: unknown; result: unknown; duration_ms?: number; is_error?: boolean; result_status?: string; github_issue_receipt?: unknown }> | null;
   knowledge_ids: number[] | null;
   model: string | null;
+  model_preference?: WebChatModelPreference | null;
   model_execution_source: 'provider' | 'local' | 'legacy' | null;
   requested_model_provider: ModelProviderId | null;
   requested_model: string | null;
@@ -625,8 +628,8 @@ export class ThreadService {
           processing_iterations, tokens_cache_creation, tokens_cache_read, active_rule_ids,
           router_decision, config_version_id, email_message_id,
           user_id, user_display_name, message_source,
-          client_request_id, delivery_status
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37)
+          client_request_id, delivery_status, model_preference
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38)
         RETURNING *`,
         [
           input.thread_id,
@@ -666,6 +669,7 @@ export class ThreadService {
           input.message_source ?? null,
           input.client_request_id ?? null,
           input.delivery_status ?? 'completed',
+          input.model_preference ?? null,
         ]
       );
 
@@ -812,13 +816,15 @@ export class ThreadService {
     client_request_id: string;
     content: string;
     message_source: CreateMessageInput['message_source'] | null;
+    model_preference?: WebChatModelPreference | null;
   } | null> {
     const result = await query<{
       client_request_id: string;
       content: string;
       message_source: CreateMessageInput['message_source'] | null;
+      model_preference?: WebChatModelPreference | null;
     }>(
-      `SELECT turn.client_request_id::text, message.content, message.message_source
+      `SELECT turn.client_request_id::text, message.content, message.message_source, message.model_preference
        FROM addie_chat_turns turn
        JOIN addie_thread_messages message
          ON message.thread_id = turn.thread_id

--- a/server/src/addie/web-chat-model-selection.ts
+++ b/server/src/addie/web-chat-model-selection.ts
@@ -1,0 +1,44 @@
+import type { ThreadMessage } from './thread-service.js';
+
+export type WebChatModelPreference = 'default' | 'gemini' | 'sonnet';
+
+export class WebChatModelPreferenceError extends Error {
+  constructor(message: string, readonly statusCode: number) { super(message); }
+}
+
+/** A model choice never supplies a provider/model ID or changes account permissions. */
+export function parseWebChatModelPreference(value: unknown, authenticated: boolean, evaluation = false): WebChatModelPreference {
+  if (value === undefined || value === 'default') return 'default';
+  if (value !== 'gemini' && value !== 'sonnet') {
+    throw new WebChatModelPreferenceError('model_preference must be default, gemini, or sonnet.', 400);
+  }
+  if (!authenticated) throw new WebChatModelPreferenceError('Sign in to choose a model.', 403);
+  if (evaluation) throw new WebChatModelPreferenceError('Model selection is unavailable on evaluation routes.', 400);
+  return value;
+}
+
+export interface WebChatModelInfo {
+  selected: WebChatModelPreference;
+  source: 'provider' | 'local' | 'legacy';
+  model: string | null;
+  requested_model: string | null;
+  fallback: boolean;
+  latency_ms: number | null;
+}
+
+/** Render stored execution evidence, including replayed and historical replies. */
+export function webChatModelInfo(message: Pick<ThreadMessage,
+  'model_preference' | 'model_execution_source' | 'provider_model' | 'requested_model'
+  | 'provider_model_resolution' | 'model_provider' | 'latency_ms'>): WebChatModelInfo {
+  const selected = message.model_preference ?? 'default';
+  const source = message.model_execution_source ?? 'legacy';
+  return {
+    selected,
+    source,
+    model: source === 'provider' ? message.provider_model ?? null : null,
+    requested_model: message.requested_model ?? null,
+    fallback: source === 'provider' && (message.provider_model_resolution === 'fallback'
+      || (selected === 'gemini' && message.model_provider !== 'google')),
+    latency_ms: message.latency_ms ?? null,
+  };
+}

--- a/server/src/db/migrations/587_addie_web_model_selection.sql
+++ b/server/src/db/migrations/587_addie_web_model_selection.sql
@@ -1,0 +1,11 @@
+-- Keep user-selected comparisons distinct from randomized assignment. The
+-- original choice is also stored on the user turn so retries cannot change it.
+ALTER TABLE addie_thread_messages
+  ADD COLUMN model_preference TEXT
+    CHECK (model_preference IN ('default', 'gemini', 'sonnet'));
+
+ALTER TABLE addie_chat_experiment_turns
+  DROP CONSTRAINT addie_chat_experiment_turns_cohort_check;
+ALTER TABLE addie_chat_experiment_turns
+  ADD CONSTRAINT addie_chat_experiment_turns_cohort_check
+    CHECK (cohort IN ('staff', 'eligible', 'existing', 'manual'));

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -1531,7 +1531,10 @@ export function createAddieChatRouter(options?: {
       });
     } catch (error) {
       if (error instanceof WebChatModelPreferenceError) {
-        return res.status(error.statusCode).json({ error: 'Invalid model preference', message: error.message });
+        return res.status(error.statusCode).json({
+          error: 'Invalid model preference',
+          message: error.statusCode === 403 ? 'Sign in to choose a model.' : 'This model selection is unavailable for the request.',
+        });
       }
       if (error instanceof ChatAttachmentValidationError) {
         logger.warn({ reason: error.message }, "Addie Chat: Invalid attachment");
@@ -2444,7 +2447,10 @@ export function createAddieChatRouter(options?: {
       res.end();
     } catch (error) {
       if (error instanceof WebChatModelPreferenceError && !res.headersSent) {
-        return res.status(error.statusCode).json({ error: 'Invalid model preference', message: error.message });
+        return res.status(error.statusCode).json({
+          error: 'Invalid model preference',
+          message: error.statusCode === 403 ? 'Sign in to choose a model.' : 'This model selection is unavailable for the request.',
+        });
       }
       logger.error({ err: error }, "Addie Chat Stream: Error handling message");
       if (claimedTurn) {

--- a/server/src/routes/addie-chat.ts
+++ b/server/src/routes/addie-chat.ts
@@ -22,7 +22,8 @@ import {
   type ExecutionPlan,
   type RoutingContext,
 } from "../addie/router.js";
-import { prepareGeminiDirectTurn, getGeminiDirectResults } from "../addie/gemini-direct-experiment.js";
+import { prepareGeminiDirectTurn, getGeminiDirectResults, geminiDirectAvailable } from "../addie/gemini-direct-experiment.js";
+import { parseWebChatModelPreference, webChatModelInfo, WebChatModelPreferenceError, type WebChatModelInfo } from "../addie/web-chat-model-selection.js";
 import type { CostEvent } from "../addie/claude-cost-tracker.js";
 import { createProductionRouter } from "../addie/router-runtime.js";
 import {
@@ -600,6 +601,7 @@ interface ConversationMessage {
   rating_notes?: string | null;
   feedback_tags?: string[] | null;
   improvement_suggestion?: string | null;
+  model_info?: WebChatModelInfo;
 }
 
 /**
@@ -1152,10 +1154,12 @@ export function createAddieChatRouter(options?: {
         conversation_id,
         user_name,
         message_source: rawMessageSource,
+        model_preference: rawModelPreference,
         attachments: rawAttachments,
         organization_id,
         github_issue_creation_requested: rawGithubIssueCreationRequested,
       } = req.body;
+      const modelPreference = parseWebChatModelPreference(rawModelPreference, !!req.user, options?.evaluationMode);
       // This is an explicit UI/API action signal, never a text classifier. A
       // model reply cannot set it, and it only controls whether a missing
       // same-turn issue receipt must yield the deterministic fallback.
@@ -1270,6 +1274,7 @@ export function createAddieChatRouter(options?: {
       await threadService.addMessage({
         thread_id: thread.thread_id,
         role: 'user',
+        model_preference: modelPreference,
         content: messageForStorage,
         content_sanitized: inputValidation.sanitized,
         flagged: inputValidation.flagged,
@@ -1354,6 +1359,7 @@ export function createAddieChatRouter(options?: {
         requestTools: tieredAccess.requestTools,
         baseRequestContext: requestContext,
         evaluation: options?.evaluationMode,
+        modelPreference,
         getControlTools: async () => isAuth
           ? await selectRoutedWebTools({
               message: messageToProcess,
@@ -1486,6 +1492,7 @@ export function createAddieChatRouter(options?: {
           : undefined,
         model: effectiveModel,
         model_execution: response.model_execution,
+        model_preference: modelPreference,
         latency_ms: latencyMs,
         tokens_input: response.usage?.input_tokens,
         tokens_output: response.usage?.output_tokens,
@@ -1512,6 +1519,7 @@ export function createAddieChatRouter(options?: {
 
       res.json({
         response: outputValidation.sanitized,
+        model_info: webChatModelInfo(assistantMessage),
         conversation_id: externalId, // Return external_id as conversation_id for API compatibility
         message_id: assistantMessage.message_id, // Now returns UUID instead of integer
         tools_used: response.tools_used,
@@ -1522,6 +1530,9 @@ export function createAddieChatRouter(options?: {
         si_session: siSession,
       });
     } catch (error) {
+      if (error instanceof WebChatModelPreferenceError) {
+        return res.status(error.statusCode).json({ error: 'Invalid model preference', message: error.message });
+      }
       if (error instanceof ChatAttachmentValidationError) {
         logger.warn({ reason: error.message }, "Addie Chat: Invalid attachment");
         return res.status(error.statusCode).json({
@@ -1540,10 +1551,14 @@ export function createAddieChatRouter(options?: {
 
   // GET /api/addie/chat/status - Check if Addie is ready
   // NOTE: This route must come BEFORE /:conversationId to avoid being matched as a conversation ID
-  apiRouter.get("/status", (req, res) => {
+  apiRouter.get("/status", optionalAuth, (req, res) => {
     res.json({
       ready: (!!injectedChatClient || (initialized && claudeClient !== null)) && isKnowledgeReady(),
       knowledge_ready: isKnowledgeReady(),
+      model_selection: {
+        enabled: !!req.user && !options?.evaluationMode,
+        gemini_available: !options?.evaluationMode && geminiDirectAvailable(injectedChatClient ?? claudeClient),
+      },
     });
   });
 
@@ -1597,12 +1612,14 @@ export function createAddieChatRouter(options?: {
         conversation_id,
         user_name,
         message_source: rawMessageSourceStream,
+        model_preference: rawModelPreference,
         attachments: rawAttachmentsStream,
         organization_id,
         client_request_id,
         retry,
         github_issue_creation_requested: rawGithubIssueCreationRequested,
       } = req.body;
+      let modelPreference = parseWebChatModelPreference(rawModelPreference, !!req.user, options?.evaluationMode);
       const attachments = validateChatAttachments(rawAttachmentsStream);
       const clientRequestId = typeof client_request_id === 'string' ? client_request_id : null;
       const retryRequested = retry === true;
@@ -1710,6 +1727,10 @@ export function createAddieChatRouter(options?: {
         .reverse()
         .find(m => m.role === 'assistant' && m.delivery_status === 'completed');
 
+      // A retry continues the original turn, even if the selector has since
+      // changed. Stored tool checkpoints and execution policy still apply.
+      if (existingUserMessage) modelPreference = existingUserMessage.model_preference ?? 'default';
+
       if (existingUserMessage && existingUserMessage.content !== messageForStorage) {
         return res.status(409).json({
           error: 'client_request_id conflict',
@@ -1790,6 +1811,7 @@ export function createAddieChatRouter(options?: {
         sendEvent('done', {
           conversation_id: externalId,
           message_id: completedAssistantMessage.message_id,
+          model_info: webChatModelInfo(completedAssistantMessage),
           replayed: true,
           certification,
         });
@@ -1828,6 +1850,7 @@ export function createAddieChatRouter(options?: {
         await threadService.addMessage({
           thread_id: thread.thread_id,
           role: 'user',
+          model_preference: modelPreference,
           content: messageForStorage,
           content_sanitized: inputValidation.sanitized,
           flagged: inputValidation.flagged,
@@ -1918,6 +1941,7 @@ export function createAddieChatRouter(options?: {
         requestTools: tieredAccess.requestTools,
         baseRequestContext: requestContext,
         evaluation: options?.evaluationMode,
+        modelPreference,
         getControlTools: async () => isAuth
           ? await selectRoutedWebTools({
               message: messageToProcess,
@@ -2251,6 +2275,7 @@ export function createAddieChatRouter(options?: {
           : undefined,
         model: effectiveModel,
         model_execution: response.model_execution,
+        model_preference: modelPreference,
         latency_ms: latencyMs,
         tokens_input: response?.usage?.input_tokens,
         tokens_output: response?.usage?.output_tokens,
@@ -2402,6 +2427,7 @@ export function createAddieChatRouter(options?: {
       sendEvent("done", {
         conversation_id: externalId,
         message_id: assistantMessage.message_id,
+        model_info: webChatModelInfo(assistantMessage),
         tools_used: toolsUsed,
         timing: response?.timing,
         usage: response?.usage,
@@ -2417,6 +2443,9 @@ export function createAddieChatRouter(options?: {
 
       res.end();
     } catch (error) {
+      if (error instanceof WebChatModelPreferenceError && !res.headersSent) {
+        return res.status(error.statusCode).json({ error: 'Invalid model preference', message: error.message });
+      }
       logger.error({ err: error }, "Addie Chat Stream: Error handling message");
       if (claimedTurn) {
         try {
@@ -2691,6 +2720,7 @@ export function createAddieChatRouter(options?: {
           rating_notes: m.rating_notes,
           feedback_tags: m.feedback_tags,
           improvement_suggestion: m.improvement_suggestion,
+          model_info: m.role === 'assistant' ? webChatModelInfo(m) : undefined,
         }));
 
       res.json({
@@ -2701,10 +2731,12 @@ export function createAddieChatRouter(options?: {
         limit,
         offset,
         messages,
+        model_preference: [...threadMessages].reverse().find(m => m.role === 'user')?.model_preference ?? 'default',
         recoverable_turn: recoverableTurn ? {
           client_request_id: recoverableTurn.client_request_id,
           message: recoverableTurn.content,
           message_source: recoverableTurn.message_source ?? 'typed',
+          model_preference: recoverableTurn.model_preference ?? 'default',
         } : null,
         read_only: channel === 'slack' || channel === 'video',
       });

--- a/server/tests/integration/thread-service.test.ts
+++ b/server/tests/integration/thread-service.test.ts
@@ -11,6 +11,7 @@ import {
   type ThreadListFilters,
 } from '../../src/addie/thread-service.js';
 import { AddieDatabase } from '../../src/db/addie-db.js';
+import { getGeminiDirectResults, GEMINI_DIRECT_EXPERIMENT } from '../../src/addie/gemini-direct-experiment.js';
 import { getModelExecutionReadiness } from '../../src/addie/model-execution-readiness.js';
 
 // These tests require a running PostgreSQL instance. Lives in integration/
@@ -143,6 +144,41 @@ describe.skipIf(!process.env.DATABASE_URL)('ThreadService Integration Tests', ()
       // Clean up
       await pool.query(`DELETE FROM addie_threads WHERE external_id = 'test-impersonation-thread'`);
     });
+  });
+
+  it('persists model choices and separates manually switched conversations from randomized outcomes', async () => {
+    const thread = await threadService.getOrCreateThread({ channel: 'web',
+      external_id: 'test-model-selection', user_type: 'workos', user_id: 'test-selector' });
+    const untouched = await threadService.getOrCreateThread({ channel: 'web',
+      external_id: 'test-randomized', user_type: 'workos', user_id: 'test-control' });
+    const chosen = await threadService.addMessage({ thread_id: thread.thread_id, role: 'user',
+      content: 'Explain AdCP', model_preference: 'gemini', client_request_id: 'ad37b1cc-fcee-43ac-8e0f-159c4a27cab6' });
+    expect(chosen.model_preference).toBe('gemini');
+    expect((await threadService.getThreadMessages(thread.thread_id))[0].model_preference).toBe('gemini');
+    // The stored user choice excludes even earlier random turns when a manual
+    // telemetry insert failed. Subsequent Default turns stay in that same group.
+    for (const [threadId, arm, cohort] of [
+      [thread.thread_id, 'gemini', 'staff'], [thread.thread_id, 'control', 'manual'],
+      [thread.thread_id, 'gemini', 'staff'], [untouched.thread_id, 'control', 'eligible'],
+    ]) {
+      await pool.query(`INSERT INTO addie_chat_experiment_turns
+        (id, experiment, thread_id, user_id, arm, cohort, started_at)
+        VALUES (gen_random_uuid(), $1, $2, 'test-selector', $3, $4, now())`,
+      [GEMINI_DIRECT_EXPERIMENT, threadId, arm, cohort]);
+    }
+    const report = await getGeminiDirectResults();
+    expect(report.cohorts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ cohort: 'manual', arm: 'gemini', turns: 2 }),
+      expect.objectContaining({ cohort: 'manual', arm: 'control', turns: 1 }),
+      expect.objectContaining({ cohort: 'eligible', arm: 'control', turns: 1 }),
+    ]));
+    expect(report.cohorts.some(row => row.cohort === 'staff')).toBe(false);
+    await pool.query("DELETE FROM addie_chat_experiment_turns WHERE thread_id = $1 AND cohort = 'manual'", [thread.thread_id]);
+    expect((await getGeminiDirectResults()).cohorts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ cohort: 'manual', arm: 'gemini', turns: 2 }),
+    ]));
+    await expect(pool.query(`UPDATE addie_thread_messages SET model_preference = 'arbitrary-model' WHERE message_id = $1`,
+      [chosen.message_id])).rejects.toThrow('check constraint');
   });
 
   describe('addMessage', () => {

--- a/server/tests/unit/addie-chat-object-authorization.test.ts
+++ b/server/tests/unit/addie-chat-object-authorization.test.ts
@@ -341,6 +341,12 @@ describe('Addie chat conversation object authorization', () => {
     }));
     mocks.addMessage.mockImplementation(async (message: { role: string }) => ({
       ...message,
+      ...((message as any).model_execution?.source === 'provider' ? {
+        model_execution_source: 'provider', model_provider: (message as any).model_execution.provider,
+        provider_model: (message as any).model_execution.model,
+        requested_model: (message as any).model_execution.requested_model,
+        provider_model_resolution: (message as any).model_execution.model_resolution,
+      } : {}),
       message_id: message.role === 'assistant' ? 'message_assistant' : 'message_user',
     }));
     mocks.processMessage.mockResolvedValue(successfulModelResponse());
@@ -351,6 +357,25 @@ describe('Addie chat conversation object authorization', () => {
       yield { type: 'text', text: 'Allowed response' };
       yield { type: 'done', response: successfulModelResponse() };
     });
+  });
+
+  it.each(['/', '/stream'])('rejects anonymous overrides and arbitrary model IDs before any effects on %s', async endpoint => {
+    mocks.authenticated = false;
+    const app = mountChatRouter();
+    expect((await request(app).post(endpoint).send({ message: 'Hello', model_preference: 'gemini' })).status).toBe(403);
+    expect((await request(app).post(endpoint).send({ message: 'Hello', model_preference: 'sonnet' })).status).toBe(403);
+    mocks.authenticated = true;
+    expect((await request(app).post(endpoint).send({ message: 'Hello', model_preference: 'arbitrary-model' })).status).toBe(400);
+    expect(mocks.addMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+    expect(mocks.processMessageStream).not.toHaveBeenCalled();
+  });
+
+  it('offers model selection to signed-in non-admins only', async () => {
+    const app = mountChatRouter();
+    expect((await request(app).get('/status')).body.model_selection.enabled).toBe(true);
+    mocks.authenticated = false;
+    expect((await request(app).get('/status')).body.model_selection.enabled).toBe(false);
   });
 
   it('denies a cross-user conversation UUID before reading history, writing, or invoking the model', async () => {
@@ -593,16 +618,37 @@ describe('Addie chat conversation object authorization', () => {
     } as unknown as Awaited<ReturnType<typeof geminiExperiment.prepareGeminiDirectTurn>>);
     try {
       const res = await request(mountChatRouter()).post(endpoint).send({
-        message: 'Explain AdCP', conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
+        message: 'Explain AdCP', model_preference: 'gemini', conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
       });
       expect(res.status).toBe(200);
       expect(res.text).toContain('Gemini response');
-      expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user_attacker', exclusionReason: null, hasPriorAssistant: false }));
+      expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user_attacker', modelPreference: 'gemini', exclusionReason: null, hasPriorAssistant: false }));
       expect(mocks.processMessage).not.toHaveBeenCalled();
       expect(mocks.processMessageStream).not.toHaveBeenCalled();
-      expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'assistant', model: 'gemini-3.7-flash', model_execution: response.model_execution }));
+      expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'assistant', model_preference: 'gemini', model: 'gemini-3.7-flash', model_execution: response.model_execution }));
+      expect(res.text).toContain('\"selected\":\"gemini\"');
+      expect(res.text).toContain('\"model\":\"gemini-3.7-flash\"');
+      expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'user', model_preference: 'gemini' }));
       expect(finish).toHaveBeenCalledWith(expect.objectContaining({ text: 'Gemini response' }), 'message_assistant');
     } finally { prepare.mockRestore(); }
+  });
+
+  it('returns the saved choice and actual provider on history and recovery', async () => {
+    const id = '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489';
+    mocks.getThreadByExternalId.mockResolvedValue({ thread_id: 'thread_attacker', channel: 'web',
+      external_id: id, user_type: 'workos', user_id: 'user_attacker' });
+    mocks.getThreadMessages.mockResolvedValue([
+      { role: 'user', content: 'Explain AdCP', model_preference: 'gemini' },
+      { role: 'assistant', content: 'Verified answer', model_preference: 'gemini', model_execution_source: 'provider',
+        model_provider: 'anthropic', provider_model: 'claude-sonnet-4-6', requested_model: 'gemini-3.7-flash',
+        provider_model_resolution: 'fallback', latency_ms: 1500 },
+    ]);
+    mocks.getRecoverableClientTurn.mockResolvedValue({ client_request_id: 'original-request', content: 'Follow up', model_preference: 'sonnet' });
+    const res = await request(mountChatRouter()).get('/' + id);
+    expect(res.status).toBe(200);
+    expect(res.body.model_preference).toBe('gemini');
+    expect(res.body.messages[1].model_info).toMatchObject({ selected: 'gemini', model: 'claude-sonnet-4-6', fallback: true, latency_ms: 1500 });
+    expect(res.body.recoverable_turn.model_preference).toBe('sonnet');
   });
 
   it('restricts experiment outcomes to site admins', async () => {
@@ -744,6 +790,8 @@ describe('Addie chat conversation object authorization', () => {
         message_id: 'message_assistant',
         role: 'assistant',
         content: 'Module complete and saved.',
+        model_preference: 'sonnet', model_execution_source: 'provider',
+        model_provider: 'anthropic', provider_model: 'claude-sonnet-4-6', provider_model_resolution: 'exact',
         delivery_status: 'completed',
       },
     ]);
@@ -751,7 +799,7 @@ describe('Addie chat conversation object authorization', () => {
     const response = await request(mountChatRouter())
       .post('/stream')
       .send({
-        message: 'Complete my module',
+        message: 'Complete my module', model_preference: 'gemini',
         conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
         client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
         retry: true,
@@ -760,6 +808,8 @@ describe('Addie chat conversation object authorization', () => {
     expect(response.status).toBe(200);
     expect(response.text).toContain('Module complete and saved.');
     expect(response.text).toContain('"replayed":true');
+    expect(response.text).toContain('"selected":"sonnet"');
+    expect(response.text).toContain('"model":"claude-sonnet-4-6"');
     expect(mocks.getThreadMessages).not.toHaveBeenCalled();
     expect(mocks.addMessage).not.toHaveBeenCalled();
     expect(mocks.processMessageStream).not.toHaveBeenCalled();
@@ -784,7 +834,7 @@ describe('Addie chat conversation object authorization', () => {
     const response = await request(mountChatRouter())
       .post('/stream')
       .send({
-        message: 'Complete my module',
+        message: 'Complete my module', model_preference: 'gemini',
         conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
         client_request_id: 'e6c3ffbe-bbf4-4ae5-a32f-713e05af4b68',
         retry: true,
@@ -976,7 +1026,7 @@ describe('Addie chat conversation object authorization', () => {
       user_id: 'user_attacker',
     });
     mocks.getMessagesByClientRequestId.mockResolvedValue([{
-      message_id: 'message_user', role: 'user', content: 'Schedule a review', delivery_status: 'completed',
+      message_id: 'message_user', role: 'user', content: 'Schedule a review', model_preference: 'sonnet', delivery_status: 'completed',
     }]);
     mocks.getThreadMessages.mockResolvedValue([
       {
@@ -1000,7 +1050,7 @@ describe('Addie chat conversation object authorization', () => {
     const response = await request(mountChatRouter())
       .post('/stream')
       .send({
-        message: 'Schedule a review',
+        message: 'Schedule a review', model_preference: 'gemini',
         conversation_id: '9f3e25b7-fc57-4ad9-bb32-0d5ecdb41489',
         client_request_id: clientRequestId,
         retry: true,
@@ -1008,6 +1058,7 @@ describe('Addie chat conversation object authorization', () => {
 
     expect(response.status).toBe(200);
     expect(replayDecision).toEqual({ allowed: false });
+    expect(mocks.addMessage).toHaveBeenCalledWith(expect.objectContaining({ role: 'assistant', model_preference: 'sonnet' }));
   });
 
   it('gives every active certification learning thread the expanded reserve', async () => {

--- a/server/tests/unit/addie/gemini-direct-experiment.test.ts
+++ b/server/tests/unit/addie/gemini-direct-experiment.test.ts
@@ -100,6 +100,59 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs());
 
 describe('Gemini Direct production integration', () => {
+  it('allows a non-admin to choose Gemini in staff mode without enrolling their thread', async () => {
+    const f = fixture([receipt([call('query_admin_analytics')]), receipt([{ text: 'Admin access required.' }])]);
+    const analytics = vi.fn();
+    const result = await run({ ...f.input, isAdmin: false, modelPreference: 'gemini',
+      requestTools: { tools: [ADMIN_ANALYTICS_TOOL], handlers: new Map([[ADMIN_ANALYTICS_TOOL.name, analytics]]) } });
+    expect(result.response?.model_execution.provider).toBe('google');
+    expect(analytics).not.toHaveBeenCalled();
+    expect(f.getControlTools).not.toHaveBeenCalled();
+    expect(mocks.query.mock.calls.some(([sql]) => sql.startsWith('UPDATE addie_threads'))).toBe(false);
+    expect(mocks.query.mock.calls.find(([sql]) => sql.startsWith('INSERT INTO addie_chat_experiment_turns'))?.[1].slice(4, 7))
+      .toEqual(['gemini', 'manual', null]);
+  });
+
+  it('switches to Sonnet and back to Default without replacing the randomized assignment', async () => {
+    const f = fixture([receipt([{ text: 'First Gemini answer.' }]), receipt([{ text: 'Default Gemini answer.' }])]);
+    await run(f.input);
+    const sonnet = await run({ ...f.input, hasPriorAssistant: true, modelPreference: 'sonnet' });
+    expect(sonnet.response?.model_execution.provider).toBe('anthropic');
+    expect(f.control).toHaveBeenCalledOnce();
+    const restored = await run({ ...f.input, hasPriorAssistant: true, modelPreference: 'default' });
+    expect(restored.response?.model_execution.provider).toBe('google');
+    expect(mocks.query.mock.calls.filter(([sql]) => sql.startsWith('UPDATE addie_threads'))).toHaveLength(2);
+    expect(mocks.query.mock.calls.filter(([sql]) => sql.startsWith('INSERT INTO addie_chat_experiment_turns'))
+      .map(([, args]) => args.slice(4, 6))).toEqual([['gemini', 'staff'], ['control', 'manual'], ['gemini', 'staff']]);
+  });
+
+  it.each(['off', 'missing_key'])('honors the Gemini kill switch for explicit choices: %s', async mode => {
+    if (mode === 'off') vi.stubEnv('ADDIE_GEMINI_DIRECT_MODE', 'off');
+    else vi.stubEnv('GEMINI_API_KEY', '');
+    const f = fixture([]);
+    const result = await run({ ...f.input, modelPreference: 'gemini' });
+    expect(result.response?.model_execution.provider).toBe('anthropic');
+    expect(f.dispatch).not.toHaveBeenCalled();
+    expect(f.client.forkForGeminiDirect).not.toHaveBeenCalled();
+    expect(mocks.query.mock.calls.find(([sql]) => sql.startsWith('INSERT INTO addie_chat_experiment_turns'))?.[1].slice(4, 7))
+      .toEqual(['gemini', 'manual', 'gemini_unavailable']);
+  });
+
+  it.each([{ userId: undefined }, { evaluation: true }])('does not allow manual selection to enroll anonymous or evaluation traffic: %j', async override => {
+    const f = fixture([]);
+    await run({ ...f.input, ...override, modelPreference: 'gemini' });
+    expect(f.dispatch).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('retains normal cost admission on explicit Gemini turns', async () => {
+    mocks.checkCostCap.mockResolvedValue({ ok: false, reason: 'cap_exceeded' });
+    const f = fixture([]);
+    const result = await run({ ...f.input, modelPreference: 'gemini' });
+    expect(f.dispatch).not.toHaveBeenCalled();
+    expect(result.response?.text).toBe('Daily cap reached.');
+  });
+
   it('preserves Markdown and version numbers across real shared-loop stream fragments', async () => {
     const text = 'In AdCP 3.2 (3.2.0-rc.1), **Reliable Reporting** has three tiers.\n\n'
       + '- **Core**: Poll `get_media_buy_delivery` and use `reporting_webhook`.\n'

--- a/server/tests/unit/addie/web-chat-model-selection.test.ts
+++ b/server/tests/unit/addie/web-chat-model-selection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseWebChatModelPreference, webChatModelInfo } from '../../../src/addie/web-chat-model-selection.js';
+
+const execution = {
+  model_preference: 'gemini' as const, model_execution_source: 'provider' as const,
+  model_provider: 'anthropic' as const, provider_model: 'claude-sonnet-4-6',
+  requested_model: 'gemini-3.7-flash', provider_model_resolution: 'fallback' as const, latency_ms: 1250,
+};
+
+describe('Web chat model choice and evidence', () => {
+  it('accepts named choices only for authenticated production requests', () => {
+    expect(parseWebChatModelPreference(undefined, false)).toBe('default');
+    expect(parseWebChatModelPreference('sonnet', true)).toBe('sonnet');
+    expect(parseWebChatModelPreference('gemini', true)).toBe('gemini');
+    expect(() => parseWebChatModelPreference('gemini', false)).toThrow('Sign in');
+    expect(() => parseWebChatModelPreference('gemini', true, true)).toThrow('evaluation');
+    for (const invalid of [null, {}, [], 'gemini-arbitrary']) {
+      expect(() => parseWebChatModelPreference(invalid, true)).toThrow('model_preference');
+    }
+  });
+
+  it('uses actual provider evidence for a handoff instead of the requested model', () => {
+    expect(webChatModelInfo(execution)).toEqual({ selected: 'gemini', source: 'provider',
+      model: 'claude-sonnet-4-6', requested_model: 'gemini-3.7-flash', fallback: true, latency_ms: 1250 });
+    expect(webChatModelInfo({ ...execution, provider_model_resolution: 'exact' }).fallback).toBe(true);
+  });
+
+  it('does not invent provider evidence for local or legacy responses', () => {
+    expect(webChatModelInfo({ ...execution, model_execution_source: 'local' })).toMatchObject({ source: 'local', model: null, fallback: false });
+    expect(webChatModelInfo({ ...execution, model_execution_source: undefined })).toMatchObject({ source: 'legacy', model: null, fallback: false });
+  });
+});

--- a/server/tests/unit/chat-model-selection.test.ts
+++ b/server/tests/unit/chat-model-selection.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { marked } from 'marked';
+import createDOMPurify from 'dompurify';
+
+const html = readFileSync(join(process.cwd(), 'server/public/chat.html'), 'utf8');
+const helper = readFileSync(join(process.cwd(), 'server/public/chat-model-selection.js'), 'utf8');
+let dom: JSDOM | undefined;
+afterEach(() => { dom?.window.close(); });
+
+function openChat(authenticated = true, geminiAvailable = true, storage: Record<string, string> = {}) {
+  const requests: Array<Record<string, any>> = [];
+  const infos: Array<Record<string, unknown>> = [];
+  const json = (value: unknown, status = 200) => new Response(JSON.stringify(value), { status });
+  dom = new JSDOM(html, {
+    url: 'https://example.test/chat', runScripts: 'dangerously', pretendToBeVisual: true,
+    beforeParse(window) {
+      window.eval(helper);
+      window.marked = marked;
+      window.DOMPurify = createDOMPurify(window);
+      window.TextDecoder = TextDecoder;
+      window.matchMedia = (() => ({ matches: false, addEventListener() {} })) as any;
+      Object.entries(storage).forEach(([key, value]) => window.localStorage.setItem(key, value));
+      window.fetch = (async (input: string, options?: RequestInit) => {
+        if (input === '/api/me') return json({ user: { id: 'member' } }, authenticated ? 200 : 401);
+        if (input === '/api/addie/chat/status') return json({ ready: true, model_selection: { enabled: authenticated, gemini_available: geminiAvailable } });
+        if (input.startsWith('/api/me/addie-home')) return json({ html: '', css: '' });
+        if (input === '/api/addie/chat/threads') return json({ conversations: [] });
+        if (input === '/api/si/sessions/user') return json({ sessions: [] });
+        if (input === '/api/addie/chat/test-thread') return json({ model_preference: 'gemini',
+          messages: [{ role: 'assistant', message_id: 'saved-answer', content: 'Saved answer',
+            model_info: { selected: 'gemini', source: 'provider', model: 'claude-sonnet-4-6', fallback: true, latency_ms: 3000 } }] });
+        if (input === '/api/addie/chat/stream') {
+          const body = JSON.parse(String(options?.body));
+          requests.push(body);
+          const info = { selected: body.model_preference, source: 'provider',
+            model: body.model_preference === 'sonnet' ? 'claude-sonnet-4-6' : 'gemini-3.7-flash', latency_ms: 1200, fallback: false };
+          infos.push(info);
+          const events = [ ['meta', { conversation_id: 'test-thread' }], ['text', { text: 'Verified answer.' }],
+            ['done', { conversation_id: 'test-thread', message_id: `answer-${requests.length}`, model_info: info }] ];
+          return new Response(events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join(''),
+            { headers: { 'Content-Type': 'text/event-stream' } });
+        }
+        return json({}, 404);
+      }) as typeof fetch;
+    },
+  });
+  return { window: dom.window, requests, infos };
+}
+
+describe('Web chat model selector', () => {
+  it('switches models for the next message in one chat and resets new chats to Default', async () => {
+    const { window, requests } = openChat();
+    const doc = window.document;
+    const select = doc.getElementById('modelSelect') as HTMLSelectElement;
+    const input = doc.getElementById('chatInput') as HTMLTextAreaElement;
+    await vi.waitFor(() => expect(doc.getElementById('modelSelector')?.hidden).toBe(false));
+    for (const choice of ['gemini', 'sonnet', 'default']) {
+      select.value = choice;
+      select.dispatchEvent(new window.Event('change'));
+      input.value = 'Explain AdCP';
+      input.dispatchEvent(new window.Event('input'));
+      doc.getElementById('sendButton')!.click();
+      await vi.waitFor(() => expect(doc.querySelectorAll('.message-model')).toHaveLength(requests.length));
+      await vi.waitFor(() => expect(select.disabled).toBe(false));
+      expect(requests.at(-1)?.model_preference).toBe(choice);
+    }
+    expect(requests).toHaveLength(3);
+    expect(requests[1].conversation_id).toBe('test-thread');
+    expect([...doc.querySelectorAll('.message-model')].map(el => el.textContent))
+      .toEqual(['Gemini 3.7 · 1.2s', 'Sonnet · 1.2s', 'Gemini 3.7 · 1.2s']);
+    select.value = 'sonnet';
+    select.dispatchEvent(new window.Event('change'));
+    expect(JSON.parse(window.localStorage.getItem('addie_active_tabs')!)[0].modelPreference).toBe('sonnet');
+    doc.getElementById('newChatBtn')!.click();
+    expect(select.value).toBe('default');
+  });
+
+  it('restores the per-chat choice and the actual fallback model from history after reload', async () => {
+    const { window } = openChat(true, true, {
+      addie_current_tab: 'test-thread',
+      addie_active_tabs: JSON.stringify([{ id: 'test-thread', title: 'Test chat', channel: 'web', modelPreference: 'sonnet' }]),
+    });
+    await vi.waitFor(() => expect(window.document.querySelector('.message-model')?.textContent).toBe('Gemini 3.7 → Sonnet · 3.0s'));
+    expect((window.document.getElementById('modelSelect') as HTMLSelectElement).value).toBe('sonnet');
+  });
+
+  it('hides selection for anonymous users and disables Gemini when unavailable', async () => {
+    const anonymous = openChat(false).window;
+    await vi.waitFor(() => expect(anonymous.document.getElementById('anonymous-banner')?.classList.contains('active')).toBe(true));
+    expect(anonymous.document.getElementById('modelSelector')?.hidden).toBe(true);
+    anonymous.close();
+    const { window } = openChat(true, false);
+    await vi.waitFor(() => expect(window.document.getElementById('modelSelector')?.hidden).toBe(false));
+    expect((window.document.querySelector('#modelSelect [value="gemini"]') as HTMLOptionElement).disabled).toBe(true);
+  });
+
+  it('renders provider strings as text without executing markup', () => {
+    const { window } = openChat();
+    const container = window.document.createElement('div');
+    (window as any).AddieChatModels.appendInfo(container, {
+      selected: 'default', source: 'provider', model: '<img src=x onerror=alert(1)>', fallback: false,
+    });
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/server/tests/unit/chat-si-branding-xss.test.ts
+++ b/server/tests/unit/chat-si-branding-xss.test.ts
@@ -72,6 +72,7 @@ function createDom(options: {
     runScripts: 'dangerously',
     pretendToBeVisual: true,
     beforeParse(window) {
+      window.eval(readFileSync(join(process.cwd(), 'server/public/chat-model-selection.js'), 'utf8'));
       const chatWindow = window as unknown as ChatWindow;
       chatWindow.__ENABLE_SI_CHAT_TEST_HOOKS__ = true;
       chatWindow.fetch = (async (input: RequestInfo | URL) => {


### PR DESCRIPTION
Signed-in web chat users can choose Default, Gemini 3.7 (beta), or Sonnet before sending the next message. The choice stays with the conversation, and answers show the actual responding model and elapsed time, including Gemini → Sonnet handoffs. Existing feedback remains attached to each answer.

Explicit choices use the existing Gemini Direct / Haiku-plus-Sonnet paths with the same account permissions, cost caps, and Gemini kill switch. Retries preserve the original turn's choice and mutation replay guard. Anonymous and evaluation requests cannot override models.

Migration 587 stores per-message preferences and adds a manual experiment cohort. Manual choices never overwrite randomized assignments; all turns in a manually switched conversation are reported separately from randomized comparisons. Automatic enrollment remains staff-only under the current production configuration. Addie code version: 2026.09.50.

Validation: 130 tests passed in Docker, covering real shared-loop provider routing, authorization, cost admission, replay, full-page DOM switching/reload/fallback labels, migration persistence, and SQL cohort separation. Typecheck passed. Generated Addie tool inventory refreshed and checked. The full server suite runs in CI; local focused checks avoid the previously observed 600-second precommit timeout. Signed-in production Chrome verification follows deployment.
