### PR TITLE
feat(compliance): persist runner version in history

### DIFF
--- a/server/src/addie/jobs/compliance-heartbeat.ts
+++ b/server/src/addie/jobs/compliance-heartbeat.ts
@@ -440,6 +440,7 @@ export async function runComplianceHeartbeatJob(options: HeartbeatOptions = {}):
           agent_url: agent.agent_url,
           requested_compliance_target: runTarget.requested,
           adcp_version: runTarget.version,
+          runner_capability_version: LIBRARY_VERSION,
           lifecycle_stage: agent.lifecycle_stage as LifecycleStage,
           overall_status: 'failing',
           headline,

--- a/server/src/addie/services/compliance-testing.ts
+++ b/server/src/addie/services/compliance-testing.ts
@@ -1452,6 +1452,7 @@ export function complianceResultToDbInput(
     requested_compliance_target: (result as ComplianceResult & { requested_compliance_target?: string })
       .requested_compliance_target ?? null,
     adcp_version: result.adcp_version ?? null,
+    runner_capability_version: result.summary.runner_capability_version ?? null,
     lifecycle_stage: lifecycleStage,
     overall_status,
     headline: result.summary.headline,

--- a/server/src/db/compliance-db.ts
+++ b/server/src/db/compliance-db.ts
@@ -112,6 +112,7 @@ export interface ComplianceRun {
   agent_url: string;
   requested_compliance_target: string | null;
   adcp_version: string | null;
+  runner_capability_version: string | null;
   lifecycle_stage: LifecycleStage;
   overall_status: OverallRunStatus;
   headline: string | null;
@@ -267,6 +268,7 @@ export interface RecordComplianceRunInput {
   agent_url: string;
   requested_compliance_target?: string | null;
   adcp_version?: string | null;
+  runner_capability_version?: string | null;
   lifecycle_stage: LifecycleStage;
   overall_status: OverallRunStatus;
   headline?: string;
@@ -610,8 +612,8 @@ export class ComplianceDatabase {
           total_duration_ms, tracks_json, tracks_passed, tracks_failed,
           tracks_skipped, tracks_partial, agent_profile_json,
           observations_json, triggered_by, triggered_org_id, dry_run,
-          notices_json, refresh_operation_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+          notices_json, refresh_operation_id, runner_capability_version
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
         ON CONFLICT (refresh_operation_id) DO NOTHING
         RETURNING *`,
         [
@@ -634,6 +636,7 @@ export class ComplianceDatabase {
           input.dry_run ?? true,
           input.notices_json ? JSON.stringify(input.notices_json) : null,
           input.refresh_operation_id ?? null,
+          input.runner_capability_version ?? null,
         ],
       );
       let run = runResult.rows[0] as ComplianceRun | undefined;

--- a/server/src/db/migrations/588_agent_compliance_runner_version.sql
+++ b/server/src/db/migrations/588_agent_compliance_runner_version.sql
@@ -1,0 +1,5 @@
+ALTER TABLE agent_compliance_runs
+  ADD COLUMN IF NOT EXISTS runner_capability_version TEXT;
+
+COMMENT ON COLUMN agent_compliance_runs.runner_capability_version IS
+  'Runner capability version recorded at execution time; NULL when not recorded, including historical runs.';

--- a/server/src/routes/registry-api.ts
+++ b/server/src/routes/registry-api.ts
@@ -7024,6 +7024,7 @@ export function createRegistryApiRouters(config: RegistryApiConfig): {
           id: run.id,
           requested_compliance_target: run.requested_compliance_target ?? null,
           adcp_version: run.adcp_version ?? null,
+          runner_capability_version: run.runner_capability_version ?? null,
           overall_status: run.overall_status,
           headline: run.headline,
           tracks_passed: run.tracks_passed,

--- a/server/src/schemas/registry.ts
+++ b/server/src/schemas/registry.ts
@@ -1328,6 +1328,9 @@ export const ComplianceRunSchema = z
     id: z.string(),
     requested_compliance_target: z.string().nullable().optional(),
     adcp_version: z.string().nullable().optional(),
+    runner_capability_version: z.string().nullable().optional().openapi({
+      description: "Runner capability version recorded at execution time, separate from the AdCP version under test. Null when not recorded, including historical runs.",
+    }),
     overall_status: z.string(),
     headline: z.string().nullable(),
     tracks_passed: z.number().int(),

--- a/server/tests/integration/registry-api-compliance-verdict-source.test.ts
+++ b/server/tests/integration/registry-api-compliance-verdict-source.test.ts
@@ -28,6 +28,7 @@ import type { Pool } from 'pg';
 import { HTTPServer } from '../../src/http.js';
 import { initializeDatabase, closeDatabase } from '../../src/db/client.js';
 import { runMigrations } from '../../src/db/migrate.js';
+import { ComplianceDatabase } from '../../src/db/compliance-db.js';
 
 vi.hoisted(() => {
   process.env.WORKOS_API_KEY ||= 'sk_test_registry_debug';
@@ -251,6 +252,61 @@ describe('GET /api/registry/agents/:encodedUrl/compliance — owner-scope gate (
   });
 
   const endpoint = `/api/registry/agents/${encodeURIComponent(AGENT_URL)}/compliance`;
+
+  it('returns null for a historical run without a recorded runner version', async () => {
+    const res = await request(app).get(`${endpoint}/history`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.runs).toEqual([
+      expect.objectContaining({ id: complianceRunId, runner_capability_version: null }),
+    ]);
+  });
+
+  it('persists each runner version through real writes and history reads, including partial runs', async () => {
+    const agentUrl = `https://runner-version-${RUN_SUFFIX}.example.com/mcp`;
+    const db = new ComplianceDatabase();
+    const expectedRuns = [];
+
+    try {
+      for (const [overallStatus, runnerVersion] of [
+        ['passing', '14.0.0-rc.12'],
+        ['partial', '14.0.0-rc.13'],
+        ['failing', null],
+      ] as const) {
+        const { run } = await db.recordComplianceRun({
+          agent_url: agentUrl,
+          requested_compliance_target: '3.1',
+          adcp_version: '3.1.0',
+          runner_capability_version: runnerVersion,
+          lifecycle_stage: 'testing',
+          overall_status: overallStatus,
+          tracks_json: [],
+          tracks_passed: 0,
+          tracks_failed: 0,
+          tracks_skipped: 0,
+          tracks_partial: 0,
+          triggered_by: 'manual',
+          dry_run: false,
+        });
+        expect(run.runner_capability_version).toBe(runnerVersion);
+        expectedRuns.push(expect.objectContaining({
+          id: run.id,
+          overall_status: overallStatus,
+          adcp_version: '3.1.0',
+          runner_capability_version: runnerVersion,
+        }));
+      }
+
+      const res = await request(app)
+        .get(`/api/registry/agents/${encodeURIComponent(agentUrl)}/compliance/history`);
+      expect(res.status).toBe(200);
+      expect(res.body.count).toBe(3);
+      expect(res.body.runs).toEqual(expect.arrayContaining(expectedRuns));
+    } finally {
+      await pool.query('DELETE FROM agent_compliance_status WHERE agent_url = $1', [agentUrl]);
+      await pool.query('DELETE FROM agent_compliance_runs WHERE agent_url = $1', [agentUrl]);
+    }
+  });
 
   const OWNER_ONLY_KEYS = [
     'verdict_source',

--- a/server/tests/unit/compliance-heartbeat.test.ts
+++ b/server/tests/unit/compliance-heartbeat.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LIBRARY_VERSION } from '@adcp/sdk';
 
 const mocks = vi.hoisted(() => ({
   getAgentsDueForCheck: vi.fn(),
@@ -489,6 +490,26 @@ describe('runComplianceHeartbeatJob', () => {
       failed: 0,
       skipped: 0,
     });
+  });
+
+  it('records the invoking runner version when comply throws without a result', async () => {
+    mocks.comply.mockRejectedValueOnce(new Error('Timed out'));
+
+    const { runComplianceHeartbeatJob } = await import('../../src/addie/jobs/compliance-heartbeat.js');
+    const result = await runComplianceHeartbeatJob({ limit: 1 });
+
+    expect(result).toEqual({ checked: 1, passed: 0, failed: 1, skipped: 0 });
+    expect(mocks.complianceResultToDbInput).not.toHaveBeenCalled();
+    expect(mocks.recordComplianceRun).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        agent_url: 'https://agent.example.com/mcp',
+        adcp_version: target.version,
+        runner_capability_version: LIBRARY_VERSION,
+        overall_status: 'failing',
+        triggered_by: 'heartbeat',
+        dry_run: false,
+      }),
+    );
   });
 
   it('counts malformed saved Basic auth as a checked failure', async () => {

--- a/server/tests/unit/compliance-testing-effective-run-status.test.ts
+++ b/server/tests/unit/compliance-testing-effective-run-status.test.ts
@@ -55,6 +55,34 @@ function makeResult(tracks: ReturnType<typeof makeTrack>[], overallStatus = 'par
   };
 }
 
+describe('complianceResultToDbInput runner version', () => {
+  it.each([
+    ['pass', 'passing'],
+    ['partial', 'partial'],
+    ['fail', 'failing'],
+  ])('preserves the emitted version for %s results', (trackStatus, overallStatus) => {
+    const baseResult = makeResult([makeTrack(trackStatus)], overallStatus);
+    const result = {
+      ...baseResult,
+      adcp_version: '3.1.0',
+      summary: { ...baseResult.summary, runner_capability_version: '14.0.0-rc.12' },
+    };
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.runner_capability_version).toBe('14.0.0-rc.12');
+    expect(out.adcp_version).toBe('3.1.0');
+    expect(out.overall_status).toBe(overallStatus);
+  });
+
+  it.each([{}, { runner_capability_version: null }])('does not invent a missing runner version: %j', fields => {
+    const baseResult = makeResult([makeTrack('pass')], 'passing');
+    const result = { ...baseResult, summary: { ...baseResult.summary, ...fields } };
+    const out = complianceResultToDbInput(result as any, 'https://agent.example.com/mcp', 'production');
+
+    expect(out.runner_capability_version).toBeNull();
+  });
+});
+
 describe('complianceResultToDbInput — effectiveRunStatus', () => {
   it('promotes all-silent to passing with zero partial/failed counters', () => {
     const result = makeResult([makeTrack('silent'), makeTrack('silent')], 'partial');

--- a/static/openapi/registry.yaml
+++ b/static/openapi/registry.yaml
@@ -4687,6 +4687,11 @@ components:
           type:
             - string
             - "null"
+        runner_capability_version:
+          type:
+            - string
+            - "null"
+          description: Runner capability version recorded at execution time, separate from the AdCP version under test. Null when not recorded, including historical runs.
         overall_status:
           type: string
         headline:


### PR DESCRIPTION
## Summary

Closes #7429.

- Persist the runner's capability version on each compliance run and expose it in the history API, separately from the AdCP version under test.
- Read the emitted value from `result.summary.runner_capability_version`, including partial results. The heartbeat exception path records the invoking SDK's `LIBRARY_VERSION` when writing a failure row.
- Add a nullable, no-default migration and regenerate the registry OpenAPI schema. Historical or missing values remain null; history reads never substitute the currently deployed version.

This is the bounded persistence slice proposed in the issue. It does not change grading, badges, materialized status tables, or the protocol package. Equal capability versions are not a guarantee of identical deployments or deterministic results. A separate deployment-provenance field remains out of scope.

## Validation

With Node 24 and PostgreSQL 16 in Docker:

- Focused adapter, heartbeat, database, and real HTTP/history integration tests: 67 passed across four files.
- Existing storyboard wrapper suite: 51 passed after fetching the archived caches required by the sparse checkout.
- `npm run typecheck`: passed.
- `npm run build:openapi` and `npm run test:openapi`: passed.
- `npm run test:migrations`: passed.
- Applied the migration twice over an existing row in a transaction; historical null and an explicitly recorded version were both preserved.
- `git diff --check`, PR title, changeset scope, and version-sync checks: passed.

No protocol changeset: this only changes the application's operational history API.

Full-suite limitation: `npm run precommit` reached the repository's 600-second timeout in `precommit:server-unit` (exit 143). The initial archived-cache failures in `storyboards.test.ts` were resolved by fetching the required release artifacts; its separate rerun passed all 51 tests. The full server suite is not being claimed as green. Keeping this draft pending CI and review.
